### PR TITLE
lubis timeinterval search replace ort with ebkey

### DIFF
--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -148,7 +148,7 @@ class TestSearchServiceView(TestsBase):
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
 
     def test_features_timeInterval(self):
-        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': 'Bern 2000-2010', 'features': 'ch.swisstopo.fixpunkte-lfp1,ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe', 'timeEnabled': 'false,true,true', 'type': 'locations'}, status=200)
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '1993034 1990-2010', 'features': 'ch.swisstopo.fixpunkte-lfp1,ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe', 'timeEnabled': 'false,true,true', 'type': 'locations'}, status=200)
         self.failUnless(resp.content_type == 'application/json')
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
 


### PR DESCRIPTION
ort will not be published in the search
the nosetest query is looking for ebkey with time Interval instead

https://github.com/geoadmin/mf-geoadmin3/issues/1319
