### PR TITLE
Avoid updating css and js during the buildout process

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -202,13 +202,10 @@ recipe = collective.recipe.cmd
 on_install = true
 on_update = true
 cmds =
-    if [ -d chsdi/static/js/ol3 ]
+    if ! [ -d chsdi/static/js/ol3 ];
     then
-      echo "ol3 fork already cloned"
-    else
       cd chsdi/static/js/ && git clone https://github.com/geoadmin/ol3.git
       cd ol3 && ../../../../buildout/bin/python build-ga.py
-      cp build/ga.css ../../css/ && cp build/ol.css ../../css/ && cp build/ga*.js ../../js/ && cp build/EPSG* ../../js/ && cp build/proj4js-com* ../../js/
       cd ../../../../
     fi
 


### PR DESCRIPTION
Since CSS and JS are commited in CHSDI, we shouldn't copy/paster those resources automatically during the buildout process.

ol3-install should only install the ol3 project, but shouldn't change the resources used in "loader.js".
