### PR TITLE
Dev snapshot tests

### DIFF
--- a/chsdi/tests/integration/test_snapshot.py
+++ b/chsdi/tests/integration/test_snapshot.py
@@ -63,7 +63,7 @@ class TestSnapshotService(TestsBase):
                 if (sug.find('b') and sug.find('b').string.find(term) != -1):
                     return True
             return False
-        self.failUnless(hasTerm('Wasserfallflue'))
+        self.failUnless(hasTerm('Wasserloch'))
         self.failUnless(hasTerm('Hochwasser'))
 
      # Make sure feature in permalink is included


### PR DESCRIPTION
This adds additional tests for snapshot service to assure that bots get what we want.

It takes around 30 seconds to run this (they tab real application)
