### PR TITLE
Add possibility to search for features only

### DIFF
--- a/chsdi/templates/index.pt
+++ b/chsdi/templates/index.pt
@@ -67,12 +67,14 @@
 
       <h2>Search</h2>
           <a href="rest/services/inspire/SearchServer?searchText=wand&type=layers">Search for layers only</a> <br>
-          <a href="rest/services/inspire/SearchServer?searchText=vd 446&features=ch.astra.ivs-reg_loc&type=locations">Search for features in ch.astra.ivs-reg_loc (type locations)</a> <br>
-          <a href="rest/services/inspire/SearchServer?searchText=vd 446&features=ch.astra.ivs-reg_loc&type=locations&bbox=551306.5625,167918.328125,551754.125,168514.625">Search for features in ch.astra.ivs-reg_loc (only features within the bbox)</a> <br>
           <a href="rest/services/inspire/SearchServer?searchText=bois&type=layers&lang=fr">Search for layers only (lang fr)</a> <br>
           <a href="rest/services/inspire/SearchServer?searchText=wasser&bbox=733040.9375,183972.484375,738163.75,183972.484375&type=locations">Search in the topic (or map) inspire for locations</a> <br>
           <a href="rest/services/blw/SearchServer?searchText=wasser&bbox=733040.9375,183972.484375,738163.75,183972.484375&type=locations">Search in the topic (or map) blw for locations</a> <br>
 
+          <a href="rest/services/inspire/SearchServer?searchText=vd 446&features=ch.astra.ivs-reg_loc&type=features">Search for features in ch.astra.ivs-reg_loc (type features)</a> <br>
+          <a href="rest/services/inspire/SearchServer?searchText=vd 446&features=ch.astra.ivs-reg_loc&type=features&bbox=551306.5625,167918.328125,551754.125,168514.625">Search for features in ch.astra.ivs-reg_loc (only features within the bbox)</a> <br>
+          <a href="rest/services/inspire/SearchServer?searchText=vd 446&features=ch.astra.ivs-reg_loc&type=locations">Combined search for locations _and_  features in ch.astra.ivs-reg_loc (type locations)</a> <br>
+          <a href="rest/services/inspire/SearchServer?searchText=vd 446&features=ch.astra.ivs-reg_loc&type=locations&bbox=551306.5625,167918.328125,551754.125,168514.625">Combined search for locations *and* features in ch.astra.ivs-reg_loc (locations and features within the bbox)</a> <br>
       <h2>Feedback</h2>
           <a href="feedback?email=chsdi3preview@admin.com&feedback=TestFromChsdi3&permalink=http:%2F%2Fmf-geoadmin3.bgdi.admin.ch&ua=IE">Feedback example</a> <br>
   </body>

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -41,7 +41,8 @@ class Search(SearchValidation):
             self._get_quad_index()
         if self.typeInfo == 'layers':
             self._layer_search()
-        if self.featureIndexes is not None and self.typeInfo == 'locations':
+        if self.featureIndexes is not None and (self.typeInfo == 'locations' or
+                                                self.typeInfo == 'features'):
             featuresCount = self._feature_search()
         if self.typeInfo == 'locations':
             self._swiss_search(self.LIMIT)


### PR DESCRIPTION
Right now, the feature search is only possible in combination with standard swissSearch (we always looks for both features and locations).

This PR adds a new type `features`, which allows to only search for features (with same parameters as the other searches). This is needed for ResultPanel in RE3
