### PR TITLE
Adapt to new catalog view

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -255,8 +255,10 @@ class Topics(Base):
     staging = Column('staging', Text)
 
 
-class Catalog(object):
+class Catalog(Base):
     __dbname__ = 'bod'
+    __tablename__ = 'view_catalog'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
     id = Column('bgdi_id', Integer, primary_key=True)
     parentId = Column('parent_id', Integer)
     topic = Column('topic', Text)
@@ -294,31 +296,6 @@ class Catalog(object):
         }[lang]
 
 
-class CatalogDe(Base, Catalog):
-    __tablename__ = 'view_catalog_de'
-    __table_args__ = ({'schema': 're3'})
-
-
-class CatalogFr(Base, Catalog):
-    __tablename__ = 'view_catalog_fr'
-    __table_args__ = ({'schema': 're3'})
-
-
-class CatalogIt(Base, Catalog):
-    __tablename__ = 'view_catalog_it'
-    __table_args__ = ({'schema': 're3'})
-
-
-class CatalogRm(Base, Catalog):
-    __tablename__ = 'view_catalog_rm'
-    __table_args__ = ({'schema': 're3'})
-
-
-class CatalogEn(Base, Catalog):
-    __tablename__ = 'view_catalog_en'
-    __table_args__ = ({'schema': 're3'})
-
-
 class OerebMetadata(Base):
     __tablename__ = 'oereb_interlis_metadata'
     __table_args__ = ({'schema': 're3', 'autoload': False})
@@ -338,19 +315,6 @@ def get_bod_model(lang):
         return BodLayerEn
     else:
         return BodLayerDe
-
-
-def get_catalog_model(lang, topic):
-    if lang == 'fr':
-        return CatalogFr
-    elif lang == 'it':
-        return CatalogIt
-    elif lang == 'rm':
-        return CatalogRm
-    elif lang == 'en':
-        return CatalogEn
-    else:
-        return CatalogDe
 
 
 def get_wmts_models(lang):

--- a/chsdi/views/catalog.py
+++ b/chsdi/views/catalog.py
@@ -4,7 +4,7 @@ from pyramid.view import view_config
 from pyramid.renderers import render_to_response
 from pyramid.httpexceptions import HTTPNotFound
 
-from chsdi.models.bod import get_catalog_model
+from chsdi.models.bod import Catalog
 from chsdi.lib.validation import MapNameValidation
 
 
@@ -18,7 +18,7 @@ class CatalogService(MapNameValidation):
 
     @view_config(route_name='catalog', renderer='jsonp')
     def catalog(self):
-        model = get_catalog_model(self.lang, self.mapName)
+        model = Catalog
         rows = self.request.db.query(model)\
             .filter(model.topic.ilike('%%%s%%' % self.mapName))\
             .order_by(model.depth)\


### PR DESCRIPTION
Because of issues with catalog labels, a new table has been created for the catalogs.
The following changes have been made in the bod.

The new view does not contain empty name_xx fields anymore.
name_de and name_fr have to be provided by the datasource (bod.re3.catalog, bod.public.dataset). 
name_it will be replaced with name_fr if empty.
name_en will be replaced with name_de if empty.
name_rm will be replaced with name_de if empty.

technical group members should not be listed in this view anymore (p.e ch.bazl.sachplan-infrastruktur-luftfahrt_kraft_surfaces, ch.bazl.sachplan-infrastruktur-luftfahrt_kraft_points, etc). 

Layers in the table bod.re3.catalog without reference in bod.public.dataset will not have any bod related information and should not be shown anymore (p.e. ch.swisstopo.swisstlm3d-karte), removed as well!

I tested and it works fine.
