### PR TITLE
use the same translation source for catalog labels

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -327,8 +327,6 @@ class Catalog(Base):
 
     def to_dict(self, lang):
 
-        self.label = self._get_label_from_lang(lang)
-
         return dict([
             (k, getattr(self, k)) for
             k in self.__dict__.keys()
@@ -336,15 +334,6 @@ class Catalog(Base):
             self.__dict__[k] is not None and
             k not in ('nameDe', 'nameFr', 'nameIt', 'nameRm', 'nameEn')
         ])
-
-    def _get_label_from_lang(self, lang):
-        return {
-            'de': self.nameDe,
-            'fr': self.nameFr,
-            'it': self.nameIt,
-            'rm': self.nameRm,
-            'en': self.nameEn
-        }[lang]
 
     @classmethod
     def get_name_from_lang(cls, lang):

--- a/chsdi/views/catalog.py
+++ b/chsdi/views/catalog.py
@@ -60,6 +60,8 @@ class CatalogService(MapNameValidation):
                 node = row.to_dict(self.lang)
                 if node['category'] != 'layer':
                     node['children'] = []
+                else:
+                    node['label'] = self.request.translate(node['idBod'])
                 nodes_depth.append(node)
             else:
                 nodes_all.append(nodes_depth)
@@ -70,6 +72,8 @@ class CatalogService(MapNameValidation):
                 node = row.to_dict(self.lang)
                 if node['category'] != 'layer':
                     node['children'] = []
+                else:
+                    node['label'] = self.request.translate(node['idBod'])
                 nodes_depth.append(node)
 
         # Append the last list


### PR DESCRIPTION
https://github.com/geoadmin/mf-geoadmin3/issues/915

Note that now layersConifg and CatalogServer use the same labels.

nameDe, nameFr, nameIt, nameRm and nameEn are still used for alphabetical order.
