### PR TITLE
Make link to object user dependent

### DIFF
--- a/buildout_ltalp.cfg
+++ b/buildout_ltalp.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltalp
 api_url = //mf-chsdi3.dev.bgdi.ch/ltalp
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltalp/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9007
 

--- a/buildout_ltboj.cfg
+++ b/buildout_ltboj.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltboj
 api_url = //mf-chsdi3.dev.bgdi.ch/ltboj
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltboj/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9009
 

--- a/buildout_ltclm.cfg
+++ b/buildout_ltclm.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltclm
 api_url = //mf-chsdi3.dev.bgdi.ch/ltclm
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltclm/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9006
 

--- a/buildout_ltfoa.cfg
+++ b/buildout_ltfoa.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltfoa
 api_url = //mf-chsdi3.dev.bgdi.ch/ltfoa
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltfoa/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9004
 

--- a/buildout_ltgal.cfg
+++ b/buildout_ltgal.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltgal
 api_url = //mf-chsdi3.dev.bgdi.ch/ltgal
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltgal/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9000
 

--- a/buildout_ltgud.cfg
+++ b/buildout_ltgud.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltgud
 api_url = //mf-chsdi3.dev.bgdi.ch/ltgud
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltgud/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9017
 

--- a/buildout_ltmoc.cfg
+++ b/buildout_ltmoc.cfg
@@ -4,6 +4,7 @@ extends = buildout_dev.cfg
 [vars]
 apache_base_path = ltmoc
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltmoc/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9005
 api_url = //mf-chsdi3.dev.bgdi.ch/ltmoc

--- a/buildout_ltmom.cfg
+++ b/buildout_ltmom.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltmom
 api_url = //mf-chsdi3.dev.bgdi.ch/ltmom
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltmom/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9001
 

--- a/buildout_ltteo.cfg
+++ b/buildout_ltteo.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = ltteo
 api_url = //mf-chsdi3.dev.bgdi.ch/ltteo
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltteo/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9008
 

--- a/buildout_lttro.cfg
+++ b/buildout_lttro.cfg
@@ -5,6 +5,7 @@ extends = buildout_dev.cfg
 apache_base_path = lttro
 api_url = //mf-chsdi3.dev.bgdi.ch/lttro
 host = mf-chsdi3.dev.bgdi.ch
+geoadminhost = mf-geoadmin3.dev.bgdi.ch/lttro/prod
 dbhost = pgcluster0t.bgdi.admin.ch
 server_port = 9018
 


### PR DESCRIPTION
https://github.com/geoadmin/mf-chsdi3/issues/353

FYI: geoadminhost is used in base.mako for link to object construction and in the snapshot service.
That's it.
