### PR TITLE
ebkey instaed of bildnummer in LUBIS tab name

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -113,7 +113,7 @@ quickview_url = get_quickview_url(request, params)
 <tr>
   <td class="cell-left"></td>
   <td>
-    <a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a>
+    <a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup?lang=${lang}" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a>
   </td>
 </tr>
 </%def>

--- a/chsdi/templates/htmlpopup/lubis_bildstreifen.mako
+++ b/chsdi/templates/htmlpopup/lubis_bildstreifen.mako
@@ -8,7 +8,7 @@
     <tr><td class="cell-left">${_('link')} Toposhop</td>   <td><a href="http://www.toposhop.admin.ch/de/shop/satair/lubis_1?ext=1&bs=${c['featureId']},${c['attributes']['toposhop_date']},${c['attributes']['toposhop_length']},${c['attributes']['resolution']},${c['attributes']['toposhop_start_x']},${c['attributes']['toposhop_start_y']},${c['attributes']['toposhop_end_x']},${c['attributes']['toposhop_end_y']}" target="toposhop">Toposhop</a></td></tr>
     <tr>
       <td class="cell-left"></td>
-      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
+      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup?lang=${lang}" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
     </tr>
 </%def>
 


### PR DESCRIPTION
This corrects https://github.com/geoadmin/mf-geoadmin3/issues/1309
I reverted the extended tooltip "lang" parameter too, because @loicgasser is working on a general solution
