### PR TITLE
Adding timeBehaviour parameter

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -87,6 +87,7 @@ class LayersConfig(Base):
     matrixSet = Column('tilematrixsetid', Text)
     timeEnabled = Column('timeenabled', Boolean)
     timestamps = Column('timestamps', postgresql.ARRAY(Text))
+    timeBehaviour = Column('time_behaviour', Text)
     maps = Column('projects', Text)
     staging = Column('staging', Text)
     wmsLayers = Column('wms_layers', Text)


### PR DESCRIPTION
This adds the new timeBehaviour parameter to the model. It exists in the db on test.

Note: if you deploy this to ab/prod, you have to deploy the db 'bod' too.
