### PR TITLE
Null fields should be allowed, otherwise, some mako will fail (legend ma...

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -40,9 +40,9 @@ class Bod(object):
         meta = {'attributes': {}}
         for k in self.__dict__.keys():
             if k != '_sa_instance_state':
-                if k in primaryAttr and self.__dict__[k] is not None:
+                if k in primaryAttr:
                     meta[k] = self.__dict__[k]
-                elif self.__dict__[k] is not None:
+                else:
                     meta['attributes'][k] = self.__dict__[k]
         return meta
 


### PR DESCRIPTION
...ko with ch.swisstopo.swisstlm3d-karte-farbe layer, as an example

This is a quick fix to get rid of some legends giving an error. The right approach would probably be to revert this PR and then to adapt the makos that fail because if it.

Sample link for testing http://mf-chsdi3.int.bgdi.ch/rest/services/ech/MapServer/ch.swisstopo.swisstlm3d-karte-farbe/legend
