### PR TITLE
Use absolute paths for directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,17 +6,17 @@
 # Packages
 *.egg
 *.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
+/dist
+/build
+/eggs
+/parts
+/bin
+/var
+/sdist
+/develop-eggs
 .installed.cfg
-lib
-lib64
+/lib
+/lib64
 
 # Installer logs
 pip-log.txt


### PR DESCRIPTION
Previously, ignoring `lib` was causing `static/lib` to be ignored as well.
