### PR TITLE
added timeout to lubis tooltip by checking picture metadata

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -15,7 +15,7 @@ def get_image_size(filename):
 
     if filename:
         try:
-            file = urllib2.urlopen("https://web-iipimage.prod.bgdi.ch/iipimage/iipsrv.fcgi?DeepZoom=" + filename + ".dzi")
+            file = urllib2.urlopen("https://web-iipimage.prod.bgdi.ch/iipimage/iipsrv.fcgi?DeepZoom=" + filename + ".dzi", timeout = 3)
             xmldoc = minidom.parse(file)
             dimensions = xmldoc.getElementsByTagName('Size')
             width = dimensions[0].getAttribute('Width')


### PR DESCRIPTION
This corrects https://github.com/geoadmin/mf-geoadmin3/issues/1275

The timeout makes the tooltip behave as if no picture is available if no answer from iipimage within 3 seconds
