### PR TITLE
Centralized link to extended tooltip in base.mako

### DIFF
--- a/chsdi/templates/htmlpopup/bakomfernsehsender.mako
+++ b/chsdi/templates/htmlpopup/bakomfernsehsender.mako
@@ -4,10 +4,6 @@
   <tr><td class="cell-left">${_('tt_ch.bakom.radio-fernsehsender_name')}</td>      <td>${c['attributes']['name']}</td></tr>
   <tr><td class="cell-left">${_('tt_ch.bakom.radio-fernsehsender_code')}</td>      <td>${c['attributes']['code'] or '-'}</td></tr>
   <tr><td class="cell-left">${_('tt_ch.bakom.leistung')}</td>                      <td>${c['attributes']['power'] or '-'}</td></tr>
-  <tr>
-    <td class="cell-left"></td>
-    <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-  </tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/htmlpopup/base.mako
+++ b/chsdi/templates/htmlpopup/base.mako
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 
-<% 
-  c = pageargs['feature']
+<%
+  c = feature['feature']
   protocol = request.scheme
-  c['bbox'] = pageargs.get('bbox')
-  c['scale'] = pageargs.get('scale')
+  c['bbox'] = feature.get('bbox')
+  c['scale'] = feature.get('scale')
   c['stable_id'] = False
-  extended = pageargs.get('extended')
   c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
   c['instanceId'] = request.registry.settings['instanceid']
-  bbox = c['bbox']
+  c['attribution'] = feature['attribution']
+  c['fullName'] = feature['fullName']
+  extended = feature['extended']
   lang = request.lang
-  attribution = pageargs.get('attribution')
-  fullName = pageargs.get('fullName')
   topic = request.matchdict.get('map')
 %>
 
@@ -36,7 +35,7 @@
 <div class="htmlpopup-container">
 % endif
   <div class="htmlpopup-header">
-    <span>${fullName}</span> (${attribution})
+    <span>${c['fullName']}</span> (${c['attribution']})
   </div>
   <div class="htmlpopup-content">
     % if extended:
@@ -46,6 +45,14 @@
       <br>
       <table>
         ${self.table_body(c, lang)}
+        % if hasExtendedInfo:
+        <tr>
+          <td class="cell-left"></td>
+          <td>
+            <a href="${h.make_agnostic(request.route_url('extendedHtmlPopup', map=topic, layerId=c['layerBodId'], featureId=str(c['featureId'])))}?lang=${lang}" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a>
+          </td>
+        </tr>
+        % endif
         % if c['stable_id'] is True:
           <tr>
             <td class="cell-left"></td>

--- a/chsdi/templates/htmlpopup/emissionplan.mako
+++ b/chsdi/templates/htmlpopup/emissionplan.mako
@@ -6,10 +6,6 @@
   <tr><td class="cell-left">${_('tt_emission_bis_m')}</td>          <td>${int(round(c['attributes']['bis_m'])) or '-'}</td></tr>
   <tr><td class="cell-left">${_('tt_emission_lre_t')}</td>          <td>${c['attributes']['lre_t'] or '-'}</td></tr>
   <tr><td class="cell-left">${_('tt_emission_lre_n')}</td>          <td>${c['attributes']['lre_n'] or '-'}</td></tr>
-  <tr>
-    <td class="cell-left"></td>
-    <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-  </tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/htmlpopup/energieforschung.mako
+++ b/chsdi/templates/htmlpopup/energieforschung.mako
@@ -32,10 +32,6 @@
   <td class="cell-left">${_('tt_ch.bfe.energieforschung_kontaktperson')}</td>
   <td>${c['attributes']['kontaktperson_bfe'] or '-'}</td>
 </tr>
-<tr>
-  <td class="cell-left"></td>
-  <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-</tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/htmlpopup/gebietsauslaesse.mako
+++ b/chsdi/templates/htmlpopup/gebietsauslaesse.mako
@@ -12,10 +12,6 @@
     <tr><td class="cell-left">${_('tt_anteil_ch')}</td>         <td>${c['attributes']['anteil_ch'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('gewaesser')}</td>         <td>${c['attributes']['gewaessern'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_kanal')}</td>       <td>${c['attributes'][kanal] or '-'}</td></tr>
-    <tr>
-      <td class="cell-left"></td>
-      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-    </tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/htmlpopup/kernkraftwerke.mako
+++ b/chsdi/templates/htmlpopup/kernkraftwerke.mako
@@ -4,10 +4,6 @@
 
 <%def name="table_body(c, lang)">
     <tr><td class="cell-left">${_('tt_kkw_name')}</td>          <td>${c['attributes']['name']}</td></tr>
-    <tr>
-      <td class="cell-left"></td>
-      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-    </tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/htmlpopup/kgs.mako
+++ b/chsdi/templates/htmlpopup/kgs.mako
@@ -9,10 +9,6 @@
     <tr><td class="cell-left">${_('x')}</td>              <td>${int(round(c['attributes']['y'],0)) or '-'}</td></tr>
     <tr><td class="cell-left">${_('gemeinde')}</td>       <td>${c['attributes']['gemeinde'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('kanton')}</td>         <td>${c['attributes']['kt_kz'] or '-'}</td></tr>
-    <tr>
-      <td class="cell-left"></td>
-      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-    </tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -54,7 +54,7 @@ params = (
     _('tt_lubis_ebkey'),
     c['attributes']['bildnummer'],
     c['attributes']['firma'],
-    fullName)
+    c['fullName'])
 quickview_url = get_quickview_url(request, params)
 %>
 <tr>
@@ -110,12 +110,6 @@ quickview_url = get_quickview_url(request, params)
   </td>
 </tr>
 % endif
-<tr>
-  <td class="cell-left"></td>
-  <td>
-    <a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup?lang=${lang}" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a>
-  </td>
-</tr>
 </%def>
 
 
@@ -144,7 +138,7 @@ params = (
     _('tt_lubis_ebkey'),
     c['attributes']['bildnummer'],
     c['attributes']['firma'],
-    fullName)
+    c['fullName'])
 quickview_url = get_quickview_url(request, params)
 %>
 <title>${_('tt_lubis_ebkey')}: ${c['attributes']['bildnummer']}</title>

--- a/chsdi/templates/htmlpopup/lubis_bildstreifen.mako
+++ b/chsdi/templates/htmlpopup/lubis_bildstreifen.mako
@@ -6,10 +6,6 @@
     <tr><td class="cell-left">${_('tt_lubis_Flugdatum')}</td>    <td>${c['attributes']['flugdatum']}</td></tr>
     <tr><td class="cell-left">${_('tt_lubis_auflosung')}</td>      <td>${c['attributes']['resolution']}</td></tr>
     <tr><td class="cell-left">${_('link')} Toposhop</td>   <td><a href="http://www.toposhop.admin.ch/de/shop/satair/lubis_1?ext=1&bs=${c['featureId']},${c['attributes']['toposhop_date']},${c['attributes']['toposhop_length']},${c['attributes']['resolution']},${c['attributes']['toposhop_start_x']},${c['attributes']['toposhop_start_y']},${c['attributes']['toposhop_end_x']},${c['attributes']['toposhop_end_y']}" target="toposhop">Toposhop</a></td></tr>
-    <tr>
-      <td class="cell-left"></td>
-      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup?lang=${lang}" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-    </tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/htmlpopup/sicherheitszoneneplan.mako
+++ b/chsdi/templates/htmlpopup/sicherheitszoneneplan.mako
@@ -11,10 +11,6 @@
     <tr><td class="cell-left">${_('geometry_type')}</td><td>${c['attributes']['zonetype_%s' % lang]}</td></tr>
     <tr><td class="cell-left">${_('originator')}</td><td>${c['attributes']['originator']}</td></tr>
     <tr><td class="cell-left">${_('kanton')}</td><td>${c['attributes']['canton']}</td></tr>
-    <tr>
-      <td class="cell-left"></td>
-      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-    </tr>
 </%def>
 
 <%def name="extended_info(c, lang)"> 

--- a/chsdi/templates/htmlpopup/statistikwasserkraftanlagen.mako
+++ b/chsdi/templates/htmlpopup/statistikwasserkraftanlagen.mako
@@ -39,10 +39,6 @@
       <td class="cell-left">${_('tt_ch.bfe.statistik-wasserkraftanlagen_endofoperation')}</td>
       <td>${c['attributes']['endofoperation'] or '-'}</td>
     </tr>
-    <tr>
-      <td class="cell-left"></td>
-      <td><a href="${c['baseUrl']}/${c['instanceId']}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup" target="_blank">${_('zusatzinfo')}<img src="http://www.swisstopo.admin.ch/images/ico_extern.gif" /></a></td>
-    </tr>
 </%def>
 
 <%def name="extended_info(c, lang)">

--- a/chsdi/templates/legend.mako
+++ b/chsdi/templates/legend.mako
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 <%
-  c = pageargs['layer']
-  hasLegend = pageargs['hasLegend']
+  c = legend['layer']
+  hasLegend = legend['hasLegend']
   host = request.host_url + request.uscript_name
   lang = request.lang
   pdf_legends = ('ch.swisstopo.geologie-eiszeit-lgm-raster', 


### PR DESCRIPTION
[#562]

The goal of this PR is to centralize the extended tooltip in base mako.
In order to do so, we need to know if for a given layer has an extended tooltip or not.

At the moment, we only have this info in the models, this is why mapservice had to be adapted.
