### PR TITLE
Fix sphinxpath

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -35,12 +35,7 @@ RewriteRule ^/${vars:instanceid}/wsgi/(static)/(.*)$  ${buildout:directory/chsdi
     Header unset Etag
 </LocationMatch>
 
-# Main entry point
-RewriteCond %{HTTP:X-Forwarded-Proto} !=https
-RewriteRule ^${vars:apache-entry-point}$ http://%{SERVER_NAME}/${vars:instanceid}/wsgi/static/doc/build/ [R=302,env=nocache:1,L]
-RewriteCond %{HTTP:X-Forwarded-Proto} =https
-RewriteRule ^${vars:apache-entry-point}$ https://%{SERVER_NAME}/${vars:instanceid}/wsgi/static/doc/build/ [R=302,env=nocache:1,L]
-Header always set Cache-Control "no-store, no-cache, must-revalidate" env=nocache
+RewriteRule ^${vars:apache-entry-point}$ /${vars:instanceid}/wsgi/ [PT]
 
 # Proxy pass pointing on api.geo.admin.ch project
 RewriteRule ^${vars:apache-entry-point}(qrcodegenerator|shorten|shorten.json)(.*)$ http://api.geo.admin.ch/$1$2 [P]
@@ -69,4 +64,4 @@ WSGIScriptAlias /${vars:instanceid}/wsgi ${buildout:directory/buildout/parts/mod
     WSGIApplicationGroup %{GLOBAL}
 </Location>
 
-RewriteRule ^${vars:apache-entry-point}(rest/services|ogcproxy|testi18n|loader.js|checker_dev|static|print|dev|feedback)(.*)$ /${vars:instanceid}/wsgi/$1$2 [PT]
+RewriteRule ^${vars:apache-entry-point}(realeasenotes|services|_static|api|rest/services|ogcproxy|testi18n|loader.js|checker_home|checker_dev|static|print|dev|feedback)(.*)$ /${vars:instanceid}/wsgi/$1$2 [PT]

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -58,14 +58,13 @@ def main(global_config, **settings):
     config.add_route('home', '/')
     config.add_route('dev', '/dev')
     config.add_route('testi18n', '/testi18n')
-    config.add_route('api', '/loader.js')
-    config.add_view(route_name='home', renderer='chsdi:static/doc/index.html', http_cache=0)
+
+    config.add_view(route_name='home', renderer='chsdi:static/doc/build/index.html', http_cache=0)
     config.add_view(route_name='dev', renderer='chsdi:templates/index.pt', http_cache=0)
     config.add_view(route_name='testi18n', renderer='chsdi:templates/testi18n.mako', http_cache=0)
-    config.add_view(route_name='api', renderer='chsdi:templates/loader.js', http_cache=0)
 
     # Application specific
-    config.add_route('topics', 'rest/services')
+    config.add_route('topics', '/rest/services')
     config.add_route('mapservice', '/rest/services/{map}/MapServer')
     config.add_route('layersconfig', '/rest/services/{map}/MapServer/layersconfig')
     config.add_route('catalog', '/rest/services/{map}/CatalogServer')
@@ -81,8 +80,15 @@ def main(global_config, **settings):
     config.add_route('feedback', '/feedback')
 
     # Checker section
+    config.add_route('checker_home', '/checker_home')
     config.add_route('checker_dev', '/checker_dev')
 
     config.scan(ignore=['chsdi.tests', 'chsdi.models.bod'])  # required to find code decorated by view_config
-    config.add_static_view('static', 'chsdi:static', cache_max_age=3600)
+
+    # Static view for sphinx
+    config.add_static_view('_static', 'chsdi:static/doc/build/_static', cache_max_age=3600)
+    config.add_static_view('api', 'chsdi:static/doc/build/api', cache_max_age=3600)
+    config.add_static_view('services', 'chsdi:static/doc/build/services', cache_max_age=3600)
+    config.add_static_view('realeasenotes', 'chsdi:static/doc/build/releasenotes', cache_max_age=3600)
+
     return config.make_wsgi_app()

--- a/chsdi/templates/index.pt
+++ b/chsdi/templates/index.pt
@@ -22,6 +22,7 @@
           <a href="testi18n?lang=toto">If not in available languages to de</a> <br>
       <h1 id="title">Services</h1>
       <h2 id="checkers">Checkers</h2>
+          <a href="checker_home">Checker for home page</a> <br>
           <a href="checker_dev">Checker for dev page</a> <br> 
       <h2 id="mapservices">Map Services</h2> 
           <h3>Mapservice (Layer metadata)</h3>

--- a/chsdi/views/checker.py
+++ b/chsdi/views/checker.py
@@ -29,7 +29,12 @@ class Checker(object):
     def make_response(self, msg):
         return Response(body=msg, status_int=self.status_int)
 
-    @view_config(route_name='checker_dev')
+    @view_config(route_name='checker_home')
     def home(self):
+        _url = self.request.route_url('home')
+        return self.make_response(self.testurl(_url))
+
+    @view_config(route_name='checker_dev')
+    def dev(self):
         _url = self.request.route_url('dev')
         return self.make_response(self.testurl(_url))


### PR DESCRIPTION
Fixes  #143 

With this PR the URL will remain as

http://api3.geo.admin.ch 

when one wants to access the doc. (and not http://api3.geo.admin.ch/main/wsgi/static/doc/build/ at the moment)

When using pserve the home page is now functional as well.

I also added a checker for the home page as well as an example.
