### PR TITLE
Add translation for attribution swisstopo private

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -1347,7 +1347,7 @@ msgid "ch.bav.sachplan-infrastruktur-schiene_ausgangslage"
 msgstr "SIS Ausgangslage "
 
 msgid "ch.bav.sachplan-infrastruktur-schiene_kraft"
-msgstr "SIS in Kraft"
+msgstr "Sachplan Infrastruktur Schiene"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=de"
@@ -1867,6 +1867,9 @@ msgstr "Einteilung Landeskarte 1:50'000"
 
 msgid "ch.swisstopo.pixelkarte-pk500.metadata"
 msgstr "Einteilung Landeskarte 1:500'000"
+
+msgid "ch.swisstopo.private"
+msgstr "swisstopo, Prv."
 
 msgid "ch.swisstopo.swissalti3d-reliefschattierung"
 msgstr "swissALTI3D Reliefschattierung"

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -94,6 +94,9 @@ msgstr ""
 msgid "ch.swisstopo.kt"
 msgstr ""
 
+msgid "ch.swisstopo.private"
+msgstr ""
+
 msgid "ch.swisstopo.kt.url"
 msgstr ""
 

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -1868,6 +1868,9 @@ msgstr "Division National Map 1:50'000"
 msgid "ch.swisstopo.pixelkarte-pk500.metadata"
 msgstr "Division National Map 1:500'000"
 
+msgid "ch.swisstopo.private"
+msgstr "swisstopo, prv."
+
 msgid "ch.swisstopo.swissalti3d-reliefschattierung"
 msgstr "swissALTI3D Hillshade"
 

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -1868,6 +1868,9 @@ msgstr "Divisiun charta naziunala 1:50'000"
 msgid "ch.swisstopo.pixelkarte-pk500.metadata"
 msgstr "Divisiun charta naziunala 1:500'000"
 
+msgid "ch.swisstopo.private"
+msgstr "swisstopo, prv."
+
 msgid "ch.swisstopo.swissalti3d-reliefschattierung"
 msgstr "swissALTI3D charta da reliev"
 

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -1347,7 +1347,7 @@ msgid "ch.bav.sachplan-infrastruktur-schiene_ausgangslage"
 msgstr "SIS données de base"
 
 msgid "ch.bav.sachplan-infrastruktur-schiene_kraft"
-msgstr "SIS en vigueur"
+msgstr "PS infrastructure rail"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=fr"
@@ -1867,6 +1867,9 @@ msgstr "Découpage carte nationale 1:50’000"
 
 msgid "ch.swisstopo.pixelkarte-pk500.metadata"
 msgstr "Découpage carte nationale 1:500’000"
+
+msgid "ch.swisstopo.private"
+msgstr "swisstopo, prv"
 
 msgid "ch.swisstopo.swissalti3d-reliefschattierung"
 msgstr "swissALTI3D estompage du relief"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -1347,7 +1347,7 @@ msgid "ch.bav.sachplan-infrastruktur-schiene_ausgangslage"
 msgstr "SIS statu quo"
 
 msgid "ch.bav.sachplan-infrastruktur-schiene_kraft"
-msgstr "SIS in vigore"
+msgstr "PS infrastruttura ferroviaria"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=it"
@@ -1867,6 +1867,9 @@ msgstr "Divisione carta nazionale 1:50'000"
 
 msgid "ch.swisstopo.pixelkarte-pk500.metadata"
 msgstr "Divisione carta nazionale 1:500'000"
+
+msgid "ch.swisstopo.private"
+msgstr "swisstopo, prv."
 
 msgid "ch.swisstopo.swissalti3d-reliefschattierung"
 msgstr "swissALTI3D Hillshade"


### PR DESCRIPTION
solve #1334 (mf-geoadmin) change attribution for layer ch.swisstopo.lubis-luftbilder-dritte-firmen and ch.swisstopo.lubis-luftbilder-dritte-kantone.
Need to update table re3.layers_js :

update re3.layers_js set attribution = 'ch.swisstopo.private' where fk_id_dataset = 'ch.swisstopo.lubis-luftbilder-dritte-firmen';
update re3.layers_js set attribution = 'ch.swisstopo.kt' where fk_id_dataset = 'ch.swisstopo.lubis-luftbilder-dritte-kantone';
