### PR TITLE
Remove <a> when contact_web is equal to '-'

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -92,7 +92,23 @@ quickview_url = get_quickview_url(request, params)
 % if 'contact_web' in c['attributes']:
 <tr>
   <th class="cell-left">${_('tt_lubis_bildorder')}</th>
-  <td>${c['attributes']['contact']} <br /> ${c['attributes']['contact_email']} <br /><a href="${c['attributes']['contact_web']}" target="_blank">${c['attributes']['contact_web']}</a></td>
+  <td>
+    ${c['attributes']['contact']} 
+    <br/> 
+    ${c['attributes']['contact_email']} 
+    <br/>
+
+% if  c['attributes']['contact_web'] != '-':
+    <a href="${c['attributes']['contact_web']}" target="_blank">
+% endif
+
+    ${c['attributes']['contact_web']}
+
+% if  c['attributes']['contact_web'] != '-':
+    </a>
+% endif
+
+  </td>
 </tr>
 % endif
 <tr>


### PR DESCRIPTION
Fix https://github.com/geoadmin/mf-geoadmin3/issues/1235

https://mf-chsdi3.dev.bgdi.ch/ltteo/rest/services/lubis/MapServer/ch.swisstopo.lubis-luftbilder-dritte-kantone/20128810167423/htmlPopup?imageDisplay=1920,636,96&lang=de&mapExtent=663253.81,191397.5,672853.81,194577.5
