### PR TITLE
Adding proxy for geodesy service

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -40,6 +40,9 @@ RewriteRule ^${vars:apache-entry-point}$ /${vars:instanceid}/wsgi/ [PT]
 # Proxy pass pointing on api.geo.admin.ch project
 RewriteRule ^${vars:apache-entry-point}(qrcodegenerator|shorten|shorten.json)(.*)$ http://api.geo.admin.ch/$1$2 [P]
 
+# Proxy pass for geodesy services
+RewriteRule ^${vars:apache-entry-point}reframe/lv03tolv95(.*)$ http://tc-geodesy.bgdi.admin.ch/reframe/lv03tolv95$1 [P]
+
 <Location ${vars:apache-entry-point}>
     Order allow,deny
     Allow from all


### PR DESCRIPTION
This addresses https://github.com/geoadmin/mf-geoadmin3/issues/711
- This geodesy service is part of the API
- It may be used with HTTPS

http://api3.geo.admin.ch/reframe/lv03tolv95?cb=angular.callbacks._1&easting=582500&northing=138500

and

https://api3.geo.admin.ch/reframe/lv03tolv95?cb=angular.callbacks._1&easting=582500&northing=138500
