### PR TITLE
[WIP] Run nosetests on target system

### DIFF
--- a/deploy/hooks/post-restore-code
+++ b/deploy/hooks/post-restore-code
@@ -13,13 +13,15 @@ cd $CODE_DIR
 ##python bootstrap.py --distribute --version 1.5.2 > /dev/null
 
 if [ -f buildout_$TARGET.cfg ]; then
-    buildout/bin/buildout -c buildout_$TARGET.cfg
+    buildout/bin/buildout -c buildout_$TARGET.cfg || exit 1
 else
-    buildout/bin/buildout
+    buildout/bin/buildout || exit 1
 fi
 
 if [[ $CODE_DIR == */branch/* ]]; then
-    buildout/bin/buildout -c buildout_branch.cfg
+    buildout/bin/buildout -c buildout_branch.cfg || exit 1
 fi
+
+buildout/bin/nosetests
 
 exit $?


### PR DESCRIPTION
I put this PR up for discussion. During deploy, we currently run our nosetests on our test instance using the test cluster db.

This is bad as it simply ignores what on our int and prod db clusters.

My initial goal was to run nosetest **_on the test instance**_ using the target db cluster. But I failed to do that and I think it would require changes in the deploy script to properly handle this. The reason for this is the the create hooks (which are run on test) don't have any target information. If you have a solution for that, please add comments (or I'll gladly review a seperate PR).

What this PR now does, it will run nosetest **_on the target instances**_ using the target db cluster. This is not ideal because 1) it runs for every instance we have, which is not needed and 2) it runs on our production environment.
