### PR TITLE
[WIP] Buildout parts to run nostests against target dbs

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -271,3 +271,16 @@ on_install = true
 cmds =
     find . -name "*.pyc" -delete -print
     find . -name "*.in" |  sed -r 's/(.*)\.in/\1/' | xargs -I {} rm -v "{}"
+
+[nosetests-template]
+recipe = z3c.recipe.filetemplate
+files = production.ini
+interpreted-options = authtkt_secret
+interpreted-options = app_version = __import__('uuid').uuid4().hex[:5]
+                      hostname = __import__('socket').gethostname()
+                      hostname-digest = __import__('hashlib').md5(options.get('hostname')).hexdigest()
+                      apache_entry_path = '/' if options.get('apache_base_path') == 'main' else ('/' + options.get('apache_base_path') + '/')
+                      git_branch = __import__('subprocess').check_output(['git', 'rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']).rstrip()
+
+extends = vars
+

--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -28,3 +28,22 @@ install_cmd =
                chmod -R g+swX  ${buildout:directory}   
                
 
+[nosetests-int]
+recipe = collective.recipe.cmd
+on_install = true
+on_update = true
+cmds = 
+           ${buildout:bin-directory}/buildout  -c buildout_int.cfg install nosetests-template
+           ${buildout:bin-directory}/nosetests
+           ${buildout:bin-directory}/buildout -c buildout_dev.cfg install template
+
+
+[nosetests-prod]
+recipe = collective.recipe.cmd
+on_install = true
+on_update = true
+cmds = 
+           ${buildout:bin-directory}/buildout  -c buildout_prod.cfg install nosetests-template
+           ${buildout:bin-directory}/nosetests
+           ${buildout:bin-directory}/buildout -c buildout_dev.cfg install template
+


### PR DESCRIPTION
Alternative approach to https://github.com/geoadmin/mf-chsdi3/pull/738

This PR add two new _buildout_ part to run _nosestest_ against the planned target DBs.

To test the integration DB:

```
 ./buildout/bin/buildout  -c buildout_dev.cfg install nosetests-int
```

To test the production cluster:

```
 ./buildout/bin/buildout  -c buildout_dev.cfg install nosetests-prod
```

The _nosetests-template_ is there to modifiy the _production.ini_ only, to minimize problems if someone is restarting apache2 during the test.
