### PR TITLE
Remove cache control config from topics and catalog views

### DIFF
--- a/chsdi/views/catalog.py
+++ b/chsdi/views/catalog.py
@@ -16,7 +16,7 @@ class CatalogService(MapNameValidation):
         self.hasMap(request.db, self.mapName)
         self.request = request
 
-    @view_config(route_name='catalog', http_cache=0, renderer='jsonp')
+    @view_config(route_name='catalog', renderer='jsonp')
     def catalog(self):
         from pyramid.renderers import render_to_response
 

--- a/chsdi/views/topics.py
+++ b/chsdi/views/topics.py
@@ -5,7 +5,7 @@ from pyramid.view import view_config
 from chsdi.models.bod import Topics
 
 
-@view_config(route_name='topics', http_cache=0, renderer='jsonp')
+@view_config(route_name='topics', renderer='jsonp')
 def topics(request):
     model = Topics
     query = request.db.query(model).order_by(model.orderKey)


### PR DESCRIPTION
It would make sense to really have a cache control for these services.
See https://github.com/geoadmin/mf-geoadmin3/pull/514
