### PR TITLE
Add corresponding layerBodId to location results

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -100,11 +100,11 @@ class Search(SearchValidation):
                 else:
                     if res['attrs']['origin'] == 'zipcode':
                         res['attrs']['layerBodId'] = 'ch.swisstopo-vd.ortschaftenverzeichnis_plz'
-                    if res['attrs']['origin'] == 'gg25':
+                    elif res['attrs']['origin'] == 'gg25':
                         res['attrs']['layerBodId'] = 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill'
-                    if res['attrs']['origin'] == 'district':
+                    elif res['attrs']['origin'] == 'district':
                         res['attrs']['layerBodId'] = 'ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill'
-                    if res['attrs']['origin'] == 'kantone':
+                    elif res['attrs']['origin'] == 'kantone':
                         res['attrs']['layerBodId'] = 'ch.swisstopo.swissboundaries3d-kanton-flaeche.fill'
                     self.results['results'].append(res)
             return len(temp)


### PR DESCRIPTION
https://github.com/geoadmin/service-sphinxsearch/issues/116

This adds the layerBodId attribute to the location search results. Clients can use this to get additional attributes using our features services (feature_id from sphinxsearch, layerBodId from searchserver)
