### PR TITLE
Increase connection timeout

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -74,6 +74,7 @@ class Search(SearchValidation):
     def _swiss_search(self, limit):
         if len(self.searchText) < 1:
             return 0
+        self.sphinx.SetConnectTimeout(1.5)
         self.sphinx.SetLimits(0, limit)
         self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_WORDCOUNT)
         self.sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, 'rank ASC, @weight DESC, num ASC')


### PR DESCRIPTION
Since we changed the infix from 2 to 1 for addresses, searchText like ch end up in internal error.
To fix this issue, we need to increase the connection timeout.
