### PR TITLE
Avoid error msg in mapproxy

### DIFF
--- a/mapproxy/createWsgi.py
+++ b/mapproxy/createWsgi.py
@@ -56,8 +56,3 @@ f=open(target, "wt")
 f.write(output)
 f.close()
 os.chmod(target, 0755)
-try:
-    geodata = grp.getgrnam('geodata')
-    os.chown(target, 2002, geodata.gr_gid)
-except KeyError:
-    print "Sorry. No group 'geodata'"


### PR DESCRIPTION
When building mapproxy part in our respective environnements, we always get this error :

Traceback (most recent call last):
  File "/home/ltgal/mf-chsdi3/mapproxy/createWsgi.py", line 63, in <module>
    os.chown(target, 2002, geodata.gr_gid)

This PR is to avoid printing this error msg.
