### PR TITLE
Ech layers are now available for all other topics

### DIFF
--- a/chsdi/views/mapservice.py
+++ b/chsdi/views/mapservice.py
@@ -544,8 +544,10 @@ def _get_layers_config_for_params(params, query, model, layerIds=None):
     bgLayers = True
     if params.mapName != 'all':
         # per default we want to include background layers
+        # we also want to always include all 'ech' layers
         query = query.filter(or_(
             model.maps.ilike('%%%s%%' % params.mapName),
+            model.maps.ilike('%%%s%%' % 'ech'),  # ech whitelist hack
             model.background == bgLayers)
         )
     query = _filter_by_geodata_staging(
@@ -590,7 +592,10 @@ def _filter_by_map_name(query, ormColumn, mapName):
     ''' Applies a map/topic filter '''
     if mapName != 'all':
         return query.filter(
-            ormColumn.ilike('%%%s%%' % mapName)
+            or_(
+                ormColumn.ilike('%%%s%%' % mapName),
+                ormColumn.ilike('%%%s%%' % 'ech')  # ech whitelist hack
+            )
         )
     return query
 

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -110,8 +110,8 @@ class Search(SearchValidation):
         mapName = self.mapName if self.mapName != 'all' else ''
         searchText = ' '.join((
             self._query_fields('@(detail,layer)'),
-            '& @topics %s' % mapName,                 # Filter by to topic if string not empty
-            '& @staging prod'                         # Only layers in prod are searched
+            '& @topics (%s | ech)' % mapName,  # Filter by to topic if string not empty, ech whitelist hack
+            '& @staging prod'                            # Only layers in prod are searched
         ))
         try:
             temp = self.sphinx.Query(searchText, index=index_name)


### PR DESCRIPTION
This is in preparation for https://github.com/geoadmin/mf-geoadmin3/issues/886

All it does is allowing all 'ech' layers to be searched, htmlpopup, extendedinfo and metadata retrieval, independant of passed topic.
