### PR TITLE
Allow empty searchText for locations and feature searches

### DIFF
--- a/chsdi/templates/index.pt
+++ b/chsdi/templates/index.pt
@@ -72,6 +72,8 @@
           <a href="rest/services/inspire/SearchServer?searchText=bois&type=layers&lang=fr">Search for layers only (lang fr)</a> <br>
           <a href="rest/services/inspire/SearchServer?searchText=wasser&bbox=733040.9375,183972.484375,738163.75,183972.484375&type=locations">Search in the topic (or map) inspire for locations</a> <br>
           <a href="rest/services/blw/SearchServer?searchText=wasser&bbox=733040.9375,183972.484375,738163.75,183972.484375&type=locations">Search in the topic (or map) blw for locations</a> <br>
+          <a
+          href="rest/services/inspire/SearchServer?searchText=&features=ch.astra.ivs-reg_loc&type=locations&bbox=551306.5625,167918.328125,551754.125,168514.625">Search for ALL features in ch.astra.ivs-reg_loc (ALL features and locations within the bbox, empty searchText)</a> <br>
 
       <h2>Feedback</h2>
           <a href="feedback?email=chsdi3preview@admin.com&feedback=TestFromChsdi3&permalink=http:%2F%2Fmf-geoadmin3.bgdi.admin.ch&ua=IE">Feedback example</a> <br>

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -12,7 +12,7 @@ class Search(SearchValidation):
 
     LIMIT = 30
     LAYER_LIMIT = 20
-    FEATURE_LIMIT = 10
+    FEATURE_LIMIT = 50
 
     def __init__(self, request):
         super(Search, self).__init__()
@@ -53,7 +53,9 @@ class Search(SearchValidation):
         self.sphinx.SetSortMode(sphinxapi.SPH_SORT_ATTR_ASC, 'rank')
         if self.quadindex is not None:
             searchText = self._query_detail('@detail')
-            searchText += ' & @geom_quadindex ' + self.quadindex + '*'
+            if searchText != '':
+                searchText += ' & '
+            searchText += '@geom_quadindex ' + self.quadindex + '*'
         else:
             searchText = self._query_detail('@detail')
         temp = self.sphinx.Query(searchText, index='swisssearch')['matches']
@@ -67,7 +69,9 @@ class Search(SearchValidation):
             # bbox
             self.sphinx.SetLimits(0, limit)
             searchText = self._query_detail('@detail')
-            searchText += ' & @geom_quadindex !' + self.quadindex + '*'
+            if searchText != '':
+                searchText += ' & '
+            searchText += '@geom_quadindex !' + self.quadindex + '*'
             temp = self.sphinx.Query(
                 searchText,
                 index='swisssearch')['matches']
@@ -95,7 +99,9 @@ class Search(SearchValidation):
             self._add_feature_queries(searchText)
         else:
             searchText = self._query_detail('@detail')
-            searchText += ' & @geom_quadindex ' + self.quadindex + '*'
+            if searchText != '':
+                searchText += ' & '
+            searchText += '@geom_quadindex ' + self.quadindex + '*'
             self._add_feature_queries(searchText)
         temp = self.sphinx.RunQueries()
         nb_match = self._nb_of_match(temp)
@@ -103,7 +109,9 @@ class Search(SearchValidation):
         # look outside the bbox if no match when the bbox is defined
         if self.quadindex is not None and nb_match == 0:
             searchText = self._query_detail('@detail')
-            searchText += ' & @geom_quadindex !' + self.quadindex + '*'
+            if searchText != '':
+                searchText += ' & '
+            searchText += '@geom_quadindex !' + self.quadindex + '*'
             self._add_feature_queries(searchText)
 
             temp = self.sphinx.RunQueries()
@@ -118,7 +126,10 @@ class Search(SearchValidation):
             if counter != len(self.searchText):
                 searchText += fields + ' *' + text + '* & '
             else:
-                searchText += fields + ' *' + text + '*'
+                if text == '':
+                    searchText += ''
+                else:
+                    searchText += fields + ' *' + text + '*'
             counter += 1
         return searchText
 


### PR DESCRIPTION
This PR allows to have an empty searchText paramenter for `locations` and `features` searches. This will allow to find _all_ features/locations in a given bounding box.

This is also needed in the ResultPanel.

Note: I increase the limit for feature results to 50.
Note: It has to be analysed what this changes means for existing search in RE3
