### PR TITLE
Use keyword filter

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -260,10 +260,14 @@ class Search(SearchValidation):
     def _detect_keywords(self):
         if len(self.searchText) > 0:
             PARCEL_KEYWORDS = ('parzelle', 'parcelle', 'parcella', 'parcel')
+            ADDRESS_KEYWORDS = ('addresse', 'adresse', 'indirizzo', 'address')
             firstWord = self.searchText[0]
             if firstWord in PARCEL_KEYWORDS:
                 # As one cannot apply filters on string attributes, we use the rank information
                 self.sphinx.SetFilter('rank', [10])
+                del self.searchText[0]
+            elif firstWord in ADDRESS_KEYWORDS:
+                self.sphinx.SetFilter('rank', [6])
                 del self.searchText[0]
 
     def _add_feature_queries(self, queryText, timeFilter):


### PR DESCRIPTION
I opened this PR to get rid of the very redundant information contained in the "detail" field of the parcels.

'parzelle', 'parcelle', 'parcella', 'parcel' is at the moment defined at the beginning of each parcel field.
This is bad for 2 reasons:
1. The size of the indices
2. Performance

This request:
http://api3.geo.admin.ch//rest/services/api/SearchServer?searchText=parcel%20bern&type=locations

takes around 630ms in prod at the moment, while it takes around 250ms in test with this modification.

I updated the view

dritte.kantone.parzellen_sphinx (got rid of keywords in detail field), deployed the DB in test and I am currently regenerating the indices.

This approach could be used in SwissSearch to filter on different origins.

Note the use of rank for filtering (Integer), if you want more info have a look at sphinx doc (attributes Vs fields)
