### PR TITLE
Add continous integration on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+    - "0.8"
+
+before_install:
+    - sudo mkdir -p /srv/tomcat/tomcat1/webapps/
+    - sudo chmod 777 /srv/tomcat/tomcat1/webapps
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libgeos-dev
+
+before_script:
+    - python bootstrap.py --version 1.5.2 --distribute --download-base http://pypi.camptocamp.net/distribute-0.6.22_fix-issue-227/ --setup-source http://pypi.camptocamp.net/distribute-0.6.22_fix-issue-227/distribute_setup.py
+
+script:
+    - buildout/bin/buildout -c buildout_prod.cfg
+


### PR DESCRIPTION
This adds a travis configuration to establish continous integration. All it does is bootstrapping and building for production.

Unfortunately, our unit tests require direct access to the database (thus requiring login credentials), so the nosetests can't be run on travis.

Any way we can seperate nose tests in a) unit tests (no access to external sources) and b) integration tests (with access to external sources)? 

Or maybe more general: shouldn't our unit tests use test fixtures (local db setups just for tests)?
