### PR TITLE
Fix indices which names are too long

### DIFF
--- a/chsdi/lib/validation.py
+++ b/chsdi/lib/validation.py
@@ -326,6 +326,11 @@ class SearchValidation(MapNameValidation):
     @featureIndexes.setter
     def featureIndexes(self, value):
         if value is not None and value != '':
+            # SphinxSearch does not support indices longer than 64
+            # characters, that's why we have to hardcode here to
+            # something below 64 (indices are prepared with this name)
+            value = value.replace('ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet', 'ch_swisstopo_geologie-hydro_karte-grundwasservul')
+            value = value.replace('ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen', 'ch_swisstopo_geologie-hydro_karte-grundwasservor')
             value = value.replace('.', '_')
             self._featureIndexes = value.split(',')
 


### PR DESCRIPTION
The reason for wwo erronouse layers in https://github.com/geoadmin/mf-geoadmin3/issues/984 was that their names are too long. There is a limit of 64 characters for sphinxsearch indices.

This https://github.com/geoadmin/service-sphinxsearch/pull/65 PR changes the length of these indices to suit the requirements of sphinxsearch.

This PR here makes sure that the layers takes the corresponding, shortend index name for sphinxsearch.

@ltclm The auto-update would need to take into account this, as the index name does not correspond to the layer name.
