### PR TITLE
Handle language in local_negiciator

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -25,6 +25,8 @@ def locale_negotiator(request):
     if lang == 'rm':
         return 'fi'
     elif lang is None or lang not in languages:
+        if request.accept_language:
+            return request.accept_language.best_match(languages, 'de')
         # the default_locale_name configuration variable
         return get_locale_name(request)
     return lang

--- a/chsdi/templates/loader.js
+++ b/chsdi/templates/loader.js
@@ -2,13 +2,7 @@
 
 <%
 mode = request.params.get('mode')
-lang = request.params.get('lang', None)
-AVAILABLE_LANGUAGES = request.registry.settings['available_languages']
-if lang is None and request.accept_language:
-    lang = request.accept_language.best_match(AVAILABLE_LANGUAGES, default_match='de')
-else:
-    lang = 'de'
-
+lang = request.params.get('lang')
 appUrl = request.application_url.replace('http:', request.scheme + ":")
 layersconfig = appUrl + '/rest/services/all/MapServer/layersconfig?lang=' + lang
 import urllib2, json


### PR DESCRIPTION
Now if the language is not defined we take what is found in the header for 
Accept-Language

if this header is not defined and the language is not passed as a parameter we use 'de'.
