### PR TITLE
LUBIS: Make requests to tiles scheme agnostic

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -14,17 +14,17 @@ def br(text):
 
 
 def determinePreviewUrl(ebkey):
-    tileUrlBasePath = "http://aerialimages0.geo.admin.ch/tiles"
+    tileUrlBasePath = 'http://aerialimages0.geo.admin.ch/tiles'
 
     def getPreviewImageUrl(ebkey):
-        return tileUrlBasePath + "/" + ebkey + "/quickview.jpg"
+        return tileUrlBasePath + '/' + ebkey + '/quickview.jpg'
 
     def getZeroTileUrl(ebkey):
-        return tileUrlBasePath + "/" + ebkey + "/0/0/0.jpg"
+        return tileUrlBasePath + '/' + ebkey + '/0/0/0.jpg'
 
     class HeadRequest(urllib2.Request):
         def get_method(self):
-            return "HEAD"
+            return 'HEAD'
 
     def testForUrl(url):
         response = None
@@ -47,7 +47,7 @@ def determinePreviewUrl(ebkey):
     url = testForUrl(getPreviewImageUrl(ebkey))
     if url == "":
         url = testForUrl(getZeroTileUrl(ebkey))
-    return url
+    return h.make_agnostic(url)
 
 def date_to_str(datum):
     try:

--- a/chsdi/templates/lubis_map.mako
+++ b/chsdi/templates/lubis_map.mako
@@ -6,7 +6,7 @@
         var height = parseInt(${height});
         var rotation= parseInt(${rotation if rotation is not None else 0}) * Math.PI / 180;
 
-        var url = 'http://aerialimages{curInstance}.geo.admin.ch/tiles/${ebkey}/';
+        var url = '//aerialimages{curInstance}.geo.admin.ch/tiles/${ebkey}/';
         var resolutions = [1]; // 1 is the min resolution of the pyramid (for all images)
         var curResolution = resolutions[0];
         var maxResolution = Math.max(width, height) / TILE_SIZE;


### PR DESCRIPTION
#680

Note that this is code preparation that can be merged without breaking existing functionality.

But it will not work under https for now, because there are access problems for the tiles under https. (See discussion #680)
