### PR TITLE
refactored OeREB interlis service to use timestamp from metadata table

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -366,6 +366,8 @@ class OerebMetadata(Base):
     idBod = Column('layer_id', Text, primary_key=True)
     header = Column('header', Text)
     footer = Column('footer', Text)
+    data_created = Column('data_created', Text)
+    data_imported = Column('data_imported', Text)
 
 
 def get_bod_model(lang):

--- a/chsdi/templates/oereb_timestamps.mako
+++ b/chsdi/templates/oereb_timestamps.mako
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 <!-- Feature Service für ÖREB-Daten
-     Stand der Daten: ${data_created}, Stand des Feature Service: ${bgdi_created}
+     Stand der Daten: ${data_created}, Stand des Feature Service: ${data_imported}
 
-     Feature Service pour des données RDPPF
-     Date des données : ${data_created}, date du Feature Service : ${bgdi_created}
+     Feature Service pour les données RDPPF
+     Date des données : ${data_created}, date du Feature Service : ${data_imported}
 
      Feature Service per i dati RDPP
-     Stato dei dati: ${data_created}, stato del Feature Service : ${bgdi_created} -->
+     Stato dei dati: ${data_created}, stato del Feature Service : ${data_imported} -->

--- a/chsdi/views/mapservice.py
+++ b/chsdi/views/mapservice.py
@@ -145,6 +145,18 @@ def _identify_oereb(request):
     )
     header = layerMetadata.header
     footer = layerMetadata.footer
+    data_created = layerMetadata.data_created
+    data_imported = layerMetadata.data_imported
+
+    comments = render(
+        'chsdi:templates/oereb_timestamps.mako',
+        {
+            'data_imported': data_imported,
+            'data_created': data_created
+        }
+    )
+    header = insertTimestamps(header, comments)
+
     # Only relation 1 to 1 is needed at the moment
     layerVectorModel = [[oereb_models_from_bodid(idBod)[0]]]
     features = []
@@ -153,17 +165,6 @@ def _identify_oereb(request):
         for fragment in temp:
             if fragment not in features:
                 features.append(fragment)
-    if len(features):
-        bgdi_created = feature.bgdi_created
-        data_created = feature.data_created
-        comments = render(
-            'chsdi:templates/oereb_timestamps.mako',
-            {
-                'bgdi_created': bgdi_created,
-                'data_created': data_created
-            }
-        )
-        header = insertTimestamps(header, comments)
     results = ''.join((
         header,
         ''.join(features),


### PR DESCRIPTION
This PR finishes the work on this ticket: https://github.com/geoadmin/mf-chsdi3/issues/461#issuecomment-39109823
by having the data status comment always visible and taking data information from the metadata table

@loicgasser you were right... it was really easy. What took me some time was nailing some stupid xml parsing errors ;)
