### PR TITLE
Use same staging wms as layer stating status

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -109,6 +109,12 @@ class LayersConfig(Base):
                     config[k] = self.__dict__[k]
         if config['type'] == 'wmts':
             del config['singleTile']
+        if config['type'] == 'wms':
+            if config['staging'] == 'test':
+                config['wmsUrl'] = config['wmsUrl'].replace('wms.geo.admin.ch', 'wms-bgdi0t.bgdi.admin.ch')
+            if config['staging'] == 'integration':
+                config['wmsUrl'] = config['wmsUrl'].replace('wms.geo.admin.ch', 'wms-bgdi0i.bgdi.admin.ch')
+
         return {self.idBod: config}
 
     def _getResolutionsFromMatrixSet(self, matrixSet):


### PR DESCRIPTION
If layer has a staging status 'test', we'll use the wms test for this layer, as done lately in RE2
