### PR TITLE
Use same rule for accents as in pgadmin

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -42,6 +42,12 @@ def round(val):
 
 def remove_accents(input_str):
     # TODO find a better way to treat those characters
+    input_str = input_str.replace(u'ü', u'ue')
+    input_str = input_str.replace(u'Ü', u'ue')
+    input_str = input_str.replace(u'ä', u'ae')
+    input_str = input_str.replace(u'Ä', u'ae')
+    input_str = input_str.replace(u'ö', u'oe')
+    input_str = input_str.replace(u'Ö', u'oe')
     input_str = input_str.replace('/', '')
     input_str = input_str.replace('(', '')
     input_str = input_str.replace(')', '')


### PR DESCRIPTION
<pre>
-- Function: remove_accents(character varying)

-- DROP FUNCTION remove_accents(character varying);

CREATE OR REPLACE FUNCTION remove_accents(string character varying)
  RETURNS character varying AS
$BODY$
    DECLARE
        res varchar;
    BEGIN
        res := replace(string, 'ü', 'ue');
        res := replace(res, 'Ü', 'ue');
        res := replace(res, 'ä', 'ae');
        res := replace(res, 'Ä', 'ae');
        res := replace(res, 'ö', 'oe');
        res := replace(res, 'Ö', 'oe');
        res := replace(res, '(', '_');
        res := replace(res, ')', '_');


        res:= translate(res, 'àáâÀÁÂ', 'aaaaaa');
        res:= translate(res, 'èéêëÈÉÊË', 'eeeeeeee');
        res:= translate(res, 'ìíîïÌÍÎÏ', 'iiiiiiii');
        res:= translate(res, 'òóôÒÓÔ', 'oooooo');
        res:= translate(res, 'ùúûÙÚÛ', 'uuuuuu');
        res:= translate(res, 'ç', 'c');

        RETURN trim(lower(res));
    END;
$BODY$
  LANGUAGE plpgsql IMMUTABLE
  COST 100;
ALTER FUNCTION remove_accents(character varying)
  OWNER TO postgres;
</pre>


This is the function we use in postgresql to remove accents.
Here we simply needed to adapt it to behave the same way in CHSDI3.
