### PR TITLE
Avoid mixing api css and chsdi extended tooltip css

### DIFF
--- a/chsdi/static/less/extended.less
+++ b/chsdi/static/less/extended.less
@@ -1,6 +1,6 @@
 @screen-tablet: 768px;
 
-.htmlpopup-container {
+.chsdi-htmlpopup-container {
   font-size: 11px;
   font-family: arial,helvetia,verdana;
   width: 60%;

--- a/chsdi/templates/htmlpopup/base.mako
+++ b/chsdi/templates/htmlpopup/base.mako
@@ -25,7 +25,7 @@
   <script src="../../../../../../static/js/blueimp-gallery-2.11.5.min.js"></script>
 % endif
 
-<div class="htmlpopup-container">
+<div class="chsdi-htmlpopup-container">
   <div class="htmlpopup-header">
     <span>${fullName}</span> (${attribution})
   </div>


### PR DESCRIPTION
We had the same className for the api CSS and the extended tooltip css.
It created conflicts in CSS. This PR solves this issue.
As a result Lubis extended tooltip looks much better!
