### PR TITLE
Making the loader.js using configurable service url

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -114,6 +114,10 @@ db = this_is_a_dummy_db_name
 schema = webapp
 # database parent schema
 parent_schema =
+# api service url
+api-url = //${vars:host}${vars:apache-entry-point}
+          
+
 
 [po2mo]
 recipe = c2c.recipe.msgfmt
@@ -203,7 +207,7 @@ cmds =
     if ! [ -d chsdi/static/js/ol3 ];
     then
       cd ${buildout:directory}/chsdi/static/js/ && git clone https://github.com/geoadmin/ol3.git
-      cd ol3 && ${buildout:bin-directory}/python build-ga.py
+      cd ol3 && API_URL=${vars:api-url} ${buildout:bin-directory}/python build-ga.py
       cd ${buildout:directory}
     fi
 
@@ -217,10 +221,11 @@ cmds =
     rm -f ${buildout:directory}/chsdi/static/js/ol3/build/ga.css &&
     rm -f ${buildout:directory}/chsdi/static/js/ol3/build/ol.css &&
     rm -f ${buildout:directory}/chsdi/static/js/ol3/build/ga*.js &&
-    ${buildout:bin-directory}/python build-ga.py &&
+    rm -f ${buildout:directory}/chsdi/static/js/ol3/build/layerconfig*.js &&
+    API_URL=${vars:api-url} ${buildout:bin-directory}/python build-ga.py &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/ga.css ${buildout:directory}/chsdi/static/css/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/ol.css ${buildout:directory}/chsdi/static/css/ &&
-    cp ${buildout:directory}/chsdi/static/js/ol3/build/*.png ${buildout:directory}/chsdi/static/css/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/ga*.js ${buildout:directory}/chsdi/static/js/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/EPSG* ${buildout:directory}/chsdi/static/js/ &&
+    cp ${buildout:directory}/chsdi/static/js/ol3/build/layersconfig.*.js  ${buildout:directory}/chsdi/static/js/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/proj4js-com* ${buildout:directory}/chsdi/static/js

--- a/chsdi/templates/loader.js
+++ b/chsdi/templates/loader.js
@@ -23,8 +23,18 @@ window.attachEvent && window.attachEvent("onload", load);
 // Load css
 document.write('<link rel="stylesheet" type="text/css" href="' + "${h.versioned(request.static_url('chsdi:static/css/ga.css'))}" + '" />');
 // Load js
-document.write('<scr' + 'ipt type="text/javascript">' + ${conf|n} + '</scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript">' + ${defaultLang|n} + '</scr' + 'ipt>');
+% if lang == 'en':
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/layersconfig.en.js'))}" +  '"></scr' + 'ipt>');
+% elif lang == 'fr':
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/layersconfig.fr.js'))}" + '"></scr' + 'ipt>');
+% elif lang == 'it':
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/layersconfig.it.js'))}" + '"></scr' + 'ipt>');
+% elif lang == 'rm':
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/layersconfig.rm.js'))}" + '"></scr' + 'ipt>');
+% else:
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/layersconfig.de.js'))}" + '"></scr' + 'ipt>');
+% endif
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/proj4js-compressed.js'))}" + '"></scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/EPSG21781.js'))}" + '"></scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/EPSG2056.js'))}" + '"></scr' + 'ipt>');


### PR DESCRIPTION
The `api-url` used by `build-ga.py`is defined in the environment related `buildout.cfg` files.

You need to test against the branch geoadmin/ol3/tree/fix-service_url  (see geoadmin/ol3/pull/62), because new externals are defined, and you need to merge geoadmin/ol3/pull/62 and `./buildout/bin/buildout install update ol3-update` before merging this PR:
