### PR TITLE
Support cadastral web map tooltip

### DIFF
--- a/chsdi/templates/htmlpopup/base.mako
+++ b/chsdi/templates/htmlpopup/base.mako
@@ -2,6 +2,8 @@
 
 <% 
   c = pageargs['feature']
+  c['bbox'] = pageargs.get('bbox')
+  c['scale'] = pageargs.get('scale')
   c['stable_id'] = False
   protocol = request.scheme
   baseUrl = protocol + '://' + request.registry.settings['geoadminhost']

--- a/chsdi/templates/htmlpopup/cadastralwebmap.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.mako
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
 <%inherit file="base.mako"/>
 
-<%def name="table_body(c,lang)">
+<%def name="table_body(c, lang)">
     % if c['attributes']['ak'] in ['D','I','F','AUT']:
         <tr><td width="150">${_('No info outside CH and FL')}</td><td></td></tr>
     % elif c['attributes']['ak'] == 'AG':
@@ -12,15 +15,15 @@
     % elif c['attributes']['ak'] == 'FR':
         <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://www.geo.fr.ch/index.php?reset_session&linkit=1&switch_id=switch_localisation&layer_select=Adresses,ParcVect,ParcVectnum,GrpMasque,GrpSituation,FondPlanContinu,copyright,Parcellaire,ParcScan&mapsize=0&recenter_bbox=${','.join(map(str,c['bbox']))}" target="_blank">FR</a></td></tr>
     % elif c['attributes']['ak'] == 'GE':
-        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://etat.geneve.ch/geoportail/monsitg/?X=${c['bbox'][0] + 2000000}&Y=${c['bbox'][1] + 1000000}&SCALE=${c.scale}" target="_blank">GE</a></td></tr>
+        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://etat.geneve.ch/geoportail/monsitg/?X=${c['bbox'][0] + 2000000}&Y=${c['bbox'][1] + 1000000}&SCALE=${c['scale']}" target="_blank">GE</a></td></tr>
     % elif c['attributes']['ak'] == 'GL':
         <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://geo.gl.ch/maps/Public?visibleLayers=MOpublic" target="_blank">GL</a></td></tr>
     % elif c['attributes']['ak'] == 'JU':
-        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://sitn.ne.ch/jura.php?Y=${c['bbox'][0]}&X=${c['bbox'][1]}&echelle=${c.scale if float(c.scale) <=5000 else 5000}&theme=cadastre" target="_blank">JU</a></td></tr>
+        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://sitn.ne.ch/jura.php?Y=${c['bbox'][0]}&X=${c['bbox'][1]}&echelle=${c['scale'] if float(c['scale']) <=5000 else 5000}&theme=cadastre" target="_blank">JU</a></td></tr>
     % elif c['attributes']['ak'] == 'SH':   
        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://www.gis.sh.ch/GIS_SH/?idp=1&uid=1&pwd=&map=10&lan=de&typ=3&bmurl=Nav@g@98@u@West@g@${c['bbox'][0]}@u@Nord@g@${c['bbox'][1]}@u@B@g@600" target="_blank">SH</a></td></tr>
     % elif c['attributes']['ak'] == 'SZ':
-        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://webmap.sz.ch/bm31_webmap/?idp=1&uid=3&bmurl=Nav@g@129@u@West@g@${c['bbox'][0]}@u@Nord@g@${c['bbox'][1]}@u@B@g@${c.scale}" target="_blank">SZ</a></td></tr>
+        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://webmap.sz.ch/bm31_webmap/?idp=1&uid=3&bmurl=Nav@g@129@u@West@g@${c['bbox'][0]}@u@Nord@g@${c['bbox'][1]}@u@B@g@${c['scale']}" target="_blank">SZ</a></td></tr>
     % elif c['attributes']['ak'] == 'SO':
         <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://www.sogis1.so.ch/sogis/internet/pmapper/somap.php?karte=ortsplan&extent=${','.join(map(str,c['bbox']))}" target="_blank">SO</a></td></tr>
     % elif c['attributes']['ak'] == 'TI':

--- a/chsdi/templates/index.pt
+++ b/chsdi/templates/index.pt
@@ -43,10 +43,10 @@
           <a href="/rest/services/ech/MapServer/identify?geometryType=esriGeometryEnvelope&geometry=630000,245000,645000,265000&imageDisplay=500,600,96&mapExtent=545132.87362333,147068.69380758,550132.87362333,150568.69380758&tolerance=1&layers=all&returnGeometry=false">Identify - without geometry</a> <br>
           <h3>Varia</h3>
           <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362">Get Feature with id 362</a> <br>
-          <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362/htmlpopup">Get Html Popup Ex 1</a> <br>
-          <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-jagdbanngebiete/145/htmlpopup?lang=fr&callback=cb">Get Html Popup Ex 2 with callback</a> <br>
-          <a href="rest/services/ech/MapServer/ch.astra.ivs-reg_loc/54967/htmlpopup">Get Html Popup Ex 3</a> <br>
-          <a href="rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/17/htmlpopup">Get Html Popup Ex 4 (cadastralwebmap + bbox)</a> <br>
+          <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362/htmlpopup">Html Popup Ex 1</a> <br>
+          <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-jagdbanngebiete/145/htmlpopup?lang=fr&callback=cb">Html Popup Ex 2 with callback</a> <br>
+          <a href="rest/services/ech/MapServer/ch.astra.ivs-reg_loc/54967/htmlpopup">Html Popup Ex 3</a> <br>
+          <a href="rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/11/htmlpopup?imageDisplay=600,400,96&mapExtent=573090.125,142393.0625,573097.625,142400.5625">Html popup Ex 4 cadastral web map</a> <br>
           <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/getlegend">Get Legend Ex 1</a> <br>
           <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-jagdbanngebiete/getlegend?lang=fr&callback=cb">Get Legend Ex 2 with callback</a> <br>
           <a href="rest/services/height?easting=600000&northing=200000">Height example</a> <br>

--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -124,6 +124,11 @@ class TestMapServiceView(TestsBase):
         self.failUnless(resp.content_type == 'text/html')
         resp.mustcontain('<table')
 
+    def test_gethtmlpopup_cadastralwebmap(self):
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/14/htmlpopup', params={'mapExtent': '485412.34375,109644.67,512974.44,135580.01999999999', 'imageDisplay': '600,400,96'}, status=200)
+        self.failUnless(resp.content_type == 'text/html')
+        resp.mustcontain('<table')
+
     def test_gethtmlpopup_valid_topic_all(self):
         resp = self.testapp.get('/rest/services/all/MapServer/ch.bafu.bundesinventare-bln/362/htmlpopup', status=200)
         self.failUnless(resp.content_type == 'text/html')


### PR DESCRIPTION
Prepare https://github.com/geoadmin/mf-geoadmin3/issues/692

Backward compatibility is ensured.

Add support for cadastral web map
Add 2 parameters to htmlpopup service (mapExtent, imageDisplay -> use default values when not defined, parameters parsing is performed thanks to the parent class)
Update examples
Add one test for cadastral web map
Limit features retrieving to 50 (in the law)
