### PR TITLE
Use ol.Map instead of ga.Map for zoomify views

### DIFF
--- a/chsdi/static/iipimage/viewer.js
+++ b/chsdi/static/iipimage/viewer.js
@@ -42,7 +42,7 @@ function init() {
   });
 
   if (url && imgWidth && imgHeight) { 
-    var map = new ga.Map({
+    var map = new ol.Map({
       layers: [
         new ol.layer.Tile({
           source: source

--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -112,7 +112,7 @@ endif
         });
 
         if (url && image_width && image_height) {
-          var map = new ga.Map({
+          var map = new ol.Map({
             layers: [
               new ol.layer.Tile({
                 source: source


### PR DESCRIPTION
This fixes the panning bug currently visible in lubis zoomify images.
