### PR TITLE
Add buildout part to clean project

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -256,3 +256,9 @@ cmds =
     cp ${buildout:directory}/chsdi/static/js/ol3/build/EPSG* ${buildout:directory}/chsdi/static/js/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/proj4js-com* ${buildout:directory}/chsdi/static/js
 
+[clean-project]
+recipe = collective.recipe.cmd
+on_install = true
+cmds =
+    find . -name "*.pyc" -delete -print
+    find . -name "*.in" |  sed -r 's/(.*)\.in/\1/' | xargs -I {} rm -v "{}"


### PR DESCRIPTION
Usage:

<pre>
buildout/bin/buildout -c buildout_xxx.cfg install clean-project
</pre>


This is useful when important changes have been made in the project.
