### PR TITLE
[WIP] Apache2 mod_wsgi daemon settings

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -79,8 +79,8 @@ RewriteRule ^${apache_entry_path}reframe/lv03tolv95(.*)$ http://tc-geodesy.bgdi.
 RewriteRule ^/${apache_base_path}/(print)(.*)$ /${vars:apache_base_path}/wsgi/$1$2 [PT]
  
 # define a process group
-# WSGIDaemonProcess must be commented/removed when running the project on windows
-WSGIDaemonProcess mf-chsdi3:${vars:apache_base_path} display-name=%{GROUP} user=${vars:modwsgi_user} processes=${vars:wsgi_processes} threads=${vars:wsgi_threads}
+# WSGIDaemonProcess, default are 1 process and 15 threads
+WSGIDaemonProcess mf-chsdi3:${vars:apache_base_path} display-name=%{GROUP} user=${vars:modwsgi_user} threads=${vars:wsgi_threads}
 
 # define the path to the WSGI app
 WSGIScriptAlias /${vars:apache_base_path}/wsgi ${buildout:directory/buildout/parts/modwsgi/wsgi}

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -126,8 +126,6 @@ robots_file = robots.txt
 deploy_target = prod
 #wsgi daemon threads
 wsgi_threads=30
-#wsgi daemon processes
-wsgi_processes=1
 
 [mapproxy]
 recipe = collective.recipe.cmd

--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -22,8 +22,6 @@ geodata_staging = test
 deploy_target = dev
 #wsgi daemon threads
 wsgi_threads=15
-#wsgi daemon processes
-wsgi_processes=1
 
 
 [fixrights]


### PR DESCRIPTION
Now we are using the default setting for Apache2's _mod_wsgi_ daemon, which are `processes=1` and `threads=15`. With theses settings, a simple test on a service with _ab_ reaches its limit with `-c=20`. Using higher values improves the situation, but further tests are needed.

http://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIDaemonProcess

Any hints welcome.
