### PR TITLE
Splitting externals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ chsdi.egg-info
 chsdi/static/doc/build/
 chsdi/static/css/extended.min.css
 chsdi/static/js/ol3/
+chsdi/static/js/layersconfig.*.js
+chsdi/static/js/serverconfig.js
+chsdi/static/js/*.css
 deploy/hooks/pre-create-code
 node_modules
 MANIFEST

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,6 +10,7 @@ parts = eggs
         node-modules
         lessc
         ol3-install
+        ol3-serverconfig
 develop = .
 index = http://pypi.camptocamp.net/pypi
 allow-hosts = pypi.camptocamp.net
@@ -211,6 +212,20 @@ cmds =
       cd ${buildout:directory}
     fi
 
+[ol3-serverconfig]
+recipe = collective.recipe.cmd
+on_install = true
+on_update = true
+cmds =
+    if  [ -d chsdi/static/js/ol3 ];
+    then
+      cd ${buildout:directory}/chsdi/static/js/ol3
+      API_URL=${vars:api-url} ${buildout:bin-directory}/python build-ga.py build/serverconfig.js &&
+      API_URL=${vars:api-url} ${buildout:bin-directory}/python build-ga.py build/layersconfig &&
+      cp ${buildout:directory}/chsdi/static/js/ol3/build/*config*.js  ${buildout:directory}/chsdi/static/js/ &&
+      cd ${buildout:directory}
+    fi
+
 [ol3-update]
 recipe = collective.recipe.cmd
 on_install = true
@@ -227,5 +242,4 @@ cmds =
     cp ${buildout:directory}/chsdi/static/js/ol3/build/ol.css ${buildout:directory}/chsdi/static/css/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/ga*.js ${buildout:directory}/chsdi/static/js/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/EPSG* ${buildout:directory}/chsdi/static/js/ &&
-    cp ${buildout:directory}/chsdi/static/js/ol3/build/layersconfig.*.js  ${buildout:directory}/chsdi/static/js/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/proj4js-com* ${buildout:directory}/chsdi/static/js

--- a/chsdi/templates/loader.js
+++ b/chsdi/templates/loader.js
@@ -7,23 +7,24 @@ appUrl = request.application_url.replace('http:', request.scheme + ':')
 layersconfig = appUrl + '/rest/services/all/MapServer/layersConfig?lang=' + lang
 import urllib2
 f = urllib2.urlopen(layersconfig)
-conf = """function getConfig(){ return %s } """ %f.read()
 defaultLang = """function getDefaultLang() { return "%s" } """ % request.lang
 %>
 
 (function() {
 var load = function() {
-  window.GeoAdmin = {};
-  window.GeoAdmin.lang = "${lang}";
+window.GeoAdmin = window.GeoAdmin || {};
+window.GeoAdmin.lang = "${lang}";
 }
 window.addEventListener ? 
 window.addEventListener("load", load, false) :
 window.attachEvent && window.attachEvent("onload", load);
 
+
 // Load css
 document.write('<link rel="stylesheet" type="text/css" href="' + "${h.versioned(request.static_url('chsdi:static/css/ga.css'))}" + '" />');
 // Load js
 document.write('<scr' + 'ipt type="text/javascript">' + ${defaultLang|n} + '</scr' + 'ipt>');
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/serverconfig.js'))}" +  '"></scr' + 'ipt>');
 % if lang == 'en':
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/layersconfig.en.js'))}" +  '"></scr' + 'ipt>');
 % elif lang == 'fr':
@@ -44,3 +45,4 @@ document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(requ
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/ga.js'))}" + '"></scr' + 'ipt>')
 % endif
 })();
+


### PR DESCRIPTION
The  `buildout` _ol3-serverconfig_ is run on all server, even when deploying. It generate two build environment dependent files  `serverconfig.js`and `layersconfig.<lang>.js`

The parts `ol3-update`is run only at will.

If anybody knows how to correctly escape the content of `layersconfig.<lang>.js` into the loader's `<scri' + 'ipt>`tag, I would be happy

So if you want to merge:
1. Test this branch against geoadmin/ol3/tree/dev_split_externals
2: If OK, merge https://github.com/geoadmin/ol3/pull/63
3. Merge this PR
4. Make a branch a run `./buildout/bin/buildout -c buildout install ol3-update3` and PR the result
5. Merge this second PR
