### PR TITLE
Adapting cookie path for geoadmin

### DIFF
--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -3,10 +3,10 @@
     Allow from all
 </Proxy>
 
-# # stateful cookies
-<Location /${vars:instanceid}/wsgi/print/>
-    Header set Set-Cookie "SRV=${hostname-digest}; path=/${vars:instanceid}/wsgi/print/"
-</Location>
+# Stateful cookies
+<LocationMatch /${vars:instanceid}/(wsgi)?/print/>
+    Header set Set-Cookie "SRV=${hostname-digest}; path=/${vars:instanceid}/print/"
+</LocationMatch>
 
 
 ProxyPass        /${vars:instanceid}/wsgi/print/ ajp://localhost:8009/print-chsdi3-${instanceid}/pdf/


### PR DESCRIPTION
Cookie path has to be the same as on the requesting project.
