### PR TITLE
Adding geoanchor and geodist sorting for features-only search

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from osgeo import osr, ogr
 from pyramid.threadlocal import get_current_registry
 from pyramid.i18n import get_locale_name
 import unicodedata
@@ -95,3 +96,14 @@ def parseHydroXML(id, root):
                         html_attr['wassertemperatur'] = attr.text
                         break
     return html_attr
+
+def transformCoordinate(wkt, srid_from, srid_to):
+    srid_in = osr.SpatialReference()
+    srid_in.ImportFromEPSG(srid_from)
+    srid_out = osr.SpatialReference()
+    srid_out.ImportFromEPSG(srid_to)
+    geom = ogr.CreateGeometryFromWkt(wkt)
+    geom.AssignSpatialReference(srid_in)
+    geom.TransformTo(srid_out)
+    return geom
+

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from osgeo import osr, ogr
-
 from pyramid.view import view_config
 import pyramid.httpexceptions as exc
 
 from chsdi.lib.validation import SearchValidation
 from chsdi.lib.helpers import remove_accents
+from chsdi.lib.helpers import transformCoordinate
 from chsdi.lib.sphinxapi import sphinxapi
 from chsdi.lib import mortonspacekey as msk
 
@@ -113,15 +112,7 @@ class Search(SearchValidation):
         centerX = (self.bbox[2] + self.bbox[0]) / 2
         centerY = (self.bbox[3] + self.bbox[1]) / 2
         wkt = 'POINT(%s %s)' % (centerX, centerY)
-        srid_out = osr.SpatialReference()
-        srid_out.ImportFromEPSG(4326)
-        srid_in = osr.SpatialReference()
-        srid_in.ImportFromEPSG(21781)
-        point = ogr.CreateGeometryFromWkt(wkt)
-        point.AssignSpatialReference(srid_in)
-        point.TransformTo(srid_out)
-        return point
- 
+        return transformCoordinate(wkt, 21781, 4326)
 
     def _feature_bbox_search(self):
         if self.quadindex is None:


### PR DESCRIPTION
This adds sorting according to geodistance of features_only search.

This is needed to have reasonable results in the feature_tree (select by rectangle) component in geoadmin3.
