### PR TITLE
[WIP] Mapproxy service extension

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -262,3 +262,10 @@ on_install = true
 cmds =
     find . -name "*.pyc" -delete -print
     find . -name "*.in" |  sed -r 's/(.*)\.in/\1/' | xargs -I {} rm -v "{}"
+
+[mapproxy]
+recipe = collective.recipe.cmd
+on_install = true
+on_update = true
+cmds =
+    ${buildout:bin-directory}/python ${buildout:directory}/mapproxy/scripts/mapproxify.py

--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -1,140 +1,18032 @@
-services:
-  # comment out unneeded services
-  demo:
-  kml:
-  #tms:
-  wms:
-    srs: ['EPSG:4326', 'EPSG:21781', 'EPSG:4258', 'EPSG:900913']
-    image_formats: ['image/jpeg', 'image/png']
-    md:
-      # metadata used in capabilities documents
-      title: GeoAdmin MapProxy WMS
-      abstract: GeoAdmin geodata
-      online_resource: http://api.geo.admin.ch/mapproxy/service?
-      contact:
-        person: webgis@swisstopo.ch
-        organization: Bundesamt für Landestopografie swisstopo
-        address: Seftigenstrasse 264
-        city: Wabern
-        postcode: 3084
-        country: Schweiz
-        phone: +41 (0)31 / 963 21 11
-        fax: +41 (0)31 / 963 24
-        email: webgis@swisstopo.ch
-      access_constraints: 'License'
-      fees: 'This service cant be used without permission'
-
-layers:
-    - name: ch.swisstopo.swissimage
-      title: Luftbilder
-      sources: [swissimage]
-    - name: ch.swisstopo.pixelkarte-farbe
-      title: Landeskarte
-      sources: [pixelkarte-farbe]
-    - name: osm
-      title: OpenStreetMap
-      sources: [osm_cache]
-    - name: ch.swisstopo.swisstlm3d-karte
-      title: TLM
-      sources: [tlm] 
-
 caches:
-  swissimage:
-    grids: [swisstopo-swissimage]
-    sources: [swissimage-tiles]
-    format: image/jpeg
-    image:
-      resampling_method: bilinear
+  ch.are.agglomerationen_isolierte_staedte_cache:
     disable_storage: true
-  pixelkarte-farbe:
+    format: image/png
     grids: [swisstopo-pixelkarte]
-    sources: [pixelkarte-farbe-tiles]
-    format: image/jpeg
+    sources: [ch.are.agglomerationen_isolierte_staedte]
+  ch.are.agglomerationen_isolierte_staedte_cache_etrs89:
     disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.agglomerationen_isolierte_staedte_cache]
+  ch.are.agglomerationen_isolierte_staedte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.agglomerationen_isolierte_staedte_cache]
+  ch.are.agglomerationen_isolierte_staedte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.agglomerationen_isolierte_staedte_cache]
+  ch.are.agglomerationen_isolierte_staedte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.agglomerationen_isolierte_staedte_cache]
+  ch.are.alpenkonvention_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.alpenkonvention]
+  ch.are.alpenkonvention_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.alpenkonvention_cache]
+  ch.are.alpenkonvention_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.alpenkonvention_cache]
+  ch.are.alpenkonvention_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.alpenkonvention_cache]
+  ch.are.alpenkonvention_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.alpenkonvention_cache]
+  ch.are.bauzonen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.bauzonen]
+  ch.are.bauzonen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.bauzonen_cache]
+  ch.are.bauzonen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.bauzonen_cache]
+  ch.are.bauzonen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.bauzonen_cache]
+  ch.are.bauzonen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.bauzonen_cache]
+  ch.are.belastung-gueterverkehr-bahn-2008_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.belastung-gueterverkehr-bahn-2008]
+  ch.are.belastung-gueterverkehr-bahn-2008_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache]
+  ch.are.belastung-gueterverkehr-bahn-2008_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache]
+  ch.are.belastung-gueterverkehr-bahn-2008_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache]
+  ch.are.belastung-gueterverkehr-bahn-2008_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache]
+  ch.are.belastung-gueterverkehr-strasse-2008_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.belastung-gueterverkehr-strasse-2008]
+  ch.are.belastung-gueterverkehr-strasse-2008_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache]
+  ch.are.belastung-gueterverkehr-strasse-2008_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache]
+  ch.are.belastung-gueterverkehr-strasse-2008_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache]
+  ch.are.belastung-gueterverkehr-strasse-2008_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache]
+  ch.are.belastung-personenverkehr-bahn-2008_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.belastung-personenverkehr-bahn-2008]
+  ch.are.belastung-personenverkehr-bahn-2008_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-bahn-2008_cache]
+  ch.are.belastung-personenverkehr-bahn-2008_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-bahn-2008_cache]
+  ch.are.belastung-personenverkehr-bahn-2008_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-bahn-2008_cache]
+  ch.are.belastung-personenverkehr-bahn-2008_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-bahn-2008_cache]
+  ch.are.belastung-personenverkehr-strasse-2008_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.belastung-personenverkehr-strasse-2008]
+  ch.are.belastung-personenverkehr-strasse-2008_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-strasse-2008_cache]
+  ch.are.belastung-personenverkehr-strasse-2008_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-strasse-2008_cache]
+  ch.are.belastung-personenverkehr-strasse-2008_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-strasse-2008_cache]
+  ch.are.belastung-personenverkehr-strasse-2008_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.belastung-personenverkehr-strasse-2008_cache]
+  ch.are.beschaeftigtendichte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.beschaeftigtendichte]
+  ch.are.beschaeftigtendichte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.beschaeftigtendichte_cache]
+  ch.are.beschaeftigtendichte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.beschaeftigtendichte_cache]
+  ch.are.beschaeftigtendichte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.beschaeftigtendichte_cache]
+  ch.are.beschaeftigtendichte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.beschaeftigtendichte_cache]
+  ch.are.bevoelkerungsdichte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.bevoelkerungsdichte]
+  ch.are.bevoelkerungsdichte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.bevoelkerungsdichte_cache]
+  ch.are.bevoelkerungsdichte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.bevoelkerungsdichte_cache]
+  ch.are.bevoelkerungsdichte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.bevoelkerungsdichte_cache]
+  ch.are.bevoelkerungsdichte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.bevoelkerungsdichte_cache]
+  ch.are.gemeindetypen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.gemeindetypen]
+  ch.are.gemeindetypen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.gemeindetypen_cache]
+  ch.are.gemeindetypen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.gemeindetypen_cache]
+  ch.are.gemeindetypen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.gemeindetypen_cache]
+  ch.are.gemeindetypen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.gemeindetypen_cache]
+  ch.are.gueteklassen_oev_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.gueteklassen_oev]
+  ch.are.gueteklassen_oev_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.gueteklassen_oev_cache]
+  ch.are.gueteklassen_oev_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.gueteklassen_oev_cache]
+  ch.are.gueteklassen_oev_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.gueteklassen_oev_cache]
+  ch.are.gueteklassen_oev_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.gueteklassen_oev_cache]
+  ch.are.landschaftstypen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.landschaftstypen]
+  ch.are.landschaftstypen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.landschaftstypen_cache]
+  ch.are.landschaftstypen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.landschaftstypen_cache]
+  ch.are.landschaftstypen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.landschaftstypen_cache]
+  ch.are.landschaftstypen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.landschaftstypen_cache]
+  ch.are.reisezeit-miv_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.reisezeit-miv]
+  ch.are.reisezeit-miv_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-miv_cache]
+  ch.are.reisezeit-miv_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-miv_cache]
+  ch.are.reisezeit-miv_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-miv_cache]
+  ch.are.reisezeit-miv_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-miv_cache]
+  ch.are.reisezeit-oev_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.are.reisezeit-oev]
+  ch.are.reisezeit-oev_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-oev_cache]
+  ch.are.reisezeit-oev_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-oev_cache]
+  ch.are.reisezeit-oev_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-oev_cache]
+  ch.are.reisezeit-oev_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.are.reisezeit-oev_cache]
+  ch.astra.ausnahmetransportrouten_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.astra.ausnahmetransportrouten]
+  ch.astra.ausnahmetransportrouten_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.astra.ausnahmetransportrouten_cache]
+  ch.astra.ausnahmetransportrouten_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.astra.ausnahmetransportrouten_cache]
+  ch.astra.ausnahmetransportrouten_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.astra.ausnahmetransportrouten_cache]
+  ch.astra.ausnahmetransportrouten_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.astra.ausnahmetransportrouten_cache]
+  ch.astra.ivs-gelaendekarte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.astra.ivs-gelaendekarte]
+  ch.astra.ivs-gelaendekarte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-gelaendekarte_cache]
+  ch.astra.ivs-gelaendekarte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-gelaendekarte_cache]
+  ch.astra.ivs-gelaendekarte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-gelaendekarte_cache]
+  ch.astra.ivs-gelaendekarte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-gelaendekarte_cache]
+  ch.astra.ivs-nat-verlaeufe_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.astra.ivs-nat-verlaeufe]
+  ch.astra.ivs-nat-verlaeufe_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat-verlaeufe_cache]
+  ch.astra.ivs-nat-verlaeufe_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat-verlaeufe_cache]
+  ch.astra.ivs-nat-verlaeufe_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat-verlaeufe_cache]
+  ch.astra.ivs-nat-verlaeufe_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat-verlaeufe_cache]
+  ch.astra.ivs-nat_abgrenzungen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.astra.ivs-nat_abgrenzungen]
+  ch.astra.ivs-nat_abgrenzungen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_abgrenzungen_cache]
+  ch.astra.ivs-nat_abgrenzungen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_abgrenzungen_cache]
+  ch.astra.ivs-nat_abgrenzungen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_abgrenzungen_cache]
+  ch.astra.ivs-nat_abgrenzungen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_abgrenzungen_cache]
+  ch.astra.ivs-nat_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.astra.ivs-nat]
+  ch.astra.ivs-nat_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_cache]
+  ch.astra.ivs-nat_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_cache]
+  ch.astra.ivs-nat_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_cache]
+  ch.astra.ivs-nat_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_cache]
+  ch.astra.ivs-nat_wegbegleiter_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.astra.ivs-nat_wegbegleiter]
+  ch.astra.ivs-nat_wegbegleiter_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_wegbegleiter_cache]
+  ch.astra.ivs-nat_wegbegleiter_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_wegbegleiter_cache]
+  ch.astra.ivs-nat_wegbegleiter_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_wegbegleiter_cache]
+  ch.astra.ivs-nat_wegbegleiter_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-nat_wegbegleiter_cache]
+  ch.astra.ivs-reg_loc_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.astra.ivs-reg_loc]
+  ch.astra.ivs-reg_loc_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-reg_loc_cache]
+  ch.astra.ivs-reg_loc_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-reg_loc_cache]
+  ch.astra.ivs-reg_loc_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-reg_loc_cache]
+  ch.astra.ivs-reg_loc_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.astra.ivs-reg_loc_cache]
+  ch.babs.kulturgueter_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.babs.kulturgueter]
+  ch.babs.kulturgueter_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.babs.kulturgueter_cache]
+  ch.babs.kulturgueter_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.babs.kulturgueter_cache]
+  ch.babs.kulturgueter_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.babs.kulturgueter_cache]
+  ch.babs.kulturgueter_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.babs.kulturgueter_cache]
+  ch.bafu.aquaprotect_050_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.aquaprotect_050]
+  ch.bafu.aquaprotect_050_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_050_cache]
+  ch.bafu.aquaprotect_050_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_050_cache]
+  ch.bafu.aquaprotect_050_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_050_cache]
+  ch.bafu.aquaprotect_050_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_050_cache]
+  ch.bafu.aquaprotect_100_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.aquaprotect_100]
+  ch.bafu.aquaprotect_100_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_100_cache]
+  ch.bafu.aquaprotect_100_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_100_cache]
+  ch.bafu.aquaprotect_100_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_100_cache]
+  ch.bafu.aquaprotect_100_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_100_cache]
+  ch.bafu.aquaprotect_250_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.aquaprotect_250]
+  ch.bafu.aquaprotect_250_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_250_cache]
+  ch.bafu.aquaprotect_250_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_250_cache]
+  ch.bafu.aquaprotect_250_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_250_cache]
+  ch.bafu.aquaprotect_250_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_250_cache]
+  ch.bafu.aquaprotect_500_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.aquaprotect_500]
+  ch.bafu.aquaprotect_500_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_500_cache]
+  ch.bafu.aquaprotect_500_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_500_cache]
+  ch.bafu.aquaprotect_500_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_500_cache]
+  ch.bafu.aquaprotect_500_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.aquaprotect_500_cache]
+  ch.bafu.biogeographische_regionen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.biogeographische_regionen]
+  ch.bafu.biogeographische_regionen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.biogeographische_regionen_cache]
+  ch.bafu.biogeographische_regionen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.biogeographische_regionen_cache]
+  ch.bafu.biogeographische_regionen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.biogeographische_regionen_cache]
+  ch.bafu.biogeographische_regionen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.biogeographische_regionen_cache]
+  ch.bafu.bundesinventare-amphibien_anhang4_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-amphibien_anhang4]
+  ch.bafu.bundesinventare-amphibien_anhang4_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache]
+  ch.bafu.bundesinventare-amphibien_anhang4_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache]
+  ch.bafu.bundesinventare-amphibien_anhang4_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache]
+  ch.bafu.bundesinventare-amphibien_anhang4_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache]
+  ch.bafu.bundesinventare-amphibien_anhoerung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-amphibien_anhoerung]
+  ch.bafu.bundesinventare-amphibien_anhoerung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_anhoerung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_anhoerung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_anhoerung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-amphibien]
+  ch.bafu.bundesinventare-amphibien_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_cache]
+  ch.bafu.bundesinventare-amphibien_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_cache]
+  ch.bafu.bundesinventare-amphibien_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_cache]
+  ch.bafu.bundesinventare-amphibien_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache]
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache]
+  ch.bafu.bundesinventare-auen_anhoerung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-auen_anhoerung]
+  ch.bafu.bundesinventare-auen_anhoerung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_anhoerung_cache]
+  ch.bafu.bundesinventare-auen_anhoerung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_anhoerung_cache]
+  ch.bafu.bundesinventare-auen_anhoerung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_anhoerung_cache]
+  ch.bafu.bundesinventare-auen_anhoerung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_anhoerung_cache]
+  ch.bafu.bundesinventare-auen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-auen]
+  ch.bafu.bundesinventare-auen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_cache]
+  ch.bafu.bundesinventare-auen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_cache]
+  ch.bafu.bundesinventare-auen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_cache]
+  ch.bafu.bundesinventare-auen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-auen_cache]
+  ch.bafu.bundesinventare-bln_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-bln]
+  ch.bafu.bundesinventare-bln_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-bln_cache]
+  ch.bafu.bundesinventare-bln_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-bln_cache]
+  ch.bafu.bundesinventare-bln_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-bln_cache]
+  ch.bafu.bundesinventare-bln_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-bln_cache]
+  ch.bafu.bundesinventare-flachmoore_anhoerung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-flachmoore_anhoerung]
+  ch.bafu.bundesinventare-flachmoore_anhoerung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-flachmoore_anhoerung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-flachmoore_anhoerung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-flachmoore_anhoerung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-flachmoore_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-flachmoore]
+  ch.bafu.bundesinventare-flachmoore_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_cache]
+  ch.bafu.bundesinventare-flachmoore_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_cache]
+  ch.bafu.bundesinventare-flachmoore_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_cache]
+  ch.bafu.bundesinventare-flachmoore_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_cache]
+  ch.bafu.bundesinventare-flachmoore_regional_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-flachmoore_regional]
+  ch.bafu.bundesinventare-flachmoore_regional_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_regional_cache]
+  ch.bafu.bundesinventare-flachmoore_regional_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_regional_cache]
+  ch.bafu.bundesinventare-flachmoore_regional_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_regional_cache]
+  ch.bafu.bundesinventare-flachmoore_regional_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-flachmoore_regional_cache]
+  ch.bafu.bundesinventare-hochmoore_anhoerung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-hochmoore_anhoerung]
+  ch.bafu.bundesinventare-hochmoore_anhoerung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-hochmoore_anhoerung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-hochmoore_anhoerung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-hochmoore_anhoerung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache]
+  ch.bafu.bundesinventare-hochmoore_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-hochmoore]
+  ch.bafu.bundesinventare-hochmoore_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_cache]
+  ch.bafu.bundesinventare-hochmoore_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_cache]
+  ch.bafu.bundesinventare-hochmoore_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_cache]
+  ch.bafu.bundesinventare-hochmoore_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-hochmoore_cache]
+  ch.bafu.bundesinventare-jagdbanngebiete_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-jagdbanngebiete]
+  ch.bafu.bundesinventare-jagdbanngebiete_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache]
+  ch.bafu.bundesinventare-jagdbanngebiete_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache]
+  ch.bafu.bundesinventare-jagdbanngebiete_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache]
+  ch.bafu.bundesinventare-jagdbanngebiete_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache]
+  ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung]
+  ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache]
+  ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache]
+  ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache]
+  ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache]
+  ch.bafu.bundesinventare-moorlandschaften_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-moorlandschaften]
+  ch.bafu.bundesinventare-moorlandschaften_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_cache]
+  ch.bafu.bundesinventare-moorlandschaften_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_cache]
+  ch.bafu.bundesinventare-moorlandschaften_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_cache]
+  ch.bafu.bundesinventare-moorlandschaften_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-moorlandschaften_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache]
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache]
+  ch.bafu.bundesinventare-vogelreservate_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-vogelreservate]
+  ch.bafu.bundesinventare-vogelreservate_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-vogelreservate_cache]
+  ch.bafu.bundesinventare-vogelreservate_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-vogelreservate_cache]
+  ch.bafu.bundesinventare-vogelreservate_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-vogelreservate_cache]
+  ch.bafu.bundesinventare-vogelreservate_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.bundesinventare-vogelreservate_cache]
+  ch.bafu.fauna-steinbockkolonien_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fauna-steinbockkolonien]
+  ch.bafu.fauna-steinbockkolonien_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-steinbockkolonien_cache]
+  ch.bafu.fauna-steinbockkolonien_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-steinbockkolonien_cache]
+  ch.bafu.fauna-steinbockkolonien_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-steinbockkolonien_cache]
+  ch.bafu.fauna-steinbockkolonien_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-steinbockkolonien_cache]
+  ch.bafu.fauna-vernetzungsachsen_national_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fauna-vernetzungsachsen_national]
+  ch.bafu.fauna-vernetzungsachsen_national_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-vernetzungsachsen_national_cache]
+  ch.bafu.fauna-vernetzungsachsen_national_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-vernetzungsachsen_national_cache]
+  ch.bafu.fauna-vernetzungsachsen_national_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-vernetzungsachsen_national_cache]
+  ch.bafu.fauna-vernetzungsachsen_national_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-vernetzungsachsen_national_cache]
+  ch.bafu.fauna-wildtierkorridor_national_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fauna-wildtierkorridor_national]
+  ch.bafu.fauna-wildtierkorridor_national_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-wildtierkorridor_national_cache]
+  ch.bafu.fauna-wildtierkorridor_national_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-wildtierkorridor_national_cache]
+  ch.bafu.fauna-wildtierkorridor_national_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-wildtierkorridor_national_cache]
+  ch.bafu.fauna-wildtierkorridor_national_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fauna-wildtierkorridor_national_cache]
+  ch.bafu.fischerei-aeschen_kernzonen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fischerei-aeschen_kernzonen]
+  ch.bafu.fischerei-aeschen_kernzonen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_kernzonen_cache]
+  ch.bafu.fischerei-aeschen_kernzonen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_kernzonen_cache]
+  ch.bafu.fischerei-aeschen_kernzonen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_kernzonen_cache]
+  ch.bafu.fischerei-aeschen_kernzonen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_kernzonen_cache]
+  ch.bafu.fischerei-aeschen_laichplaetze_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fischerei-aeschen_laichplaetze]
+  ch.bafu.fischerei-aeschen_laichplaetze_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache]
+  ch.bafu.fischerei-aeschen_laichplaetze_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache]
+  ch.bafu.fischerei-aeschen_laichplaetze_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache]
+  ch.bafu.fischerei-aeschen_laichplaetze_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache]
+  ch.bafu.fischerei-aeschen_larvenhabitate_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fischerei-aeschen_larvenhabitate]
+  ch.bafu.fischerei-aeschen_larvenhabitate_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache]
+  ch.bafu.fischerei-aeschen_larvenhabitate_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache]
+  ch.bafu.fischerei-aeschen_larvenhabitate_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache]
+  ch.bafu.fischerei-aeschen_larvenhabitate_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache]
+  ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet]
+  ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache]
+  ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache]
+  ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache]
+  ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache]
+  ch.bafu.fischerei-krebspest_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fischerei-krebspest]
+  ch.bafu.fischerei-krebspest_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-krebspest_cache]
+  ch.bafu.fischerei-krebspest_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-krebspest_cache]
+  ch.bafu.fischerei-krebspest_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-krebspest_cache]
+  ch.bafu.fischerei-krebspest_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-krebspest_cache]
+  ch.bafu.fischerei-nasenlaichplaetze_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fischerei-nasenlaichplaetze]
+  ch.bafu.fischerei-nasenlaichplaetze_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-nasenlaichplaetze_cache]
+  ch.bafu.fischerei-nasenlaichplaetze_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-nasenlaichplaetze_cache]
+  ch.bafu.fischerei-nasenlaichplaetze_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-nasenlaichplaetze_cache]
+  ch.bafu.fischerei-nasenlaichplaetze_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-nasenlaichplaetze_cache]
+  ch.bafu.fischerei-proliferative_nierenkrankheit_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.fischerei-proliferative_nierenkrankheit]
+  ch.bafu.fischerei-proliferative_nierenkrankheit_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache]
+  ch.bafu.fischerei-proliferative_nierenkrankheit_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache]
+  ch.bafu.fischerei-proliferative_nierenkrankheit_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache]
+  ch.bafu.fischerei-proliferative_nierenkrankheit_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache]
+  ch.bafu.flora-schwingrasen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.flora-schwingrasen]
+  ch.bafu.flora-schwingrasen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-schwingrasen_cache]
+  ch.bafu.flora-schwingrasen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-schwingrasen_cache]
+  ch.bafu.flora-schwingrasen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-schwingrasen_cache]
+  ch.bafu.flora-schwingrasen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-schwingrasen_cache]
+  ch.bafu.flora-verbreitungskarten_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.flora-verbreitungskarten]
+  ch.bafu.flora-verbreitungskarten_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-verbreitungskarten_cache]
+  ch.bafu.flora-verbreitungskarten_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-verbreitungskarten_cache]
+  ch.bafu.flora-verbreitungskarten_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-verbreitungskarten_cache]
+  ch.bafu.flora-verbreitungskarten_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-verbreitungskarten_cache]
+  ch.bafu.flora-weltensutter_atlas_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.flora-weltensutter_atlas]
+  ch.bafu.flora-weltensutter_atlas_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-weltensutter_atlas_cache]
+  ch.bafu.flora-weltensutter_atlas_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-weltensutter_atlas_cache]
+  ch.bafu.flora-weltensutter_atlas_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-weltensutter_atlas_cache]
+  ch.bafu.flora-weltensutter_atlas_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.flora-weltensutter_atlas_cache]
+  ch.bafu.gefahren-baugrundklassen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.gefahren-baugrundklassen]
+  ch.bafu.gefahren-baugrundklassen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-baugrundklassen_cache]
+  ch.bafu.gefahren-baugrundklassen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-baugrundklassen_cache]
+  ch.bafu.gefahren-baugrundklassen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-baugrundklassen_cache]
+  ch.bafu.gefahren-baugrundklassen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-baugrundklassen_cache]
+  ch.bafu.gefahren-gefaehrdungszonen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.gefahren-gefaehrdungszonen]
+  ch.bafu.gefahren-gefaehrdungszonen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-gefaehrdungszonen_cache]
+  ch.bafu.gefahren-gefaehrdungszonen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-gefaehrdungszonen_cache]
+  ch.bafu.gefahren-gefaehrdungszonen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-gefaehrdungszonen_cache]
+  ch.bafu.gefahren-gefaehrdungszonen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-gefaehrdungszonen_cache]
+  ch.bafu.gefahren-historische_erdbeben_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.gefahren-historische_erdbeben]
+  ch.bafu.gefahren-historische_erdbeben_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-historische_erdbeben_cache]
+  ch.bafu.gefahren-historische_erdbeben_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-historische_erdbeben_cache]
+  ch.bafu.gefahren-historische_erdbeben_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-historische_erdbeben_cache]
+  ch.bafu.gefahren-historische_erdbeben_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-historische_erdbeben_cache]
+  ch.bafu.gefahren-mikrozonierung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.gefahren-mikrozonierung]
+  ch.bafu.gefahren-mikrozonierung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-mikrozonierung_cache]
+  ch.bafu.gefahren-mikrozonierung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-mikrozonierung_cache]
+  ch.bafu.gefahren-mikrozonierung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-mikrozonierung_cache]
+  ch.bafu.gefahren-mikrozonierung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-mikrozonierung_cache]
+  ch.bafu.gefahren-spektral_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.gefahren-spektral]
+  ch.bafu.gefahren-spektral_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-spektral_cache]
+  ch.bafu.gefahren-spektral_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-spektral_cache]
+  ch.bafu.gefahren-spektral_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-spektral_cache]
+  ch.bafu.gefahren-spektral_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.gefahren-spektral_cache]
+  ch.bafu.holznutzung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.holznutzung]
+  ch.bafu.holznutzung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holznutzung_cache]
+  ch.bafu.holznutzung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holznutzung_cache]
+  ch.bafu.holznutzung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holznutzung_cache]
+  ch.bafu.holznutzung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holznutzung_cache]
+  ch.bafu.holzvorrat_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.holzvorrat]
+  ch.bafu.holzvorrat_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzvorrat_cache]
+  ch.bafu.holzvorrat_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzvorrat_cache]
+  ch.bafu.holzvorrat_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzvorrat_cache]
+  ch.bafu.holzvorrat_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzvorrat_cache]
+  ch.bafu.holzzuwachs_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.holzzuwachs]
+  ch.bafu.holzzuwachs_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzzuwachs_cache]
+  ch.bafu.holzzuwachs_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzzuwachs_cache]
+  ch.bafu.holzzuwachs_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzzuwachs_cache]
+  ch.bafu.holzzuwachs_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.holzzuwachs_cache]
+  ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen]
+  ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache]
+  ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache]
+  ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache]
+  ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache]
+  ch.bafu.hydrologie-hydromessstationen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.hydrologie-hydromessstationen]
+  ch.bafu.hydrologie-hydromessstationen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-hydromessstationen_cache]
+  ch.bafu.hydrologie-hydromessstationen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-hydromessstationen_cache]
+  ch.bafu.hydrologie-hydromessstationen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-hydromessstationen_cache]
+  ch.bafu.hydrologie-hydromessstationen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-hydromessstationen_cache]
+  ch.bafu.hydrologie-wassertemperaturmessstationen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.hydrologie-wassertemperaturmessstationen]
+  ch.bafu.hydrologie-wassertemperaturmessstationen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache]
+  ch.bafu.hydrologie-wassertemperaturmessstationen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache]
+  ch.bafu.hydrologie-wassertemperaturmessstationen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache]
+  ch.bafu.hydrologie-wassertemperaturmessstationen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache]
+  ch.bafu.laerm-bahnlaerm_nacht_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.laerm-bahnlaerm_nacht]
+  ch.bafu.laerm-bahnlaerm_nacht_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_nacht_cache]
+  ch.bafu.laerm-bahnlaerm_nacht_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_nacht_cache]
+  ch.bafu.laerm-bahnlaerm_nacht_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_nacht_cache]
+  ch.bafu.laerm-bahnlaerm_nacht_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_nacht_cache]
+  ch.bafu.laerm-bahnlaerm_tag_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.laerm-bahnlaerm_tag]
+  ch.bafu.laerm-bahnlaerm_tag_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_tag_cache]
+  ch.bafu.laerm-bahnlaerm_tag_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_tag_cache]
+  ch.bafu.laerm-bahnlaerm_tag_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_tag_cache]
+  ch.bafu.laerm-bahnlaerm_tag_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-bahnlaerm_tag_cache]
+  ch.bafu.laerm-strassenlaerm_nacht_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.laerm-strassenlaerm_nacht]
+  ch.bafu.laerm-strassenlaerm_nacht_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_nacht_cache]
+  ch.bafu.laerm-strassenlaerm_nacht_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_nacht_cache]
+  ch.bafu.laerm-strassenlaerm_nacht_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_nacht_cache]
+  ch.bafu.laerm-strassenlaerm_nacht_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_nacht_cache]
+  ch.bafu.laerm-strassenlaerm_tag_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.laerm-strassenlaerm_tag]
+  ch.bafu.laerm-strassenlaerm_tag_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_tag_cache]
+  ch.bafu.laerm-strassenlaerm_tag_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_tag_cache]
+  ch.bafu.laerm-strassenlaerm_tag_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_tag_cache]
+  ch.bafu.laerm-strassenlaerm_tag_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.laerm-strassenlaerm_tag_cache]
+  ch.bafu.landesforstinventar-baumarten_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.landesforstinventar-baumarten]
+  ch.bafu.landesforstinventar-baumarten_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-baumarten_cache]
+  ch.bafu.landesforstinventar-baumarten_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-baumarten_cache]
+  ch.bafu.landesforstinventar-baumarten_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-baumarten_cache]
+  ch.bafu.landesforstinventar-baumarten_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-baumarten_cache]
+  ch.bafu.landesforstinventar-totholz_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.landesforstinventar-totholz]
+  ch.bafu.landesforstinventar-totholz_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-totholz_cache]
+  ch.bafu.landesforstinventar-totholz_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-totholz_cache]
+  ch.bafu.landesforstinventar-totholz_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-totholz_cache]
+  ch.bafu.landesforstinventar-totholz_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-totholz_cache]
+  ch.bafu.landesforstinventar-waldanteil_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.landesforstinventar-waldanteil]
+  ch.bafu.landesforstinventar-waldanteil_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-waldanteil_cache]
+  ch.bafu.landesforstinventar-waldanteil_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-waldanteil_cache]
+  ch.bafu.landesforstinventar-waldanteil_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-waldanteil_cache]
+  ch.bafu.landesforstinventar-waldanteil_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.landesforstinventar-waldanteil_cache]
+  ch.bafu.moose_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.moose]
+  ch.bafu.moose_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.moose_cache]
+  ch.bafu.moose_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.moose_cache]
+  ch.bafu.moose_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.moose_cache]
+  ch.bafu.moose_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.moose_cache]
+  ch.bafu.nabelstationen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.nabelstationen]
+  ch.bafu.nabelstationen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.nabelstationen_cache]
+  ch.bafu.nabelstationen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.nabelstationen_cache]
+  ch.bafu.nabelstationen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.nabelstationen_cache]
+  ch.bafu.nabelstationen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.nabelstationen_cache]
+  ch.bafu.naqua-grundwasser_nitrat_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.naqua-grundwasser_nitrat]
+  ch.bafu.naqua-grundwasser_nitrat_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_nitrat_cache]
+  ch.bafu.naqua-grundwasser_nitrat_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_nitrat_cache]
+  ch.bafu.naqua-grundwasser_nitrat_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_nitrat_cache]
+  ch.bafu.naqua-grundwasser_nitrat_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_nitrat_cache]
+  ch.bafu.naqua-grundwasser_psm_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.naqua-grundwasser_psm]
+  ch.bafu.naqua-grundwasser_psm_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_psm_cache]
+  ch.bafu.naqua-grundwasser_psm_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_psm_cache]
+  ch.bafu.naqua-grundwasser_psm_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_psm_cache]
+  ch.bafu.naqua-grundwasser_psm_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_psm_cache]
+  ch.bafu.naqua-grundwasser_voc_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.naqua-grundwasser_voc]
+  ch.bafu.naqua-grundwasser_voc_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_voc_cache]
+  ch.bafu.naqua-grundwasser_voc_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_voc_cache]
+  ch.bafu.naqua-grundwasser_voc_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_voc_cache]
+  ch.bafu.naqua-grundwasser_voc_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.naqua-grundwasser_voc_cache]
+  ch.bafu.oekomorphologie-f_abschnitte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.oekomorphologie-f_abschnitte]
+  ch.bafu.oekomorphologie-f_abschnitte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abschnitte_cache]
+  ch.bafu.oekomorphologie-f_abschnitte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abschnitte_cache]
+  ch.bafu.oekomorphologie-f_abschnitte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abschnitte_cache]
+  ch.bafu.oekomorphologie-f_abschnitte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abschnitte_cache]
+  ch.bafu.oekomorphologie-f_abstuerze_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.oekomorphologie-f_abstuerze]
+  ch.bafu.oekomorphologie-f_abstuerze_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abstuerze_cache]
+  ch.bafu.oekomorphologie-f_abstuerze_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abstuerze_cache]
+  ch.bafu.oekomorphologie-f_abstuerze_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abstuerze_cache]
+  ch.bafu.oekomorphologie-f_abstuerze_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_abstuerze_cache]
+  ch.bafu.oekomorphologie-f_bauwerke_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.oekomorphologie-f_bauwerke]
+  ch.bafu.oekomorphologie-f_bauwerke_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_bauwerke_cache]
+  ch.bafu.oekomorphologie-f_bauwerke_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_bauwerke_cache]
+  ch.bafu.oekomorphologie-f_bauwerke_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_bauwerke_cache]
+  ch.bafu.oekomorphologie-f_bauwerke_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.oekomorphologie-f_bauwerke_cache]
+  ch.bafu.permafrost_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.permafrost]
+  ch.bafu.permafrost_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.permafrost_cache]
+  ch.bafu.permafrost_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.permafrost_cache]
+  ch.bafu.permafrost_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.permafrost_cache]
+  ch.bafu.permafrost_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.permafrost_cache]
+  ch.bafu.ren-extensive_landwirtschaftsgebiete_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete]
+  ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache]
+  ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache]
+  ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache]
+  ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache]
+  ch.bafu.ren-feuchtgebiete_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.ren-feuchtgebiete]
+  ch.bafu.ren-feuchtgebiete_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-feuchtgebiete_cache]
+  ch.bafu.ren-feuchtgebiete_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-feuchtgebiete_cache]
+  ch.bafu.ren-feuchtgebiete_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-feuchtgebiete_cache]
+  ch.bafu.ren-feuchtgebiete_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-feuchtgebiete_cache]
+  ch.bafu.ren-fliessgewaesser_seen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.ren-fliessgewaesser_seen]
+  ch.bafu.ren-fliessgewaesser_seen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-fliessgewaesser_seen_cache]
+  ch.bafu.ren-fliessgewaesser_seen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-fliessgewaesser_seen_cache]
+  ch.bafu.ren-fliessgewaesser_seen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-fliessgewaesser_seen_cache]
+  ch.bafu.ren-fliessgewaesser_seen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-fliessgewaesser_seen_cache]
+  ch.bafu.ren-trockenstandorte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.ren-trockenstandorte]
+  ch.bafu.ren-trockenstandorte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-trockenstandorte_cache]
+  ch.bafu.ren-trockenstandorte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-trockenstandorte_cache]
+  ch.bafu.ren-trockenstandorte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-trockenstandorte_cache]
+  ch.bafu.ren-trockenstandorte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-trockenstandorte_cache]
+  ch.bafu.ren-wald_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.ren-wald]
+  ch.bafu.ren-wald_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-wald_cache]
+  ch.bafu.ren-wald_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-wald_cache]
+  ch.bafu.ren-wald_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-wald_cache]
+  ch.bafu.ren-wald_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.ren-wald_cache]
+  ch.bafu.schutzgebiete-biosphaerenreservate_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.schutzgebiete-biosphaerenreservate]
+  ch.bafu.schutzgebiete-biosphaerenreservate_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache]
+  ch.bafu.schutzgebiete-biosphaerenreservate_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache]
+  ch.bafu.schutzgebiete-biosphaerenreservate_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache]
+  ch.bafu.schutzgebiete-biosphaerenreservate_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache]
+  ch.bafu.schutzgebiete-luftfahrt_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.schutzgebiete-luftfahrt]
+  ch.bafu.schutzgebiete-luftfahrt_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-luftfahrt_cache]
+  ch.bafu.schutzgebiete-luftfahrt_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-luftfahrt_cache]
+  ch.bafu.schutzgebiete-luftfahrt_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-luftfahrt_cache]
+  ch.bafu.schutzgebiete-luftfahrt_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-luftfahrt_cache]
+  ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung]
+  ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache]
+  ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache]
+  ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache]
+  ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache]
+  ch.bafu.schutzgebiete-ramsar_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.schutzgebiete-ramsar]
+  ch.bafu.schutzgebiete-ramsar_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-ramsar_cache]
+  ch.bafu.schutzgebiete-ramsar_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-ramsar_cache]
+  ch.bafu.schutzgebiete-ramsar_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-ramsar_cache]
+  ch.bafu.schutzgebiete-ramsar_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-ramsar_cache]
+  ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark]
+  ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache]
+  ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache]
+  ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache]
+  ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache]
+  ch.bafu.schutzgebiete-smaragd_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.schutzgebiete-smaragd]
+  ch.bafu.schutzgebiete-smaragd_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-smaragd_cache]
+  ch.bafu.schutzgebiete-smaragd_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-smaragd_cache]
+  ch.bafu.schutzgebiete-smaragd_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-smaragd_cache]
+  ch.bafu.schutzgebiete-smaragd_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.schutzgebiete-smaragd_cache]
+  ch.bafu.showme-gemeinden_hochwasser_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_hochwasser]
+  ch.bafu.showme-gemeinden_hochwasser_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_hochwasser_cache]
+  ch.bafu.showme-gemeinden_hochwasser_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_hochwasser_cache]
+  ch.bafu.showme-gemeinden_hochwasser_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_hochwasser_cache]
+  ch.bafu.showme-gemeinden_hochwasser_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_hochwasser_cache]
+  ch.bafu.showme-gemeinden_lawinen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_lawinen]
+  ch.bafu.showme-gemeinden_lawinen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_lawinen_cache]
+  ch.bafu.showme-gemeinden_lawinen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_lawinen_cache]
+  ch.bafu.showme-gemeinden_lawinen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_lawinen_cache]
+  ch.bafu.showme-gemeinden_lawinen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_lawinen_cache]
+  ch.bafu.showme-gemeinden_rutschungen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_rutschungen]
+  ch.bafu.showme-gemeinden_rutschungen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_rutschungen_cache]
+  ch.bafu.showme-gemeinden_rutschungen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_rutschungen_cache]
+  ch.bafu.showme-gemeinden_rutschungen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_rutschungen_cache]
+  ch.bafu.showme-gemeinden_rutschungen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_rutschungen_cache]
+  ch.bafu.showme-gemeinden_sturzprozesse_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_sturzprozesse]
+  ch.bafu.showme-gemeinden_sturzprozesse_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache]
+  ch.bafu.showme-gemeinden_sturzprozesse_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache]
+  ch.bafu.showme-gemeinden_sturzprozesse_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache]
+  ch.bafu.showme-gemeinden_sturzprozesse_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache]
+  ch.bafu.showme-kantone_hochwasser_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_hochwasser]
+  ch.bafu.showme-kantone_hochwasser_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_hochwasser_cache]
+  ch.bafu.showme-kantone_hochwasser_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_hochwasser_cache]
+  ch.bafu.showme-kantone_hochwasser_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_hochwasser_cache]
+  ch.bafu.showme-kantone_hochwasser_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_hochwasser_cache]
+  ch.bafu.showme-kantone_lawinen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_lawinen]
+  ch.bafu.showme-kantone_lawinen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_lawinen_cache]
+  ch.bafu.showme-kantone_lawinen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_lawinen_cache]
+  ch.bafu.showme-kantone_lawinen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_lawinen_cache]
+  ch.bafu.showme-kantone_lawinen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_lawinen_cache]
+  ch.bafu.showme-kantone_rutschungen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_rutschungen]
+  ch.bafu.showme-kantone_rutschungen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_rutschungen_cache]
+  ch.bafu.showme-kantone_rutschungen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_rutschungen_cache]
+  ch.bafu.showme-kantone_rutschungen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_rutschungen_cache]
+  ch.bafu.showme-kantone_rutschungen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_rutschungen_cache]
+  ch.bafu.showme-kantone_sturzprozesse_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_sturzprozesse]
+  ch.bafu.showme-kantone_sturzprozesse_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_sturzprozesse_cache]
+  ch.bafu.showme-kantone_sturzprozesse_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_sturzprozesse_cache]
+  ch.bafu.showme-kantone_sturzprozesse_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_sturzprozesse_cache]
+  ch.bafu.showme-kantone_sturzprozesse_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.showme-kantone_sturzprozesse_cache]
+  ch.bafu.silvaprotect-hangmuren_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.silvaprotect-hangmuren]
+  ch.bafu.silvaprotect-hangmuren_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-hangmuren_cache]
+  ch.bafu.silvaprotect-hangmuren_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-hangmuren_cache]
+  ch.bafu.silvaprotect-hangmuren_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-hangmuren_cache]
+  ch.bafu.silvaprotect-hangmuren_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-hangmuren_cache]
+  ch.bafu.silvaprotect-lawinen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.silvaprotect-lawinen]
+  ch.bafu.silvaprotect-lawinen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-lawinen_cache]
+  ch.bafu.silvaprotect-lawinen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-lawinen_cache]
+  ch.bafu.silvaprotect-lawinen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-lawinen_cache]
+  ch.bafu.silvaprotect-lawinen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-lawinen_cache]
+  ch.bafu.silvaprotect-murgang_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.silvaprotect-murgang]
+  ch.bafu.silvaprotect-murgang_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-murgang_cache]
+  ch.bafu.silvaprotect-murgang_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-murgang_cache]
+  ch.bafu.silvaprotect-murgang_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-murgang_cache]
+  ch.bafu.silvaprotect-murgang_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-murgang_cache]
+  ch.bafu.silvaprotect-sturz_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.silvaprotect-sturz]
+  ch.bafu.silvaprotect-sturz_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-sturz_cache]
+  ch.bafu.silvaprotect-sturz_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-sturz_cache]
+  ch.bafu.silvaprotect-sturz_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-sturz_cache]
+  ch.bafu.silvaprotect-sturz_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-sturz_cache]
+  ch.bafu.silvaprotect-uebersarung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.silvaprotect-uebersarung]
+  ch.bafu.silvaprotect-uebersarung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-uebersarung_cache]
+  ch.bafu.silvaprotect-uebersarung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-uebersarung_cache]
+  ch.bafu.silvaprotect-uebersarung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-uebersarung_cache]
+  ch.bafu.silvaprotect-uebersarung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.silvaprotect-uebersarung_cache]
+  ch.bafu.swissprtr_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.swissprtr]
+  ch.bafu.swissprtr_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.swissprtr_cache]
+  ch.bafu.swissprtr_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.swissprtr_cache]
+  ch.bafu.swissprtr_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.swissprtr_cache]
+  ch.bafu.swissprtr_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.swissprtr_cache]
+  ch.bafu.unesco-weltnaturerbe_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.unesco-weltnaturerbe]
+  ch.bafu.unesco-weltnaturerbe_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.unesco-weltnaturerbe_cache]
+  ch.bafu.unesco-weltnaturerbe_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.unesco-weltnaturerbe_cache]
+  ch.bafu.unesco-weltnaturerbe_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.unesco-weltnaturerbe_cache]
+  ch.bafu.unesco-weltnaturerbe_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.unesco-weltnaturerbe_cache]
+  ch.bafu.waldschadenflaechen-lothar_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.waldschadenflaechen-lothar]
+  ch.bafu.waldschadenflaechen-lothar_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-lothar_cache]
+  ch.bafu.waldschadenflaechen-lothar_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-lothar_cache]
+  ch.bafu.waldschadenflaechen-lothar_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-lothar_cache]
+  ch.bafu.waldschadenflaechen-lothar_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-lothar_cache]
+  ch.bafu.waldschadenflaechen-vivian_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.waldschadenflaechen-vivian]
+  ch.bafu.waldschadenflaechen-vivian_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-vivian_cache]
+  ch.bafu.waldschadenflaechen-vivian_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-vivian_cache]
+  ch.bafu.waldschadenflaechen-vivian_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-vivian_cache]
+  ch.bafu.waldschadenflaechen-vivian_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.waldschadenflaechen-vivian_cache]
+  ch.bafu.wasser-entnahme_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wasser-entnahme]
+  ch.bafu.wasser-entnahme_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-entnahme_cache]
+  ch.bafu.wasser-entnahme_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-entnahme_cache]
+  ch.bafu.wasser-entnahme_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-entnahme_cache]
+  ch.bafu.wasser-entnahme_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-entnahme_cache]
+  ch.bafu.wasser-gebietsauslaesse_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wasser-gebietsauslaesse]
+  ch.bafu.wasser-gebietsauslaesse_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-gebietsauslaesse_cache]
+  ch.bafu.wasser-gebietsauslaesse_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-gebietsauslaesse_cache]
+  ch.bafu.wasser-gebietsauslaesse_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-gebietsauslaesse_cache]
+  ch.bafu.wasser-gebietsauslaesse_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-gebietsauslaesse_cache]
+  ch.bafu.wasser-leitungen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wasser-leitungen]
+  ch.bafu.wasser-leitungen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-leitungen_cache]
+  ch.bafu.wasser-leitungen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-leitungen_cache]
+  ch.bafu.wasser-leitungen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-leitungen_cache]
+  ch.bafu.wasser-leitungen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-leitungen_cache]
+  ch.bafu.wasser-rueckgabe_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wasser-rueckgabe]
+  ch.bafu.wasser-rueckgabe_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-rueckgabe_cache]
+  ch.bafu.wasser-rueckgabe_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-rueckgabe_cache]
+  ch.bafu.wasser-rueckgabe_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-rueckgabe_cache]
+  ch.bafu.wasser-rueckgabe_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-rueckgabe_cache]
+  ch.bafu.wasser-teileinzugsgebiete_2_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_2]
+  ch.bafu.wasser-teileinzugsgebiete_2_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache]
+  ch.bafu.wasser-teileinzugsgebiete_2_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache]
+  ch.bafu.wasser-teileinzugsgebiete_2_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache]
+  ch.bafu.wasser-teileinzugsgebiete_2_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache]
+  ch.bafu.wasser-teileinzugsgebiete_40_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_40]
+  ch.bafu.wasser-teileinzugsgebiete_40_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache]
+  ch.bafu.wasser-teileinzugsgebiete_40_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache]
+  ch.bafu.wasser-teileinzugsgebiete_40_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache]
+  ch.bafu.wasser-teileinzugsgebiete_40_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache]
+  ch.bafu.wasser-vorfluter_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wasser-vorfluter]
+  ch.bafu.wasser-vorfluter_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-vorfluter_cache]
+  ch.bafu.wasser-vorfluter_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-vorfluter_cache]
+  ch.bafu.wasser-vorfluter_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-vorfluter_cache]
+  ch.bafu.wasser-vorfluter_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wasser-vorfluter_cache]
+  ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete]
+  ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wildruhezonen-jagdbanngebiete_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wildruhezonen-jagdbanngebiete]
+  ch.bafu.wildruhezonen-jagdbanngebiete_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wildruhezonen-jagdbanngebiete_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wildruhezonen-jagdbanngebiete_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wildruhezonen-jagdbanngebiete_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache]
+  ch.bafu.wrz-jagdbanngebiete_select_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wrz-jagdbanngebiete_select]
+  ch.bafu.wrz-jagdbanngebiete_select_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-jagdbanngebiete_select_cache]
+  ch.bafu.wrz-jagdbanngebiete_select_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-jagdbanngebiete_select_cache]
+  ch.bafu.wrz-jagdbanngebiete_select_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-jagdbanngebiete_select_cache]
+  ch.bafu.wrz-jagdbanngebiete_select_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-jagdbanngebiete_select_cache]
+  ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen]
+  ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache]
+  ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache]
+  ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache]
+  ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache]
+  ch.bafu.wrz-wildruhezonen_portal_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wrz-wildruhezonen_portal]
+  ch.bafu.wrz-wildruhezonen_portal_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen_portal_cache]
+  ch.bafu.wrz-wildruhezonen_portal_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen_portal_cache]
+  ch.bafu.wrz-wildruhezonen_portal_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen_portal_cache]
+  ch.bafu.wrz-wildruhezonen_portal_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bafu.wrz-wildruhezonen_portal_cache]
+  ch.bag.zecken-fsme-faelle_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bag.zecken-fsme-faelle]
+  ch.bag.zecken-fsme-faelle_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-faelle_cache]
+  ch.bag.zecken-fsme-faelle_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-faelle_cache]
+  ch.bag.zecken-fsme-faelle_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-faelle_cache]
+  ch.bag.zecken-fsme-faelle_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-faelle_cache]
+  ch.bag.zecken-fsme-impfung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bag.zecken-fsme-impfung]
+  ch.bag.zecken-fsme-impfung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-impfung_cache]
+  ch.bag.zecken-fsme-impfung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-impfung_cache]
+  ch.bag.zecken-fsme-impfung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-impfung_cache]
+  ch.bag.zecken-fsme-impfung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-fsme-impfung_cache]
+  ch.bag.zecken-lyme_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bag.zecken-lyme]
+  ch.bag.zecken-lyme_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-lyme_cache]
+  ch.bag.zecken-lyme_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-lyme_cache]
+  ch.bag.zecken-lyme_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-lyme_cache]
+  ch.bag.zecken-lyme_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bag.zecken-lyme_cache]
+  ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder]
+  ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache]
+  ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache]
+  ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache]
+  ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache]
+  ch.bak.schutzgebiete-unesco_weltkulturerbe_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe]
+  ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache]
+  ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache]
+  ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache]
+  ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache]
+  ch.bakom.versorgungsgebiet-tv_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.versorgungsgebiet-tv]
+  ch.bakom.versorgungsgebiet-tv_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-tv_cache]
+  ch.bakom.versorgungsgebiet-tv_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-tv_cache]
+  ch.bakom.versorgungsgebiet-tv_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-tv_cache]
+  ch.bakom.versorgungsgebiet-tv_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-tv_cache]
+  ch.bakom.versorgungsgebiet-ukw_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.versorgungsgebiet-ukw]
+  ch.bakom.versorgungsgebiet-ukw_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-ukw_cache]
+  ch.bakom.versorgungsgebiet-ukw_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-ukw_cache]
+  ch.bakom.versorgungsgebiet-ukw_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-ukw_cache]
+  ch.bakom.versorgungsgebiet-ukw_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bakom.versorgungsgebiet-ukw_cache]
+  ch.bav.laerm-emissionplan_eisenbahn_2015_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bav.laerm-emissionplan_eisenbahn_2015]
+  ch.bav.laerm-emissionplan_eisenbahn_2015_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache]
+  ch.bav.laerm-emissionplan_eisenbahn_2015_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache]
+  ch.bav.laerm-emissionplan_eisenbahn_2015_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache]
+  ch.bav.laerm-emissionplan_eisenbahn_2015_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache]
+  ch.bazl.heliports-gebirgslandeplaetze_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bazl.heliports-gebirgslandeplaetze]
+  ch.bazl.heliports-gebirgslandeplaetze_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bazl.heliports-gebirgslandeplaetze_cache]
+  ch.bazl.heliports-gebirgslandeplaetze_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bazl.heliports-gebirgslandeplaetze_cache]
+  ch.bazl.heliports-gebirgslandeplaetze_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bazl.heliports-gebirgslandeplaetze_cache]
+  ch.bazl.heliports-gebirgslandeplaetze_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bazl.heliports-gebirgslandeplaetze_cache]
+  ch.bazl.landschaftsruhezonen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bazl.landschaftsruhezonen]
+  ch.bazl.landschaftsruhezonen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bazl.landschaftsruhezonen_cache]
+  ch.bazl.landschaftsruhezonen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bazl.landschaftsruhezonen_cache]
+  ch.bazl.landschaftsruhezonen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bazl.landschaftsruhezonen_cache]
+  ch.bazl.landschaftsruhezonen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bazl.landschaftsruhezonen_cache]
+  ch.bazl.luftfahrtkarten-icao_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bazl.luftfahrtkarten-icao]
+  ch.bazl.luftfahrtkarten-icao_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bazl.luftfahrtkarten-icao_cache]
+  ch.bazl.luftfahrtkarten-icao_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bazl.luftfahrtkarten-icao_cache]
+  ch.bazl.luftfahrtkarten-icao_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bazl.luftfahrtkarten-icao_cache]
+  ch.bazl.luftfahrtkarten-icao_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bazl.luftfahrtkarten-icao_cache]
+  ch.bazl.points-of-interest_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bazl.points-of-interest]
+  ch.bazl.points-of-interest_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bazl.points-of-interest_cache]
+  ch.bazl.points-of-interest_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bazl.points-of-interest_cache]
+  ch.bazl.points-of-interest_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bazl.points-of-interest_cache]
+  ch.bazl.points-of-interest_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bazl.points-of-interest_cache]
+  ch.bazl.projektierungszonen-flughafenanlagen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bazl.projektierungszonen-flughafenanlagen]
+  ch.bazl.projektierungszonen-flughafenanlagen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache]
+  ch.bazl.projektierungszonen-flughafenanlagen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache]
+  ch.bazl.projektierungszonen-flughafenanlagen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache]
+  ch.bazl.projektierungszonen-flughafenanlagen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache]
+  ch.bazl.segelflugkarte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bazl.segelflugkarte]
+  ch.bazl.segelflugkarte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bazl.segelflugkarte_cache]
+  ch.bazl.segelflugkarte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bazl.segelflugkarte_cache]
+  ch.bazl.segelflugkarte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bazl.segelflugkarte_cache]
+  ch.bazl.segelflugkarte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bazl.segelflugkarte_cache]
+  ch.bfe.kernkraftwerke_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfe.kernkraftwerke]
+  ch.bfe.kernkraftwerke_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kernkraftwerke_cache]
+  ch.bfe.kernkraftwerke_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kernkraftwerke_cache]
+  ch.bfe.kernkraftwerke_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kernkraftwerke_cache]
+  ch.bfe.kernkraftwerke_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kernkraftwerke_cache]
+  ch.bfe.kleinwasserkraftpotentiale_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfe.kleinwasserkraftpotentiale]
+  ch.bfe.kleinwasserkraftpotentiale_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kleinwasserkraftpotentiale_cache]
+  ch.bfe.kleinwasserkraftpotentiale_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kleinwasserkraftpotentiale_cache]
+  ch.bfe.kleinwasserkraftpotentiale_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kleinwasserkraftpotentiale_cache]
+  ch.bfe.kleinwasserkraftpotentiale_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfe.kleinwasserkraftpotentiale_cache]
+  ch.bfs.arealstatistik-1985_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-1985]
+  ch.bfs.arealstatistik-1985_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1985_cache]
+  ch.bfs.arealstatistik-1985_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1985_cache]
+  ch.bfs.arealstatistik-1985_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1985_cache]
+  ch.bfs.arealstatistik-1985_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1985_cache]
+  ch.bfs.arealstatistik-1997_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-1997]
+  ch.bfs.arealstatistik-1997_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1997_cache]
+  ch.bfs.arealstatistik-1997_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1997_cache]
+  ch.bfs.arealstatistik-1997_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1997_cache]
+  ch.bfs.arealstatistik-1997_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-1997_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1985_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1985]
+  ch.bfs.arealstatistik-bodenbedeckung-1985_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1985_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1985_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1985_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1997_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1997]
+  ch.bfs.arealstatistik-bodenbedeckung-1997_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1997_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1997_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache]
+  ch.bfs.arealstatistik-bodenbedeckung-1997_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache]
+  ch.bfs.arealstatistik-bodenbedeckung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung]
+  ch.bfs.arealstatistik-bodenbedeckung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung_cache]
+  ch.bfs.arealstatistik-bodenbedeckung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung_cache]
+  ch.bfs.arealstatistik-bodenbedeckung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung_cache]
+  ch.bfs.arealstatistik-bodenbedeckung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodenbedeckung_cache]
+  ch.bfs.arealstatistik-bodennutzung-1985_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1985]
+  ch.bfs.arealstatistik-bodennutzung-1985_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache]
+  ch.bfs.arealstatistik-bodennutzung-1985_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache]
+  ch.bfs.arealstatistik-bodennutzung-1985_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache]
+  ch.bfs.arealstatistik-bodennutzung-1985_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache]
+  ch.bfs.arealstatistik-bodennutzung-1997_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1997]
+  ch.bfs.arealstatistik-bodennutzung-1997_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache]
+  ch.bfs.arealstatistik-bodennutzung-1997_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache]
+  ch.bfs.arealstatistik-bodennutzung-1997_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache]
+  ch.bfs.arealstatistik-bodennutzung-1997_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache]
+  ch.bfs.arealstatistik-bodennutzung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-bodennutzung]
+  ch.bfs.arealstatistik-bodennutzung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung_cache]
+  ch.bfs.arealstatistik-bodennutzung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung_cache]
+  ch.bfs.arealstatistik-bodennutzung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung_cache]
+  ch.bfs.arealstatistik-bodennutzung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-bodennutzung_cache]
+  ch.bfs.arealstatistik-hintergrund_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-hintergrund]
+  ch.bfs.arealstatistik-hintergrund_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-hintergrund_cache]
+  ch.bfs.arealstatistik-hintergrund_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-hintergrund_cache]
+  ch.bfs.arealstatistik-hintergrund_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-hintergrund_cache]
+  ch.bfs.arealstatistik-hintergrund_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-hintergrund_cache]
+  ch.bfs.arealstatistik-waldmischungsgrad_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik-waldmischungsgrad]
+  ch.bfs.arealstatistik-waldmischungsgrad_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache]
+  ch.bfs.arealstatistik-waldmischungsgrad_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache]
+  ch.bfs.arealstatistik-waldmischungsgrad_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache]
+  ch.bfs.arealstatistik-waldmischungsgrad_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache]
+  ch.bfs.arealstatistik_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.arealstatistik]
+  ch.bfs.arealstatistik_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik_cache]
+  ch.bfs.arealstatistik_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik_cache]
+  ch.bfs.arealstatistik_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik_cache]
+  ch.bfs.arealstatistik_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.arealstatistik_cache]
+  ch.bfs.gebaeude_wohnungs_register_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bfs.gebaeude_wohnungs_register]
+  ch.bfs.gebaeude_wohnungs_register_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.bfs.gebaeude_wohnungs_register_cache]
+  ch.bfs.gebaeude_wohnungs_register_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.bfs.gebaeude_wohnungs_register_cache]
+  ch.bfs.gebaeude_wohnungs_register_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.bfs.gebaeude_wohnungs_register_cache]
+  ch.bfs.gebaeude_wohnungs_register_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.bfs.gebaeude_wohnungs_register_cache]
+  ch.blw.alpprodukte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.alpprodukte]
+  ch.blw.alpprodukte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.alpprodukte_cache]
+  ch.blw.alpprodukte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.alpprodukte_cache]
+  ch.blw.alpprodukte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.alpprodukte_cache]
+  ch.blw.alpprodukte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.alpprodukte_cache]
+  ch.blw.bergprodukte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bergprodukte]
+  ch.blw.bergprodukte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bergprodukte_cache]
+  ch.blw.bergprodukte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bergprodukte_cache]
+  ch.blw.bergprodukte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bergprodukte_cache]
+  ch.blw.bergprodukte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bergprodukte_cache]
+  ch.blw.bewaesserungsbeduerftigkeit_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bewaesserungsbeduerftigkeit]
+  ch.blw.bewaesserungsbeduerftigkeit_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bewaesserungsbeduerftigkeit_cache]
+  ch.blw.bewaesserungsbeduerftigkeit_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bewaesserungsbeduerftigkeit_cache]
+  ch.blw.bewaesserungsbeduerftigkeit_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bewaesserungsbeduerftigkeit_cache]
+  ch.blw.bewaesserungsbeduerftigkeit_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bewaesserungsbeduerftigkeit_cache]
+  ch.blw.bodeneignung-gruendigkeit_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-gruendigkeit]
+  ch.blw.bodeneignung-gruendigkeit_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-gruendigkeit_cache]
+  ch.blw.bodeneignung-gruendigkeit_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-gruendigkeit_cache]
+  ch.blw.bodeneignung-gruendigkeit_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-gruendigkeit_cache]
+  ch.blw.bodeneignung-gruendigkeit_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-gruendigkeit_cache]
+  ch.blw.bodeneignung-kulturland_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-kulturland]
+  ch.blw.bodeneignung-kulturland_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturland_cache]
+  ch.blw.bodeneignung-kulturland_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturland_cache]
+  ch.blw.bodeneignung-kulturland_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturland_cache]
+  ch.blw.bodeneignung-kulturland_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturland_cache]
+  ch.blw.bodeneignung-kulturtyp_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-kulturtyp]
+  ch.blw.bodeneignung-kulturtyp_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturtyp_cache]
+  ch.blw.bodeneignung-kulturtyp_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturtyp_cache]
+  ch.blw.bodeneignung-kulturtyp_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturtyp_cache]
+  ch.blw.bodeneignung-kulturtyp_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-kulturtyp_cache]
+  ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen]
+  ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache]
+  ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache]
+  ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache]
+  ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache]
+  ch.blw.bodeneignung-skelettgehalt_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-skelettgehalt]
+  ch.blw.bodeneignung-skelettgehalt_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-skelettgehalt_cache]
+  ch.blw.bodeneignung-skelettgehalt_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-skelettgehalt_cache]
+  ch.blw.bodeneignung-skelettgehalt_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-skelettgehalt_cache]
+  ch.blw.bodeneignung-skelettgehalt_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-skelettgehalt_cache]
+  ch.blw.bodeneignung-vernaessung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-vernaessung]
+  ch.blw.bodeneignung-vernaessung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-vernaessung_cache]
+  ch.blw.bodeneignung-vernaessung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-vernaessung_cache]
+  ch.blw.bodeneignung-vernaessung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-vernaessung_cache]
+  ch.blw.bodeneignung-vernaessung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-vernaessung_cache]
+  ch.blw.bodeneignung-wasserdurchlaessigkeit_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit]
+  ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache]
+  ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache]
+  ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache]
+  ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache]
+  ch.blw.bodeneignung-wasserspeichervermoegen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.bodeneignung-wasserspeichervermoegen]
+  ch.blw.bodeneignung-wasserspeichervermoegen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache]
+  ch.blw.bodeneignung-wasserspeichervermoegen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache]
+  ch.blw.bodeneignung-wasserspeichervermoegen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache]
+  ch.blw.bodeneignung-wasserspeichervermoegen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache]
+  ch.blw.erosion-mit_bergzonen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.erosion-mit_bergzonen]
+  ch.blw.erosion-mit_bergzonen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-mit_bergzonen_cache]
+  ch.blw.erosion-mit_bergzonen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-mit_bergzonen_cache]
+  ch.blw.erosion-mit_bergzonen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-mit_bergzonen_cache]
+  ch.blw.erosion-mit_bergzonen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-mit_bergzonen_cache]
+  ch.blw.erosion-quantitativ_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.erosion-quantitativ]
+  ch.blw.erosion-quantitativ_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-quantitativ_cache]
+  ch.blw.erosion-quantitativ_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-quantitativ_cache]
+  ch.blw.erosion-quantitativ_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-quantitativ_cache]
+  ch.blw.erosion-quantitativ_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion-quantitativ_cache]
+  ch.blw.erosion_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.erosion]
+  ch.blw.erosion_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion_cache]
+  ch.blw.erosion_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion_cache]
+  ch.blw.erosion_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion_cache]
+  ch.blw.erosion_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.erosion_cache]
+  ch.blw.feldblockkarte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.feldblockkarte]
+  ch.blw.feldblockkarte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.feldblockkarte_cache]
+  ch.blw.feldblockkarte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.feldblockkarte_cache]
+  ch.blw.feldblockkarte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.feldblockkarte_cache]
+  ch.blw.feldblockkarte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.feldblockkarte_cache]
+  ch.blw.gewaesseranschlusskarte-direkt_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.gewaesseranschlusskarte-direkt]
+  ch.blw.gewaesseranschlusskarte-direkt_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte-direkt_cache]
+  ch.blw.gewaesseranschlusskarte-direkt_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte-direkt_cache]
+  ch.blw.gewaesseranschlusskarte-direkt_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte-direkt_cache]
+  ch.blw.gewaesseranschlusskarte-direkt_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte-direkt_cache]
+  ch.blw.gewaesseranschlusskarte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.gewaesseranschlusskarte]
+  ch.blw.gewaesseranschlusskarte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte_cache]
+  ch.blw.gewaesseranschlusskarte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte_cache]
+  ch.blw.gewaesseranschlusskarte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte_cache]
+  ch.blw.gewaesseranschlusskarte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.gewaesseranschlusskarte_cache]
+  ch.blw.hang_steillagen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.hang_steillagen]
+  ch.blw.hang_steillagen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.hang_steillagen_cache]
+  ch.blw.hang_steillagen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.hang_steillagen_cache]
+  ch.blw.hang_steillagen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.hang_steillagen_cache]
+  ch.blw.hang_steillagen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.hang_steillagen_cache]
+  ch.blw.klimaeignung-futterbau_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-futterbau]
+  ch.blw.klimaeignung-futterbau_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-futterbau_cache]
+  ch.blw.klimaeignung-futterbau_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-futterbau_cache]
+  ch.blw.klimaeignung-futterbau_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-futterbau_cache]
+  ch.blw.klimaeignung-futterbau_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-futterbau_cache]
+  ch.blw.klimaeignung-getreidebau_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-getreidebau]
+  ch.blw.klimaeignung-getreidebau_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-getreidebau_cache]
+  ch.blw.klimaeignung-getreidebau_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-getreidebau_cache]
+  ch.blw.klimaeignung-getreidebau_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-getreidebau_cache]
+  ch.blw.klimaeignung-getreidebau_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-getreidebau_cache]
+  ch.blw.klimaeignung-kartoffeln_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-kartoffeln]
+  ch.blw.klimaeignung-kartoffeln_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kartoffeln_cache]
+  ch.blw.klimaeignung-kartoffeln_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kartoffeln_cache]
+  ch.blw.klimaeignung-kartoffeln_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kartoffeln_cache]
+  ch.blw.klimaeignung-kartoffeln_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kartoffeln_cache]
+  ch.blw.klimaeignung-koernermais_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-koernermais]
+  ch.blw.klimaeignung-koernermais_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-koernermais_cache]
+  ch.blw.klimaeignung-koernermais_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-koernermais_cache]
+  ch.blw.klimaeignung-koernermais_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-koernermais_cache]
+  ch.blw.klimaeignung-koernermais_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-koernermais_cache]
+  ch.blw.klimaeignung-kulturland_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-kulturland]
+  ch.blw.klimaeignung-kulturland_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kulturland_cache]
+  ch.blw.klimaeignung-kulturland_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kulturland_cache]
+  ch.blw.klimaeignung-kulturland_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kulturland_cache]
+  ch.blw.klimaeignung-kulturland_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-kulturland_cache]
+  ch.blw.klimaeignung-spezialkulturen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-spezialkulturen]
+  ch.blw.klimaeignung-spezialkulturen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-spezialkulturen_cache]
+  ch.blw.klimaeignung-spezialkulturen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-spezialkulturen_cache]
+  ch.blw.klimaeignung-spezialkulturen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-spezialkulturen_cache]
+  ch.blw.klimaeignung-spezialkulturen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-spezialkulturen_cache]
+  ch.blw.klimaeignung-typ_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-typ]
+  ch.blw.klimaeignung-typ_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-typ_cache]
+  ch.blw.klimaeignung-typ_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-typ_cache]
+  ch.blw.klimaeignung-typ_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-typ_cache]
+  ch.blw.klimaeignung-typ_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-typ_cache]
+  ch.blw.klimaeignung-zwischenfruchtbau_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.klimaeignung-zwischenfruchtbau]
+  ch.blw.klimaeignung-zwischenfruchtbau_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache]
+  ch.blw.klimaeignung-zwischenfruchtbau_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache]
+  ch.blw.klimaeignung-zwischenfruchtbau_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache]
+  ch.blw.klimaeignung-zwischenfruchtbau_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache]
+  ch.blw.landwirtschaftliche-zonengrenzen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.landwirtschaftliche-zonengrenzen]
+  ch.blw.landwirtschaftliche-zonengrenzen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache]
+  ch.blw.landwirtschaftliche-zonengrenzen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache]
+  ch.blw.landwirtschaftliche-zonengrenzen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache]
+  ch.blw.landwirtschaftliche-zonengrenzen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache]
+  ch.blw.niederschlagshaushalt_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.niederschlagshaushalt]
+  ch.blw.niederschlagshaushalt_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.niederschlagshaushalt_cache]
+  ch.blw.niederschlagshaushalt_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.niederschlagshaushalt_cache]
+  ch.blw.niederschlagshaushalt_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.niederschlagshaushalt_cache]
+  ch.blw.niederschlagshaushalt_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.niederschlagshaushalt_cache]
+  ch.blw.steil_terrassenlagen_rebbau_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.steil_terrassenlagen_rebbau]
+  ch.blw.steil_terrassenlagen_rebbau_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.steil_terrassenlagen_rebbau_cache]
+  ch.blw.steil_terrassenlagen_rebbau_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.steil_terrassenlagen_rebbau_cache]
+  ch.blw.steil_terrassenlagen_rebbau_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.steil_terrassenlagen_rebbau_cache]
+  ch.blw.steil_terrassenlagen_rebbau_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.steil_terrassenlagen_rebbau_cache]
+  ch.blw.ursprungsbezeichnungen-fleisch_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.ursprungsbezeichnungen-fleisch]
+  ch.blw.ursprungsbezeichnungen-fleisch_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache]
+  ch.blw.ursprungsbezeichnungen-fleisch_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache]
+  ch.blw.ursprungsbezeichnungen-fleisch_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache]
+  ch.blw.ursprungsbezeichnungen-fleisch_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache]
+  ch.blw.ursprungsbezeichnungen-kaese_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.ursprungsbezeichnungen-kaese]
+  ch.blw.ursprungsbezeichnungen-kaese_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-kaese_cache]
+  ch.blw.ursprungsbezeichnungen-kaese_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-kaese_cache]
+  ch.blw.ursprungsbezeichnungen-kaese_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-kaese_cache]
+  ch.blw.ursprungsbezeichnungen-kaese_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-kaese_cache]
+  ch.blw.ursprungsbezeichnungen-pflanzen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.ursprungsbezeichnungen-pflanzen]
+  ch.blw.ursprungsbezeichnungen-pflanzen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache]
+  ch.blw.ursprungsbezeichnungen-pflanzen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache]
+  ch.blw.ursprungsbezeichnungen-pflanzen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache]
+  ch.blw.ursprungsbezeichnungen-pflanzen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache]
+  ch.blw.ursprungsbezeichnungen-spirituosen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.ursprungsbezeichnungen-spirituosen]
+  ch.blw.ursprungsbezeichnungen-spirituosen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache]
+  ch.blw.ursprungsbezeichnungen-spirituosen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache]
+  ch.blw.ursprungsbezeichnungen-spirituosen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache]
+  ch.blw.ursprungsbezeichnungen-spirituosen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache]
+  ch.ensi.zonenplan-notfallschutz-kernanlagen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen]
+  ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache]
+  ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache]
+  ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache]
+  ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache]
+  ch.kantone.ivs-reg_loc_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.kantone.ivs-reg_loc]
+  ch.kantone.ivs-reg_loc_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.kantone.ivs-reg_loc_cache]
+  ch.kantone.ivs-reg_loc_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.kantone.ivs-reg_loc_cache]
+  ch.kantone.ivs-reg_loc_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.kantone.ivs-reg_loc_cache]
+  ch.kantone.ivs-reg_loc_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.kantone.ivs-reg_loc_cache]
+  ch.swisstopo-vd.spannungsarme-gebiete_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo-vd.spannungsarme-gebiete]
+  ch.swisstopo-vd.spannungsarme-gebiete_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache]
+  ch.swisstopo-vd.spannungsarme-gebiete_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache]
+  ch.swisstopo-vd.spannungsarme-gebiete_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache]
+  ch.swisstopo-vd.spannungsarme-gebiete_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache]
+  ch.swisstopo.dreiecksvermaschung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.dreiecksvermaschung]
+  ch.swisstopo.dreiecksvermaschung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.dreiecksvermaschung_cache]
+  ch.swisstopo.dreiecksvermaschung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.dreiecksvermaschung_cache]
+  ch.swisstopo.dreiecksvermaschung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.dreiecksvermaschung_cache]
+  ch.swisstopo.dreiecksvermaschung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.dreiecksvermaschung_cache]
+  ch.swisstopo.fixpunkte-agnes_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.fixpunkte-agnes]
+  ch.swisstopo.fixpunkte-agnes_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-agnes_cache]
+  ch.swisstopo.fixpunkte-agnes_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-agnes_cache]
+  ch.swisstopo.fixpunkte-agnes_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-agnes_cache]
+  ch.swisstopo.fixpunkte-agnes_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-agnes_cache]
+  ch.swisstopo.fixpunkte-hfp1_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.fixpunkte-hfp1]
+  ch.swisstopo.fixpunkte-hfp1_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp1_cache]
+  ch.swisstopo.fixpunkte-hfp1_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp1_cache]
+  ch.swisstopo.fixpunkte-hfp1_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp1_cache]
+  ch.swisstopo.fixpunkte-hfp1_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp1_cache]
+  ch.swisstopo.fixpunkte-hfp2_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.fixpunkte-hfp2]
+  ch.swisstopo.fixpunkte-hfp2_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp2_cache]
+  ch.swisstopo.fixpunkte-hfp2_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp2_cache]
+  ch.swisstopo.fixpunkte-hfp2_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp2_cache]
+  ch.swisstopo.fixpunkte-hfp2_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-hfp2_cache]
+  ch.swisstopo.fixpunkte-lfp1_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.fixpunkte-lfp1]
+  ch.swisstopo.fixpunkte-lfp1_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp1_cache]
+  ch.swisstopo.fixpunkte-lfp1_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp1_cache]
+  ch.swisstopo.fixpunkte-lfp1_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp1_cache]
+  ch.swisstopo.fixpunkte-lfp1_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp1_cache]
+  ch.swisstopo.fixpunkte-lfp2_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.fixpunkte-lfp2]
+  ch.swisstopo.fixpunkte-lfp2_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp2_cache]
+  ch.swisstopo.fixpunkte-lfp2_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp2_cache]
+  ch.swisstopo.fixpunkte-lfp2_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp2_cache]
+  ch.swisstopo.fixpunkte-lfp2_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.fixpunkte-lfp2_cache]
+  ch.swisstopo.geoidmodell-ch1903_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geoidmodell-ch1903]
+  ch.swisstopo.geoidmodell-ch1903_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-ch1903_cache]
+  ch.swisstopo.geoidmodell-ch1903_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-ch1903_cache]
+  ch.swisstopo.geoidmodell-ch1903_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-ch1903_cache]
+  ch.swisstopo.geoidmodell-ch1903_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-ch1903_cache]
+  ch.swisstopo.geoidmodell-etrs89_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geoidmodell-etrs89]
+  ch.swisstopo.geoidmodell-etrs89_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-etrs89_cache]
+  ch.swisstopo.geoidmodell-etrs89_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-etrs89_cache]
+  ch.swisstopo.geoidmodell-etrs89_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-etrs89_cache]
+  ch.swisstopo.geoidmodell-etrs89_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geoidmodell-etrs89_cache]
+  ch.swisstopo.geologie-eiszeit-lgm-raster_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-eiszeit-lgm-raster]
+  ch.swisstopo.geologie-eiszeit-lgm-raster_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache]
+  ch.swisstopo.geologie-eiszeit-lgm-raster_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache]
+  ch.swisstopo.geologie-eiszeit-lgm-raster_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache]
+  ch.swisstopo.geologie-eiszeit-lgm-raster_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache]
+  ch.swisstopo.geologie-generalkarte-ggk200_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-generalkarte-ggk200]
+  ch.swisstopo.geologie-generalkarte-ggk200_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache]
+  ch.swisstopo.geologie-generalkarte-ggk200_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache]
+  ch.swisstopo.geologie-generalkarte-ggk200_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache]
+  ch.swisstopo.geologie-generalkarte-ggk200_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache]
+  ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien]
+  ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache]
+  ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache]
+  ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache]
+  ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache]
+  ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien]
+  ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache]
+  ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache]
+  ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache]
+  ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache]
+  ch.swisstopo.geologie-geolkarten500.metadata_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geolkarten500.metadata]
+  ch.swisstopo.geologie-geolkarten500.metadata_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache]
+  ch.swisstopo.geologie-geolkarten500.metadata_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache]
+  ch.swisstopo.geologie-geolkarten500.metadata_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache]
+  ch.swisstopo.geologie-geolkarten500.metadata_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache]
+  ch.swisstopo.geologie-geologische_karte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geologische_karte]
+  ch.swisstopo.geologie-geologische_karte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologische_karte_cache]
+  ch.swisstopo.geologie-geologische_karte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologische_karte_cache]
+  ch.swisstopo.geologie-geologische_karte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologische_karte_cache]
+  ch.swisstopo.geologie-geologische_karte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologische_karte_cache]
+  ch.swisstopo.geologie-geologischer_atlas_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geologischer_atlas]
+  ch.swisstopo.geologie-geologischer_atlas_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologischer_atlas_cache]
+  ch.swisstopo.geologie-geologischer_atlas_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologischer_atlas_cache]
+  ch.swisstopo.geologie-geologischer_atlas_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologischer_atlas_cache]
+  ch.swisstopo.geologie-geologischer_atlas_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geologischer_atlas_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache]
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache]
+  ch.swisstopo.geologie-geophysik-deklination_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geophysik-deklination]
+  ch.swisstopo.geologie-geophysik-deklination_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-deklination_cache]
+  ch.swisstopo.geologie-geophysik-deklination_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-deklination_cache]
+  ch.swisstopo.geologie-geophysik-deklination_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-deklination_cache]
+  ch.swisstopo.geologie-geophysik-deklination_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-deklination_cache]
+  ch.swisstopo.geologie-geophysik-geothermie_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geophysik-geothermie]
+  ch.swisstopo.geologie-geophysik-geothermie_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-geothermie_cache]
+  ch.swisstopo.geologie-geophysik-geothermie_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-geothermie_cache]
+  ch.swisstopo.geologie-geophysik-geothermie_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-geothermie_cache]
+  ch.swisstopo.geologie-geophysik-geothermie_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-geothermie_cache]
+  ch.swisstopo.geologie-geophysik-inklination_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geophysik-inklination]
+  ch.swisstopo.geologie-geophysik-inklination_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-inklination_cache]
+  ch.swisstopo.geologie-geophysik-inklination_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-inklination_cache]
+  ch.swisstopo.geologie-geophysik-inklination_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-inklination_cache]
+  ch.swisstopo.geologie-geophysik-inklination_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-inklination_cache]
+  ch.swisstopo.geologie-geophysik-totalintensitaet_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geophysik-totalintensitaet]
+  ch.swisstopo.geologie-geophysik-totalintensitaet_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache]
+  ch.swisstopo.geologie-geophysik-totalintensitaet_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache]
+  ch.swisstopo.geologie-geophysik-totalintensitaet_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache]
+  ch.swisstopo.geologie-geophysik-totalintensitaet_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache]
+  ch.swisstopo.geologie-geotechnik-gk200_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-gk200]
+  ch.swisstopo.geologie-geotechnik-gk200_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk200_cache]
+  ch.swisstopo.geologie-geotechnik-gk200_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk200_cache]
+  ch.swisstopo.geologie-geotechnik-gk200_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk200_cache]
+  ch.swisstopo.geologie-geotechnik-gk200_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk200_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-genese_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-genese]
+  ch.swisstopo.geologie-geotechnik-gk500-genese_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-genese_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-genese_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-genese_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung]
+  ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen]
+  ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache]
+  ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache]
+  ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200]
+  ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache]
+  ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache]
+  ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache]
+  ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache]
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache]
+  ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke]
+  ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache]
+  ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache]
+  ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache]
+  ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache]
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache]
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache]
+  ch.swisstopo.geologie-geotope_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-geotope]
+  ch.swisstopo.geologie-geotope_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotope_cache]
+  ch.swisstopo.geologie-geotope_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotope_cache]
+  ch.swisstopo.geologie-geotope_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotope_cache]
+  ch.swisstopo.geologie-geotope_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-geotope_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata]
+  ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas]
+  ch.swisstopo.geologie-gravimetrischer_atlas_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache]
+  ch.swisstopo.geologie-gravimetrischer_atlas_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache]
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache]
+  ch.swisstopo.geologie-rohstoffe-industrieminerale_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale]
+  ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache]
+  ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache]
+  ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache]
+  ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache]
+  ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas]
+  ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache]
+  ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache]
+  ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache]
+  ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache]
+  ch.swisstopo.geologie-rohstoffe-vererzungen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-rohstoffe-vererzungen]
+  ch.swisstopo.geologie-rohstoffe-vererzungen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache]
+  ch.swisstopo.geologie-rohstoffe-vererzungen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache]
+  ch.swisstopo.geologie-rohstoffe-vererzungen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache]
+  ch.swisstopo.geologie-rohstoffe-vererzungen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache]
+  ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata]
+  ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache]
+  ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache]
+  ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache]
+  ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache]
+  ch.swisstopo.geologie-tektonische_karte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.geologie-tektonische_karte]
+  ch.swisstopo.geologie-tektonische_karte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-tektonische_karte_cache]
+  ch.swisstopo.geologie-tektonische_karte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-tektonische_karte_cache]
+  ch.swisstopo.geologie-tektonische_karte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-tektonische_karte_cache]
+  ch.swisstopo.geologie-tektonische_karte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.geologie-tektonische_karte_cache]
+  ch.swisstopo.hangneigung-ueber_30_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.hangneigung-ueber_30]
+  ch.swisstopo.hangneigung-ueber_30_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hangneigung-ueber_30_cache]
+  ch.swisstopo.hangneigung-ueber_30_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hangneigung-ueber_30_cache]
+  ch.swisstopo.hangneigung-ueber_30_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hangneigung-ueber_30_cache]
+  ch.swisstopo.hangneigung-ueber_30_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hangneigung-ueber_30_cache]
+  ch.swisstopo.hiks-dufour-timeseries_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.hiks-dufour-timeseries]
+  ch.swisstopo.hiks-dufour-timeseries_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour-timeseries_cache]
+  ch.swisstopo.hiks-dufour-timeseries_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour-timeseries_cache]
+  ch.swisstopo.hiks-dufour-timeseries_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour-timeseries_cache]
+  ch.swisstopo.hiks-dufour-timeseries_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour-timeseries_cache]
+  ch.swisstopo.hiks-dufour_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.hiks-dufour]
+  ch.swisstopo.hiks-dufour_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour_cache]
+  ch.swisstopo.hiks-dufour_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour_cache]
+  ch.swisstopo.hiks-dufour_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour_cache]
+  ch.swisstopo.hiks-dufour_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-dufour_cache]
+  ch.swisstopo.hiks-siegfried-ta25_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.hiks-siegfried-ta25]
+  ch.swisstopo.hiks-siegfried-ta25_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta25_cache]
+  ch.swisstopo.hiks-siegfried-ta25_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta25_cache]
+  ch.swisstopo.hiks-siegfried-ta25_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta25_cache]
+  ch.swisstopo.hiks-siegfried-ta25_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta25_cache]
+  ch.swisstopo.hiks-siegfried-ta50_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.hiks-siegfried-ta50]
+  ch.swisstopo.hiks-siegfried-ta50_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta50_cache]
+  ch.swisstopo.hiks-siegfried-ta50_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta50_cache]
+  ch.swisstopo.hiks-siegfried-ta50_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta50_cache]
+  ch.swisstopo.hiks-siegfried-ta50_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried-ta50_cache]
+  ch.swisstopo.hiks-siegfried_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.hiks-siegfried]
+  ch.swisstopo.hiks-siegfried_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried_cache]
+  ch.swisstopo.hiks-siegfried_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried_cache]
+  ch.swisstopo.hiks-siegfried_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried_cache]
+  ch.swisstopo.hiks-siegfried_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.hiks-siegfried_cache]
+  ch.swisstopo.koordinatenaenderung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.koordinatenaenderung]
+  ch.swisstopo.koordinatenaenderung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.koordinatenaenderung_cache]
+  ch.swisstopo.koordinatenaenderung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.koordinatenaenderung_cache]
+  ch.swisstopo.koordinatenaenderung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.koordinatenaenderung_cache]
+  ch.swisstopo.koordinatenaenderung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.koordinatenaenderung_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-firmen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen]
+  ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-kantone_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone]
+  ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache]
+  ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache]
+  ch.swisstopo.lubis-luftbilder_farbe_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.lubis-luftbilder_farbe]
+  ch.swisstopo.lubis-luftbilder_farbe_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_farbe_cache]
+  ch.swisstopo.lubis-luftbilder_farbe_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_farbe_cache]
+  ch.swisstopo.lubis-luftbilder_farbe_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_farbe_cache]
+  ch.swisstopo.lubis-luftbilder_farbe_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_farbe_cache]
+  ch.swisstopo.lubis-luftbilder_infrarot_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.lubis-luftbilder_infrarot]
+  ch.swisstopo.lubis-luftbilder_infrarot_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache]
+  ch.swisstopo.lubis-luftbilder_infrarot_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache]
+  ch.swisstopo.lubis-luftbilder_infrarot_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache]
+  ch.swisstopo.lubis-luftbilder_infrarot_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache]
+  ch.swisstopo.lubis-luftbilder_schwarzweiss_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss]
+  ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache]
+  ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache]
+  ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache]
+  ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache]
+  ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale]
+  ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale]
+  ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale]
+  ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale]
+  ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale]
+  ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale]
+  ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache]
+  ch.swisstopo.pixelkarte-farbe_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-farbe]
+  ch.swisstopo.pixelkarte-farbe_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe_cache]
+  ch.swisstopo.pixelkarte-farbe_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe_cache]
+  ch.swisstopo.pixelkarte-farbe_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe_cache]
+  ch.swisstopo.pixelkarte-farbe_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-farbe_cache]
+  ch.swisstopo.pixelkarte-grau_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.pixelkarte-grau]
+  ch.swisstopo.pixelkarte-grau_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-grau_cache]
+  ch.swisstopo.pixelkarte-grau_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-grau_cache]
+  ch.swisstopo.pixelkarte-grau_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-grau_cache]
+  ch.swisstopo.pixelkarte-grau_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.pixelkarte-grau_cache]
+  ch.swisstopo.swissalti3d-reliefschattierung_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissalti3d-reliefschattierung]
+  ch.swisstopo.swissalti3d-reliefschattierung_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache]
+  ch.swisstopo.swissalti3d-reliefschattierung_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache]
+  ch.swisstopo.swissalti3d-reliefschattierung_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache]
+  ch.swisstopo.swissalti3d-reliefschattierung_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache]
+  ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill]
+  ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill]
+  ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill]
+  ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill]
+  ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache]
+  ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache]
+  ch.swisstopo.swissbuildings3d_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissbuildings3d]
+  ch.swisstopo.swissbuildings3d_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissbuildings3d_cache]
+  ch.swisstopo.swissbuildings3d_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissbuildings3d_cache]
+  ch.swisstopo.swissbuildings3d_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissbuildings3d_cache]
+  ch.swisstopo.swissbuildings3d_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissbuildings3d_cache]
+  ch.swisstopo.swissimage_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissimage]
+  ch.swisstopo.swissimage_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissimage_cache]
+  ch.swisstopo.swissimage_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissimage_cache]
+  ch.swisstopo.swissimage_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissimage_cache]
+  ch.swisstopo.swissimage_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swissimage_cache]
+  ch.swisstopo.swisstlm3d-karte-farbe_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swisstlm3d-karte-farbe]
+  ch.swisstopo.swisstlm3d-karte-farbe_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache]
+  ch.swisstopo.swisstlm3d-karte-farbe_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache]
+  ch.swisstopo.swisstlm3d-karte-farbe_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache]
+  ch.swisstopo.swisstlm3d-karte-farbe_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache]
+  ch.swisstopo.swisstlm3d-karte-grau_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swisstlm3d-karte-grau]
+  ch.swisstopo.swisstlm3d-karte-grau_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-grau_cache]
+  ch.swisstopo.swisstlm3d-karte-grau_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-grau_cache]
+  ch.swisstopo.swisstlm3d-karte-grau_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-grau_cache]
+  ch.swisstopo.swisstlm3d-karte-grau_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-karte-grau_cache]
+  ch.swisstopo.swisstlm3d-wanderwege_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swisstlm3d-wanderwege]
+  ch.swisstopo.swisstlm3d-wanderwege_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-wanderwege_cache]
+  ch.swisstopo.swisstlm3d-wanderwege_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-wanderwege_cache]
+  ch.swisstopo.swisstlm3d-wanderwege_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-wanderwege_cache]
+  ch.swisstopo.swisstlm3d-wanderwege_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.swisstlm3d-wanderwege_cache]
+  ch.swisstopo.transformationsgenauigkeit_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.transformationsgenauigkeit]
+  ch.swisstopo.transformationsgenauigkeit_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.transformationsgenauigkeit_cache]
+  ch.swisstopo.transformationsgenauigkeit_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.transformationsgenauigkeit_cache]
+  ch.swisstopo.transformationsgenauigkeit_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.transformationsgenauigkeit_cache]
+  ch.swisstopo.transformationsgenauigkeit_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.transformationsgenauigkeit_cache]
+  ch.swisstopo.treasurehunt_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.treasurehunt]
+  ch.swisstopo.treasurehunt_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.treasurehunt_cache]
+  ch.swisstopo.treasurehunt_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.treasurehunt_cache]
+  ch.swisstopo.treasurehunt_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.treasurehunt_cache]
+  ch.swisstopo.treasurehunt_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.treasurehunt_cache]
+  ch.swisstopo.vec200-adminboundaries-protectedarea_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-adminboundaries-protectedarea]
+  ch.swisstopo.vec200-adminboundaries-protectedarea_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache]
+  ch.swisstopo.vec200-adminboundaries-protectedarea_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache]
+  ch.swisstopo.vec200-adminboundaries-protectedarea_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache]
+  ch.swisstopo.vec200-adminboundaries-protectedarea_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache]
+  ch.swisstopo.vec200-building_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-building]
+  ch.swisstopo.vec200-building_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-building_cache]
+  ch.swisstopo.vec200-building_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-building_cache]
+  ch.swisstopo.vec200-building_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-building_cache]
+  ch.swisstopo.vec200-building_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-building_cache]
+  ch.swisstopo.vec200-hydrography_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-hydrography]
+  ch.swisstopo.vec200-hydrography_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-hydrography_cache]
+  ch.swisstopo.vec200-hydrography_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-hydrography_cache]
+  ch.swisstopo.vec200-hydrography_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-hydrography_cache]
+  ch.swisstopo.vec200-hydrography_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-hydrography_cache]
+  ch.swisstopo.vec200-landcover-wald_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-landcover-wald]
+  ch.swisstopo.vec200-landcover-wald_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover-wald_cache]
+  ch.swisstopo.vec200-landcover-wald_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover-wald_cache]
+  ch.swisstopo.vec200-landcover-wald_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover-wald_cache]
+  ch.swisstopo.vec200-landcover-wald_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover-wald_cache]
+  ch.swisstopo.vec200-landcover_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-landcover]
+  ch.swisstopo.vec200-landcover_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover_cache]
+  ch.swisstopo.vec200-landcover_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover_cache]
+  ch.swisstopo.vec200-landcover_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover_cache]
+  ch.swisstopo.vec200-landcover_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-landcover_cache]
+  ch.swisstopo.vec200-miscellaneous-geodpoint_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-miscellaneous-geodpoint]
+  ch.swisstopo.vec200-miscellaneous-geodpoint_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache]
+  ch.swisstopo.vec200-miscellaneous-geodpoint_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache]
+  ch.swisstopo.vec200-miscellaneous-geodpoint_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache]
+  ch.swisstopo.vec200-miscellaneous-geodpoint_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache]
+  ch.swisstopo.vec200-miscellaneous_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-miscellaneous]
+  ch.swisstopo.vec200-miscellaneous_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous_cache]
+  ch.swisstopo.vec200-miscellaneous_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous_cache]
+  ch.swisstopo.vec200-miscellaneous_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous_cache]
+  ch.swisstopo.vec200-miscellaneous_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-miscellaneous_cache]
+  ch.swisstopo.vec200-names-namedlocation_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-names-namedlocation]
+  ch.swisstopo.vec200-names-namedlocation_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-names-namedlocation_cache]
+  ch.swisstopo.vec200-names-namedlocation_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-names-namedlocation_cache]
+  ch.swisstopo.vec200-names-namedlocation_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-names-namedlocation_cache]
+  ch.swisstopo.vec200-names-namedlocation_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-names-namedlocation_cache]
+  ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr]
+  ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache]
+  ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache]
+  ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache]
+  ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache]
+  ch.swisstopo.vec200-transportation-strassennetz_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec200-transportation-strassennetz]
+  ch.swisstopo.vec200-transportation-strassennetz_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-strassennetz_cache]
+  ch.swisstopo.vec200-transportation-strassennetz_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-strassennetz_cache]
+  ch.swisstopo.vec200-transportation-strassennetz_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-strassennetz_cache]
+  ch.swisstopo.vec200-transportation-strassennetz_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec200-transportation-strassennetz_cache]
+  ch.swisstopo.vec25-anlagen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-anlagen]
+  ch.swisstopo.vec25-anlagen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-anlagen_cache]
+  ch.swisstopo.vec25-anlagen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-anlagen_cache]
+  ch.swisstopo.vec25-anlagen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-anlagen_cache]
+  ch.swisstopo.vec25-anlagen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-anlagen_cache]
+  ch.swisstopo.vec25-einzelobjekte_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-einzelobjekte]
+  ch.swisstopo.vec25-einzelobjekte_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-einzelobjekte_cache]
+  ch.swisstopo.vec25-einzelobjekte_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-einzelobjekte_cache]
+  ch.swisstopo.vec25-einzelobjekte_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-einzelobjekte_cache]
+  ch.swisstopo.vec25-einzelobjekte_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-einzelobjekte_cache]
+  ch.swisstopo.vec25-eisenbahnnetz_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-eisenbahnnetz]
+  ch.swisstopo.vec25-eisenbahnnetz_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-eisenbahnnetz_cache]
+  ch.swisstopo.vec25-eisenbahnnetz_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-eisenbahnnetz_cache]
+  ch.swisstopo.vec25-eisenbahnnetz_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-eisenbahnnetz_cache]
+  ch.swisstopo.vec25-eisenbahnnetz_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-eisenbahnnetz_cache]
+  ch.swisstopo.vec25-gebaeude_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-gebaeude]
+  ch.swisstopo.vec25-gebaeude_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gebaeude_cache]
+  ch.swisstopo.vec25-gebaeude_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gebaeude_cache]
+  ch.swisstopo.vec25-gebaeude_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gebaeude_cache]
+  ch.swisstopo.vec25-gebaeude_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gebaeude_cache]
+  ch.swisstopo.vec25-gewaessernetz_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-gewaessernetz]
+  ch.swisstopo.vec25-gewaessernetz_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gewaessernetz_cache]
+  ch.swisstopo.vec25-gewaessernetz_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gewaessernetz_cache]
+  ch.swisstopo.vec25-gewaessernetz_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gewaessernetz_cache]
+  ch.swisstopo.vec25-gewaessernetz_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-gewaessernetz_cache]
+  ch.swisstopo.vec25-heckenbaeume_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-heckenbaeume]
+  ch.swisstopo.vec25-heckenbaeume_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-heckenbaeume_cache]
+  ch.swisstopo.vec25-heckenbaeume_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-heckenbaeume_cache]
+  ch.swisstopo.vec25-heckenbaeume_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-heckenbaeume_cache]
+  ch.swisstopo.vec25-heckenbaeume_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-heckenbaeume_cache]
+  ch.swisstopo.vec25-primaerflaechen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-primaerflaechen]
+  ch.swisstopo.vec25-primaerflaechen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-primaerflaechen_cache]
+  ch.swisstopo.vec25-primaerflaechen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-primaerflaechen_cache]
+  ch.swisstopo.vec25-primaerflaechen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-primaerflaechen_cache]
+  ch.swisstopo.vec25-primaerflaechen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-primaerflaechen_cache]
+  ch.swisstopo.vec25-strassennetz_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-strassennetz]
+  ch.swisstopo.vec25-strassennetz_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-strassennetz_cache]
+  ch.swisstopo.vec25-strassennetz_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-strassennetz_cache]
+  ch.swisstopo.vec25-strassennetz_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-strassennetz_cache]
+  ch.swisstopo.vec25-strassennetz_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-strassennetz_cache]
+  ch.swisstopo.vec25-uebrigerverkehr_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.vec25-uebrigerverkehr]
+  ch.swisstopo.vec25-uebrigerverkehr_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-uebrigerverkehr_cache]
+  ch.swisstopo.vec25-uebrigerverkehr_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-uebrigerverkehr_cache]
+  ch.swisstopo.vec25-uebrigerverkehr_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-uebrigerverkehr_cache]
+  ch.swisstopo.vec25-uebrigerverkehr_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.vec25-uebrigerverkehr_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp1_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp1]
+  ch.swisstopo.verschiebungsvektoren-tsp1_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp1_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp1_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp1_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp2_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp2]
+  ch.swisstopo.verschiebungsvektoren-tsp2_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp2_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp2_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache]
+  ch.swisstopo.verschiebungsvektoren-tsp2_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache]
+  ch.swisstopo.zeitreihen_cache:
+    disable_storage: true
+    format: image/jpeg
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen]
+  ch.swisstopo.zeitreihen_cache_etrs89:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.zeitreihen_cache]
+  ch.swisstopo.zeitreihen_cache_lv95:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.zeitreihen_cache]
+  ch.swisstopo.zeitreihen_cache_mercator:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.zeitreihen_cache]
+  ch.swisstopo.zeitreihen_cache_wgs84:
+    disable_storage: true
+    format: image/jpeg
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.swisstopo.zeitreihen_cache]
+  ch.vbs.territorialregionen_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.vbs.territorialregionen]
+  ch.vbs.territorialregionen_cache_etrs89:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_etrs89]
+    meta_size: [4, 4]
+    sources: [ch.vbs.territorialregionen_cache]
+  ch.vbs.territorialregionen_cache_lv95:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_lv95]
+    meta_size: [4, 4]
+    sources: [ch.vbs.territorialregionen_cache]
+  ch.vbs.territorialregionen_cache_mercator:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_mercator]
+    meta_size: [4, 4]
+    sources: [ch.vbs.territorialregionen_cache]
+  ch.vbs.territorialregionen_cache_wgs84:
+    disable_storage: true
+    format: image/png
+    grids: [lowres_wgs84]
+    meta_size: [4, 4]
+    sources: [ch.vbs.territorialregionen_cache]
   osm_cache:
+    concurrent_tile_creators: 4
+    disable_storage: true
     grids: [global_mercator_osm]
     sources: [osm_tms]
-    disable_storage: true
-    concurrent_tile_creators: 4
     watermark:
-      text: '@ OpenStreetMap contributors'
+      color: [0, 0, 0]
       font_size: 14
       opacity: 100
-      color: [0,0,0]
-  tlm:
-    grids: [swisstopo-tlm]
-    sources: [tlm-tiles]
-    format: image/jpeg
-    disable_storage: true 
-    image:
-      resampling_method: nearest
-
+      text: '@ OpenStreetMap contributors'
+globals:
+  cache: {concurrent_tile_creators: 32}
+  image: {resampling_method: bicubic}
+grids:
+  global_mercator_osm: {base: GLOBAL_MERCATOR, num_levels: 18, origin: nw}
+  lowres_etrs89:
+    bbox: [420000, 30000, 900000, 350000]
+    bbox_srs: EPSG:21781
+    origin: nw
+    res: [1.40625, 0.00549316, 0.703125, 0.00274658, 0.3515625, 0.00137329, 0.17578125,
+      0.00068664, 0.08789062, 0.00034332, 0.04394531, 0.00017166, 0.02197266, 8.583e-05,
+      0.01098633, 4.292e-05, 2.146e-05, 1.073e-05, 5.36e-06, 2.68e-06, 1.34e-06, 6.7e-07]
+    srs: EPSG:4258
+    stretch_factor: 1.0
+  lowres_lv95:
+    bbox: [420000, 30000, 900000, 350000]
+    bbox_srs: EPSG:21781
+    origin: nw
+    res: [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
+      1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5]
+    srs: EPSG:2056
+    stretch_factor: 1.0
+  lowres_mercator: {base: GLOBAL_MERCATOR, num_levels: 18, origin: nw}
+  lowres_wgs84:
+    bbox: [420000, 30000, 900000, 350000]
+    bbox_srs: EPSG:21781
+    origin: nw
+    res: [1.40625, 0.00549316, 0.703125, 0.00274658, 0.3515625, 0.00137329, 0.17578125,
+      0.00068664, 0.08789062, 0.00034332, 0.04394531, 0.00017166, 0.02197266, 8.583e-05,
+      0.01098633, 4.292e-05, 2.146e-05, 1.073e-05, 5.36e-06, 2.68e-06, 1.34e-06, 6.7e-07]
+    srs: EPSG:4326
+    stretch_factor: 0.8
+  swisstopo-pixelkarte:
+    bbox: [420000, 30000, 900000, 350000]
+    bbox_srs: EPSG:21781
+    origin: nw
+    res: [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
+      1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5]
+    srs: EPSG:21781
+    stretch_factor: 1.0
+  swisstopo-swissimage:
+    bbox: [420000, 30000, 900000, 350000]
+    bbox_srs: EPSG:21781
+    origin: nw
+    res: [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
+      1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5, 0.25]
+    srs: EPSG:21781
+    stretch_factor: 1.0
+layers:
+- name: osm
+  sources: [osm_cache]
+  title: OpenStreetMap
+- dimensions: &id001
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.are.agglomerationen_isolierte_staedte.mercator
+  sources: [ch.are.agglomerationen_isolierte_staedte_cache_mercator]
+  title: "Agglomerationen und isolierte St\xE4dte"
+- dimensions: *id001
+  name: ch.are.agglomerationen_isolierte_staedte.etrs89
+  sources: [ch.are.agglomerationen_isolierte_staedte_cache_etrs89]
+  title: "Agglomerationen und isolierte St\xE4dte"
+- dimensions: *id001
+  name: ch.are.agglomerationen_isolierte_staedte.wgs84
+  sources: [ch.are.agglomerationen_isolierte_staedte_cache_wgs84]
+  title: "Agglomerationen und isolierte St\xE4dte"
+- dimensions: *id001
+  name: ch.are.agglomerationen_isolierte_staedte.lv95
+  sources: [ch.are.agglomerationen_isolierte_staedte_cache_lv95]
+  title: "Agglomerationen und isolierte St\xE4dte"
+- dimensions: *id001
+  name: ch.are.agglomerationen_isolierte_staedte
+  sources: [ch.are.agglomerationen_isolierte_staedte_cache]
+  title: "Agglomerationen und isolierte St\xE4dte"
+- dimensions: &id002
+    Time:
+      default: '20090101'
+      values: ['20090101']
+  name: ch.are.alpenkonvention.mercator
+  sources: [ch.are.alpenkonvention_cache_mercator]
+  title: Alpenkonvention
+- dimensions: *id002
+  name: ch.are.alpenkonvention.etrs89
+  sources: [ch.are.alpenkonvention_cache_etrs89]
+  title: Alpenkonvention
+- dimensions: *id002
+  name: ch.are.alpenkonvention.wgs84
+  sources: [ch.are.alpenkonvention_cache_wgs84]
+  title: Alpenkonvention
+- dimensions: *id002
+  name: ch.are.alpenkonvention.lv95
+  sources: [ch.are.alpenkonvention_cache_lv95]
+  title: Alpenkonvention
+- dimensions: *id002
+  name: ch.are.alpenkonvention
+  sources: [ch.are.alpenkonvention_cache]
+  title: Alpenkonvention
+- dimensions: &id003
+    Time:
+      default: '20120101'
+      values: ['20120101']
+  name: ch.are.bauzonen.mercator
+  sources: [ch.are.bauzonen_cache_mercator]
+  title: Bauzonen Schweiz (harmonisiert)
+- dimensions: *id003
+  name: ch.are.bauzonen.etrs89
+  sources: [ch.are.bauzonen_cache_etrs89]
+  title: Bauzonen Schweiz (harmonisiert)
+- dimensions: *id003
+  name: ch.are.bauzonen.wgs84
+  sources: [ch.are.bauzonen_cache_wgs84]
+  title: Bauzonen Schweiz (harmonisiert)
+- dimensions: *id003
+  name: ch.are.bauzonen.lv95
+  sources: [ch.are.bauzonen_cache_lv95]
+  title: Bauzonen Schweiz (harmonisiert)
+- dimensions: *id003
+  name: ch.are.bauzonen
+  sources: [ch.are.bauzonen_cache]
+  title: Bauzonen Schweiz (harmonisiert)
+- dimensions: &id004
+    Time:
+      default: '20080101'
+      values: ['20080101']
+  name: ch.are.belastung-gueterverkehr-bahn-2008.mercator
+  sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache_mercator]
+  title: "G\xFCterverkehr 2008"
+- dimensions: *id004
+  name: ch.are.belastung-gueterverkehr-bahn-2008.etrs89
+  sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache_etrs89]
+  title: "G\xFCterverkehr 2008"
+- dimensions: *id004
+  name: ch.are.belastung-gueterverkehr-bahn-2008.wgs84
+  sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache_wgs84]
+  title: "G\xFCterverkehr 2008"
+- dimensions: *id004
+  name: ch.are.belastung-gueterverkehr-bahn-2008.lv95
+  sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache_lv95]
+  title: "G\xFCterverkehr 2008"
+- dimensions: *id004
+  name: ch.are.belastung-gueterverkehr-bahn-2008
+  sources: [ch.are.belastung-gueterverkehr-bahn-2008_cache]
+  title: "G\xFCterverkehr 2008"
+- dimensions: &id005
+    Time:
+      default: '20080101'
+      values: ['20080101']
+  name: ch.are.belastung-gueterverkehr-strasse-2008.mercator
+  sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache_mercator]
+  title: "Schwerer G\xFCterverkehr 2008"
+- dimensions: *id005
+  name: ch.are.belastung-gueterverkehr-strasse-2008.etrs89
+  sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache_etrs89]
+  title: "Schwerer G\xFCterverkehr 2008"
+- dimensions: *id005
+  name: ch.are.belastung-gueterverkehr-strasse-2008.wgs84
+  sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache_wgs84]
+  title: "Schwerer G\xFCterverkehr 2008"
+- dimensions: *id005
+  name: ch.are.belastung-gueterverkehr-strasse-2008.lv95
+  sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache_lv95]
+  title: "Schwerer G\xFCterverkehr 2008"
+- dimensions: *id005
+  name: ch.are.belastung-gueterverkehr-strasse-2008
+  sources: [ch.are.belastung-gueterverkehr-strasse-2008_cache]
+  title: "Schwerer G\xFCterverkehr 2008"
+- dimensions: &id006
+    Time:
+      default: '20080101'
+      values: ['20080101']
+  name: ch.are.belastung-personenverkehr-bahn-2008.mercator
+  sources: [ch.are.belastung-personenverkehr-bahn-2008_cache_mercator]
+  title: Personenverkehr 2008
+- dimensions: *id006
+  name: ch.are.belastung-personenverkehr-bahn-2008.etrs89
+  sources: [ch.are.belastung-personenverkehr-bahn-2008_cache_etrs89]
+  title: Personenverkehr 2008
+- dimensions: *id006
+  name: ch.are.belastung-personenverkehr-bahn-2008.wgs84
+  sources: [ch.are.belastung-personenverkehr-bahn-2008_cache_wgs84]
+  title: Personenverkehr 2008
+- dimensions: *id006
+  name: ch.are.belastung-personenverkehr-bahn-2008.lv95
+  sources: [ch.are.belastung-personenverkehr-bahn-2008_cache_lv95]
+  title: Personenverkehr 2008
+- dimensions: *id006
+  name: ch.are.belastung-personenverkehr-bahn-2008
+  sources: [ch.are.belastung-personenverkehr-bahn-2008_cache]
+  title: Personenverkehr 2008
+- dimensions: &id007
+    Time:
+      default: '20080101'
+      values: ['20080101']
+  name: ch.are.belastung-personenverkehr-strasse-2008.mercator
+  sources: [ch.are.belastung-personenverkehr-strasse-2008_cache_mercator]
+  title: Personenverkehr 2008
+- dimensions: *id007
+  name: ch.are.belastung-personenverkehr-strasse-2008.etrs89
+  sources: [ch.are.belastung-personenverkehr-strasse-2008_cache_etrs89]
+  title: Personenverkehr 2008
+- dimensions: *id007
+  name: ch.are.belastung-personenverkehr-strasse-2008.wgs84
+  sources: [ch.are.belastung-personenverkehr-strasse-2008_cache_wgs84]
+  title: Personenverkehr 2008
+- dimensions: *id007
+  name: ch.are.belastung-personenverkehr-strasse-2008.lv95
+  sources: [ch.are.belastung-personenverkehr-strasse-2008_cache_lv95]
+  title: Personenverkehr 2008
+- dimensions: *id007
+  name: ch.are.belastung-personenverkehr-strasse-2008
+  sources: [ch.are.belastung-personenverkehr-strasse-2008_cache]
+  title: Personenverkehr 2008
+- dimensions: &id008
+    Time:
+      default: '20111231'
+      values: ['20111231']
+  name: ch.are.beschaeftigtendichte.mercator
+  sources: [ch.are.beschaeftigtendichte_cache_mercator]
+  title: "Besch\xE4ftigtendichte"
+- dimensions: *id008
+  name: ch.are.beschaeftigtendichte.etrs89
+  sources: [ch.are.beschaeftigtendichte_cache_etrs89]
+  title: "Besch\xE4ftigtendichte"
+- dimensions: *id008
+  name: ch.are.beschaeftigtendichte.wgs84
+  sources: [ch.are.beschaeftigtendichte_cache_wgs84]
+  title: "Besch\xE4ftigtendichte"
+- dimensions: *id008
+  name: ch.are.beschaeftigtendichte.lv95
+  sources: [ch.are.beschaeftigtendichte_cache_lv95]
+  title: "Besch\xE4ftigtendichte"
+- dimensions: *id008
+  name: ch.are.beschaeftigtendichte
+  sources: [ch.are.beschaeftigtendichte_cache]
+  title: "Besch\xE4ftigtendichte"
+- dimensions: &id009
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.bevoelkerungsdichte.mercator
+  sources: [ch.are.bevoelkerungsdichte_cache_mercator]
+  title: "Bev\xF6lkerungsdichte"
+- dimensions: *id009
+  name: ch.are.bevoelkerungsdichte.etrs89
+  sources: [ch.are.bevoelkerungsdichte_cache_etrs89]
+  title: "Bev\xF6lkerungsdichte"
+- dimensions: *id009
+  name: ch.are.bevoelkerungsdichte.wgs84
+  sources: [ch.are.bevoelkerungsdichte_cache_wgs84]
+  title: "Bev\xF6lkerungsdichte"
+- dimensions: *id009
+  name: ch.are.bevoelkerungsdichte.lv95
+  sources: [ch.are.bevoelkerungsdichte_cache_lv95]
+  title: "Bev\xF6lkerungsdichte"
+- dimensions: *id009
+  name: ch.are.bevoelkerungsdichte
+  sources: [ch.are.bevoelkerungsdichte_cache]
+  title: "Bev\xF6lkerungsdichte"
+- dimensions: &id010
+    Time:
+      default: '20140101'
+      values: ['20140101', '20120101']
+  name: ch.are.gemeindetypen.mercator
+  sources: [ch.are.gemeindetypen_cache_mercator]
+  title: Gemeindetypologie ARE
+- dimensions: *id010
+  name: ch.are.gemeindetypen.etrs89
+  sources: [ch.are.gemeindetypen_cache_etrs89]
+  title: Gemeindetypologie ARE
+- dimensions: *id010
+  name: ch.are.gemeindetypen.wgs84
+  sources: [ch.are.gemeindetypen_cache_wgs84]
+  title: Gemeindetypologie ARE
+- dimensions: *id010
+  name: ch.are.gemeindetypen.lv95
+  sources: [ch.are.gemeindetypen_cache_lv95]
+  title: Gemeindetypologie ARE
+- dimensions: *id010
+  name: ch.are.gemeindetypen
+  sources: [ch.are.gemeindetypen_cache]
+  title: Gemeindetypologie ARE
+- dimensions: &id011
+    Time:
+      default: '20131231'
+      values: ['20131231', '20101213', '20091213']
+  name: ch.are.gueteklassen_oev.mercator
+  sources: [ch.are.gueteklassen_oev_cache_mercator]
+  title: "\xD6V-G\xFCteklassen ARE"
+- dimensions: *id011
+  name: ch.are.gueteklassen_oev.etrs89
+  sources: [ch.are.gueteklassen_oev_cache_etrs89]
+  title: "\xD6V-G\xFCteklassen ARE"
+- dimensions: *id011
+  name: ch.are.gueteklassen_oev.wgs84
+  sources: [ch.are.gueteklassen_oev_cache_wgs84]
+  title: "\xD6V-G\xFCteklassen ARE"
+- dimensions: *id011
+  name: ch.are.gueteklassen_oev.lv95
+  sources: [ch.are.gueteklassen_oev_cache_lv95]
+  title: "\xD6V-G\xFCteklassen ARE"
+- dimensions: *id011
+  name: ch.are.gueteklassen_oev
+  sources: [ch.are.gueteklassen_oev_cache]
+  title: "\xD6V-G\xFCteklassen ARE"
+- dimensions: &id012
+    Time:
+      default: '20100831'
+      values: ['20100831']
+  name: ch.are.landschaftstypen.mercator
+  sources: [ch.are.landschaftstypen_cache_mercator]
+  title: Landschaftstypologie Schweiz
+- dimensions: *id012
+  name: ch.are.landschaftstypen.etrs89
+  sources: [ch.are.landschaftstypen_cache_etrs89]
+  title: Landschaftstypologie Schweiz
+- dimensions: *id012
+  name: ch.are.landschaftstypen.wgs84
+  sources: [ch.are.landschaftstypen_cache_wgs84]
+  title: Landschaftstypologie Schweiz
+- dimensions: *id012
+  name: ch.are.landschaftstypen.lv95
+  sources: [ch.are.landschaftstypen_cache_lv95]
+  title: Landschaftstypologie Schweiz
+- dimensions: *id012
+  name: ch.are.landschaftstypen
+  sources: [ch.are.landschaftstypen_cache]
+  title: Landschaftstypologie Schweiz
+- dimensions: &id013
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.reisezeit-miv.mercator
+  sources: [ch.are.reisezeit-miv_cache_mercator]
+  title: Reisezeit zu Zentren MIV
+- dimensions: *id013
+  name: ch.are.reisezeit-miv.etrs89
+  sources: [ch.are.reisezeit-miv_cache_etrs89]
+  title: Reisezeit zu Zentren MIV
+- dimensions: *id013
+  name: ch.are.reisezeit-miv.wgs84
+  sources: [ch.are.reisezeit-miv_cache_wgs84]
+  title: Reisezeit zu Zentren MIV
+- dimensions: *id013
+  name: ch.are.reisezeit-miv.lv95
+  sources: [ch.are.reisezeit-miv_cache_lv95]
+  title: Reisezeit zu Zentren MIV
+- dimensions: *id013
+  name: ch.are.reisezeit-miv
+  sources: [ch.are.reisezeit-miv_cache]
+  title: Reisezeit zu Zentren MIV
+- dimensions: &id014
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.reisezeit-oev.mercator
+  sources: [ch.are.reisezeit-oev_cache_mercator]
+  title: "Reisezeit zu Zentren \xD6V"
+- dimensions: *id014
+  name: ch.are.reisezeit-oev.etrs89
+  sources: [ch.are.reisezeit-oev_cache_etrs89]
+  title: "Reisezeit zu Zentren \xD6V"
+- dimensions: *id014
+  name: ch.are.reisezeit-oev.wgs84
+  sources: [ch.are.reisezeit-oev_cache_wgs84]
+  title: "Reisezeit zu Zentren \xD6V"
+- dimensions: *id014
+  name: ch.are.reisezeit-oev.lv95
+  sources: [ch.are.reisezeit-oev_cache_lv95]
+  title: "Reisezeit zu Zentren \xD6V"
+- dimensions: *id014
+  name: ch.are.reisezeit-oev
+  sources: [ch.are.reisezeit-oev_cache]
+  title: "Reisezeit zu Zentren \xD6V"
+- dimensions: &id015
+    Time:
+      default: '20111010'
+      values: ['20111010']
+  name: ch.astra.ausnahmetransportrouten.mercator
+  sources: [ch.astra.ausnahmetransportrouten_cache_mercator]
+  title: Ausnahmetransportrouten
+- dimensions: *id015
+  name: ch.astra.ausnahmetransportrouten.etrs89
+  sources: [ch.astra.ausnahmetransportrouten_cache_etrs89]
+  title: Ausnahmetransportrouten
+- dimensions: *id015
+  name: ch.astra.ausnahmetransportrouten.wgs84
+  sources: [ch.astra.ausnahmetransportrouten_cache_wgs84]
+  title: Ausnahmetransportrouten
+- dimensions: *id015
+  name: ch.astra.ausnahmetransportrouten.lv95
+  sources: [ch.astra.ausnahmetransportrouten_cache_lv95]
+  title: Ausnahmetransportrouten
+- dimensions: *id015
+  name: ch.astra.ausnahmetransportrouten
+  sources: [ch.astra.ausnahmetransportrouten_cache]
+  title: Ausnahmetransportrouten
+- dimensions: &id016
+    Time:
+      default: '19980816'
+      values: ['19980816']
+  name: ch.astra.ivs-gelaendekarte.mercator
+  sources: [ch.astra.ivs-gelaendekarte_cache_mercator]
+  title: "IVS Gel\xE4ndekarte"
+- dimensions: *id016
+  name: ch.astra.ivs-gelaendekarte.etrs89
+  sources: [ch.astra.ivs-gelaendekarte_cache_etrs89]
+  title: "IVS Gel\xE4ndekarte"
+- dimensions: *id016
+  name: ch.astra.ivs-gelaendekarte.wgs84
+  sources: [ch.astra.ivs-gelaendekarte_cache_wgs84]
+  title: "IVS Gel\xE4ndekarte"
+- dimensions: *id016
+  name: ch.astra.ivs-gelaendekarte.lv95
+  sources: [ch.astra.ivs-gelaendekarte_cache_lv95]
+  title: "IVS Gel\xE4ndekarte"
+- dimensions: *id016
+  name: ch.astra.ivs-gelaendekarte
+  sources: [ch.astra.ivs-gelaendekarte_cache]
+  title: "IVS Gel\xE4ndekarte"
+- dimensions: &id017
+    Time:
+      default: '20100416'
+      values: ['20100416', '20070712']
+  name: ch.astra.ivs-nat.mercator
+  sources: [ch.astra.ivs-nat_cache_mercator]
+  title: IVS National
+- dimensions: *id017
+  name: ch.astra.ivs-nat.etrs89
+  sources: [ch.astra.ivs-nat_cache_etrs89]
+  title: IVS National
+- dimensions: *id017
+  name: ch.astra.ivs-nat.wgs84
+  sources: [ch.astra.ivs-nat_cache_wgs84]
+  title: IVS National
+- dimensions: *id017
+  name: ch.astra.ivs-nat.lv95
+  sources: [ch.astra.ivs-nat_cache_lv95]
+  title: IVS National
+- dimensions: *id017
+  name: ch.astra.ivs-nat
+  sources: [ch.astra.ivs-nat_cache]
+  title: IVS National
+- dimensions: &id018
+    Time:
+      default: '20100416'
+      values: ['20100416']
+  name: ch.astra.ivs-nat-verlaeufe.mercator
+  sources: [ch.astra.ivs-nat-verlaeufe_cache_mercator]
+  title: IVS historischer Verlauf
+- dimensions: *id018
+  name: ch.astra.ivs-nat-verlaeufe.etrs89
+  sources: [ch.astra.ivs-nat-verlaeufe_cache_etrs89]
+  title: IVS historischer Verlauf
+- dimensions: *id018
+  name: ch.astra.ivs-nat-verlaeufe.wgs84
+  sources: [ch.astra.ivs-nat-verlaeufe_cache_wgs84]
+  title: IVS historischer Verlauf
+- dimensions: *id018
+  name: ch.astra.ivs-nat-verlaeufe.lv95
+  sources: [ch.astra.ivs-nat-verlaeufe_cache_lv95]
+  title: IVS historischer Verlauf
+- dimensions: *id018
+  name: ch.astra.ivs-nat-verlaeufe
+  sources: [ch.astra.ivs-nat-verlaeufe_cache]
+  title: IVS historischer Verlauf
+- dimensions: &id019
+    Time:
+      default: '20100414'
+      values: ['20100414']
+  name: ch.astra.ivs-nat_abgrenzungen.mercator
+  sources: [ch.astra.ivs-nat_abgrenzungen_cache_mercator]
+  title: IVS Abgrenzungen
+- dimensions: *id019
+  name: ch.astra.ivs-nat_abgrenzungen.etrs89
+  sources: [ch.astra.ivs-nat_abgrenzungen_cache_etrs89]
+  title: IVS Abgrenzungen
+- dimensions: *id019
+  name: ch.astra.ivs-nat_abgrenzungen.wgs84
+  sources: [ch.astra.ivs-nat_abgrenzungen_cache_wgs84]
+  title: IVS Abgrenzungen
+- dimensions: *id019
+  name: ch.astra.ivs-nat_abgrenzungen.lv95
+  sources: [ch.astra.ivs-nat_abgrenzungen_cache_lv95]
+  title: IVS Abgrenzungen
+- dimensions: *id019
+  name: ch.astra.ivs-nat_abgrenzungen
+  sources: [ch.astra.ivs-nat_abgrenzungen_cache]
+  title: IVS Abgrenzungen
+- dimensions: &id020
+    Time:
+      default: '20100414'
+      values: ['20100414']
+  name: ch.astra.ivs-nat_wegbegleiter.mercator
+  sources: [ch.astra.ivs-nat_wegbegleiter_cache_mercator]
+  title: IVS Wegbegleiter
+- dimensions: *id020
+  name: ch.astra.ivs-nat_wegbegleiter.etrs89
+  sources: [ch.astra.ivs-nat_wegbegleiter_cache_etrs89]
+  title: IVS Wegbegleiter
+- dimensions: *id020
+  name: ch.astra.ivs-nat_wegbegleiter.wgs84
+  sources: [ch.astra.ivs-nat_wegbegleiter_cache_wgs84]
+  title: IVS Wegbegleiter
+- dimensions: *id020
+  name: ch.astra.ivs-nat_wegbegleiter.lv95
+  sources: [ch.astra.ivs-nat_wegbegleiter_cache_lv95]
+  title: IVS Wegbegleiter
+- dimensions: *id020
+  name: ch.astra.ivs-nat_wegbegleiter
+  sources: [ch.astra.ivs-nat_wegbegleiter_cache]
+  title: IVS Wegbegleiter
+- dimensions: &id021
+    Time:
+      default: '20100416'
+      values: ['20100416', '20070712']
+  name: ch.astra.ivs-reg_loc.mercator
+  sources: [ch.astra.ivs-reg_loc_cache_mercator]
+  title: IVS Regional und Lokal
+- dimensions: *id021
+  name: ch.astra.ivs-reg_loc.etrs89
+  sources: [ch.astra.ivs-reg_loc_cache_etrs89]
+  title: IVS Regional und Lokal
+- dimensions: *id021
+  name: ch.astra.ivs-reg_loc.wgs84
+  sources: [ch.astra.ivs-reg_loc_cache_wgs84]
+  title: IVS Regional und Lokal
+- dimensions: *id021
+  name: ch.astra.ivs-reg_loc.lv95
+  sources: [ch.astra.ivs-reg_loc_cache_lv95]
+  title: IVS Regional und Lokal
+- dimensions: *id021
+  name: ch.astra.ivs-reg_loc
+  sources: [ch.astra.ivs-reg_loc_cache]
+  title: IVS Regional und Lokal
+- dimensions: &id022
+    Time:
+      default: '20140120'
+      values: ['20140120', '20130220', '20091127']
+  name: ch.babs.kulturgueter.mercator
+  sources: [ch.babs.kulturgueter_cache_mercator]
+  title: "Kulturg\xFCterschutz Inventar"
+- dimensions: *id022
+  name: ch.babs.kulturgueter.etrs89
+  sources: [ch.babs.kulturgueter_cache_etrs89]
+  title: "Kulturg\xFCterschutz Inventar"
+- dimensions: *id022
+  name: ch.babs.kulturgueter.wgs84
+  sources: [ch.babs.kulturgueter_cache_wgs84]
+  title: "Kulturg\xFCterschutz Inventar"
+- dimensions: *id022
+  name: ch.babs.kulturgueter.lv95
+  sources: [ch.babs.kulturgueter_cache_lv95]
+  title: "Kulturg\xFCterschutz Inventar"
+- dimensions: *id022
+  name: ch.babs.kulturgueter
+  sources: [ch.babs.kulturgueter_cache]
+  title: "Kulturg\xFCterschutz Inventar"
+- dimensions: &id023
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_050.mercator
+  sources: [ch.bafu.aquaprotect_050_cache_mercator]
+  title: "\xDCberschwemmung Aquaprotect 50"
+- dimensions: *id023
+  name: ch.bafu.aquaprotect_050.etrs89
+  sources: [ch.bafu.aquaprotect_050_cache_etrs89]
+  title: "\xDCberschwemmung Aquaprotect 50"
+- dimensions: *id023
+  name: ch.bafu.aquaprotect_050.wgs84
+  sources: [ch.bafu.aquaprotect_050_cache_wgs84]
+  title: "\xDCberschwemmung Aquaprotect 50"
+- dimensions: *id023
+  name: ch.bafu.aquaprotect_050.lv95
+  sources: [ch.bafu.aquaprotect_050_cache_lv95]
+  title: "\xDCberschwemmung Aquaprotect 50"
+- dimensions: *id023
+  name: ch.bafu.aquaprotect_050
+  sources: [ch.bafu.aquaprotect_050_cache]
+  title: "\xDCberschwemmung Aquaprotect 50"
+- dimensions: &id024
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_100.mercator
+  sources: [ch.bafu.aquaprotect_100_cache_mercator]
+  title: "\xDCberschwemmung Aquaprotect 100"
+- dimensions: *id024
+  name: ch.bafu.aquaprotect_100.etrs89
+  sources: [ch.bafu.aquaprotect_100_cache_etrs89]
+  title: "\xDCberschwemmung Aquaprotect 100"
+- dimensions: *id024
+  name: ch.bafu.aquaprotect_100.wgs84
+  sources: [ch.bafu.aquaprotect_100_cache_wgs84]
+  title: "\xDCberschwemmung Aquaprotect 100"
+- dimensions: *id024
+  name: ch.bafu.aquaprotect_100.lv95
+  sources: [ch.bafu.aquaprotect_100_cache_lv95]
+  title: "\xDCberschwemmung Aquaprotect 100"
+- dimensions: *id024
+  name: ch.bafu.aquaprotect_100
+  sources: [ch.bafu.aquaprotect_100_cache]
+  title: "\xDCberschwemmung Aquaprotect 100"
+- dimensions: &id025
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_250.mercator
+  sources: [ch.bafu.aquaprotect_250_cache_mercator]
+  title: "\xDCberschwemmung Aquaprotect 250"
+- dimensions: *id025
+  name: ch.bafu.aquaprotect_250.etrs89
+  sources: [ch.bafu.aquaprotect_250_cache_etrs89]
+  title: "\xDCberschwemmung Aquaprotect 250"
+- dimensions: *id025
+  name: ch.bafu.aquaprotect_250.wgs84
+  sources: [ch.bafu.aquaprotect_250_cache_wgs84]
+  title: "\xDCberschwemmung Aquaprotect 250"
+- dimensions: *id025
+  name: ch.bafu.aquaprotect_250.lv95
+  sources: [ch.bafu.aquaprotect_250_cache_lv95]
+  title: "\xDCberschwemmung Aquaprotect 250"
+- dimensions: *id025
+  name: ch.bafu.aquaprotect_250
+  sources: [ch.bafu.aquaprotect_250_cache]
+  title: "\xDCberschwemmung Aquaprotect 250"
+- dimensions: &id026
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_500.mercator
+  sources: [ch.bafu.aquaprotect_500_cache_mercator]
+  title: "\xDCberschwemmung Aquaprotect 500"
+- dimensions: *id026
+  name: ch.bafu.aquaprotect_500.etrs89
+  sources: [ch.bafu.aquaprotect_500_cache_etrs89]
+  title: "\xDCberschwemmung Aquaprotect 500"
+- dimensions: *id026
+  name: ch.bafu.aquaprotect_500.wgs84
+  sources: [ch.bafu.aquaprotect_500_cache_wgs84]
+  title: "\xDCberschwemmung Aquaprotect 500"
+- dimensions: *id026
+  name: ch.bafu.aquaprotect_500.lv95
+  sources: [ch.bafu.aquaprotect_500_cache_lv95]
+  title: "\xDCberschwemmung Aquaprotect 500"
+- dimensions: *id026
+  name: ch.bafu.aquaprotect_500
+  sources: [ch.bafu.aquaprotect_500_cache]
+  title: "\xDCberschwemmung Aquaprotect 500"
+- dimensions: &id027
+    Time:
+      default: '20040302'
+      values: ['20040302']
+  name: ch.bafu.biogeographische_regionen.mercator
+  sources: [ch.bafu.biogeographische_regionen_cache_mercator]
+  title: Biogeographische Regionen
+- dimensions: *id027
+  name: ch.bafu.biogeographische_regionen.etrs89
+  sources: [ch.bafu.biogeographische_regionen_cache_etrs89]
+  title: Biogeographische Regionen
+- dimensions: *id027
+  name: ch.bafu.biogeographische_regionen.wgs84
+  sources: [ch.bafu.biogeographische_regionen_cache_wgs84]
+  title: Biogeographische Regionen
+- dimensions: *id027
+  name: ch.bafu.biogeographische_regionen.lv95
+  sources: [ch.bafu.biogeographische_regionen_cache_lv95]
+  title: Biogeographische Regionen
+- dimensions: *id027
+  name: ch.bafu.biogeographische_regionen
+  sources: [ch.bafu.biogeographische_regionen_cache]
+  title: Biogeographische Regionen
+- dimensions: &id028
+    Time:
+      default: '20070702'
+      values: ['20070702']
+  name: ch.bafu.bundesinventare-amphibien.mercator
+  sources: [ch.bafu.bundesinventare-amphibien_cache_mercator]
+  title: Amphibien Ortsfeste Objekte
+- dimensions: *id028
+  name: ch.bafu.bundesinventare-amphibien.etrs89
+  sources: [ch.bafu.bundesinventare-amphibien_cache_etrs89]
+  title: Amphibien Ortsfeste Objekte
+- dimensions: *id028
+  name: ch.bafu.bundesinventare-amphibien.wgs84
+  sources: [ch.bafu.bundesinventare-amphibien_cache_wgs84]
+  title: Amphibien Ortsfeste Objekte
+- dimensions: *id028
+  name: ch.bafu.bundesinventare-amphibien.lv95
+  sources: [ch.bafu.bundesinventare-amphibien_cache_lv95]
+  title: Amphibien Ortsfeste Objekte
+- dimensions: *id028
+  name: ch.bafu.bundesinventare-amphibien
+  sources: [ch.bafu.bundesinventare-amphibien_cache]
+  title: Amphibien Ortsfeste Objekte
+- dimensions: &id029
+    Time:
+      default: '20111205'
+      values: ['20111205']
+  name: ch.bafu.bundesinventare-amphibien_anhang4.mercator
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache_mercator]
+  title: Amphibien Anhang 4
+- dimensions: *id029
+  name: ch.bafu.bundesinventare-amphibien_anhang4.etrs89
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache_etrs89]
+  title: Amphibien Anhang 4
+- dimensions: *id029
+  name: ch.bafu.bundesinventare-amphibien_anhang4.wgs84
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache_wgs84]
+  title: Amphibien Anhang 4
+- dimensions: *id029
+  name: ch.bafu.bundesinventare-amphibien_anhang4.lv95
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache_lv95]
+  title: Amphibien Anhang 4
+- dimensions: *id029
+  name: ch.bafu.bundesinventare-amphibien_anhang4
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_cache]
+  title: Amphibien Anhang 4
+- dimensions: &id030
+    Time:
+      default: '20140505'
+      values: ['20140505']
+  name: ch.bafu.bundesinventare-amphibien_anhoerung.mercator
+  sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache_mercator]
+  title: "Amphibien - Anh\xF6rung 2014"
+- dimensions: *id030
+  name: ch.bafu.bundesinventare-amphibien_anhoerung.etrs89
+  sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache_etrs89]
+  title: "Amphibien - Anh\xF6rung 2014"
+- dimensions: *id030
+  name: ch.bafu.bundesinventare-amphibien_anhoerung.wgs84
+  sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache_wgs84]
+  title: "Amphibien - Anh\xF6rung 2014"
+- dimensions: *id030
+  name: ch.bafu.bundesinventare-amphibien_anhoerung.lv95
+  sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache_lv95]
+  title: "Amphibien - Anh\xF6rung 2014"
+- dimensions: *id030
+  name: ch.bafu.bundesinventare-amphibien_anhoerung
+  sources: [ch.bafu.bundesinventare-amphibien_anhoerung_cache]
+  title: "Amphibien - Anh\xF6rung 2014"
+- dimensions: &id031
+    Time:
+      default: '20070702'
+      values: ['20070702']
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte.mercator
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_mercator]
+  title: Amphibien Wanderobjekte
+- dimensions: *id031
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte.etrs89
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_etrs89]
+  title: Amphibien Wanderobjekte
+- dimensions: *id031
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte.wgs84
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_wgs84]
+  title: Amphibien Wanderobjekte
+- dimensions: *id031
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte.lv95
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache_lv95]
+  title: Amphibien Wanderobjekte
+- dimensions: *id031
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_cache]
+  title: Amphibien Wanderobjekte
+- dimensions: &id032
+    Time:
+      default: '20140505'
+      values: ['20140505']
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung.mercator
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_mercator]
+  title: Amphibien Wanderobjekte 2014
+- dimensions: *id032
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung.etrs89
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_etrs89]
+  title: Amphibien Wanderobjekte 2014
+- dimensions: *id032
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung.wgs84
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_wgs84]
+  title: Amphibien Wanderobjekte 2014
+- dimensions: *id032
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung.lv95
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache_lv95]
+  title: Amphibien Wanderobjekte 2014
+- dimensions: *id032
+  name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung
+  sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_cache]
+  title: Amphibien Wanderobjekte 2014
+- dimensions: &id033
+    Time:
+      default: '20070701'
+      values: ['20070701']
+  name: ch.bafu.bundesinventare-auen.mercator
+  sources: [ch.bafu.bundesinventare-auen_cache_mercator]
+  title: Auengebiete
+- dimensions: *id033
+  name: ch.bafu.bundesinventare-auen.etrs89
+  sources: [ch.bafu.bundesinventare-auen_cache_etrs89]
+  title: Auengebiete
+- dimensions: *id033
+  name: ch.bafu.bundesinventare-auen.wgs84
+  sources: [ch.bafu.bundesinventare-auen_cache_wgs84]
+  title: Auengebiete
+- dimensions: *id033
+  name: ch.bafu.bundesinventare-auen.lv95
+  sources: [ch.bafu.bundesinventare-auen_cache_lv95]
+  title: Auengebiete
+- dimensions: *id033
+  name: ch.bafu.bundesinventare-auen
+  sources: [ch.bafu.bundesinventare-auen_cache]
+  title: Auengebiete
+- dimensions: &id034
+    Time:
+      default: '20140505'
+      values: ['20140505']
+  name: ch.bafu.bundesinventare-auen_anhoerung.mercator
+  sources: [ch.bafu.bundesinventare-auen_anhoerung_cache_mercator]
+  title: "Auen - Anh\xF6rung 2014"
+- dimensions: *id034
+  name: ch.bafu.bundesinventare-auen_anhoerung.etrs89
+  sources: [ch.bafu.bundesinventare-auen_anhoerung_cache_etrs89]
+  title: "Auen - Anh\xF6rung 2014"
+- dimensions: *id034
+  name: ch.bafu.bundesinventare-auen_anhoerung.wgs84
+  sources: [ch.bafu.bundesinventare-auen_anhoerung_cache_wgs84]
+  title: "Auen - Anh\xF6rung 2014"
+- dimensions: *id034
+  name: ch.bafu.bundesinventare-auen_anhoerung.lv95
+  sources: [ch.bafu.bundesinventare-auen_anhoerung_cache_lv95]
+  title: "Auen - Anh\xF6rung 2014"
+- dimensions: *id034
+  name: ch.bafu.bundesinventare-auen_anhoerung
+  sources: [ch.bafu.bundesinventare-auen_anhoerung_cache]
+  title: "Auen - Anh\xF6rung 2014"
+- dimensions: &id035
+    Time:
+      default: '20010809'
+      values: ['20010809']
+  name: ch.bafu.bundesinventare-bln.mercator
+  sources: [ch.bafu.bundesinventare-bln_cache_mercator]
+  title: BLN
+- dimensions: *id035
+  name: ch.bafu.bundesinventare-bln.etrs89
+  sources: [ch.bafu.bundesinventare-bln_cache_etrs89]
+  title: BLN
+- dimensions: *id035
+  name: ch.bafu.bundesinventare-bln.wgs84
+  sources: [ch.bafu.bundesinventare-bln_cache_wgs84]
+  title: BLN
+- dimensions: *id035
+  name: ch.bafu.bundesinventare-bln.lv95
+  sources: [ch.bafu.bundesinventare-bln_cache_lv95]
+  title: BLN
+- dimensions: *id035
+  name: ch.bafu.bundesinventare-bln
+  sources: [ch.bafu.bundesinventare-bln_cache]
+  title: BLN
+- dimensions: &id036
+    Time:
+      default: '20100623'
+      values: ['20100623']
+  name: ch.bafu.bundesinventare-flachmoore.mercator
+  sources: [ch.bafu.bundesinventare-flachmoore_cache_mercator]
+  title: Flachmoore
+- dimensions: *id036
+  name: ch.bafu.bundesinventare-flachmoore.etrs89
+  sources: [ch.bafu.bundesinventare-flachmoore_cache_etrs89]
+  title: Flachmoore
+- dimensions: *id036
+  name: ch.bafu.bundesinventare-flachmoore.wgs84
+  sources: [ch.bafu.bundesinventare-flachmoore_cache_wgs84]
+  title: Flachmoore
+- dimensions: *id036
+  name: ch.bafu.bundesinventare-flachmoore.lv95
+  sources: [ch.bafu.bundesinventare-flachmoore_cache_lv95]
+  title: Flachmoore
+- dimensions: *id036
+  name: ch.bafu.bundesinventare-flachmoore
+  sources: [ch.bafu.bundesinventare-flachmoore_cache]
+  title: Flachmoore
+- dimensions: &id037
+    Time:
+      default: '20140505'
+      values: ['20140505']
+  name: ch.bafu.bundesinventare-flachmoore_anhoerung.mercator
+  sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache_mercator]
+  title: "Flachmoore Anh\xF6rung 2014"
+- dimensions: *id037
+  name: ch.bafu.bundesinventare-flachmoore_anhoerung.etrs89
+  sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache_etrs89]
+  title: "Flachmoore Anh\xF6rung 2014"
+- dimensions: *id037
+  name: ch.bafu.bundesinventare-flachmoore_anhoerung.wgs84
+  sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache_wgs84]
+  title: "Flachmoore Anh\xF6rung 2014"
+- dimensions: *id037
+  name: ch.bafu.bundesinventare-flachmoore_anhoerung.lv95
+  sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache_lv95]
+  title: "Flachmoore Anh\xF6rung 2014"
+- dimensions: *id037
+  name: ch.bafu.bundesinventare-flachmoore_anhoerung
+  sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_cache]
+  title: "Flachmoore Anh\xF6rung 2014"
+- dimensions: &id038
+    Time:
+      default: '20070731'
+      values: ['20070731']
+  name: ch.bafu.bundesinventare-flachmoore_regional.mercator
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_cache_mercator]
+  title: Flachmoore regional
+- dimensions: *id038
+  name: ch.bafu.bundesinventare-flachmoore_regional.etrs89
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_cache_etrs89]
+  title: Flachmoore regional
+- dimensions: *id038
+  name: ch.bafu.bundesinventare-flachmoore_regional.wgs84
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_cache_wgs84]
+  title: Flachmoore regional
+- dimensions: *id038
+  name: ch.bafu.bundesinventare-flachmoore_regional.lv95
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_cache_lv95]
+  title: Flachmoore regional
+- dimensions: *id038
+  name: ch.bafu.bundesinventare-flachmoore_regional
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_cache]
+  title: Flachmoore regional
+- dimensions: &id039
+    Time:
+      default: '20080721'
+      values: ['20080721']
+  name: ch.bafu.bundesinventare-hochmoore.mercator
+  sources: [ch.bafu.bundesinventare-hochmoore_cache_mercator]
+  title: Hochmoore
+- dimensions: *id039
+  name: ch.bafu.bundesinventare-hochmoore.etrs89
+  sources: [ch.bafu.bundesinventare-hochmoore_cache_etrs89]
+  title: Hochmoore
+- dimensions: *id039
+  name: ch.bafu.bundesinventare-hochmoore.wgs84
+  sources: [ch.bafu.bundesinventare-hochmoore_cache_wgs84]
+  title: Hochmoore
+- dimensions: *id039
+  name: ch.bafu.bundesinventare-hochmoore.lv95
+  sources: [ch.bafu.bundesinventare-hochmoore_cache_lv95]
+  title: Hochmoore
+- dimensions: *id039
+  name: ch.bafu.bundesinventare-hochmoore
+  sources: [ch.bafu.bundesinventare-hochmoore_cache]
+  title: Hochmoore
+- dimensions: &id040
+    Time:
+      default: '20140505'
+      values: ['20140505']
+  name: ch.bafu.bundesinventare-hochmoore_anhoerung.mercator
+  sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache_mercator]
+  title: "Hochmoore - Anh\xF6rung 2014"
+- dimensions: *id040
+  name: ch.bafu.bundesinventare-hochmoore_anhoerung.etrs89
+  sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache_etrs89]
+  title: "Hochmoore - Anh\xF6rung 2014"
+- dimensions: *id040
+  name: ch.bafu.bundesinventare-hochmoore_anhoerung.wgs84
+  sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache_wgs84]
+  title: "Hochmoore - Anh\xF6rung 2014"
+- dimensions: *id040
+  name: ch.bafu.bundesinventare-hochmoore_anhoerung.lv95
+  sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache_lv95]
+  title: "Hochmoore - Anh\xF6rung 2014"
+- dimensions: *id040
+  name: ch.bafu.bundesinventare-hochmoore_anhoerung
+  sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_cache]
+  title: "Hochmoore - Anh\xF6rung 2014"
+- dimensions: &id041
+    Time:
+      default: '20131202'
+      values: ['20131202', '20100801']
+  name: ch.bafu.bundesinventare-jagdbanngebiete.mercator
+  sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache_mercator]
+  title: Jagdbanngebiete
+- dimensions: *id041
+  name: ch.bafu.bundesinventare-jagdbanngebiete.etrs89
+  sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache_etrs89]
+  title: Jagdbanngebiete
+- dimensions: *id041
+  name: ch.bafu.bundesinventare-jagdbanngebiete.wgs84
+  sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache_wgs84]
+  title: Jagdbanngebiete
+- dimensions: *id041
+  name: ch.bafu.bundesinventare-jagdbanngebiete.lv95
+  sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache_lv95]
+  title: Jagdbanngebiete
+- dimensions: *id041
+  name: ch.bafu.bundesinventare-jagdbanngebiete
+  sources: [ch.bafu.bundesinventare-jagdbanngebiete_cache]
+  title: Jagdbanngebiete
+- dimensions: &id042
+    Time:
+      default: '20070701'
+      values: ['20070701']
+  name: ch.bafu.bundesinventare-moorlandschaften.mercator
+  sources: [ch.bafu.bundesinventare-moorlandschaften_cache_mercator]
+  title: Moorlandschaften
+- dimensions: *id042
+  name: ch.bafu.bundesinventare-moorlandschaften.etrs89
+  sources: [ch.bafu.bundesinventare-moorlandschaften_cache_etrs89]
+  title: Moorlandschaften
+- dimensions: *id042
+  name: ch.bafu.bundesinventare-moorlandschaften.wgs84
+  sources: [ch.bafu.bundesinventare-moorlandschaften_cache_wgs84]
+  title: Moorlandschaften
+- dimensions: *id042
+  name: ch.bafu.bundesinventare-moorlandschaften.lv95
+  sources: [ch.bafu.bundesinventare-moorlandschaften_cache_lv95]
+  title: Moorlandschaften
+- dimensions: *id042
+  name: ch.bafu.bundesinventare-moorlandschaften
+  sources: [ch.bafu.bundesinventare-moorlandschaften_cache]
+  title: Moorlandschaften
+- dimensions: &id043
+    Time:
+      default: '20140505'
+      values: ['20140505']
+  name: ch.bafu.bundesinventare-moorlandschaften_anhoerung.mercator
+  sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_mercator]
+  title: "Moorlandschaften - Anh\xF6rung 2014"
+- dimensions: *id043
+  name: ch.bafu.bundesinventare-moorlandschaften_anhoerung.etrs89
+  sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_etrs89]
+  title: "Moorlandschaften - Anh\xF6rung 2014"
+- dimensions: *id043
+  name: ch.bafu.bundesinventare-moorlandschaften_anhoerung.wgs84
+  sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_wgs84]
+  title: "Moorlandschaften - Anh\xF6rung 2014"
+- dimensions: *id043
+  name: ch.bafu.bundesinventare-moorlandschaften_anhoerung.lv95
+  sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache_lv95]
+  title: "Moorlandschaften - Anh\xF6rung 2014"
+- dimensions: *id043
+  name: ch.bafu.bundesinventare-moorlandschaften_anhoerung
+  sources: [ch.bafu.bundesinventare-moorlandschaften_anhoerung_cache]
+  title: "Moorlandschaften - Anh\xF6rung 2014"
+- dimensions: &id044
+    Time:
+      default: '20130624'
+      values: ['20130624', '20120312', '20100201']
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden.mercator
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_mercator]
+  title: Trockenwiesen und -weiden (TWW)
+- dimensions: *id044
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden.etrs89
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_etrs89]
+  title: Trockenwiesen und -weiden (TWW)
+- dimensions: *id044
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden.wgs84
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_wgs84]
+  title: Trockenwiesen und -weiden (TWW)
+- dimensions: *id044
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden.lv95
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache_lv95]
+  title: Trockenwiesen und -weiden (TWW)
+- dimensions: *id044
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_cache]
+  title: Trockenwiesen und -weiden (TWW)
+- dimensions: &id045
+    Time:
+      default: '20120111'
+      values: ['20120111']
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.mercator
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_mercator]
+  title: TWW Anhang 2
+- dimensions: *id045
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.etrs89
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_etrs89]
+  title: TWW Anhang 2
+- dimensions: *id045
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.wgs84
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_wgs84]
+  title: TWW Anhang 2
+- dimensions: *id045
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.lv95
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache_lv95]
+  title: TWW Anhang 2
+- dimensions: *id045
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_cache]
+  title: TWW Anhang 2
+- dimensions: &id046
+    Time:
+      default: '20140505'
+      values: ['20140505']
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung.mercator
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_mercator]
+  title: "TWW - Anh\xF6rung 2014"
+- dimensions: *id046
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung.etrs89
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_etrs89]
+  title: "TWW - Anh\xF6rung 2014"
+- dimensions: *id046
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung.wgs84
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_wgs84]
+  title: "TWW - Anh\xF6rung 2014"
+- dimensions: *id046
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung.lv95
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache_lv95]
+  title: "TWW - Anh\xF6rung 2014"
+- dimensions: *id046
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_cache]
+  title: "TWW - Anh\xF6rung 2014"
+- dimensions: &id047
+    Time:
+      default: '20090617'
+      values: ['20090617']
+  name: ch.bafu.bundesinventare-vogelreservate.mercator
+  sources: [ch.bafu.bundesinventare-vogelreservate_cache_mercator]
+  title: Wasser- und Zugvogelreservate
+- dimensions: *id047
+  name: ch.bafu.bundesinventare-vogelreservate.etrs89
+  sources: [ch.bafu.bundesinventare-vogelreservate_cache_etrs89]
+  title: Wasser- und Zugvogelreservate
+- dimensions: *id047
+  name: ch.bafu.bundesinventare-vogelreservate.wgs84
+  sources: [ch.bafu.bundesinventare-vogelreservate_cache_wgs84]
+  title: Wasser- und Zugvogelreservate
+- dimensions: *id047
+  name: ch.bafu.bundesinventare-vogelreservate.lv95
+  sources: [ch.bafu.bundesinventare-vogelreservate_cache_lv95]
+  title: Wasser- und Zugvogelreservate
+- dimensions: *id047
+  name: ch.bafu.bundesinventare-vogelreservate
+  sources: [ch.bafu.bundesinventare-vogelreservate_cache]
+  title: Wasser- und Zugvogelreservate
+- dimensions: &id048
+    Time:
+      default: '20020114'
+      values: ['20020114']
+  name: ch.bafu.fauna-steinbockkolonien.mercator
+  sources: [ch.bafu.fauna-steinbockkolonien_cache_mercator]
+  title: Steinbockkolonien
+- dimensions: *id048
+  name: ch.bafu.fauna-steinbockkolonien.etrs89
+  sources: [ch.bafu.fauna-steinbockkolonien_cache_etrs89]
+  title: Steinbockkolonien
+- dimensions: *id048
+  name: ch.bafu.fauna-steinbockkolonien.wgs84
+  sources: [ch.bafu.fauna-steinbockkolonien_cache_wgs84]
+  title: Steinbockkolonien
+- dimensions: *id048
+  name: ch.bafu.fauna-steinbockkolonien.lv95
+  sources: [ch.bafu.fauna-steinbockkolonien_cache_lv95]
+  title: Steinbockkolonien
+- dimensions: *id048
+  name: ch.bafu.fauna-steinbockkolonien
+  sources: [ch.bafu.fauna-steinbockkolonien_cache]
+  title: Steinbockkolonien
+- dimensions: &id049
+    Time:
+      default: '20130528'
+      values: ['20130528', '20080721']
+  name: ch.bafu.fauna-vernetzungsachsen_national.mercator
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_cache_mercator]
+  title: Vernetzungssystem Wildtiere
+- dimensions: *id049
+  name: ch.bafu.fauna-vernetzungsachsen_national.etrs89
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_cache_etrs89]
+  title: Vernetzungssystem Wildtiere
+- dimensions: *id049
+  name: ch.bafu.fauna-vernetzungsachsen_national.wgs84
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_cache_wgs84]
+  title: Vernetzungssystem Wildtiere
+- dimensions: *id049
+  name: ch.bafu.fauna-vernetzungsachsen_national.lv95
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_cache_lv95]
+  title: Vernetzungssystem Wildtiere
+- dimensions: *id049
+  name: ch.bafu.fauna-vernetzungsachsen_national
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_cache]
+  title: Vernetzungssystem Wildtiere
+- dimensions: &id050
+    Time:
+      default: '20130528'
+      values: ['20130528', '20080721']
+  name: ch.bafu.fauna-wildtierkorridor_national.mercator
+  sources: [ch.bafu.fauna-wildtierkorridor_national_cache_mercator]
+  title: "Wildtierkorridore \xDCberregional"
+- dimensions: *id050
+  name: ch.bafu.fauna-wildtierkorridor_national.etrs89
+  sources: [ch.bafu.fauna-wildtierkorridor_national_cache_etrs89]
+  title: "Wildtierkorridore \xDCberregional"
+- dimensions: *id050
+  name: ch.bafu.fauna-wildtierkorridor_national.wgs84
+  sources: [ch.bafu.fauna-wildtierkorridor_national_cache_wgs84]
+  title: "Wildtierkorridore \xDCberregional"
+- dimensions: *id050
+  name: ch.bafu.fauna-wildtierkorridor_national.lv95
+  sources: [ch.bafu.fauna-wildtierkorridor_national_cache_lv95]
+  title: "Wildtierkorridore \xDCberregional"
+- dimensions: *id050
+  name: ch.bafu.fauna-wildtierkorridor_national
+  sources: [ch.bafu.fauna-wildtierkorridor_national_cache]
+  title: "Wildtierkorridore \xDCberregional"
+- dimensions: &id051
+    Time:
+      default: '20110829'
+      values: ['20110829']
+  name: ch.bafu.fischerei-aeschen_kernzonen.mercator
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_cache_mercator]
+  title: "\xC4schen: Kernzonen"
+- dimensions: *id051
+  name: ch.bafu.fischerei-aeschen_kernzonen.etrs89
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_cache_etrs89]
+  title: "\xC4schen: Kernzonen"
+- dimensions: *id051
+  name: ch.bafu.fischerei-aeschen_kernzonen.wgs84
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_cache_wgs84]
+  title: "\xC4schen: Kernzonen"
+- dimensions: *id051
+  name: ch.bafu.fischerei-aeschen_kernzonen.lv95
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_cache_lv95]
+  title: "\xC4schen: Kernzonen"
+- dimensions: *id051
+  name: ch.bafu.fischerei-aeschen_kernzonen
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_cache]
+  title: "\xC4schen: Kernzonen"
+- dimensions: &id052
+    Time:
+      default: '20110829'
+      values: ['20110829']
+  name: ch.bafu.fischerei-aeschen_laichplaetze.mercator
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache_mercator]
+  title: "\xC4schen: Laichpl\xE4tze"
+- dimensions: *id052
+  name: ch.bafu.fischerei-aeschen_laichplaetze.etrs89
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache_etrs89]
+  title: "\xC4schen: Laichpl\xE4tze"
+- dimensions: *id052
+  name: ch.bafu.fischerei-aeschen_laichplaetze.wgs84
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache_wgs84]
+  title: "\xC4schen: Laichpl\xE4tze"
+- dimensions: *id052
+  name: ch.bafu.fischerei-aeschen_laichplaetze.lv95
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache_lv95]
+  title: "\xC4schen: Laichpl\xE4tze"
+- dimensions: *id052
+  name: ch.bafu.fischerei-aeschen_laichplaetze
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_cache]
+  title: "\xC4schen: Laichpl\xE4tze"
+- dimensions: &id053
+    Time:
+      default: '20110829'
+      values: ['20110829']
+  name: ch.bafu.fischerei-aeschen_larvenhabitate.mercator
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache_mercator]
+  title: "\xC4schen: Larvenhabitate"
+- dimensions: *id053
+  name: ch.bafu.fischerei-aeschen_larvenhabitate.etrs89
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache_etrs89]
+  title: "\xC4schen: Larvenhabitate"
+- dimensions: *id053
+  name: ch.bafu.fischerei-aeschen_larvenhabitate.wgs84
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache_wgs84]
+  title: "\xC4schen: Larvenhabitate"
+- dimensions: *id053
+  name: ch.bafu.fischerei-aeschen_larvenhabitate.lv95
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache_lv95]
+  title: "\xC4schen: Larvenhabitate"
+- dimensions: *id053
+  name: ch.bafu.fischerei-aeschen_larvenhabitate
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_cache]
+  title: "\xC4schen: Larvenhabitate"
+- dimensions: &id054
+    Time:
+      default: '20110905'
+      values: ['20110905']
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet.mercator
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_mercator]
+  title: "\xC4schen: Verbreitungsgebiet"
+- dimensions: *id054
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet.etrs89
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_etrs89]
+  title: "\xC4schen: Verbreitungsgebiet"
+- dimensions: *id054
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet.wgs84
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_wgs84]
+  title: "\xC4schen: Verbreitungsgebiet"
+- dimensions: *id054
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet.lv95
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache_lv95]
+  title: "\xC4schen: Verbreitungsgebiet"
+- dimensions: *id054
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_cache]
+  title: "\xC4schen: Verbreitungsgebiet"
+- dimensions: &id055
+    Time:
+      default: '20110107'
+      values: ['20110107']
+  name: ch.bafu.fischerei-krebspest.mercator
+  sources: [ch.bafu.fischerei-krebspest_cache_mercator]
+  title: Krebspest
+- dimensions: *id055
+  name: ch.bafu.fischerei-krebspest.etrs89
+  sources: [ch.bafu.fischerei-krebspest_cache_etrs89]
+  title: Krebspest
+- dimensions: *id055
+  name: ch.bafu.fischerei-krebspest.wgs84
+  sources: [ch.bafu.fischerei-krebspest_cache_wgs84]
+  title: Krebspest
+- dimensions: *id055
+  name: ch.bafu.fischerei-krebspest.lv95
+  sources: [ch.bafu.fischerei-krebspest_cache_lv95]
+  title: Krebspest
+- dimensions: *id055
+  name: ch.bafu.fischerei-krebspest
+  sources: [ch.bafu.fischerei-krebspest_cache]
+  title: Krebspest
+- dimensions: &id056
+    Time:
+      default: '20060220'
+      values: ['20060220']
+  name: ch.bafu.fischerei-nasenlaichplaetze.mercator
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_cache_mercator]
+  title: "Nasenlaichpl\xE4tze"
+- dimensions: *id056
+  name: ch.bafu.fischerei-nasenlaichplaetze.etrs89
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_cache_etrs89]
+  title: "Nasenlaichpl\xE4tze"
+- dimensions: *id056
+  name: ch.bafu.fischerei-nasenlaichplaetze.wgs84
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_cache_wgs84]
+  title: "Nasenlaichpl\xE4tze"
+- dimensions: *id056
+  name: ch.bafu.fischerei-nasenlaichplaetze.lv95
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_cache_lv95]
+  title: "Nasenlaichpl\xE4tze"
+- dimensions: *id056
+  name: ch.bafu.fischerei-nasenlaichplaetze
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_cache]
+  title: "Nasenlaichpl\xE4tze"
+- dimensions: &id057
+    Time:
+      default: '20140120'
+      values: ['20140120', '20110825']
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit.mercator
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache_mercator]
+  title: PKD (Proliferative Nierenkrankheit)
+- dimensions: *id057
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit.etrs89
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache_etrs89]
+  title: PKD (Proliferative Nierenkrankheit)
+- dimensions: *id057
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit.wgs84
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache_wgs84]
+  title: PKD (Proliferative Nierenkrankheit)
+- dimensions: *id057
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit.lv95
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache_lv95]
+  title: PKD (Proliferative Nierenkrankheit)
+- dimensions: *id057
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_cache]
+  title: PKD (Proliferative Nierenkrankheit)
+- dimensions: &id058
+    Time:
+      default: '19920822'
+      values: ['19920822']
+  name: ch.bafu.flora-schwingrasen.mercator
+  sources: [ch.bafu.flora-schwingrasen_cache_mercator]
+  title: Schwingrasen
+- dimensions: *id058
+  name: ch.bafu.flora-schwingrasen.etrs89
+  sources: [ch.bafu.flora-schwingrasen_cache_etrs89]
+  title: Schwingrasen
+- dimensions: *id058
+  name: ch.bafu.flora-schwingrasen.wgs84
+  sources: [ch.bafu.flora-schwingrasen_cache_wgs84]
+  title: Schwingrasen
+- dimensions: *id058
+  name: ch.bafu.flora-schwingrasen.lv95
+  sources: [ch.bafu.flora-schwingrasen_cache_lv95]
+  title: Schwingrasen
+- dimensions: *id058
+  name: ch.bafu.flora-schwingrasen
+  sources: [ch.bafu.flora-schwingrasen_cache]
+  title: Schwingrasen
+- dimensions: &id059
+    Time:
+      default: '20080612'
+      values: ['20080612']
+  name: ch.bafu.flora-verbreitungskarten.mercator
+  sources: [ch.bafu.flora-verbreitungskarten_cache_mercator]
+  title: Raster Verbreitungskarten
+- dimensions: *id059
+  name: ch.bafu.flora-verbreitungskarten.etrs89
+  sources: [ch.bafu.flora-verbreitungskarten_cache_etrs89]
+  title: Raster Verbreitungskarten
+- dimensions: *id059
+  name: ch.bafu.flora-verbreitungskarten.wgs84
+  sources: [ch.bafu.flora-verbreitungskarten_cache_wgs84]
+  title: Raster Verbreitungskarten
+- dimensions: *id059
+  name: ch.bafu.flora-verbreitungskarten.lv95
+  sources: [ch.bafu.flora-verbreitungskarten_cache_lv95]
+  title: Raster Verbreitungskarten
+- dimensions: *id059
+  name: ch.bafu.flora-verbreitungskarten
+  sources: [ch.bafu.flora-verbreitungskarten_cache]
+  title: Raster Verbreitungskarten
+- dimensions: &id060
+    Time:
+      default: '20080612'
+      values: ['20080612']
+  name: ch.bafu.flora-weltensutter_atlas.mercator
+  sources: [ch.bafu.flora-weltensutter_atlas_cache_mercator]
+  title: Atlas Welten&amp;Sutter
+- dimensions: *id060
+  name: ch.bafu.flora-weltensutter_atlas.etrs89
+  sources: [ch.bafu.flora-weltensutter_atlas_cache_etrs89]
+  title: Atlas Welten&amp;Sutter
+- dimensions: *id060
+  name: ch.bafu.flora-weltensutter_atlas.wgs84
+  sources: [ch.bafu.flora-weltensutter_atlas_cache_wgs84]
+  title: Atlas Welten&amp;Sutter
+- dimensions: *id060
+  name: ch.bafu.flora-weltensutter_atlas.lv95
+  sources: [ch.bafu.flora-weltensutter_atlas_cache_lv95]
+  title: Atlas Welten&amp;Sutter
+- dimensions: *id060
+  name: ch.bafu.flora-weltensutter_atlas
+  sources: [ch.bafu.flora-weltensutter_atlas_cache]
+  title: Atlas Welten&amp;Sutter
+- dimensions: &id061
+    Time:
+      default: '20140314'
+      values: ['20140314', '20130903', '20121219', '20110906']
+  name: ch.bafu.gefahren-baugrundklassen.mercator
+  sources: [ch.bafu.gefahren-baugrundklassen_cache_mercator]
+  title: Baugrundklassen
+- dimensions: *id061
+  name: ch.bafu.gefahren-baugrundklassen.etrs89
+  sources: [ch.bafu.gefahren-baugrundklassen_cache_etrs89]
+  title: Baugrundklassen
+- dimensions: *id061
+  name: ch.bafu.gefahren-baugrundklassen.wgs84
+  sources: [ch.bafu.gefahren-baugrundklassen_cache_wgs84]
+  title: Baugrundklassen
+- dimensions: *id061
+  name: ch.bafu.gefahren-baugrundklassen.lv95
+  sources: [ch.bafu.gefahren-baugrundklassen_cache_lv95]
+  title: Baugrundklassen
+- dimensions: *id061
+  name: ch.bafu.gefahren-baugrundklassen
+  sources: [ch.bafu.gefahren-baugrundklassen_cache]
+  title: Baugrundklassen
+- dimensions: &id062
+    Time:
+      default: '20030102'
+      values: ['20030102']
+  name: ch.bafu.gefahren-gefaehrdungszonen.mercator
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_cache_mercator]
+  title: "Gef\xE4hrdungszonen f\xFCr Erdbeben"
+- dimensions: *id062
+  name: ch.bafu.gefahren-gefaehrdungszonen.etrs89
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_cache_etrs89]
+  title: "Gef\xE4hrdungszonen f\xFCr Erdbeben"
+- dimensions: *id062
+  name: ch.bafu.gefahren-gefaehrdungszonen.wgs84
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_cache_wgs84]
+  title: "Gef\xE4hrdungszonen f\xFCr Erdbeben"
+- dimensions: *id062
+  name: ch.bafu.gefahren-gefaehrdungszonen.lv95
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_cache_lv95]
+  title: "Gef\xE4hrdungszonen f\xFCr Erdbeben"
+- dimensions: *id062
+  name: ch.bafu.gefahren-gefaehrdungszonen
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_cache]
+  title: "Gef\xE4hrdungszonen f\xFCr Erdbeben"
+- dimensions: &id063
+    Time:
+      default: '20110428'
+      values: ['20110428']
+  name: ch.bafu.gefahren-historische_erdbeben.mercator
+  sources: [ch.bafu.gefahren-historische_erdbeben_cache_mercator]
+  title: Historische Erdbeben
+- dimensions: *id063
+  name: ch.bafu.gefahren-historische_erdbeben.etrs89
+  sources: [ch.bafu.gefahren-historische_erdbeben_cache_etrs89]
+  title: Historische Erdbeben
+- dimensions: *id063
+  name: ch.bafu.gefahren-historische_erdbeben.wgs84
+  sources: [ch.bafu.gefahren-historische_erdbeben_cache_wgs84]
+  title: Historische Erdbeben
+- dimensions: *id063
+  name: ch.bafu.gefahren-historische_erdbeben.lv95
+  sources: [ch.bafu.gefahren-historische_erdbeben_cache_lv95]
+  title: Historische Erdbeben
+- dimensions: *id063
+  name: ch.bafu.gefahren-historische_erdbeben
+  sources: [ch.bafu.gefahren-historische_erdbeben_cache]
+  title: Historische Erdbeben
+- dimensions: &id064
+    Time:
+      default: '20121219'
+      values: ['20121219', '20110906']
+  name: ch.bafu.gefahren-mikrozonierung.mercator
+  sources: [ch.bafu.gefahren-mikrozonierung_cache_mercator]
+  title: Mikrozonierungen
+- dimensions: *id064
+  name: ch.bafu.gefahren-mikrozonierung.etrs89
+  sources: [ch.bafu.gefahren-mikrozonierung_cache_etrs89]
+  title: Mikrozonierungen
+- dimensions: *id064
+  name: ch.bafu.gefahren-mikrozonierung.wgs84
+  sources: [ch.bafu.gefahren-mikrozonierung_cache_wgs84]
+  title: Mikrozonierungen
+- dimensions: *id064
+  name: ch.bafu.gefahren-mikrozonierung.lv95
+  sources: [ch.bafu.gefahren-mikrozonierung_cache_lv95]
+  title: Mikrozonierungen
+- dimensions: *id064
+  name: ch.bafu.gefahren-mikrozonierung
+  sources: [ch.bafu.gefahren-mikrozonierung_cache]
+  title: Mikrozonierungen
+- dimensions: &id065
+    Time:
+      default: '20140314'
+      values: ['20140314', '20130903', '20121219', '20110607']
+  name: ch.bafu.gefahren-spektral.mercator
+  sources: [ch.bafu.gefahren-spektral_cache_mercator]
+  title: Spektrale Mikrozonierung
+- dimensions: *id065
+  name: ch.bafu.gefahren-spektral.etrs89
+  sources: [ch.bafu.gefahren-spektral_cache_etrs89]
+  title: Spektrale Mikrozonierung
+- dimensions: *id065
+  name: ch.bafu.gefahren-spektral.wgs84
+  sources: [ch.bafu.gefahren-spektral_cache_wgs84]
+  title: Spektrale Mikrozonierung
+- dimensions: *id065
+  name: ch.bafu.gefahren-spektral.lv95
+  sources: [ch.bafu.gefahren-spektral_cache_lv95]
+  title: Spektrale Mikrozonierung
+- dimensions: *id065
+  name: ch.bafu.gefahren-spektral
+  sources: [ch.bafu.gefahren-spektral_cache]
+  title: Spektrale Mikrozonierung
+- dimensions: &id066
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.holznutzung.mercator
+  sources: [ch.bafu.holznutzung_cache_mercator]
+  title: "Holznutzung und Mortalit\xE4t (LFI)"
+- dimensions: *id066
+  name: ch.bafu.holznutzung.etrs89
+  sources: [ch.bafu.holznutzung_cache_etrs89]
+  title: "Holznutzung und Mortalit\xE4t (LFI)"
+- dimensions: *id066
+  name: ch.bafu.holznutzung.wgs84
+  sources: [ch.bafu.holznutzung_cache_wgs84]
+  title: "Holznutzung und Mortalit\xE4t (LFI)"
+- dimensions: *id066
+  name: ch.bafu.holznutzung.lv95
+  sources: [ch.bafu.holznutzung_cache_lv95]
+  title: "Holznutzung und Mortalit\xE4t (LFI)"
+- dimensions: *id066
+  name: ch.bafu.holznutzung
+  sources: [ch.bafu.holznutzung_cache]
+  title: "Holznutzung und Mortalit\xE4t (LFI)"
+- dimensions: &id067
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.holzvorrat.mercator
+  sources: [ch.bafu.holzvorrat_cache_mercator]
+  title: Holzvorrat (LFI)
+- dimensions: *id067
+  name: ch.bafu.holzvorrat.etrs89
+  sources: [ch.bafu.holzvorrat_cache_etrs89]
+  title: Holzvorrat (LFI)
+- dimensions: *id067
+  name: ch.bafu.holzvorrat.wgs84
+  sources: [ch.bafu.holzvorrat_cache_wgs84]
+  title: Holzvorrat (LFI)
+- dimensions: *id067
+  name: ch.bafu.holzvorrat.lv95
+  sources: [ch.bafu.holzvorrat_cache_lv95]
+  title: Holzvorrat (LFI)
+- dimensions: *id067
+  name: ch.bafu.holzvorrat
+  sources: [ch.bafu.holzvorrat_cache]
+  title: Holzvorrat (LFI)
+- dimensions: &id068
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.holzzuwachs.mercator
+  sources: [ch.bafu.holzzuwachs_cache_mercator]
+  title: Holzzuwachs (LFI)
+- dimensions: *id068
+  name: ch.bafu.holzzuwachs.etrs89
+  sources: [ch.bafu.holzzuwachs_cache_etrs89]
+  title: Holzzuwachs (LFI)
+- dimensions: *id068
+  name: ch.bafu.holzzuwachs.wgs84
+  sources: [ch.bafu.holzzuwachs_cache_wgs84]
+  title: Holzzuwachs (LFI)
+- dimensions: *id068
+  name: ch.bafu.holzzuwachs.lv95
+  sources: [ch.bafu.holzzuwachs_cache_lv95]
+  title: Holzzuwachs (LFI)
+- dimensions: *id068
+  name: ch.bafu.holzzuwachs
+  sources: [ch.bafu.holzzuwachs_cache]
+  title: Holzzuwachs (LFI)
+- dimensions: &id069
+    Time:
+      default: '20130301'
+      values: ['20130301']
+  name: ch.bafu.hydrologie-gewaesserzustandsmessstationen.mercator
+  sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_mercator]
+  title: "Messstandorte Gew\xE4sserzustand"
+- dimensions: *id069
+  name: ch.bafu.hydrologie-gewaesserzustandsmessstationen.etrs89
+  sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_etrs89]
+  title: "Messstandorte Gew\xE4sserzustand"
+- dimensions: *id069
+  name: ch.bafu.hydrologie-gewaesserzustandsmessstationen.wgs84
+  sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_wgs84]
+  title: "Messstandorte Gew\xE4sserzustand"
+- dimensions: *id069
+  name: ch.bafu.hydrologie-gewaesserzustandsmessstationen.lv95
+  sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache_lv95]
+  title: "Messstandorte Gew\xE4sserzustand"
+- dimensions: *id069
+  name: ch.bafu.hydrologie-gewaesserzustandsmessstationen
+  sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_cache]
+  title: "Messstandorte Gew\xE4sserzustand"
+- dimensions: &id070
+    Time:
+      default: '20081201'
+      values: ['20081201']
+  name: ch.bafu.hydrologie-hydromessstationen.mercator
+  sources: [ch.bafu.hydrologie-hydromessstationen_cache_mercator]
+  title: Hydrologische Messstationen
+- dimensions: *id070
+  name: ch.bafu.hydrologie-hydromessstationen.etrs89
+  sources: [ch.bafu.hydrologie-hydromessstationen_cache_etrs89]
+  title: Hydrologische Messstationen
+- dimensions: *id070
+  name: ch.bafu.hydrologie-hydromessstationen.wgs84
+  sources: [ch.bafu.hydrologie-hydromessstationen_cache_wgs84]
+  title: Hydrologische Messstationen
+- dimensions: *id070
+  name: ch.bafu.hydrologie-hydromessstationen.lv95
+  sources: [ch.bafu.hydrologie-hydromessstationen_cache_lv95]
+  title: Hydrologische Messstationen
+- dimensions: *id070
+  name: ch.bafu.hydrologie-hydromessstationen
+  sources: [ch.bafu.hydrologie-hydromessstationen_cache]
+  title: Hydrologische Messstationen
+- dimensions: &id071
+    Time:
+      default: '20130322'
+      values: ['20130322']
+  name: ch.bafu.hydrologie-wassertemperaturmessstationen.mercator
+  sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache_mercator]
+  title: Messstationen Wassertemperatur
+- dimensions: *id071
+  name: ch.bafu.hydrologie-wassertemperaturmessstationen.etrs89
+  sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache_etrs89]
+  title: Messstationen Wassertemperatur
+- dimensions: *id071
+  name: ch.bafu.hydrologie-wassertemperaturmessstationen.wgs84
+  sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache_wgs84]
+  title: Messstationen Wassertemperatur
+- dimensions: *id071
+  name: ch.bafu.hydrologie-wassertemperaturmessstationen.lv95
+  sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache_lv95]
+  title: Messstationen Wassertemperatur
+- dimensions: *id071
+  name: ch.bafu.hydrologie-wassertemperaturmessstationen
+  sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_cache]
+  title: Messstationen Wassertemperatur
+- dimensions: &id072
+    Time:
+      default: '20061231'
+      values: ['20061231']
+  name: ch.bafu.laerm-bahnlaerm_nacht.mercator
+  sources: [ch.bafu.laerm-bahnlaerm_nacht_cache_mercator]
+  title: "Eisenbahnl\xE4rm Nacht"
+- dimensions: *id072
+  name: ch.bafu.laerm-bahnlaerm_nacht.etrs89
+  sources: [ch.bafu.laerm-bahnlaerm_nacht_cache_etrs89]
+  title: "Eisenbahnl\xE4rm Nacht"
+- dimensions: *id072
+  name: ch.bafu.laerm-bahnlaerm_nacht.wgs84
+  sources: [ch.bafu.laerm-bahnlaerm_nacht_cache_wgs84]
+  title: "Eisenbahnl\xE4rm Nacht"
+- dimensions: *id072
+  name: ch.bafu.laerm-bahnlaerm_nacht.lv95
+  sources: [ch.bafu.laerm-bahnlaerm_nacht_cache_lv95]
+  title: "Eisenbahnl\xE4rm Nacht"
+- dimensions: *id072
+  name: ch.bafu.laerm-bahnlaerm_nacht
+  sources: [ch.bafu.laerm-bahnlaerm_nacht_cache]
+  title: "Eisenbahnl\xE4rm Nacht"
+- dimensions: &id073
+    Time:
+      default: '20061231'
+      values: ['20061231']
+  name: ch.bafu.laerm-bahnlaerm_tag.mercator
+  sources: [ch.bafu.laerm-bahnlaerm_tag_cache_mercator]
+  title: "Eisenbahnl\xE4rm Tag"
+- dimensions: *id073
+  name: ch.bafu.laerm-bahnlaerm_tag.etrs89
+  sources: [ch.bafu.laerm-bahnlaerm_tag_cache_etrs89]
+  title: "Eisenbahnl\xE4rm Tag"
+- dimensions: *id073
+  name: ch.bafu.laerm-bahnlaerm_tag.wgs84
+  sources: [ch.bafu.laerm-bahnlaerm_tag_cache_wgs84]
+  title: "Eisenbahnl\xE4rm Tag"
+- dimensions: *id073
+  name: ch.bafu.laerm-bahnlaerm_tag.lv95
+  sources: [ch.bafu.laerm-bahnlaerm_tag_cache_lv95]
+  title: "Eisenbahnl\xE4rm Tag"
+- dimensions: *id073
+  name: ch.bafu.laerm-bahnlaerm_tag
+  sources: [ch.bafu.laerm-bahnlaerm_tag_cache]
+  title: "Eisenbahnl\xE4rm Tag"
+- dimensions: &id074
+    Time:
+      default: '20101231'
+      values: ['20101231']
+  name: ch.bafu.laerm-strassenlaerm_nacht.mercator
+  sources: [ch.bafu.laerm-strassenlaerm_nacht_cache_mercator]
+  title: "Strassenverkehrsl\xE4rm Nacht"
+- dimensions: *id074
+  name: ch.bafu.laerm-strassenlaerm_nacht.etrs89
+  sources: [ch.bafu.laerm-strassenlaerm_nacht_cache_etrs89]
+  title: "Strassenverkehrsl\xE4rm Nacht"
+- dimensions: *id074
+  name: ch.bafu.laerm-strassenlaerm_nacht.wgs84
+  sources: [ch.bafu.laerm-strassenlaerm_nacht_cache_wgs84]
+  title: "Strassenverkehrsl\xE4rm Nacht"
+- dimensions: *id074
+  name: ch.bafu.laerm-strassenlaerm_nacht.lv95
+  sources: [ch.bafu.laerm-strassenlaerm_nacht_cache_lv95]
+  title: "Strassenverkehrsl\xE4rm Nacht"
+- dimensions: *id074
+  name: ch.bafu.laerm-strassenlaerm_nacht
+  sources: [ch.bafu.laerm-strassenlaerm_nacht_cache]
+  title: "Strassenverkehrsl\xE4rm Nacht"
+- dimensions: &id075
+    Time:
+      default: '20101231'
+      values: ['20101231']
+  name: ch.bafu.laerm-strassenlaerm_tag.mercator
+  sources: [ch.bafu.laerm-strassenlaerm_tag_cache_mercator]
+  title: "Strassenverkehrsl\xE4rm Tag"
+- dimensions: *id075
+  name: ch.bafu.laerm-strassenlaerm_tag.etrs89
+  sources: [ch.bafu.laerm-strassenlaerm_tag_cache_etrs89]
+  title: "Strassenverkehrsl\xE4rm Tag"
+- dimensions: *id075
+  name: ch.bafu.laerm-strassenlaerm_tag.wgs84
+  sources: [ch.bafu.laerm-strassenlaerm_tag_cache_wgs84]
+  title: "Strassenverkehrsl\xE4rm Tag"
+- dimensions: *id075
+  name: ch.bafu.laerm-strassenlaerm_tag.lv95
+  sources: [ch.bafu.laerm-strassenlaerm_tag_cache_lv95]
+  title: "Strassenverkehrsl\xE4rm Tag"
+- dimensions: *id075
+  name: ch.bafu.laerm-strassenlaerm_tag
+  sources: [ch.bafu.laerm-strassenlaerm_tag_cache]
+  title: "Strassenverkehrsl\xE4rm Tag"
+- dimensions: &id076
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.landesforstinventar-baumarten.mercator
+  sources: [ch.bafu.landesforstinventar-baumarten_cache_mercator]
+  title: Baumarten (LFI)
+- dimensions: *id076
+  name: ch.bafu.landesforstinventar-baumarten.etrs89
+  sources: [ch.bafu.landesforstinventar-baumarten_cache_etrs89]
+  title: Baumarten (LFI)
+- dimensions: *id076
+  name: ch.bafu.landesforstinventar-baumarten.wgs84
+  sources: [ch.bafu.landesforstinventar-baumarten_cache_wgs84]
+  title: Baumarten (LFI)
+- dimensions: *id076
+  name: ch.bafu.landesforstinventar-baumarten.lv95
+  sources: [ch.bafu.landesforstinventar-baumarten_cache_lv95]
+  title: Baumarten (LFI)
+- dimensions: *id076
+  name: ch.bafu.landesforstinventar-baumarten
+  sources: [ch.bafu.landesforstinventar-baumarten_cache]
+  title: Baumarten (LFI)
+- dimensions: &id077
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.landesforstinventar-totholz.mercator
+  sources: [ch.bafu.landesforstinventar-totholz_cache_mercator]
+  title: Totholz (LFI)
+- dimensions: *id077
+  name: ch.bafu.landesforstinventar-totholz.etrs89
+  sources: [ch.bafu.landesforstinventar-totholz_cache_etrs89]
+  title: Totholz (LFI)
+- dimensions: *id077
+  name: ch.bafu.landesforstinventar-totholz.wgs84
+  sources: [ch.bafu.landesforstinventar-totholz_cache_wgs84]
+  title: Totholz (LFI)
+- dimensions: *id077
+  name: ch.bafu.landesforstinventar-totholz.lv95
+  sources: [ch.bafu.landesforstinventar-totholz_cache_lv95]
+  title: Totholz (LFI)
+- dimensions: *id077
+  name: ch.bafu.landesforstinventar-totholz
+  sources: [ch.bafu.landesforstinventar-totholz_cache]
+  title: Totholz (LFI)
+- dimensions: &id078
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.landesforstinventar-waldanteil.mercator
+  sources: [ch.bafu.landesforstinventar-waldanteil_cache_mercator]
+  title: Waldanteil (LFI)
+- dimensions: *id078
+  name: ch.bafu.landesforstinventar-waldanteil.etrs89
+  sources: [ch.bafu.landesforstinventar-waldanteil_cache_etrs89]
+  title: Waldanteil (LFI)
+- dimensions: *id078
+  name: ch.bafu.landesforstinventar-waldanteil.wgs84
+  sources: [ch.bafu.landesforstinventar-waldanteil_cache_wgs84]
+  title: Waldanteil (LFI)
+- dimensions: *id078
+  name: ch.bafu.landesforstinventar-waldanteil.lv95
+  sources: [ch.bafu.landesforstinventar-waldanteil_cache_lv95]
+  title: Waldanteil (LFI)
+- dimensions: *id078
+  name: ch.bafu.landesforstinventar-waldanteil
+  sources: [ch.bafu.landesforstinventar-waldanteil_cache]
+  title: Waldanteil (LFI)
+- dimensions: &id079
+    Time:
+      default: '20120416'
+      values: ['20120416']
+  name: ch.bafu.moose.mercator
+  sources: [ch.bafu.moose_cache_mercator]
+  title: Rote Liste Moose
+- dimensions: *id079
+  name: ch.bafu.moose.etrs89
+  sources: [ch.bafu.moose_cache_etrs89]
+  title: Rote Liste Moose
+- dimensions: *id079
+  name: ch.bafu.moose.wgs84
+  sources: [ch.bafu.moose_cache_wgs84]
+  title: Rote Liste Moose
+- dimensions: *id079
+  name: ch.bafu.moose.lv95
+  sources: [ch.bafu.moose_cache_lv95]
+  title: Rote Liste Moose
+- dimensions: *id079
+  name: ch.bafu.moose
+  sources: [ch.bafu.moose_cache]
+  title: Rote Liste Moose
+- dimensions: &id080
+    Time:
+      default: '20110309'
+      values: ['20110309']
+  name: ch.bafu.nabelstationen.mercator
+  sources: [ch.bafu.nabelstationen_cache_mercator]
+  title: 'Luftbelastung: Stationen NABEL'
+- dimensions: *id080
+  name: ch.bafu.nabelstationen.etrs89
+  sources: [ch.bafu.nabelstationen_cache_etrs89]
+  title: 'Luftbelastung: Stationen NABEL'
+- dimensions: *id080
+  name: ch.bafu.nabelstationen.wgs84
+  sources: [ch.bafu.nabelstationen_cache_wgs84]
+  title: 'Luftbelastung: Stationen NABEL'
+- dimensions: *id080
+  name: ch.bafu.nabelstationen.lv95
+  sources: [ch.bafu.nabelstationen_cache_lv95]
+  title: 'Luftbelastung: Stationen NABEL'
+- dimensions: *id080
+  name: ch.bafu.nabelstationen
+  sources: [ch.bafu.nabelstationen_cache]
+  title: 'Luftbelastung: Stationen NABEL'
+- dimensions: &id081
+    Time:
+      default: '20130305'
+      values: ['20130305']
+  name: ch.bafu.naqua-grundwasser_nitrat.mercator
+  sources: [ch.bafu.naqua-grundwasser_nitrat_cache_mercator]
+  title: Nitrat
+- dimensions: *id081
+  name: ch.bafu.naqua-grundwasser_nitrat.etrs89
+  sources: [ch.bafu.naqua-grundwasser_nitrat_cache_etrs89]
+  title: Nitrat
+- dimensions: *id081
+  name: ch.bafu.naqua-grundwasser_nitrat.wgs84
+  sources: [ch.bafu.naqua-grundwasser_nitrat_cache_wgs84]
+  title: Nitrat
+- dimensions: *id081
+  name: ch.bafu.naqua-grundwasser_nitrat.lv95
+  sources: [ch.bafu.naqua-grundwasser_nitrat_cache_lv95]
+  title: Nitrat
+- dimensions: *id081
+  name: ch.bafu.naqua-grundwasser_nitrat
+  sources: [ch.bafu.naqua-grundwasser_nitrat_cache]
+  title: Nitrat
+- dimensions: &id082
+    Time:
+      default: '20130305'
+      values: ['20130305']
+  name: ch.bafu.naqua-grundwasser_psm.mercator
+  sources: [ch.bafu.naqua-grundwasser_psm_cache_mercator]
+  title: Pflanzenschutzmittel
+- dimensions: *id082
+  name: ch.bafu.naqua-grundwasser_psm.etrs89
+  sources: [ch.bafu.naqua-grundwasser_psm_cache_etrs89]
+  title: Pflanzenschutzmittel
+- dimensions: *id082
+  name: ch.bafu.naqua-grundwasser_psm.wgs84
+  sources: [ch.bafu.naqua-grundwasser_psm_cache_wgs84]
+  title: Pflanzenschutzmittel
+- dimensions: *id082
+  name: ch.bafu.naqua-grundwasser_psm.lv95
+  sources: [ch.bafu.naqua-grundwasser_psm_cache_lv95]
+  title: Pflanzenschutzmittel
+- dimensions: *id082
+  name: ch.bafu.naqua-grundwasser_psm
+  sources: [ch.bafu.naqua-grundwasser_psm_cache]
+  title: Pflanzenschutzmittel
+- dimensions: &id083
+    Time:
+      default: '20130305'
+      values: ['20130305']
+  name: ch.bafu.naqua-grundwasser_voc.mercator
+  sources: [ch.bafu.naqua-grundwasser_voc_cache_mercator]
+  title: "Fl\xFCchtige org. Verbindungen"
+- dimensions: *id083
+  name: ch.bafu.naqua-grundwasser_voc.etrs89
+  sources: [ch.bafu.naqua-grundwasser_voc_cache_etrs89]
+  title: "Fl\xFCchtige org. Verbindungen"
+- dimensions: *id083
+  name: ch.bafu.naqua-grundwasser_voc.wgs84
+  sources: [ch.bafu.naqua-grundwasser_voc_cache_wgs84]
+  title: "Fl\xFCchtige org. Verbindungen"
+- dimensions: *id083
+  name: ch.bafu.naqua-grundwasser_voc.lv95
+  sources: [ch.bafu.naqua-grundwasser_voc_cache_lv95]
+  title: "Fl\xFCchtige org. Verbindungen"
+- dimensions: *id083
+  name: ch.bafu.naqua-grundwasser_voc
+  sources: [ch.bafu.naqua-grundwasser_voc_cache]
+  title: "Fl\xFCchtige org. Verbindungen"
+- dimensions: &id084
+    Time:
+      default: '20080913'
+      values: ['20080913']
+  name: ch.bafu.oekomorphologie-f_abschnitte.mercator
+  sources: [ch.bafu.oekomorphologie-f_abschnitte_cache_mercator]
+  title: "\xD6komorphologie F - Abschnitte"
+- dimensions: *id084
+  name: ch.bafu.oekomorphologie-f_abschnitte.etrs89
+  sources: [ch.bafu.oekomorphologie-f_abschnitte_cache_etrs89]
+  title: "\xD6komorphologie F - Abschnitte"
+- dimensions: *id084
+  name: ch.bafu.oekomorphologie-f_abschnitte.wgs84
+  sources: [ch.bafu.oekomorphologie-f_abschnitte_cache_wgs84]
+  title: "\xD6komorphologie F - Abschnitte"
+- dimensions: *id084
+  name: ch.bafu.oekomorphologie-f_abschnitte.lv95
+  sources: [ch.bafu.oekomorphologie-f_abschnitte_cache_lv95]
+  title: "\xD6komorphologie F - Abschnitte"
+- dimensions: *id084
+  name: ch.bafu.oekomorphologie-f_abschnitte
+  sources: [ch.bafu.oekomorphologie-f_abschnitte_cache]
+  title: "\xD6komorphologie F - Abschnitte"
+- dimensions: &id085
+    Time:
+      default: '20110912'
+      values: ['20110912']
+  name: ch.bafu.oekomorphologie-f_abstuerze.mercator
+  sources: [ch.bafu.oekomorphologie-f_abstuerze_cache_mercator]
+  title: "\xD6komorphologie F - Abst\xFCrze"
+- dimensions: *id085
+  name: ch.bafu.oekomorphologie-f_abstuerze.etrs89
+  sources: [ch.bafu.oekomorphologie-f_abstuerze_cache_etrs89]
+  title: "\xD6komorphologie F - Abst\xFCrze"
+- dimensions: *id085
+  name: ch.bafu.oekomorphologie-f_abstuerze.wgs84
+  sources: [ch.bafu.oekomorphologie-f_abstuerze_cache_wgs84]
+  title: "\xD6komorphologie F - Abst\xFCrze"
+- dimensions: *id085
+  name: ch.bafu.oekomorphologie-f_abstuerze.lv95
+  sources: [ch.bafu.oekomorphologie-f_abstuerze_cache_lv95]
+  title: "\xD6komorphologie F - Abst\xFCrze"
+- dimensions: *id085
+  name: ch.bafu.oekomorphologie-f_abstuerze
+  sources: [ch.bafu.oekomorphologie-f_abstuerze_cache]
+  title: "\xD6komorphologie F - Abst\xFCrze"
+- dimensions: &id086
+    Time:
+      default: '20110912'
+      values: ['20110912']
+  name: ch.bafu.oekomorphologie-f_bauwerke.mercator
+  sources: [ch.bafu.oekomorphologie-f_bauwerke_cache_mercator]
+  title: "\xD6komorphologie F - Bauwerke"
+- dimensions: *id086
+  name: ch.bafu.oekomorphologie-f_bauwerke.etrs89
+  sources: [ch.bafu.oekomorphologie-f_bauwerke_cache_etrs89]
+  title: "\xD6komorphologie F - Bauwerke"
+- dimensions: *id086
+  name: ch.bafu.oekomorphologie-f_bauwerke.wgs84
+  sources: [ch.bafu.oekomorphologie-f_bauwerke_cache_wgs84]
+  title: "\xD6komorphologie F - Bauwerke"
+- dimensions: *id086
+  name: ch.bafu.oekomorphologie-f_bauwerke.lv95
+  sources: [ch.bafu.oekomorphologie-f_bauwerke_cache_lv95]
+  title: "\xD6komorphologie F - Bauwerke"
+- dimensions: *id086
+  name: ch.bafu.oekomorphologie-f_bauwerke
+  sources: [ch.bafu.oekomorphologie-f_bauwerke_cache]
+  title: "\xD6komorphologie F - Bauwerke"
+- dimensions: &id087
+    Time:
+      default: '20110317'
+      values: ['20110317']
+  name: ch.bafu.permafrost.mercator
+  sources: [ch.bafu.permafrost_cache_mercator]
+  title: Permafrosthinweiskarte
+- dimensions: *id087
+  name: ch.bafu.permafrost.etrs89
+  sources: [ch.bafu.permafrost_cache_etrs89]
+  title: Permafrosthinweiskarte
+- dimensions: *id087
+  name: ch.bafu.permafrost.wgs84
+  sources: [ch.bafu.permafrost_cache_wgs84]
+  title: Permafrosthinweiskarte
+- dimensions: *id087
+  name: ch.bafu.permafrost.lv95
+  sources: [ch.bafu.permafrost_cache_lv95]
+  title: Permafrosthinweiskarte
+- dimensions: *id087
+  name: ch.bafu.permafrost
+  sources: [ch.bafu.permafrost_cache]
+  title: Permafrosthinweiskarte
+- dimensions: &id088
+    Time:
+      default: '20110214'
+      values: ['20110214']
+  name: ch.bafu.ren-extensive_landwirtschaftsgebiete.mercator
+  sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_mercator]
+  title: REN  Extensives Landwirtschaftsgebiet
+- dimensions: *id088
+  name: ch.bafu.ren-extensive_landwirtschaftsgebiete.etrs89
+  sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_etrs89]
+  title: REN  Extensives Landwirtschaftsgebiet
+- dimensions: *id088
+  name: ch.bafu.ren-extensive_landwirtschaftsgebiete.wgs84
+  sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_wgs84]
+  title: REN  Extensives Landwirtschaftsgebiet
+- dimensions: *id088
+  name: ch.bafu.ren-extensive_landwirtschaftsgebiete.lv95
+  sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache_lv95]
+  title: REN  Extensives Landwirtschaftsgebiet
+- dimensions: *id088
+  name: ch.bafu.ren-extensive_landwirtschaftsgebiete
+  sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_cache]
+  title: REN  Extensives Landwirtschaftsgebiet
+- dimensions: &id089
+    Time:
+      default: '20110214'
+      values: ['20110214']
+  name: ch.bafu.ren-feuchtgebiete.mercator
+  sources: [ch.bafu.ren-feuchtgebiete_cache_mercator]
+  title: REN  Feuchtgebiet
+- dimensions: *id089
+  name: ch.bafu.ren-feuchtgebiete.etrs89
+  sources: [ch.bafu.ren-feuchtgebiete_cache_etrs89]
+  title: REN  Feuchtgebiet
+- dimensions: *id089
+  name: ch.bafu.ren-feuchtgebiete.wgs84
+  sources: [ch.bafu.ren-feuchtgebiete_cache_wgs84]
+  title: REN  Feuchtgebiet
+- dimensions: *id089
+  name: ch.bafu.ren-feuchtgebiete.lv95
+  sources: [ch.bafu.ren-feuchtgebiete_cache_lv95]
+  title: REN  Feuchtgebiet
+- dimensions: *id089
+  name: ch.bafu.ren-feuchtgebiete
+  sources: [ch.bafu.ren-feuchtgebiete_cache]
+  title: REN  Feuchtgebiet
+- dimensions: &id090
+    Time:
+      default: '20110214'
+      values: ['20110214']
+  name: ch.bafu.ren-fliessgewaesser_seen.mercator
+  sources: [ch.bafu.ren-fliessgewaesser_seen_cache_mercator]
+  title: "REN  Fliessgew\xE4sser / Seen"
+- dimensions: *id090
+  name: ch.bafu.ren-fliessgewaesser_seen.etrs89
+  sources: [ch.bafu.ren-fliessgewaesser_seen_cache_etrs89]
+  title: "REN  Fliessgew\xE4sser / Seen"
+- dimensions: *id090
+  name: ch.bafu.ren-fliessgewaesser_seen.wgs84
+  sources: [ch.bafu.ren-fliessgewaesser_seen_cache_wgs84]
+  title: "REN  Fliessgew\xE4sser / Seen"
+- dimensions: *id090
+  name: ch.bafu.ren-fliessgewaesser_seen.lv95
+  sources: [ch.bafu.ren-fliessgewaesser_seen_cache_lv95]
+  title: "REN  Fliessgew\xE4sser / Seen"
+- dimensions: *id090
+  name: ch.bafu.ren-fliessgewaesser_seen
+  sources: [ch.bafu.ren-fliessgewaesser_seen_cache]
+  title: "REN  Fliessgew\xE4sser / Seen"
+- dimensions: &id091
+    Time:
+      default: '20110214'
+      values: ['20110214']
+  name: ch.bafu.ren-trockenstandorte.mercator
+  sources: [ch.bafu.ren-trockenstandorte_cache_mercator]
+  title: REN  Trockenstandort
+- dimensions: *id091
+  name: ch.bafu.ren-trockenstandorte.etrs89
+  sources: [ch.bafu.ren-trockenstandorte_cache_etrs89]
+  title: REN  Trockenstandort
+- dimensions: *id091
+  name: ch.bafu.ren-trockenstandorte.wgs84
+  sources: [ch.bafu.ren-trockenstandorte_cache_wgs84]
+  title: REN  Trockenstandort
+- dimensions: *id091
+  name: ch.bafu.ren-trockenstandorte.lv95
+  sources: [ch.bafu.ren-trockenstandorte_cache_lv95]
+  title: REN  Trockenstandort
+- dimensions: *id091
+  name: ch.bafu.ren-trockenstandorte
+  sources: [ch.bafu.ren-trockenstandorte_cache]
+  title: REN  Trockenstandort
+- dimensions: &id092
+    Time:
+      default: '20110214'
+      values: ['20110214']
+  name: ch.bafu.ren-wald.mercator
+  sources: [ch.bafu.ren-wald_cache_mercator]
+  title: REN  Wald
+- dimensions: *id092
+  name: ch.bafu.ren-wald.etrs89
+  sources: [ch.bafu.ren-wald_cache_etrs89]
+  title: REN  Wald
+- dimensions: *id092
+  name: ch.bafu.ren-wald.wgs84
+  sources: [ch.bafu.ren-wald_cache_wgs84]
+  title: REN  Wald
+- dimensions: *id092
+  name: ch.bafu.ren-wald.lv95
+  sources: [ch.bafu.ren-wald_cache_lv95]
+  title: REN  Wald
+- dimensions: *id092
+  name: ch.bafu.ren-wald
+  sources: [ch.bafu.ren-wald_cache]
+  title: REN  Wald
+- dimensions: &id093
+    Time:
+      default: '20120109'
+      values: ['20120109']
+  name: ch.bafu.schutzgebiete-biosphaerenreservate.mercator
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache_mercator]
+  title: "Biosph\xE4renreservate"
+- dimensions: *id093
+  name: ch.bafu.schutzgebiete-biosphaerenreservate.etrs89
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache_etrs89]
+  title: "Biosph\xE4renreservate"
+- dimensions: *id093
+  name: ch.bafu.schutzgebiete-biosphaerenreservate.wgs84
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache_wgs84]
+  title: "Biosph\xE4renreservate"
+- dimensions: *id093
+  name: ch.bafu.schutzgebiete-biosphaerenreservate.lv95
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache_lv95]
+  title: "Biosph\xE4renreservate"
+- dimensions: *id093
+  name: ch.bafu.schutzgebiete-biosphaerenreservate
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_cache]
+  title: "Biosph\xE4renreservate"
+- dimensions: &id094
+    Time:
+      default: '20110818'
+      values: ['20110818']
+  name: ch.bafu.schutzgebiete-luftfahrt.mercator
+  sources: [ch.bafu.schutzgebiete-luftfahrt_cache_mercator]
+  title: Schutzgebiete
+- dimensions: *id094
+  name: ch.bafu.schutzgebiete-luftfahrt.etrs89
+  sources: [ch.bafu.schutzgebiete-luftfahrt_cache_etrs89]
+  title: Schutzgebiete
+- dimensions: *id094
+  name: ch.bafu.schutzgebiete-luftfahrt.wgs84
+  sources: [ch.bafu.schutzgebiete-luftfahrt_cache_wgs84]
+  title: Schutzgebiete
+- dimensions: *id094
+  name: ch.bafu.schutzgebiete-luftfahrt.lv95
+  sources: [ch.bafu.schutzgebiete-luftfahrt_cache_lv95]
+  title: Schutzgebiete
+- dimensions: *id094
+  name: ch.bafu.schutzgebiete-luftfahrt
+  sources: [ch.bafu.schutzgebiete-luftfahrt_cache]
+  title: Schutzgebiete
+- dimensions: &id095
+    Time:
+      default: '20140402'
+      values: ['20140402', '20130416', '20121023', '20120127', '20110103']
+  name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.mercator
+  sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_mercator]
+  title: "P\xE4rke"
+- dimensions: *id095
+  name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.etrs89
+  sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_etrs89]
+  title: "P\xE4rke"
+- dimensions: *id095
+  name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.wgs84
+  sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_wgs84]
+  title: "P\xE4rke"
+- dimensions: *id095
+  name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.lv95
+  sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache_lv95]
+  title: "P\xE4rke"
+- dimensions: *id095
+  name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung
+  sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_cache]
+  title: "P\xE4rke"
+- dimensions: &id096
+    Time:
+      default: '20110830'
+      values: ['20110830', '20050202']
+  name: ch.bafu.schutzgebiete-ramsar.mercator
+  sources: [ch.bafu.schutzgebiete-ramsar_cache_mercator]
+  title: Ramsar
+- dimensions: *id096
+  name: ch.bafu.schutzgebiete-ramsar.etrs89
+  sources: [ch.bafu.schutzgebiete-ramsar_cache_etrs89]
+  title: Ramsar
+- dimensions: *id096
+  name: ch.bafu.schutzgebiete-ramsar.wgs84
+  sources: [ch.bafu.schutzgebiete-ramsar_cache_wgs84]
+  title: Ramsar
+- dimensions: *id096
+  name: ch.bafu.schutzgebiete-ramsar.lv95
+  sources: [ch.bafu.schutzgebiete-ramsar_cache_lv95]
+  title: Ramsar
+- dimensions: *id096
+  name: ch.bafu.schutzgebiete-ramsar
+  sources: [ch.bafu.schutzgebiete-ramsar_cache]
+  title: Ramsar
+- dimensions: &id097
+    Time:
+      default: '20010117'
+      values: ['20010117']
+  name: ch.bafu.schutzgebiete-schweizerischer_nationalpark.mercator
+  sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_mercator]
+  title: Nationalpark
+- dimensions: *id097
+  name: ch.bafu.schutzgebiete-schweizerischer_nationalpark.etrs89
+  sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_etrs89]
+  title: Nationalpark
+- dimensions: *id097
+  name: ch.bafu.schutzgebiete-schweizerischer_nationalpark.wgs84
+  sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_wgs84]
+  title: Nationalpark
+- dimensions: *id097
+  name: ch.bafu.schutzgebiete-schweizerischer_nationalpark.lv95
+  sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache_lv95]
+  title: Nationalpark
+- dimensions: *id097
+  name: ch.bafu.schutzgebiete-schweizerischer_nationalpark
+  sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_cache]
+  title: Nationalpark
+- dimensions: &id098
+    Time:
+      default: '20090917'
+      values: ['20090917']
+  name: ch.bafu.schutzgebiete-smaragd.mercator
+  sources: [ch.bafu.schutzgebiete-smaragd_cache_mercator]
+  title: Smaragd
+- dimensions: *id098
+  name: ch.bafu.schutzgebiete-smaragd.etrs89
+  sources: [ch.bafu.schutzgebiete-smaragd_cache_etrs89]
+  title: Smaragd
+- dimensions: *id098
+  name: ch.bafu.schutzgebiete-smaragd.wgs84
+  sources: [ch.bafu.schutzgebiete-smaragd_cache_wgs84]
+  title: Smaragd
+- dimensions: *id098
+  name: ch.bafu.schutzgebiete-smaragd.lv95
+  sources: [ch.bafu.schutzgebiete-smaragd_cache_lv95]
+  title: Smaragd
+- dimensions: *id098
+  name: ch.bafu.schutzgebiete-smaragd
+  sources: [ch.bafu.schutzgebiete-smaragd_cache]
+  title: Smaragd
+- dimensions: &id099
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-gemeinden_hochwasser.mercator
+  sources: [ch.bafu.showme-gemeinden_hochwasser_cache_mercator]
+  title: 'ShowMe Gemeinden: Hochwasser'
+- dimensions: *id099
+  name: ch.bafu.showme-gemeinden_hochwasser.etrs89
+  sources: [ch.bafu.showme-gemeinden_hochwasser_cache_etrs89]
+  title: 'ShowMe Gemeinden: Hochwasser'
+- dimensions: *id099
+  name: ch.bafu.showme-gemeinden_hochwasser.wgs84
+  sources: [ch.bafu.showme-gemeinden_hochwasser_cache_wgs84]
+  title: 'ShowMe Gemeinden: Hochwasser'
+- dimensions: *id099
+  name: ch.bafu.showme-gemeinden_hochwasser.lv95
+  sources: [ch.bafu.showme-gemeinden_hochwasser_cache_lv95]
+  title: 'ShowMe Gemeinden: Hochwasser'
+- dimensions: *id099
+  name: ch.bafu.showme-gemeinden_hochwasser
+  sources: [ch.bafu.showme-gemeinden_hochwasser_cache]
+  title: 'ShowMe Gemeinden: Hochwasser'
+- dimensions: &id100
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-gemeinden_lawinen.mercator
+  sources: [ch.bafu.showme-gemeinden_lawinen_cache_mercator]
+  title: 'ShowMe Gemeinden: Lawinen'
+- dimensions: *id100
+  name: ch.bafu.showme-gemeinden_lawinen.etrs89
+  sources: [ch.bafu.showme-gemeinden_lawinen_cache_etrs89]
+  title: 'ShowMe Gemeinden: Lawinen'
+- dimensions: *id100
+  name: ch.bafu.showme-gemeinden_lawinen.wgs84
+  sources: [ch.bafu.showme-gemeinden_lawinen_cache_wgs84]
+  title: 'ShowMe Gemeinden: Lawinen'
+- dimensions: *id100
+  name: ch.bafu.showme-gemeinden_lawinen.lv95
+  sources: [ch.bafu.showme-gemeinden_lawinen_cache_lv95]
+  title: 'ShowMe Gemeinden: Lawinen'
+- dimensions: *id100
+  name: ch.bafu.showme-gemeinden_lawinen
+  sources: [ch.bafu.showme-gemeinden_lawinen_cache]
+  title: 'ShowMe Gemeinden: Lawinen'
+- dimensions: &id101
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-gemeinden_rutschungen.mercator
+  sources: [ch.bafu.showme-gemeinden_rutschungen_cache_mercator]
+  title: 'ShowMe Gemeinden: Rutschungen'
+- dimensions: *id101
+  name: ch.bafu.showme-gemeinden_rutschungen.etrs89
+  sources: [ch.bafu.showme-gemeinden_rutschungen_cache_etrs89]
+  title: 'ShowMe Gemeinden: Rutschungen'
+- dimensions: *id101
+  name: ch.bafu.showme-gemeinden_rutschungen.wgs84
+  sources: [ch.bafu.showme-gemeinden_rutschungen_cache_wgs84]
+  title: 'ShowMe Gemeinden: Rutschungen'
+- dimensions: *id101
+  name: ch.bafu.showme-gemeinden_rutschungen.lv95
+  sources: [ch.bafu.showme-gemeinden_rutschungen_cache_lv95]
+  title: 'ShowMe Gemeinden: Rutschungen'
+- dimensions: *id101
+  name: ch.bafu.showme-gemeinden_rutschungen
+  sources: [ch.bafu.showme-gemeinden_rutschungen_cache]
+  title: 'ShowMe Gemeinden: Rutschungen'
+- dimensions: &id102
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-gemeinden_sturzprozesse.mercator
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache_mercator]
+  title: 'ShowMe Gemeinden: Sturzprozesse'
+- dimensions: *id102
+  name: ch.bafu.showme-gemeinden_sturzprozesse.etrs89
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache_etrs89]
+  title: 'ShowMe Gemeinden: Sturzprozesse'
+- dimensions: *id102
+  name: ch.bafu.showme-gemeinden_sturzprozesse.wgs84
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache_wgs84]
+  title: 'ShowMe Gemeinden: Sturzprozesse'
+- dimensions: *id102
+  name: ch.bafu.showme-gemeinden_sturzprozesse.lv95
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache_lv95]
+  title: 'ShowMe Gemeinden: Sturzprozesse'
+- dimensions: *id102
+  name: ch.bafu.showme-gemeinden_sturzprozesse
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_cache]
+  title: 'ShowMe Gemeinden: Sturzprozesse'
+- dimensions: &id103
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-kantone_hochwasser.mercator
+  sources: [ch.bafu.showme-kantone_hochwasser_cache_mercator]
+  title: 'ShowMe Kantone: Hochwasser'
+- dimensions: *id103
+  name: ch.bafu.showme-kantone_hochwasser.etrs89
+  sources: [ch.bafu.showme-kantone_hochwasser_cache_etrs89]
+  title: 'ShowMe Kantone: Hochwasser'
+- dimensions: *id103
+  name: ch.bafu.showme-kantone_hochwasser.wgs84
+  sources: [ch.bafu.showme-kantone_hochwasser_cache_wgs84]
+  title: 'ShowMe Kantone: Hochwasser'
+- dimensions: *id103
+  name: ch.bafu.showme-kantone_hochwasser.lv95
+  sources: [ch.bafu.showme-kantone_hochwasser_cache_lv95]
+  title: 'ShowMe Kantone: Hochwasser'
+- dimensions: *id103
+  name: ch.bafu.showme-kantone_hochwasser
+  sources: [ch.bafu.showme-kantone_hochwasser_cache]
+  title: 'ShowMe Kantone: Hochwasser'
+- dimensions: &id104
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-kantone_lawinen.mercator
+  sources: [ch.bafu.showme-kantone_lawinen_cache_mercator]
+  title: 'ShowMe Kantone: Lawinen'
+- dimensions: *id104
+  name: ch.bafu.showme-kantone_lawinen.etrs89
+  sources: [ch.bafu.showme-kantone_lawinen_cache_etrs89]
+  title: 'ShowMe Kantone: Lawinen'
+- dimensions: *id104
+  name: ch.bafu.showme-kantone_lawinen.wgs84
+  sources: [ch.bafu.showme-kantone_lawinen_cache_wgs84]
+  title: 'ShowMe Kantone: Lawinen'
+- dimensions: *id104
+  name: ch.bafu.showme-kantone_lawinen.lv95
+  sources: [ch.bafu.showme-kantone_lawinen_cache_lv95]
+  title: 'ShowMe Kantone: Lawinen'
+- dimensions: *id104
+  name: ch.bafu.showme-kantone_lawinen
+  sources: [ch.bafu.showme-kantone_lawinen_cache]
+  title: 'ShowMe Kantone: Lawinen'
+- dimensions: &id105
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-kantone_rutschungen.mercator
+  sources: [ch.bafu.showme-kantone_rutschungen_cache_mercator]
+  title: 'ShowMe Kantone: Rutschungen'
+- dimensions: *id105
+  name: ch.bafu.showme-kantone_rutschungen.etrs89
+  sources: [ch.bafu.showme-kantone_rutschungen_cache_etrs89]
+  title: 'ShowMe Kantone: Rutschungen'
+- dimensions: *id105
+  name: ch.bafu.showme-kantone_rutschungen.wgs84
+  sources: [ch.bafu.showme-kantone_rutschungen_cache_wgs84]
+  title: 'ShowMe Kantone: Rutschungen'
+- dimensions: *id105
+  name: ch.bafu.showme-kantone_rutschungen.lv95
+  sources: [ch.bafu.showme-kantone_rutschungen_cache_lv95]
+  title: 'ShowMe Kantone: Rutschungen'
+- dimensions: *id105
+  name: ch.bafu.showme-kantone_rutschungen
+  sources: [ch.bafu.showme-kantone_rutschungen_cache]
+  title: 'ShowMe Kantone: Rutschungen'
+- dimensions: &id106
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101', '20110101', '20100101']
+  name: ch.bafu.showme-kantone_sturzprozesse.mercator
+  sources: [ch.bafu.showme-kantone_sturzprozesse_cache_mercator]
+  title: 'ShowMe Kantone: Sturzprozesse'
+- dimensions: *id106
+  name: ch.bafu.showme-kantone_sturzprozesse.etrs89
+  sources: [ch.bafu.showme-kantone_sturzprozesse_cache_etrs89]
+  title: 'ShowMe Kantone: Sturzprozesse'
+- dimensions: *id106
+  name: ch.bafu.showme-kantone_sturzprozesse.wgs84
+  sources: [ch.bafu.showme-kantone_sturzprozesse_cache_wgs84]
+  title: 'ShowMe Kantone: Sturzprozesse'
+- dimensions: *id106
+  name: ch.bafu.showme-kantone_sturzprozesse.lv95
+  sources: [ch.bafu.showme-kantone_sturzprozesse_cache_lv95]
+  title: 'ShowMe Kantone: Sturzprozesse'
+- dimensions: *id106
+  name: ch.bafu.showme-kantone_sturzprozesse
+  sources: [ch.bafu.showme-kantone_sturzprozesse_cache]
+  title: 'ShowMe Kantone: Sturzprozesse'
+- dimensions: &id107
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-hangmuren.mercator
+  sources: [ch.bafu.silvaprotect-hangmuren_cache_mercator]
+  title: Hangmuren
+- dimensions: *id107
+  name: ch.bafu.silvaprotect-hangmuren.etrs89
+  sources: [ch.bafu.silvaprotect-hangmuren_cache_etrs89]
+  title: Hangmuren
+- dimensions: *id107
+  name: ch.bafu.silvaprotect-hangmuren.wgs84
+  sources: [ch.bafu.silvaprotect-hangmuren_cache_wgs84]
+  title: Hangmuren
+- dimensions: *id107
+  name: ch.bafu.silvaprotect-hangmuren.lv95
+  sources: [ch.bafu.silvaprotect-hangmuren_cache_lv95]
+  title: Hangmuren
+- dimensions: *id107
+  name: ch.bafu.silvaprotect-hangmuren
+  sources: [ch.bafu.silvaprotect-hangmuren_cache]
+  title: Hangmuren
+- dimensions: &id108
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-lawinen.mercator
+  sources: [ch.bafu.silvaprotect-lawinen_cache_mercator]
+  title: Lawinen
+- dimensions: *id108
+  name: ch.bafu.silvaprotect-lawinen.etrs89
+  sources: [ch.bafu.silvaprotect-lawinen_cache_etrs89]
+  title: Lawinen
+- dimensions: *id108
+  name: ch.bafu.silvaprotect-lawinen.wgs84
+  sources: [ch.bafu.silvaprotect-lawinen_cache_wgs84]
+  title: Lawinen
+- dimensions: *id108
+  name: ch.bafu.silvaprotect-lawinen.lv95
+  sources: [ch.bafu.silvaprotect-lawinen_cache_lv95]
+  title: Lawinen
+- dimensions: *id108
+  name: ch.bafu.silvaprotect-lawinen
+  sources: [ch.bafu.silvaprotect-lawinen_cache]
+  title: Lawinen
+- dimensions: &id109
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-murgang.mercator
+  sources: [ch.bafu.silvaprotect-murgang_cache_mercator]
+  title: Murgang
+- dimensions: *id109
+  name: ch.bafu.silvaprotect-murgang.etrs89
+  sources: [ch.bafu.silvaprotect-murgang_cache_etrs89]
+  title: Murgang
+- dimensions: *id109
+  name: ch.bafu.silvaprotect-murgang.wgs84
+  sources: [ch.bafu.silvaprotect-murgang_cache_wgs84]
+  title: Murgang
+- dimensions: *id109
+  name: ch.bafu.silvaprotect-murgang.lv95
+  sources: [ch.bafu.silvaprotect-murgang_cache_lv95]
+  title: Murgang
+- dimensions: *id109
+  name: ch.bafu.silvaprotect-murgang
+  sources: [ch.bafu.silvaprotect-murgang_cache]
+  title: Murgang
+- dimensions: &id110
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-sturz.mercator
+  sources: [ch.bafu.silvaprotect-sturz_cache_mercator]
+  title: Sturz
+- dimensions: *id110
+  name: ch.bafu.silvaprotect-sturz.etrs89
+  sources: [ch.bafu.silvaprotect-sturz_cache_etrs89]
+  title: Sturz
+- dimensions: *id110
+  name: ch.bafu.silvaprotect-sturz.wgs84
+  sources: [ch.bafu.silvaprotect-sturz_cache_wgs84]
+  title: Sturz
+- dimensions: *id110
+  name: ch.bafu.silvaprotect-sturz.lv95
+  sources: [ch.bafu.silvaprotect-sturz_cache_lv95]
+  title: Sturz
+- dimensions: *id110
+  name: ch.bafu.silvaprotect-sturz
+  sources: [ch.bafu.silvaprotect-sturz_cache]
+  title: Sturz
+- dimensions: &id111
+    Time:
+      default: '20080501'
+      values: ['20080501']
+  name: ch.bafu.silvaprotect-uebersarung.mercator
+  sources: [ch.bafu.silvaprotect-uebersarung_cache_mercator]
+  title: "\xDCbersarung"
+- dimensions: *id111
+  name: ch.bafu.silvaprotect-uebersarung.etrs89
+  sources: [ch.bafu.silvaprotect-uebersarung_cache_etrs89]
+  title: "\xDCbersarung"
+- dimensions: *id111
+  name: ch.bafu.silvaprotect-uebersarung.wgs84
+  sources: [ch.bafu.silvaprotect-uebersarung_cache_wgs84]
+  title: "\xDCbersarung"
+- dimensions: *id111
+  name: ch.bafu.silvaprotect-uebersarung.lv95
+  sources: [ch.bafu.silvaprotect-uebersarung_cache_lv95]
+  title: "\xDCbersarung"
+- dimensions: *id111
+  name: ch.bafu.silvaprotect-uebersarung
+  sources: [ch.bafu.silvaprotect-uebersarung_cache]
+  title: "\xDCbersarung"
+- dimensions: &id112
+    Time:
+      default: '20140213'
+      values: ['20140213', '20130207', '20120404', '20110222']
+  name: ch.bafu.swissprtr.mercator
+  sources: [ch.bafu.swissprtr_cache_mercator]
+  title: Schadstoff-Freisetzungen (SwissPRTR)
+- dimensions: *id112
+  name: ch.bafu.swissprtr.etrs89
+  sources: [ch.bafu.swissprtr_cache_etrs89]
+  title: Schadstoff-Freisetzungen (SwissPRTR)
+- dimensions: *id112
+  name: ch.bafu.swissprtr.wgs84
+  sources: [ch.bafu.swissprtr_cache_wgs84]
+  title: Schadstoff-Freisetzungen (SwissPRTR)
+- dimensions: *id112
+  name: ch.bafu.swissprtr.lv95
+  sources: [ch.bafu.swissprtr_cache_lv95]
+  title: Schadstoff-Freisetzungen (SwissPRTR)
+- dimensions: *id112
+  name: ch.bafu.swissprtr
+  sources: [ch.bafu.swissprtr_cache]
+  title: Schadstoff-Freisetzungen (SwissPRTR)
+- dimensions: &id113
+    Time:
+      default: '20080724'
+      values: ['20080724']
+  name: ch.bafu.unesco-weltnaturerbe.mercator
+  sources: [ch.bafu.unesco-weltnaturerbe_cache_mercator]
+  title: "UNESCO-Welterbe Naturst\xE4tten"
+- dimensions: *id113
+  name: ch.bafu.unesco-weltnaturerbe.etrs89
+  sources: [ch.bafu.unesco-weltnaturerbe_cache_etrs89]
+  title: "UNESCO-Welterbe Naturst\xE4tten"
+- dimensions: *id113
+  name: ch.bafu.unesco-weltnaturerbe.wgs84
+  sources: [ch.bafu.unesco-weltnaturerbe_cache_wgs84]
+  title: "UNESCO-Welterbe Naturst\xE4tten"
+- dimensions: *id113
+  name: ch.bafu.unesco-weltnaturerbe.lv95
+  sources: [ch.bafu.unesco-weltnaturerbe_cache_lv95]
+  title: "UNESCO-Welterbe Naturst\xE4tten"
+- dimensions: *id113
+  name: ch.bafu.unesco-weltnaturerbe
+  sources: [ch.bafu.unesco-weltnaturerbe_cache]
+  title: "UNESCO-Welterbe Naturst\xE4tten"
+- dimensions: &id114
+    Time:
+      default: '20001001'
+      values: ['20001001']
+  name: ch.bafu.waldschadenflaechen-lothar.mercator
+  sources: [ch.bafu.waldschadenflaechen-lothar_cache_mercator]
+  title: Sturmschaden Lothar
+- dimensions: *id114
+  name: ch.bafu.waldschadenflaechen-lothar.etrs89
+  sources: [ch.bafu.waldschadenflaechen-lothar_cache_etrs89]
+  title: Sturmschaden Lothar
+- dimensions: *id114
+  name: ch.bafu.waldschadenflaechen-lothar.wgs84
+  sources: [ch.bafu.waldschadenflaechen-lothar_cache_wgs84]
+  title: Sturmschaden Lothar
+- dimensions: *id114
+  name: ch.bafu.waldschadenflaechen-lothar.lv95
+  sources: [ch.bafu.waldschadenflaechen-lothar_cache_lv95]
+  title: Sturmschaden Lothar
+- dimensions: *id114
+  name: ch.bafu.waldschadenflaechen-lothar
+  sources: [ch.bafu.waldschadenflaechen-lothar_cache]
+  title: Sturmschaden Lothar
+- dimensions: &id115
+    Time:
+      default: '19920115'
+      values: ['19920115']
+  name: ch.bafu.waldschadenflaechen-vivian.mercator
+  sources: [ch.bafu.waldschadenflaechen-vivian_cache_mercator]
+  title: Sturmschaden Vivian
+- dimensions: *id115
+  name: ch.bafu.waldschadenflaechen-vivian.etrs89
+  sources: [ch.bafu.waldschadenflaechen-vivian_cache_etrs89]
+  title: Sturmschaden Vivian
+- dimensions: *id115
+  name: ch.bafu.waldschadenflaechen-vivian.wgs84
+  sources: [ch.bafu.waldschadenflaechen-vivian_cache_wgs84]
+  title: Sturmschaden Vivian
+- dimensions: *id115
+  name: ch.bafu.waldschadenflaechen-vivian.lv95
+  sources: [ch.bafu.waldschadenflaechen-vivian_cache_lv95]
+  title: Sturmschaden Vivian
+- dimensions: *id115
+  name: ch.bafu.waldschadenflaechen-vivian
+  sources: [ch.bafu.waldschadenflaechen-vivian_cache]
+  title: Sturmschaden Vivian
+- dimensions: &id116
+    Time:
+      default: '20040101'
+      values: ['20040101']
+  name: ch.bafu.wasser-entnahme.mercator
+  sources: [ch.bafu.wasser-entnahme_cache_mercator]
+  title: Wasserentnahme
+- dimensions: *id116
+  name: ch.bafu.wasser-entnahme.etrs89
+  sources: [ch.bafu.wasser-entnahme_cache_etrs89]
+  title: Wasserentnahme
+- dimensions: *id116
+  name: ch.bafu.wasser-entnahme.wgs84
+  sources: [ch.bafu.wasser-entnahme_cache_wgs84]
+  title: Wasserentnahme
+- dimensions: *id116
+  name: ch.bafu.wasser-entnahme.lv95
+  sources: [ch.bafu.wasser-entnahme_cache_lv95]
+  title: Wasserentnahme
+- dimensions: *id116
+  name: ch.bafu.wasser-entnahme
+  sources: [ch.bafu.wasser-entnahme_cache]
+  title: Wasserentnahme
+- dimensions: &id117
+    Time:
+      default: '20120701'
+      values: ['20120701']
+  name: ch.bafu.wasser-gebietsauslaesse.mercator
+  sources: [ch.bafu.wasser-gebietsauslaesse_cache_mercator]
+  title: "Gebietsausl\xE4sse"
+- dimensions: *id117
+  name: ch.bafu.wasser-gebietsauslaesse.etrs89
+  sources: [ch.bafu.wasser-gebietsauslaesse_cache_etrs89]
+  title: "Gebietsausl\xE4sse"
+- dimensions: *id117
+  name: ch.bafu.wasser-gebietsauslaesse.wgs84
+  sources: [ch.bafu.wasser-gebietsauslaesse_cache_wgs84]
+  title: "Gebietsausl\xE4sse"
+- dimensions: *id117
+  name: ch.bafu.wasser-gebietsauslaesse.lv95
+  sources: [ch.bafu.wasser-gebietsauslaesse_cache_lv95]
+  title: "Gebietsausl\xE4sse"
+- dimensions: *id117
+  name: ch.bafu.wasser-gebietsauslaesse
+  sources: [ch.bafu.wasser-gebietsauslaesse_cache]
+  title: "Gebietsausl\xE4sse"
+- dimensions: &id118
+    Time:
+      default: '20040101'
+      values: ['20040101']
+  name: ch.bafu.wasser-leitungen.mercator
+  sources: [ch.bafu.wasser-leitungen_cache_mercator]
+  title: Zuleitung
+- dimensions: *id118
+  name: ch.bafu.wasser-leitungen.etrs89
+  sources: [ch.bafu.wasser-leitungen_cache_etrs89]
+  title: Zuleitung
+- dimensions: *id118
+  name: ch.bafu.wasser-leitungen.wgs84
+  sources: [ch.bafu.wasser-leitungen_cache_wgs84]
+  title: Zuleitung
+- dimensions: *id118
+  name: ch.bafu.wasser-leitungen.lv95
+  sources: [ch.bafu.wasser-leitungen_cache_lv95]
+  title: Zuleitung
+- dimensions: *id118
+  name: ch.bafu.wasser-leitungen
+  sources: [ch.bafu.wasser-leitungen_cache]
+  title: Zuleitung
+- dimensions: &id119
+    Time:
+      default: '20040101'
+      values: ['20040101']
+  name: ch.bafu.wasser-rueckgabe.mercator
+  sources: [ch.bafu.wasser-rueckgabe_cache_mercator]
+  title: "Wasserr\xFCckgabe"
+- dimensions: *id119
+  name: ch.bafu.wasser-rueckgabe.etrs89
+  sources: [ch.bafu.wasser-rueckgabe_cache_etrs89]
+  title: "Wasserr\xFCckgabe"
+- dimensions: *id119
+  name: ch.bafu.wasser-rueckgabe.wgs84
+  sources: [ch.bafu.wasser-rueckgabe_cache_wgs84]
+  title: "Wasserr\xFCckgabe"
+- dimensions: *id119
+  name: ch.bafu.wasser-rueckgabe.lv95
+  sources: [ch.bafu.wasser-rueckgabe_cache_lv95]
+  title: "Wasserr\xFCckgabe"
+- dimensions: *id119
+  name: ch.bafu.wasser-rueckgabe
+  sources: [ch.bafu.wasser-rueckgabe_cache]
+  title: "Wasserr\xFCckgabe"
+- dimensions: &id120
+    Time:
+      default: '20120701'
+      values: ['20120701']
+  name: ch.bafu.wasser-teileinzugsgebiete_2.mercator
+  sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache_mercator]
+  title: Teileinzugsgebiete 2km2
+- dimensions: *id120
+  name: ch.bafu.wasser-teileinzugsgebiete_2.etrs89
+  sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache_etrs89]
+  title: Teileinzugsgebiete 2km2
+- dimensions: *id120
+  name: ch.bafu.wasser-teileinzugsgebiete_2.wgs84
+  sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache_wgs84]
+  title: Teileinzugsgebiete 2km2
+- dimensions: *id120
+  name: ch.bafu.wasser-teileinzugsgebiete_2.lv95
+  sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache_lv95]
+  title: Teileinzugsgebiete 2km2
+- dimensions: *id120
+  name: ch.bafu.wasser-teileinzugsgebiete_2
+  sources: [ch.bafu.wasser-teileinzugsgebiete_2_cache]
+  title: Teileinzugsgebiete 2km2
+- dimensions: &id121
+    Time:
+      default: '20120701'
+      values: ['20120701']
+  name: ch.bafu.wasser-teileinzugsgebiete_40.mercator
+  sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache_mercator]
+  title: Teileinzugsgebiete 40km2
+- dimensions: *id121
+  name: ch.bafu.wasser-teileinzugsgebiete_40.etrs89
+  sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache_etrs89]
+  title: Teileinzugsgebiete 40km2
+- dimensions: *id121
+  name: ch.bafu.wasser-teileinzugsgebiete_40.wgs84
+  sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache_wgs84]
+  title: Teileinzugsgebiete 40km2
+- dimensions: *id121
+  name: ch.bafu.wasser-teileinzugsgebiete_40.lv95
+  sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache_lv95]
+  title: Teileinzugsgebiete 40km2
+- dimensions: *id121
+  name: ch.bafu.wasser-teileinzugsgebiete_40
+  sources: [ch.bafu.wasser-teileinzugsgebiete_40_cache]
+  title: Teileinzugsgebiete 40km2
+- dimensions: &id122
+    Time:
+      default: '20120702'
+      values: ['20120702', '20120701']
+  name: ch.bafu.wasser-vorfluter.mercator
+  sources: [ch.bafu.wasser-vorfluter_cache_mercator]
+  title: Vorfluter
+- dimensions: *id122
+  name: ch.bafu.wasser-vorfluter.etrs89
+  sources: [ch.bafu.wasser-vorfluter_cache_etrs89]
+  title: Vorfluter
+- dimensions: *id122
+  name: ch.bafu.wasser-vorfluter.wgs84
+  sources: [ch.bafu.wasser-vorfluter_cache_wgs84]
+  title: Vorfluter
+- dimensions: *id122
+  name: ch.bafu.wasser-vorfluter.lv95
+  sources: [ch.bafu.wasser-vorfluter_cache_lv95]
+  title: Vorfluter
+- dimensions: *id122
+  name: ch.bafu.wasser-vorfluter
+  sources: [ch.bafu.wasser-vorfluter_cache]
+  title: Vorfluter
+- dimensions: &id123
+    Time:
+      default: '20111129'
+      values: ['20111129']
+  name: ch.bafu.wege-wildruhezonen-jagdbanngebiete.mercator
+  sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_mercator]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id123
+  name: ch.bafu.wege-wildruhezonen-jagdbanngebiete.etrs89
+  sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_etrs89]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id123
+  name: ch.bafu.wege-wildruhezonen-jagdbanngebiete.wgs84
+  sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_wgs84]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id123
+  name: ch.bafu.wege-wildruhezonen-jagdbanngebiete.lv95
+  sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache_lv95]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id123
+  name: ch.bafu.wege-wildruhezonen-jagdbanngebiete
+  sources: [ch.bafu.wege-wildruhezonen-jagdbanngebiete_cache]
+  title: WRZ Portal - Wege und Routen
+- dimensions: &id124
+    Time:
+      default: '20111129'
+      values: ['20111129']
+  name: ch.bafu.wildruhezonen-jagdbanngebiete.mercator
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache_mercator]
+  title: Wildruhezonen - Portal
+- dimensions: *id124
+  name: ch.bafu.wildruhezonen-jagdbanngebiete.etrs89
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache_etrs89]
+  title: Wildruhezonen - Portal
+- dimensions: *id124
+  name: ch.bafu.wildruhezonen-jagdbanngebiete.wgs84
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache_wgs84]
+  title: Wildruhezonen - Portal
+- dimensions: *id124
+  name: ch.bafu.wildruhezonen-jagdbanngebiete.lv95
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache_lv95]
+  title: Wildruhezonen - Portal
+- dimensions: *id124
+  name: ch.bafu.wildruhezonen-jagdbanngebiete
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_cache]
+  title: Wildruhezonen - Portal
+- dimensions: &id125
+    Time:
+      default: '20140107'
+      values: ['20140107', '20100801']
+  name: ch.bafu.wrz-jagdbanngebiete_select.mercator
+  sources: [ch.bafu.wrz-jagdbanngebiete_select_cache_mercator]
+  title: Jagdbanngebiete - select
+- dimensions: *id125
+  name: ch.bafu.wrz-jagdbanngebiete_select.etrs89
+  sources: [ch.bafu.wrz-jagdbanngebiete_select_cache_etrs89]
+  title: Jagdbanngebiete - select
+- dimensions: *id125
+  name: ch.bafu.wrz-jagdbanngebiete_select.wgs84
+  sources: [ch.bafu.wrz-jagdbanngebiete_select_cache_wgs84]
+  title: Jagdbanngebiete - select
+- dimensions: *id125
+  name: ch.bafu.wrz-jagdbanngebiete_select.lv95
+  sources: [ch.bafu.wrz-jagdbanngebiete_select_cache_lv95]
+  title: Jagdbanngebiete - select
+- dimensions: *id125
+  name: ch.bafu.wrz-jagdbanngebiete_select
+  sources: [ch.bafu.wrz-jagdbanngebiete_select_cache]
+  title: Jagdbanngebiete - select
+- dimensions: &id126
+    Time:
+      default: '20140107'
+      values: ['20140107', '20131107', '20130111']
+  name: ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen.mercator
+  sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_mercator]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id126
+  name: ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen.etrs89
+  sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_etrs89]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id126
+  name: ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen.wgs84
+  sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_wgs84]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id126
+  name: ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen.lv95
+  sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache_lv95]
+  title: WRZ Portal - Wege und Routen
+- dimensions: *id126
+  name: ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen
+  sources: [ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen_cache]
+  title: WRZ Portal - Wege und Routen
+- dimensions: &id127
+    Time:
+      default: '20131118'
+      values: ['20131118', '20130111']
+  name: ch.bafu.wrz-wildruhezonen_portal.mercator
+  sources: [ch.bafu.wrz-wildruhezonen_portal_cache_mercator]
+  title: Wildruhezonen - Portal
+- dimensions: *id127
+  name: ch.bafu.wrz-wildruhezonen_portal.etrs89
+  sources: [ch.bafu.wrz-wildruhezonen_portal_cache_etrs89]
+  title: Wildruhezonen - Portal
+- dimensions: *id127
+  name: ch.bafu.wrz-wildruhezonen_portal.wgs84
+  sources: [ch.bafu.wrz-wildruhezonen_portal_cache_wgs84]
+  title: Wildruhezonen - Portal
+- dimensions: *id127
+  name: ch.bafu.wrz-wildruhezonen_portal.lv95
+  sources: [ch.bafu.wrz-wildruhezonen_portal_cache_lv95]
+  title: Wildruhezonen - Portal
+- dimensions: *id127
+  name: ch.bafu.wrz-wildruhezonen_portal
+  sources: [ch.bafu.wrz-wildruhezonen_portal_cache]
+  title: Wildruhezonen - Portal
+- dimensions: &id128
+    Time:
+      default: '20140220'
+      values: ['20140220', '20121231']
+  name: ch.bag.zecken-fsme-faelle.mercator
+  sources: [ch.bag.zecken-fsme-faelle_cache_mercator]
+  title: "FSME - Lokale H\xE4ufungen"
+- dimensions: *id128
+  name: ch.bag.zecken-fsme-faelle.etrs89
+  sources: [ch.bag.zecken-fsme-faelle_cache_etrs89]
+  title: "FSME - Lokale H\xE4ufungen"
+- dimensions: *id128
+  name: ch.bag.zecken-fsme-faelle.wgs84
+  sources: [ch.bag.zecken-fsme-faelle_cache_wgs84]
+  title: "FSME - Lokale H\xE4ufungen"
+- dimensions: *id128
+  name: ch.bag.zecken-fsme-faelle.lv95
+  sources: [ch.bag.zecken-fsme-faelle_cache_lv95]
+  title: "FSME - Lokale H\xE4ufungen"
+- dimensions: *id128
+  name: ch.bag.zecken-fsme-faelle
+  sources: [ch.bag.zecken-fsme-faelle_cache]
+  title: "FSME - Lokale H\xE4ufungen"
+- dimensions: &id129
+    Time:
+      default: '20140220'
+      values: ['20140220', '20121231']
+  name: ch.bag.zecken-fsme-impfung.mercator
+  sources: [ch.bag.zecken-fsme-impfung_cache_mercator]
+  title: FSME - Impfempfehlung
+- dimensions: *id129
+  name: ch.bag.zecken-fsme-impfung.etrs89
+  sources: [ch.bag.zecken-fsme-impfung_cache_etrs89]
+  title: FSME - Impfempfehlung
+- dimensions: *id129
+  name: ch.bag.zecken-fsme-impfung.wgs84
+  sources: [ch.bag.zecken-fsme-impfung_cache_wgs84]
+  title: FSME - Impfempfehlung
+- dimensions: *id129
+  name: ch.bag.zecken-fsme-impfung.lv95
+  sources: [ch.bag.zecken-fsme-impfung_cache_lv95]
+  title: FSME - Impfempfehlung
+- dimensions: *id129
+  name: ch.bag.zecken-fsme-impfung
+  sources: [ch.bag.zecken-fsme-impfung_cache]
+  title: FSME - Impfempfehlung
+- dimensions: &id130
+    Time:
+      default: '20110613'
+      values: ['20110613']
+  name: ch.bag.zecken-lyme.mercator
+  sources: [ch.bag.zecken-lyme_cache_mercator]
+  title: Borreliose Risikogebiete
+- dimensions: *id130
+  name: ch.bag.zecken-lyme.etrs89
+  sources: [ch.bag.zecken-lyme_cache_etrs89]
+  title: Borreliose Risikogebiete
+- dimensions: *id130
+  name: ch.bag.zecken-lyme.wgs84
+  sources: [ch.bag.zecken-lyme_cache_wgs84]
+  title: Borreliose Risikogebiete
+- dimensions: *id130
+  name: ch.bag.zecken-lyme.lv95
+  sources: [ch.bag.zecken-lyme_cache_lv95]
+  title: Borreliose Risikogebiete
+- dimensions: *id130
+  name: ch.bag.zecken-lyme
+  sources: [ch.bag.zecken-lyme_cache]
+  title: Borreliose Risikogebiete
+- dimensions: &id131
+    Time:
+      default: '20131113'
+      values: ['20131113', '20121218', '20120510', '20110915']
+  name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder.mercator
+  sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_mercator]
+  title: Bundesinventar ISOS
+- dimensions: *id131
+  name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder.etrs89
+  sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_etrs89]
+  title: Bundesinventar ISOS
+- dimensions: *id131
+  name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder.wgs84
+  sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_wgs84]
+  title: Bundesinventar ISOS
+- dimensions: *id131
+  name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder.lv95
+  sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache_lv95]
+  title: Bundesinventar ISOS
+- dimensions: *id131
+  name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder
+  sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_cache]
+  title: Bundesinventar ISOS
+- dimensions: &id132
+    Time:
+      default: '20120203'
+      values: ['20120203']
+  name: ch.bak.schutzgebiete-unesco_weltkulturerbe.mercator
+  sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_mercator]
+  title: "UNESCO-Welterbe Kulturst\xE4tten"
+- dimensions: *id132
+  name: ch.bak.schutzgebiete-unesco_weltkulturerbe.etrs89
+  sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_etrs89]
+  title: "UNESCO-Welterbe Kulturst\xE4tten"
+- dimensions: *id132
+  name: ch.bak.schutzgebiete-unesco_weltkulturerbe.wgs84
+  sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_wgs84]
+  title: "UNESCO-Welterbe Kulturst\xE4tten"
+- dimensions: *id132
+  name: ch.bak.schutzgebiete-unesco_weltkulturerbe.lv95
+  sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache_lv95]
+  title: "UNESCO-Welterbe Kulturst\xE4tten"
+- dimensions: *id132
+  name: ch.bak.schutzgebiete-unesco_weltkulturerbe
+  sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_cache]
+  title: "UNESCO-Welterbe Kulturst\xE4tten"
+- dimensions: &id133
+    Time:
+      default: '20070704'
+      values: ['20070704']
+  name: ch.bakom.versorgungsgebiet-tv.mercator
+  sources: [ch.bakom.versorgungsgebiet-tv_cache_mercator]
+  title: Versorgungsgebiete TV
+- dimensions: *id133
+  name: ch.bakom.versorgungsgebiet-tv.etrs89
+  sources: [ch.bakom.versorgungsgebiet-tv_cache_etrs89]
+  title: Versorgungsgebiete TV
+- dimensions: *id133
+  name: ch.bakom.versorgungsgebiet-tv.wgs84
+  sources: [ch.bakom.versorgungsgebiet-tv_cache_wgs84]
+  title: Versorgungsgebiete TV
+- dimensions: *id133
+  name: ch.bakom.versorgungsgebiet-tv.lv95
+  sources: [ch.bakom.versorgungsgebiet-tv_cache_lv95]
+  title: Versorgungsgebiete TV
+- dimensions: *id133
+  name: ch.bakom.versorgungsgebiet-tv
+  sources: [ch.bakom.versorgungsgebiet-tv_cache]
+  title: Versorgungsgebiete TV
+- dimensions: &id134
+    Time:
+      default: '20070704'
+      values: ['20070704']
+  name: ch.bakom.versorgungsgebiet-ukw.mercator
+  sources: [ch.bakom.versorgungsgebiet-ukw_cache_mercator]
+  title: Versorgungsgebiete Radio
+- dimensions: *id134
+  name: ch.bakom.versorgungsgebiet-ukw.etrs89
+  sources: [ch.bakom.versorgungsgebiet-ukw_cache_etrs89]
+  title: Versorgungsgebiete Radio
+- dimensions: *id134
+  name: ch.bakom.versorgungsgebiet-ukw.wgs84
+  sources: [ch.bakom.versorgungsgebiet-ukw_cache_wgs84]
+  title: Versorgungsgebiete Radio
+- dimensions: *id134
+  name: ch.bakom.versorgungsgebiet-ukw.lv95
+  sources: [ch.bakom.versorgungsgebiet-ukw_cache_lv95]
+  title: Versorgungsgebiete Radio
+- dimensions: *id134
+  name: ch.bakom.versorgungsgebiet-ukw
+  sources: [ch.bakom.versorgungsgebiet-ukw_cache]
+  title: Versorgungsgebiete Radio
+- dimensions: &id135
+    Time:
+      default: '20101109'
+      values: ['20101109']
+  name: ch.bav.laerm-emissionplan_eisenbahn_2015.mercator
+  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache_mercator]
+  title: Emissionsplan Eisenbahn  2015
+- dimensions: *id135
+  name: ch.bav.laerm-emissionplan_eisenbahn_2015.etrs89
+  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache_etrs89]
+  title: Emissionsplan Eisenbahn  2015
+- dimensions: *id135
+  name: ch.bav.laerm-emissionplan_eisenbahn_2015.wgs84
+  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache_wgs84]
+  title: Emissionsplan Eisenbahn  2015
+- dimensions: *id135
+  name: ch.bav.laerm-emissionplan_eisenbahn_2015.lv95
+  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache_lv95]
+  title: Emissionsplan Eisenbahn  2015
+- dimensions: *id135
+  name: ch.bav.laerm-emissionplan_eisenbahn_2015
+  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_cache]
+  title: Emissionsplan Eisenbahn  2015
+- dimensions: &id136
+    Time:
+      default: '20110926'
+      values: ['20110926']
+  name: ch.bazl.heliports-gebirgslandeplaetze.mercator
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_cache_mercator]
+  title: "Heliports/Gebirgslandepl\xE4tze"
+- dimensions: *id136
+  name: ch.bazl.heliports-gebirgslandeplaetze.etrs89
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_cache_etrs89]
+  title: "Heliports/Gebirgslandepl\xE4tze"
+- dimensions: *id136
+  name: ch.bazl.heliports-gebirgslandeplaetze.wgs84
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_cache_wgs84]
+  title: "Heliports/Gebirgslandepl\xE4tze"
+- dimensions: *id136
+  name: ch.bazl.heliports-gebirgslandeplaetze.lv95
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_cache_lv95]
+  title: "Heliports/Gebirgslandepl\xE4tze"
+- dimensions: *id136
+  name: ch.bazl.heliports-gebirgslandeplaetze
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_cache]
+  title: "Heliports/Gebirgslandepl\xE4tze"
+- dimensions: &id137
+    Time:
+      default: '20110101'
+      values: ['20110101']
+  name: ch.bazl.landschaftsruhezonen.mercator
+  sources: [ch.bazl.landschaftsruhezonen_cache_mercator]
+  title: Landschaftsruhezonen Luftfahrt
+- dimensions: *id137
+  name: ch.bazl.landschaftsruhezonen.etrs89
+  sources: [ch.bazl.landschaftsruhezonen_cache_etrs89]
+  title: Landschaftsruhezonen Luftfahrt
+- dimensions: *id137
+  name: ch.bazl.landschaftsruhezonen.wgs84
+  sources: [ch.bazl.landschaftsruhezonen_cache_wgs84]
+  title: Landschaftsruhezonen Luftfahrt
+- dimensions: *id137
+  name: ch.bazl.landschaftsruhezonen.lv95
+  sources: [ch.bazl.landschaftsruhezonen_cache_lv95]
+  title: Landschaftsruhezonen Luftfahrt
+- dimensions: *id137
+  name: ch.bazl.landschaftsruhezonen
+  sources: [ch.bazl.landschaftsruhezonen_cache]
+  title: Landschaftsruhezonen Luftfahrt
+- dimensions: &id138
+    Time:
+      default: '20140306'
+      values: ['20140306', '20130307', '20120308', '20110310']
+  name: ch.bazl.luftfahrtkarten-icao.mercator
+  sources: [ch.bazl.luftfahrtkarten-icao_cache_mercator]
+  title: Luftfahrtkarte ICAO
+- dimensions: *id138
+  name: ch.bazl.luftfahrtkarten-icao.etrs89
+  sources: [ch.bazl.luftfahrtkarten-icao_cache_etrs89]
+  title: Luftfahrtkarte ICAO
+- dimensions: *id138
+  name: ch.bazl.luftfahrtkarten-icao.wgs84
+  sources: [ch.bazl.luftfahrtkarten-icao_cache_wgs84]
+  title: Luftfahrtkarte ICAO
+- dimensions: *id138
+  name: ch.bazl.luftfahrtkarten-icao.lv95
+  sources: [ch.bazl.luftfahrtkarten-icao_cache_lv95]
+  title: Luftfahrtkarte ICAO
+- dimensions: *id138
+  name: ch.bazl.luftfahrtkarten-icao
+  sources: [ch.bazl.luftfahrtkarten-icao_cache]
+  title: Luftfahrtkarte ICAO
+- dimensions: &id139
+    Time:
+      default: '20120829'
+      values: ['20120829']
+  name: ch.bazl.points-of-interest.mercator
+  sources: [ch.bazl.points-of-interest_cache_mercator]
+  title: Points of Interest
+- dimensions: *id139
+  name: ch.bazl.points-of-interest.etrs89
+  sources: [ch.bazl.points-of-interest_cache_etrs89]
+  title: Points of Interest
+- dimensions: *id139
+  name: ch.bazl.points-of-interest.wgs84
+  sources: [ch.bazl.points-of-interest_cache_wgs84]
+  title: Points of Interest
+- dimensions: *id139
+  name: ch.bazl.points-of-interest.lv95
+  sources: [ch.bazl.points-of-interest_cache_lv95]
+  title: Points of Interest
+- dimensions: *id139
+  name: ch.bazl.points-of-interest
+  sources: [ch.bazl.points-of-interest_cache]
+  title: Points of Interest
+- dimensions: &id140
+    Time:
+      default: '20130822'
+      values: ['20130822']
+  name: ch.bazl.projektierungszonen-flughafenanlagen.mercator
+  sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache_mercator]
+  title: "Projektierungszonen: Flugh\xE4fen"
+- dimensions: *id140
+  name: ch.bazl.projektierungszonen-flughafenanlagen.etrs89
+  sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache_etrs89]
+  title: "Projektierungszonen: Flugh\xE4fen"
+- dimensions: *id140
+  name: ch.bazl.projektierungszonen-flughafenanlagen.wgs84
+  sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache_wgs84]
+  title: "Projektierungszonen: Flugh\xE4fen"
+- dimensions: *id140
+  name: ch.bazl.projektierungszonen-flughafenanlagen.lv95
+  sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache_lv95]
+  title: "Projektierungszonen: Flugh\xE4fen"
+- dimensions: *id140
+  name: ch.bazl.projektierungszonen-flughafenanlagen
+  sources: [ch.bazl.projektierungszonen-flughafenanlagen_cache]
+  title: "Projektierungszonen: Flugh\xE4fen"
+- dimensions: &id141
+    Time:
+      default: '20140306'
+      values: ['20140306', '20130307', '20120308']
+  name: ch.bazl.segelflugkarte.mercator
+  sources: [ch.bazl.segelflugkarte_cache_mercator]
+  title: Segelflugkarte
+- dimensions: *id141
+  name: ch.bazl.segelflugkarte.etrs89
+  sources: [ch.bazl.segelflugkarte_cache_etrs89]
+  title: Segelflugkarte
+- dimensions: *id141
+  name: ch.bazl.segelflugkarte.wgs84
+  sources: [ch.bazl.segelflugkarte_cache_wgs84]
+  title: Segelflugkarte
+- dimensions: *id141
+  name: ch.bazl.segelflugkarte.lv95
+  sources: [ch.bazl.segelflugkarte_cache_lv95]
+  title: Segelflugkarte
+- dimensions: *id141
+  name: ch.bazl.segelflugkarte
+  sources: [ch.bazl.segelflugkarte_cache]
+  title: Segelflugkarte
+- dimensions: &id142
+    Time:
+      default: '20120911'
+      values: ['20120911']
+  name: ch.bfe.kernkraftwerke.mercator
+  sources: [ch.bfe.kernkraftwerke_cache_mercator]
+  title: Kernkraftwerke
+- dimensions: *id142
+  name: ch.bfe.kernkraftwerke.etrs89
+  sources: [ch.bfe.kernkraftwerke_cache_etrs89]
+  title: Kernkraftwerke
+- dimensions: *id142
+  name: ch.bfe.kernkraftwerke.wgs84
+  sources: [ch.bfe.kernkraftwerke_cache_wgs84]
+  title: Kernkraftwerke
+- dimensions: *id142
+  name: ch.bfe.kernkraftwerke.lv95
+  sources: [ch.bfe.kernkraftwerke_cache_lv95]
+  title: Kernkraftwerke
+- dimensions: *id142
+  name: ch.bfe.kernkraftwerke
+  sources: [ch.bfe.kernkraftwerke_cache]
+  title: Kernkraftwerke
+- dimensions: &id143
+    Time:
+      default: '20120531'
+      values: ['20120531']
+  name: ch.bfe.kleinwasserkraftpotentiale.mercator
+  sources: [ch.bfe.kleinwasserkraftpotentiale_cache_mercator]
+  title: Kleinwasserkraftpotentiale
+- dimensions: *id143
+  name: ch.bfe.kleinwasserkraftpotentiale.etrs89
+  sources: [ch.bfe.kleinwasserkraftpotentiale_cache_etrs89]
+  title: Kleinwasserkraftpotentiale
+- dimensions: *id143
+  name: ch.bfe.kleinwasserkraftpotentiale.wgs84
+  sources: [ch.bfe.kleinwasserkraftpotentiale_cache_wgs84]
+  title: Kleinwasserkraftpotentiale
+- dimensions: *id143
+  name: ch.bfe.kleinwasserkraftpotentiale.lv95
+  sources: [ch.bfe.kleinwasserkraftpotentiale_cache_lv95]
+  title: Kleinwasserkraftpotentiale
+- dimensions: *id143
+  name: ch.bfe.kleinwasserkraftpotentiale
+  sources: [ch.bfe.kleinwasserkraftpotentiale_cache]
+  title: Kleinwasserkraftpotentiale
+- dimensions: &id144
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik.mercator
+  sources: [ch.bfs.arealstatistik_cache_mercator]
+  title: Arealstatistik 2004/09 NOAS04
+- dimensions: *id144
+  name: ch.bfs.arealstatistik.etrs89
+  sources: [ch.bfs.arealstatistik_cache_etrs89]
+  title: Arealstatistik 2004/09 NOAS04
+- dimensions: *id144
+  name: ch.bfs.arealstatistik.wgs84
+  sources: [ch.bfs.arealstatistik_cache_wgs84]
+  title: Arealstatistik 2004/09 NOAS04
+- dimensions: *id144
+  name: ch.bfs.arealstatistik.lv95
+  sources: [ch.bfs.arealstatistik_cache_lv95]
+  title: Arealstatistik 2004/09 NOAS04
+- dimensions: *id144
+  name: ch.bfs.arealstatistik
+  sources: [ch.bfs.arealstatistik_cache]
+  title: Arealstatistik 2004/09 NOAS04
+- dimensions: &id145
+    Time:
+      default: '20131121'
+      values: ['20131121', '19790101']
+  name: ch.bfs.arealstatistik-1985.mercator
+  sources: [ch.bfs.arealstatistik-1985_cache_mercator]
+  title: Arealstatistik 1979/85 NOAS04
+- dimensions: *id145
+  name: ch.bfs.arealstatistik-1985.etrs89
+  sources: [ch.bfs.arealstatistik-1985_cache_etrs89]
+  title: Arealstatistik 1979/85 NOAS04
+- dimensions: *id145
+  name: ch.bfs.arealstatistik-1985.wgs84
+  sources: [ch.bfs.arealstatistik-1985_cache_wgs84]
+  title: Arealstatistik 1979/85 NOAS04
+- dimensions: *id145
+  name: ch.bfs.arealstatistik-1985.lv95
+  sources: [ch.bfs.arealstatistik-1985_cache_lv95]
+  title: Arealstatistik 1979/85 NOAS04
+- dimensions: *id145
+  name: ch.bfs.arealstatistik-1985
+  sources: [ch.bfs.arealstatistik-1985_cache]
+  title: Arealstatistik 1979/85 NOAS04
+- dimensions: &id146
+    Time:
+      default: '20131121'
+      values: ['20131121', '19920101']
+  name: ch.bfs.arealstatistik-1997.mercator
+  sources: [ch.bfs.arealstatistik-1997_cache_mercator]
+  title: Arealstatistik 1992/97 NOAS04
+- dimensions: *id146
+  name: ch.bfs.arealstatistik-1997.etrs89
+  sources: [ch.bfs.arealstatistik-1997_cache_etrs89]
+  title: Arealstatistik 1992/97 NOAS04
+- dimensions: *id146
+  name: ch.bfs.arealstatistik-1997.wgs84
+  sources: [ch.bfs.arealstatistik-1997_cache_wgs84]
+  title: Arealstatistik 1992/97 NOAS04
+- dimensions: *id146
+  name: ch.bfs.arealstatistik-1997.lv95
+  sources: [ch.bfs.arealstatistik-1997_cache_lv95]
+  title: Arealstatistik 1992/97 NOAS04
+- dimensions: *id146
+  name: ch.bfs.arealstatistik-1997
+  sources: [ch.bfs.arealstatistik-1997_cache]
+  title: Arealstatistik 1992/97 NOAS04
+- dimensions: &id147
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-bodenbedeckung.mercator
+  sources: [ch.bfs.arealstatistik-bodenbedeckung_cache_mercator]
+  title: Arealstatistik 2004/09 NOLC04
+- dimensions: *id147
+  name: ch.bfs.arealstatistik-bodenbedeckung.etrs89
+  sources: [ch.bfs.arealstatistik-bodenbedeckung_cache_etrs89]
+  title: Arealstatistik 2004/09 NOLC04
+- dimensions: *id147
+  name: ch.bfs.arealstatistik-bodenbedeckung.wgs84
+  sources: [ch.bfs.arealstatistik-bodenbedeckung_cache_wgs84]
+  title: Arealstatistik 2004/09 NOLC04
+- dimensions: *id147
+  name: ch.bfs.arealstatistik-bodenbedeckung.lv95
+  sources: [ch.bfs.arealstatistik-bodenbedeckung_cache_lv95]
+  title: Arealstatistik 2004/09 NOLC04
+- dimensions: *id147
+  name: ch.bfs.arealstatistik-bodenbedeckung
+  sources: [ch.bfs.arealstatistik-bodenbedeckung_cache]
+  title: Arealstatistik 2004/09 NOLC04
+- dimensions: &id148
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-bodenbedeckung-1985.mercator
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache_mercator]
+  title: Arealstatistik 1979/85 NOLC04
+- dimensions: *id148
+  name: ch.bfs.arealstatistik-bodenbedeckung-1985.etrs89
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache_etrs89]
+  title: Arealstatistik 1979/85 NOLC04
+- dimensions: *id148
+  name: ch.bfs.arealstatistik-bodenbedeckung-1985.wgs84
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache_wgs84]
+  title: Arealstatistik 1979/85 NOLC04
+- dimensions: *id148
+  name: ch.bfs.arealstatistik-bodenbedeckung-1985.lv95
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache_lv95]
+  title: Arealstatistik 1979/85 NOLC04
+- dimensions: *id148
+  name: ch.bfs.arealstatistik-bodenbedeckung-1985
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_cache]
+  title: Arealstatistik 1979/85 NOLC04
+- dimensions: &id149
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-bodenbedeckung-1997.mercator
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache_mercator]
+  title: Arealstatistik 1992/97 NOLC04
+- dimensions: *id149
+  name: ch.bfs.arealstatistik-bodenbedeckung-1997.etrs89
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache_etrs89]
+  title: Arealstatistik 1992/97 NOLC04
+- dimensions: *id149
+  name: ch.bfs.arealstatistik-bodenbedeckung-1997.wgs84
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache_wgs84]
+  title: Arealstatistik 1992/97 NOLC04
+- dimensions: *id149
+  name: ch.bfs.arealstatistik-bodenbedeckung-1997.lv95
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache_lv95]
+  title: Arealstatistik 1992/97 NOLC04
+- dimensions: *id149
+  name: ch.bfs.arealstatistik-bodenbedeckung-1997
+  sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_cache]
+  title: Arealstatistik 1992/97 NOLC04
+- dimensions: &id150
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-bodennutzung.mercator
+  sources: [ch.bfs.arealstatistik-bodennutzung_cache_mercator]
+  title: 'Arealstatistik 2004/09 NOLU04 '
+- dimensions: *id150
+  name: ch.bfs.arealstatistik-bodennutzung.etrs89
+  sources: [ch.bfs.arealstatistik-bodennutzung_cache_etrs89]
+  title: 'Arealstatistik 2004/09 NOLU04 '
+- dimensions: *id150
+  name: ch.bfs.arealstatistik-bodennutzung.wgs84
+  sources: [ch.bfs.arealstatistik-bodennutzung_cache_wgs84]
+  title: 'Arealstatistik 2004/09 NOLU04 '
+- dimensions: *id150
+  name: ch.bfs.arealstatistik-bodennutzung.lv95
+  sources: [ch.bfs.arealstatistik-bodennutzung_cache_lv95]
+  title: 'Arealstatistik 2004/09 NOLU04 '
+- dimensions: *id150
+  name: ch.bfs.arealstatistik-bodennutzung
+  sources: [ch.bfs.arealstatistik-bodennutzung_cache]
+  title: 'Arealstatistik 2004/09 NOLU04 '
+- dimensions: &id151
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-bodennutzung-1985.mercator
+  sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache_mercator]
+  title: Arealstatistik 1979/85 NOLU04
+- dimensions: *id151
+  name: ch.bfs.arealstatistik-bodennutzung-1985.etrs89
+  sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache_etrs89]
+  title: Arealstatistik 1979/85 NOLU04
+- dimensions: *id151
+  name: ch.bfs.arealstatistik-bodennutzung-1985.wgs84
+  sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache_wgs84]
+  title: Arealstatistik 1979/85 NOLU04
+- dimensions: *id151
+  name: ch.bfs.arealstatistik-bodennutzung-1985.lv95
+  sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache_lv95]
+  title: Arealstatistik 1979/85 NOLU04
+- dimensions: *id151
+  name: ch.bfs.arealstatistik-bodennutzung-1985
+  sources: [ch.bfs.arealstatistik-bodennutzung-1985_cache]
+  title: Arealstatistik 1979/85 NOLU04
+- dimensions: &id152
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-bodennutzung-1997.mercator
+  sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache_mercator]
+  title: Arealstatistik 1992/97 NOLU04
+- dimensions: *id152
+  name: ch.bfs.arealstatistik-bodennutzung-1997.etrs89
+  sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache_etrs89]
+  title: Arealstatistik 1992/97 NOLU04
+- dimensions: *id152
+  name: ch.bfs.arealstatistik-bodennutzung-1997.wgs84
+  sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache_wgs84]
+  title: Arealstatistik 1992/97 NOLU04
+- dimensions: *id152
+  name: ch.bfs.arealstatistik-bodennutzung-1997.lv95
+  sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache_lv95]
+  title: Arealstatistik 1992/97 NOLU04
+- dimensions: *id152
+  name: ch.bfs.arealstatistik-bodennutzung-1997
+  sources: [ch.bfs.arealstatistik-bodennutzung-1997_cache]
+  title: Arealstatistik 1992/97 NOLU04
+- dimensions: &id153
+    Time:
+      default: '20070116'
+      values: ['20070116']
+  name: ch.bfs.arealstatistik-hintergrund.mercator
+  sources: [ch.bfs.arealstatistik-hintergrund_cache_mercator]
+  title: Vereinfachte Bodennutzung
+- dimensions: *id153
+  name: ch.bfs.arealstatistik-hintergrund.etrs89
+  sources: [ch.bfs.arealstatistik-hintergrund_cache_etrs89]
+  title: Vereinfachte Bodennutzung
+- dimensions: *id153
+  name: ch.bfs.arealstatistik-hintergrund.wgs84
+  sources: [ch.bfs.arealstatistik-hintergrund_cache_wgs84]
+  title: Vereinfachte Bodennutzung
+- dimensions: *id153
+  name: ch.bfs.arealstatistik-hintergrund.lv95
+  sources: [ch.bfs.arealstatistik-hintergrund_cache_lv95]
+  title: Vereinfachte Bodennutzung
+- dimensions: *id153
+  name: ch.bfs.arealstatistik-hintergrund
+  sources: [ch.bfs.arealstatistik-hintergrund_cache]
+  title: Vereinfachte Bodennutzung
+- dimensions: &id154
+    Time:
+      default: '19970901'
+      values: ['19970901']
+  name: ch.bfs.arealstatistik-waldmischungsgrad.mercator
+  sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache_mercator]
+  title: Waldmischungsgrad 1990/1992
+- dimensions: *id154
+  name: ch.bfs.arealstatistik-waldmischungsgrad.etrs89
+  sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache_etrs89]
+  title: Waldmischungsgrad 1990/1992
+- dimensions: *id154
+  name: ch.bfs.arealstatistik-waldmischungsgrad.wgs84
+  sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache_wgs84]
+  title: Waldmischungsgrad 1990/1992
+- dimensions: *id154
+  name: ch.bfs.arealstatistik-waldmischungsgrad.lv95
+  sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache_lv95]
+  title: Waldmischungsgrad 1990/1992
+- dimensions: *id154
+  name: ch.bfs.arealstatistik-waldmischungsgrad
+  sources: [ch.bfs.arealstatistik-waldmischungsgrad_cache]
+  title: Waldmischungsgrad 1990/1992
+- dimensions: &id155
+    Time:
+      default: '20130212'
+      values: ['20130212']
+  name: ch.bfs.gebaeude_wohnungs_register.mercator
+  sources: [ch.bfs.gebaeude_wohnungs_register_cache_mercator]
+  title: "Geb\xE4ude- und Wohnungsregister"
+- dimensions: *id155
+  name: ch.bfs.gebaeude_wohnungs_register.etrs89
+  sources: [ch.bfs.gebaeude_wohnungs_register_cache_etrs89]
+  title: "Geb\xE4ude- und Wohnungsregister"
+- dimensions: *id155
+  name: ch.bfs.gebaeude_wohnungs_register.wgs84
+  sources: [ch.bfs.gebaeude_wohnungs_register_cache_wgs84]
+  title: "Geb\xE4ude- und Wohnungsregister"
+- dimensions: *id155
+  name: ch.bfs.gebaeude_wohnungs_register.lv95
+  sources: [ch.bfs.gebaeude_wohnungs_register_cache_lv95]
+  title: "Geb\xE4ude- und Wohnungsregister"
+- dimensions: *id155
+  name: ch.bfs.gebaeude_wohnungs_register
+  sources: [ch.bfs.gebaeude_wohnungs_register_cache]
+  title: "Geb\xE4ude- und Wohnungsregister"
+- dimensions: &id156
+    Time:
+      default: '20130531'
+      values: ['20130531', '20081024']
+  name: ch.blw.alpprodukte.mercator
+  sources: [ch.blw.alpprodukte_cache_mercator]
+  title: Alpprodukte
+- dimensions: *id156
+  name: ch.blw.alpprodukte.etrs89
+  sources: [ch.blw.alpprodukte_cache_etrs89]
+  title: Alpprodukte
+- dimensions: *id156
+  name: ch.blw.alpprodukte.wgs84
+  sources: [ch.blw.alpprodukte_cache_wgs84]
+  title: Alpprodukte
+- dimensions: *id156
+  name: ch.blw.alpprodukte.lv95
+  sources: [ch.blw.alpprodukte_cache_lv95]
+  title: Alpprodukte
+- dimensions: *id156
+  name: ch.blw.alpprodukte
+  sources: [ch.blw.alpprodukte_cache]
+  title: Alpprodukte
+- dimensions: &id157
+    Time:
+      default: '20130531'
+      values: ['20130531', '20081024']
+  name: ch.blw.bergprodukte.mercator
+  sources: [ch.blw.bergprodukte_cache_mercator]
+  title: Bergprodukte
+- dimensions: *id157
+  name: ch.blw.bergprodukte.etrs89
+  sources: [ch.blw.bergprodukte_cache_etrs89]
+  title: Bergprodukte
+- dimensions: *id157
+  name: ch.blw.bergprodukte.wgs84
+  sources: [ch.blw.bergprodukte_cache_wgs84]
+  title: Bergprodukte
+- dimensions: *id157
+  name: ch.blw.bergprodukte.lv95
+  sources: [ch.blw.bergprodukte_cache_lv95]
+  title: Bergprodukte
+- dimensions: *id157
+  name: ch.blw.bergprodukte
+  sources: [ch.blw.bergprodukte_cache]
+  title: Bergprodukte
+- dimensions: &id158
+    Time:
+      default: '20091110'
+      values: ['20091110']
+  name: ch.blw.bewaesserungsbeduerftigkeit.mercator
+  sources: [ch.blw.bewaesserungsbeduerftigkeit_cache_mercator]
+  title: "Bew\xE4sserungsbed\xFCrftigkeit"
+- dimensions: *id158
+  name: ch.blw.bewaesserungsbeduerftigkeit.etrs89
+  sources: [ch.blw.bewaesserungsbeduerftigkeit_cache_etrs89]
+  title: "Bew\xE4sserungsbed\xFCrftigkeit"
+- dimensions: *id158
+  name: ch.blw.bewaesserungsbeduerftigkeit.wgs84
+  sources: [ch.blw.bewaesserungsbeduerftigkeit_cache_wgs84]
+  title: "Bew\xE4sserungsbed\xFCrftigkeit"
+- dimensions: *id158
+  name: ch.blw.bewaesserungsbeduerftigkeit.lv95
+  sources: [ch.blw.bewaesserungsbeduerftigkeit_cache_lv95]
+  title: "Bew\xE4sserungsbed\xFCrftigkeit"
+- dimensions: *id158
+  name: ch.blw.bewaesserungsbeduerftigkeit
+  sources: [ch.blw.bewaesserungsbeduerftigkeit_cache]
+  title: "Bew\xE4sserungsbed\xFCrftigkeit"
+- dimensions: &id159
+    Time:
+      default: '20120601'
+      values: ['20120601']
+  name: ch.blw.bodeneignung-gruendigkeit.mercator
+  sources: [ch.blw.bodeneignung-gruendigkeit_cache_mercator]
+  title: "Gr\xFCndigkeit"
+- dimensions: *id159
+  name: ch.blw.bodeneignung-gruendigkeit.etrs89
+  sources: [ch.blw.bodeneignung-gruendigkeit_cache_etrs89]
+  title: "Gr\xFCndigkeit"
+- dimensions: *id159
+  name: ch.blw.bodeneignung-gruendigkeit.wgs84
+  sources: [ch.blw.bodeneignung-gruendigkeit_cache_wgs84]
+  title: "Gr\xFCndigkeit"
+- dimensions: *id159
+  name: ch.blw.bodeneignung-gruendigkeit.lv95
+  sources: [ch.blw.bodeneignung-gruendigkeit_cache_lv95]
+  title: "Gr\xFCndigkeit"
+- dimensions: *id159
+  name: ch.blw.bodeneignung-gruendigkeit
+  sources: [ch.blw.bodeneignung-gruendigkeit_cache]
+  title: "Gr\xFCndigkeit"
+- dimensions: &id160
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.bodeneignung-kulturland.mercator
+  sources: [ch.blw.bodeneignung-kulturland_cache_mercator]
+  title: "Bodeneignung f\xFCr Kulturland"
+- dimensions: *id160
+  name: ch.blw.bodeneignung-kulturland.etrs89
+  sources: [ch.blw.bodeneignung-kulturland_cache_etrs89]
+  title: "Bodeneignung f\xFCr Kulturland"
+- dimensions: *id160
+  name: ch.blw.bodeneignung-kulturland.wgs84
+  sources: [ch.blw.bodeneignung-kulturland_cache_wgs84]
+  title: "Bodeneignung f\xFCr Kulturland"
+- dimensions: *id160
+  name: ch.blw.bodeneignung-kulturland.lv95
+  sources: [ch.blw.bodeneignung-kulturland_cache_lv95]
+  title: "Bodeneignung f\xFCr Kulturland"
+- dimensions: *id160
+  name: ch.blw.bodeneignung-kulturland
+  sources: [ch.blw.bodeneignung-kulturland_cache]
+  title: "Bodeneignung f\xFCr Kulturland"
+- dimensions: &id161
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.bodeneignung-kulturtyp.mercator
+  sources: [ch.blw.bodeneignung-kulturtyp_cache_mercator]
+  title: 'Bodeneignung: Kulturtyp'
+- dimensions: *id161
+  name: ch.blw.bodeneignung-kulturtyp.etrs89
+  sources: [ch.blw.bodeneignung-kulturtyp_cache_etrs89]
+  title: 'Bodeneignung: Kulturtyp'
+- dimensions: *id161
+  name: ch.blw.bodeneignung-kulturtyp.wgs84
+  sources: [ch.blw.bodeneignung-kulturtyp_cache_wgs84]
+  title: 'Bodeneignung: Kulturtyp'
+- dimensions: *id161
+  name: ch.blw.bodeneignung-kulturtyp.lv95
+  sources: [ch.blw.bodeneignung-kulturtyp_cache_lv95]
+  title: 'Bodeneignung: Kulturtyp'
+- dimensions: *id161
+  name: ch.blw.bodeneignung-kulturtyp
+  sources: [ch.blw.bodeneignung-kulturtyp_cache]
+  title: 'Bodeneignung: Kulturtyp'
+- dimensions: &id162
+    Time:
+      default: '20120601'
+      values: ['20120601']
+  name: ch.blw.bodeneignung-naehrstoffspeichervermoegen.mercator
+  sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_mercator]
+  title: "N\xE4hrstoffspeicherverm\xF6gen"
+- dimensions: *id162
+  name: ch.blw.bodeneignung-naehrstoffspeichervermoegen.etrs89
+  sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_etrs89]
+  title: "N\xE4hrstoffspeicherverm\xF6gen"
+- dimensions: *id162
+  name: ch.blw.bodeneignung-naehrstoffspeichervermoegen.wgs84
+  sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_wgs84]
+  title: "N\xE4hrstoffspeicherverm\xF6gen"
+- dimensions: *id162
+  name: ch.blw.bodeneignung-naehrstoffspeichervermoegen.lv95
+  sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache_lv95]
+  title: "N\xE4hrstoffspeicherverm\xF6gen"
+- dimensions: *id162
+  name: ch.blw.bodeneignung-naehrstoffspeichervermoegen
+  sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_cache]
+  title: "N\xE4hrstoffspeicherverm\xF6gen"
+- dimensions: &id163
+    Time:
+      default: '20120601'
+      values: ['20120601']
+  name: ch.blw.bodeneignung-skelettgehalt.mercator
+  sources: [ch.blw.bodeneignung-skelettgehalt_cache_mercator]
+  title: Skelettgehalt
+- dimensions: *id163
+  name: ch.blw.bodeneignung-skelettgehalt.etrs89
+  sources: [ch.blw.bodeneignung-skelettgehalt_cache_etrs89]
+  title: Skelettgehalt
+- dimensions: *id163
+  name: ch.blw.bodeneignung-skelettgehalt.wgs84
+  sources: [ch.blw.bodeneignung-skelettgehalt_cache_wgs84]
+  title: Skelettgehalt
+- dimensions: *id163
+  name: ch.blw.bodeneignung-skelettgehalt.lv95
+  sources: [ch.blw.bodeneignung-skelettgehalt_cache_lv95]
+  title: Skelettgehalt
+- dimensions: *id163
+  name: ch.blw.bodeneignung-skelettgehalt
+  sources: [ch.blw.bodeneignung-skelettgehalt_cache]
+  title: Skelettgehalt
+- dimensions: &id164
+    Time:
+      default: '20120601'
+      values: ['20120601']
+  name: ch.blw.bodeneignung-vernaessung.mercator
+  sources: [ch.blw.bodeneignung-vernaessung_cache_mercator]
+  title: "Vern\xE4ssung"
+- dimensions: *id164
+  name: ch.blw.bodeneignung-vernaessung.etrs89
+  sources: [ch.blw.bodeneignung-vernaessung_cache_etrs89]
+  title: "Vern\xE4ssung"
+- dimensions: *id164
+  name: ch.blw.bodeneignung-vernaessung.wgs84
+  sources: [ch.blw.bodeneignung-vernaessung_cache_wgs84]
+  title: "Vern\xE4ssung"
+- dimensions: *id164
+  name: ch.blw.bodeneignung-vernaessung.lv95
+  sources: [ch.blw.bodeneignung-vernaessung_cache_lv95]
+  title: "Vern\xE4ssung"
+- dimensions: *id164
+  name: ch.blw.bodeneignung-vernaessung
+  sources: [ch.blw.bodeneignung-vernaessung_cache]
+  title: "Vern\xE4ssung"
+- dimensions: &id165
+    Time:
+      default: '20120601'
+      values: ['20120601']
+  name: ch.blw.bodeneignung-wasserdurchlaessigkeit.mercator
+  sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_mercator]
+  title: "Wasserdurchl\xE4ssigkeit"
+- dimensions: *id165
+  name: ch.blw.bodeneignung-wasserdurchlaessigkeit.etrs89
+  sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_etrs89]
+  title: "Wasserdurchl\xE4ssigkeit"
+- dimensions: *id165
+  name: ch.blw.bodeneignung-wasserdurchlaessigkeit.wgs84
+  sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_wgs84]
+  title: "Wasserdurchl\xE4ssigkeit"
+- dimensions: *id165
+  name: ch.blw.bodeneignung-wasserdurchlaessigkeit.lv95
+  sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache_lv95]
+  title: "Wasserdurchl\xE4ssigkeit"
+- dimensions: *id165
+  name: ch.blw.bodeneignung-wasserdurchlaessigkeit
+  sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_cache]
+  title: "Wasserdurchl\xE4ssigkeit"
+- dimensions: &id166
+    Time:
+      default: '20120601'
+      values: ['20120601']
+  name: ch.blw.bodeneignung-wasserspeichervermoegen.mercator
+  sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache_mercator]
+  title: "Wasserspeicherverm\xF6gen"
+- dimensions: *id166
+  name: ch.blw.bodeneignung-wasserspeichervermoegen.etrs89
+  sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache_etrs89]
+  title: "Wasserspeicherverm\xF6gen"
+- dimensions: *id166
+  name: ch.blw.bodeneignung-wasserspeichervermoegen.wgs84
+  sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache_wgs84]
+  title: "Wasserspeicherverm\xF6gen"
+- dimensions: *id166
+  name: ch.blw.bodeneignung-wasserspeichervermoegen.lv95
+  sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache_lv95]
+  title: "Wasserspeicherverm\xF6gen"
+- dimensions: *id166
+  name: ch.blw.bodeneignung-wasserspeichervermoegen
+  sources: [ch.blw.bodeneignung-wasserspeichervermoegen_cache]
+  title: "Wasserspeicherverm\xF6gen"
+- dimensions: &id167
+    Time:
+      default: '20100103'
+      values: ['20100103']
+  name: ch.blw.erosion.mercator
+  sources: [ch.blw.erosion_cache_mercator]
+  title: Erosionsrisiko qualitativ 1
+- dimensions: *id167
+  name: ch.blw.erosion.etrs89
+  sources: [ch.blw.erosion_cache_etrs89]
+  title: Erosionsrisiko qualitativ 1
+- dimensions: *id167
+  name: ch.blw.erosion.wgs84
+  sources: [ch.blw.erosion_cache_wgs84]
+  title: Erosionsrisiko qualitativ 1
+- dimensions: *id167
+  name: ch.blw.erosion.lv95
+  sources: [ch.blw.erosion_cache_lv95]
+  title: Erosionsrisiko qualitativ 1
+- dimensions: *id167
+  name: ch.blw.erosion
+  sources: [ch.blw.erosion_cache]
+  title: Erosionsrisiko qualitativ 1
+- dimensions: &id168
+    Time:
+      default: '20100103'
+      values: ['20100103']
+  name: ch.blw.erosion-mit_bergzonen.mercator
+  sources: [ch.blw.erosion-mit_bergzonen_cache_mercator]
+  title: Erosionsrisiko qualitativ 2
+- dimensions: *id168
+  name: ch.blw.erosion-mit_bergzonen.etrs89
+  sources: [ch.blw.erosion-mit_bergzonen_cache_etrs89]
+  title: Erosionsrisiko qualitativ 2
+- dimensions: *id168
+  name: ch.blw.erosion-mit_bergzonen.wgs84
+  sources: [ch.blw.erosion-mit_bergzonen_cache_wgs84]
+  title: Erosionsrisiko qualitativ 2
+- dimensions: *id168
+  name: ch.blw.erosion-mit_bergzonen.lv95
+  sources: [ch.blw.erosion-mit_bergzonen_cache_lv95]
+  title: Erosionsrisiko qualitativ 2
+- dimensions: *id168
+  name: ch.blw.erosion-mit_bergzonen
+  sources: [ch.blw.erosion-mit_bergzonen_cache]
+  title: Erosionsrisiko qualitativ 2
+- dimensions: &id169
+    Time:
+      default: '20100601'
+      values: ['20100601']
+  name: ch.blw.erosion-quantitativ.mercator
+  sources: [ch.blw.erosion-quantitativ_cache_mercator]
+  title: Erosionsrisiko quantitativ
+- dimensions: *id169
+  name: ch.blw.erosion-quantitativ.etrs89
+  sources: [ch.blw.erosion-quantitativ_cache_etrs89]
+  title: Erosionsrisiko quantitativ
+- dimensions: *id169
+  name: ch.blw.erosion-quantitativ.wgs84
+  sources: [ch.blw.erosion-quantitativ_cache_wgs84]
+  title: Erosionsrisiko quantitativ
+- dimensions: *id169
+  name: ch.blw.erosion-quantitativ.lv95
+  sources: [ch.blw.erosion-quantitativ_cache_lv95]
+  title: Erosionsrisiko quantitativ
+- dimensions: *id169
+  name: ch.blw.erosion-quantitativ
+  sources: [ch.blw.erosion-quantitativ_cache]
+  title: Erosionsrisiko quantitativ
+- dimensions: &id170
+    Time:
+      default: '20120601'
+      values: ['20120601']
+  name: ch.blw.feldblockkarte.mercator
+  sources: [ch.blw.feldblockkarte_cache_mercator]
+  title: Feldblockkarte
+- dimensions: *id170
+  name: ch.blw.feldblockkarte.etrs89
+  sources: [ch.blw.feldblockkarte_cache_etrs89]
+  title: Feldblockkarte
+- dimensions: *id170
+  name: ch.blw.feldblockkarte.wgs84
+  sources: [ch.blw.feldblockkarte_cache_wgs84]
+  title: Feldblockkarte
+- dimensions: *id170
+  name: ch.blw.feldblockkarte.lv95
+  sources: [ch.blw.feldblockkarte_cache_lv95]
+  title: Feldblockkarte
+- dimensions: *id170
+  name: ch.blw.feldblockkarte
+  sources: [ch.blw.feldblockkarte_cache]
+  title: Feldblockkarte
+- dimensions: &id171
+    Time:
+      default: '20121201'
+      values: ['20121201']
+  name: ch.blw.gewaesseranschlusskarte.mercator
+  sources: [ch.blw.gewaesseranschlusskarte_cache_mercator]
+  title: "Gew\xE4sseranschluss"
+- dimensions: *id171
+  name: ch.blw.gewaesseranschlusskarte.etrs89
+  sources: [ch.blw.gewaesseranschlusskarte_cache_etrs89]
+  title: "Gew\xE4sseranschluss"
+- dimensions: *id171
+  name: ch.blw.gewaesseranschlusskarte.wgs84
+  sources: [ch.blw.gewaesseranschlusskarte_cache_wgs84]
+  title: "Gew\xE4sseranschluss"
+- dimensions: *id171
+  name: ch.blw.gewaesseranschlusskarte.lv95
+  sources: [ch.blw.gewaesseranschlusskarte_cache_lv95]
+  title: "Gew\xE4sseranschluss"
+- dimensions: *id171
+  name: ch.blw.gewaesseranschlusskarte
+  sources: [ch.blw.gewaesseranschlusskarte_cache]
+  title: "Gew\xE4sseranschluss"
+- dimensions: &id172
+    Time:
+      default: '20121201'
+      values: ['20121201']
+  name: ch.blw.gewaesseranschlusskarte-direkt.mercator
+  sources: [ch.blw.gewaesseranschlusskarte-direkt_cache_mercator]
+  title: "Gew\xE4sseranschluss erweitert"
+- dimensions: *id172
+  name: ch.blw.gewaesseranschlusskarte-direkt.etrs89
+  sources: [ch.blw.gewaesseranschlusskarte-direkt_cache_etrs89]
+  title: "Gew\xE4sseranschluss erweitert"
+- dimensions: *id172
+  name: ch.blw.gewaesseranschlusskarte-direkt.wgs84
+  sources: [ch.blw.gewaesseranschlusskarte-direkt_cache_wgs84]
+  title: "Gew\xE4sseranschluss erweitert"
+- dimensions: *id172
+  name: ch.blw.gewaesseranschlusskarte-direkt.lv95
+  sources: [ch.blw.gewaesseranschlusskarte-direkt_cache_lv95]
+  title: "Gew\xE4sseranschluss erweitert"
+- dimensions: *id172
+  name: ch.blw.gewaesseranschlusskarte-direkt
+  sources: [ch.blw.gewaesseranschlusskarte-direkt_cache]
+  title: "Gew\xE4sseranschluss erweitert"
+- dimensions: &id173
+    Time:
+      default: '20121231'
+      values: ['20121231', '20100501']
+  name: ch.blw.hang_steillagen.mercator
+  sources: [ch.blw.hang_steillagen_cache_mercator]
+  title: Hanglagen
+- dimensions: *id173
+  name: ch.blw.hang_steillagen.etrs89
+  sources: [ch.blw.hang_steillagen_cache_etrs89]
+  title: Hanglagen
+- dimensions: *id173
+  name: ch.blw.hang_steillagen.wgs84
+  sources: [ch.blw.hang_steillagen_cache_wgs84]
+  title: Hanglagen
+- dimensions: *id173
+  name: ch.blw.hang_steillagen.lv95
+  sources: [ch.blw.hang_steillagen_cache_lv95]
+  title: Hanglagen
+- dimensions: *id173
+  name: ch.blw.hang_steillagen
+  sources: [ch.blw.hang_steillagen_cache]
+  title: Hanglagen
+- dimensions: &id174
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-futterbau.mercator
+  sources: [ch.blw.klimaeignung-futterbau_cache_mercator]
+  title: Klimaeignung Futterbau
+- dimensions: *id174
+  name: ch.blw.klimaeignung-futterbau.etrs89
+  sources: [ch.blw.klimaeignung-futterbau_cache_etrs89]
+  title: Klimaeignung Futterbau
+- dimensions: *id174
+  name: ch.blw.klimaeignung-futterbau.wgs84
+  sources: [ch.blw.klimaeignung-futterbau_cache_wgs84]
+  title: Klimaeignung Futterbau
+- dimensions: *id174
+  name: ch.blw.klimaeignung-futterbau.lv95
+  sources: [ch.blw.klimaeignung-futterbau_cache_lv95]
+  title: Klimaeignung Futterbau
+- dimensions: *id174
+  name: ch.blw.klimaeignung-futterbau
+  sources: [ch.blw.klimaeignung-futterbau_cache]
+  title: Klimaeignung Futterbau
+- dimensions: &id175
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-getreidebau.mercator
+  sources: [ch.blw.klimaeignung-getreidebau_cache_mercator]
+  title: Klimaeignung Getreidebau
+- dimensions: *id175
+  name: ch.blw.klimaeignung-getreidebau.etrs89
+  sources: [ch.blw.klimaeignung-getreidebau_cache_etrs89]
+  title: Klimaeignung Getreidebau
+- dimensions: *id175
+  name: ch.blw.klimaeignung-getreidebau.wgs84
+  sources: [ch.blw.klimaeignung-getreidebau_cache_wgs84]
+  title: Klimaeignung Getreidebau
+- dimensions: *id175
+  name: ch.blw.klimaeignung-getreidebau.lv95
+  sources: [ch.blw.klimaeignung-getreidebau_cache_lv95]
+  title: Klimaeignung Getreidebau
+- dimensions: *id175
+  name: ch.blw.klimaeignung-getreidebau
+  sources: [ch.blw.klimaeignung-getreidebau_cache]
+  title: Klimaeignung Getreidebau
+- dimensions: &id176
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-kartoffeln.mercator
+  sources: [ch.blw.klimaeignung-kartoffeln_cache_mercator]
+  title: Klimaeignung Kartoffeln
+- dimensions: *id176
+  name: ch.blw.klimaeignung-kartoffeln.etrs89
+  sources: [ch.blw.klimaeignung-kartoffeln_cache_etrs89]
+  title: Klimaeignung Kartoffeln
+- dimensions: *id176
+  name: ch.blw.klimaeignung-kartoffeln.wgs84
+  sources: [ch.blw.klimaeignung-kartoffeln_cache_wgs84]
+  title: Klimaeignung Kartoffeln
+- dimensions: *id176
+  name: ch.blw.klimaeignung-kartoffeln.lv95
+  sources: [ch.blw.klimaeignung-kartoffeln_cache_lv95]
+  title: Klimaeignung Kartoffeln
+- dimensions: *id176
+  name: ch.blw.klimaeignung-kartoffeln
+  sources: [ch.blw.klimaeignung-kartoffeln_cache]
+  title: Klimaeignung Kartoffeln
+- dimensions: &id177
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-koernermais.mercator
+  sources: [ch.blw.klimaeignung-koernermais_cache_mercator]
+  title: "Klimaeignung K\xF6rnermais"
+- dimensions: *id177
+  name: ch.blw.klimaeignung-koernermais.etrs89
+  sources: [ch.blw.klimaeignung-koernermais_cache_etrs89]
+  title: "Klimaeignung K\xF6rnermais"
+- dimensions: *id177
+  name: ch.blw.klimaeignung-koernermais.wgs84
+  sources: [ch.blw.klimaeignung-koernermais_cache_wgs84]
+  title: "Klimaeignung K\xF6rnermais"
+- dimensions: *id177
+  name: ch.blw.klimaeignung-koernermais.lv95
+  sources: [ch.blw.klimaeignung-koernermais_cache_lv95]
+  title: "Klimaeignung K\xF6rnermais"
+- dimensions: *id177
+  name: ch.blw.klimaeignung-koernermais
+  sources: [ch.blw.klimaeignung-koernermais_cache]
+  title: "Klimaeignung K\xF6rnermais"
+- dimensions: &id178
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-kulturland.mercator
+  sources: [ch.blw.klimaeignung-kulturland_cache_mercator]
+  title: Klimaeignung Kulturland
+- dimensions: *id178
+  name: ch.blw.klimaeignung-kulturland.etrs89
+  sources: [ch.blw.klimaeignung-kulturland_cache_etrs89]
+  title: Klimaeignung Kulturland
+- dimensions: *id178
+  name: ch.blw.klimaeignung-kulturland.wgs84
+  sources: [ch.blw.klimaeignung-kulturland_cache_wgs84]
+  title: Klimaeignung Kulturland
+- dimensions: *id178
+  name: ch.blw.klimaeignung-kulturland.lv95
+  sources: [ch.blw.klimaeignung-kulturland_cache_lv95]
+  title: Klimaeignung Kulturland
+- dimensions: *id178
+  name: ch.blw.klimaeignung-kulturland
+  sources: [ch.blw.klimaeignung-kulturland_cache]
+  title: Klimaeignung Kulturland
+- dimensions: &id179
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-spezialkulturen.mercator
+  sources: [ch.blw.klimaeignung-spezialkulturen_cache_mercator]
+  title: Klimaeignung Spezialkulturen
+- dimensions: *id179
+  name: ch.blw.klimaeignung-spezialkulturen.etrs89
+  sources: [ch.blw.klimaeignung-spezialkulturen_cache_etrs89]
+  title: Klimaeignung Spezialkulturen
+- dimensions: *id179
+  name: ch.blw.klimaeignung-spezialkulturen.wgs84
+  sources: [ch.blw.klimaeignung-spezialkulturen_cache_wgs84]
+  title: Klimaeignung Spezialkulturen
+- dimensions: *id179
+  name: ch.blw.klimaeignung-spezialkulturen.lv95
+  sources: [ch.blw.klimaeignung-spezialkulturen_cache_lv95]
+  title: Klimaeignung Spezialkulturen
+- dimensions: *id179
+  name: ch.blw.klimaeignung-spezialkulturen
+  sources: [ch.blw.klimaeignung-spezialkulturen_cache]
+  title: Klimaeignung Spezialkulturen
+- dimensions: &id180
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-typ.mercator
+  sources: [ch.blw.klimaeignung-typ_cache_mercator]
+  title: "Klimaeignung \xDCbersicht"
+- dimensions: *id180
+  name: ch.blw.klimaeignung-typ.etrs89
+  sources: [ch.blw.klimaeignung-typ_cache_etrs89]
+  title: "Klimaeignung \xDCbersicht"
+- dimensions: *id180
+  name: ch.blw.klimaeignung-typ.wgs84
+  sources: [ch.blw.klimaeignung-typ_cache_wgs84]
+  title: "Klimaeignung \xDCbersicht"
+- dimensions: *id180
+  name: ch.blw.klimaeignung-typ.lv95
+  sources: [ch.blw.klimaeignung-typ_cache_lv95]
+  title: "Klimaeignung \xDCbersicht"
+- dimensions: *id180
+  name: ch.blw.klimaeignung-typ
+  sources: [ch.blw.klimaeignung-typ_cache]
+  title: "Klimaeignung \xDCbersicht"
+- dimensions: &id181
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.klimaeignung-zwischenfruchtbau.mercator
+  sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache_mercator]
+  title: Klimaeignung Zwischenfruchtbau
+- dimensions: *id181
+  name: ch.blw.klimaeignung-zwischenfruchtbau.etrs89
+  sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache_etrs89]
+  title: Klimaeignung Zwischenfruchtbau
+- dimensions: *id181
+  name: ch.blw.klimaeignung-zwischenfruchtbau.wgs84
+  sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache_wgs84]
+  title: Klimaeignung Zwischenfruchtbau
+- dimensions: *id181
+  name: ch.blw.klimaeignung-zwischenfruchtbau.lv95
+  sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache_lv95]
+  title: Klimaeignung Zwischenfruchtbau
+- dimensions: *id181
+  name: ch.blw.klimaeignung-zwischenfruchtbau
+  sources: [ch.blw.klimaeignung-zwischenfruchtbau_cache]
+  title: Klimaeignung Zwischenfruchtbau
+- dimensions: &id182
+    Time:
+      default: '20140417'
+      values: ['20140417', '20140108', '20130531', '20111214', '20111010']
+  name: ch.blw.landwirtschaftliche-zonengrenzen.mercator
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache_mercator]
+  title: Landwirtschaftliche Zonengrenzen
+- dimensions: *id182
+  name: ch.blw.landwirtschaftliche-zonengrenzen.etrs89
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache_etrs89]
+  title: Landwirtschaftliche Zonengrenzen
+- dimensions: *id182
+  name: ch.blw.landwirtschaftliche-zonengrenzen.wgs84
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache_wgs84]
+  title: Landwirtschaftliche Zonengrenzen
+- dimensions: *id182
+  name: ch.blw.landwirtschaftliche-zonengrenzen.lv95
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache_lv95]
+  title: Landwirtschaftliche Zonengrenzen
+- dimensions: *id182
+  name: ch.blw.landwirtschaftliche-zonengrenzen
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_cache]
+  title: Landwirtschaftliche Zonengrenzen
+- dimensions: &id183
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.niederschlagshaushalt.mercator
+  sources: [ch.blw.niederschlagshaushalt_cache_mercator]
+  title: Niederschlagshaushalt
+- dimensions: *id183
+  name: ch.blw.niederschlagshaushalt.etrs89
+  sources: [ch.blw.niederschlagshaushalt_cache_etrs89]
+  title: Niederschlagshaushalt
+- dimensions: *id183
+  name: ch.blw.niederschlagshaushalt.wgs84
+  sources: [ch.blw.niederschlagshaushalt_cache_wgs84]
+  title: Niederschlagshaushalt
+- dimensions: *id183
+  name: ch.blw.niederschlagshaushalt.lv95
+  sources: [ch.blw.niederschlagshaushalt_cache_lv95]
+  title: Niederschlagshaushalt
+- dimensions: *id183
+  name: ch.blw.niederschlagshaushalt
+  sources: [ch.blw.niederschlagshaushalt_cache]
+  title: Niederschlagshaushalt
+- dimensions: &id184
+    Time:
+      default: '20121231'
+      values: ['20121231', '20100501']
+  name: ch.blw.steil_terrassenlagen_rebbau.mercator
+  sources: [ch.blw.steil_terrassenlagen_rebbau_cache_mercator]
+  title: "Rebfl\xE4chen in Hanglagen"
+- dimensions: *id184
+  name: ch.blw.steil_terrassenlagen_rebbau.etrs89
+  sources: [ch.blw.steil_terrassenlagen_rebbau_cache_etrs89]
+  title: "Rebfl\xE4chen in Hanglagen"
+- dimensions: *id184
+  name: ch.blw.steil_terrassenlagen_rebbau.wgs84
+  sources: [ch.blw.steil_terrassenlagen_rebbau_cache_wgs84]
+  title: "Rebfl\xE4chen in Hanglagen"
+- dimensions: *id184
+  name: ch.blw.steil_terrassenlagen_rebbau.lv95
+  sources: [ch.blw.steil_terrassenlagen_rebbau_cache_lv95]
+  title: "Rebfl\xE4chen in Hanglagen"
+- dimensions: *id184
+  name: ch.blw.steil_terrassenlagen_rebbau
+  sources: [ch.blw.steil_terrassenlagen_rebbau_cache]
+  title: "Rebfl\xE4chen in Hanglagen"
+- dimensions: &id185
+    Time:
+      default: '20110805'
+      values: ['20110805', '20081024']
+  name: ch.blw.ursprungsbezeichnungen-fleisch.mercator
+  sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache_mercator]
+  title: GGA Fleischware
+- dimensions: *id185
+  name: ch.blw.ursprungsbezeichnungen-fleisch.etrs89
+  sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache_etrs89]
+  title: GGA Fleischware
+- dimensions: *id185
+  name: ch.blw.ursprungsbezeichnungen-fleisch.wgs84
+  sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache_wgs84]
+  title: GGA Fleischware
+- dimensions: *id185
+  name: ch.blw.ursprungsbezeichnungen-fleisch.lv95
+  sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache_lv95]
+  title: GGA Fleischware
+- dimensions: *id185
+  name: ch.blw.ursprungsbezeichnungen-fleisch
+  sources: [ch.blw.ursprungsbezeichnungen-fleisch_cache]
+  title: GGA Fleischware
+- dimensions: &id186
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.ursprungsbezeichnungen-kaese.mercator
+  sources: [ch.blw.ursprungsbezeichnungen-kaese_cache_mercator]
+  title: "GUB K\xE4se"
+- dimensions: *id186
+  name: ch.blw.ursprungsbezeichnungen-kaese.etrs89
+  sources: [ch.blw.ursprungsbezeichnungen-kaese_cache_etrs89]
+  title: "GUB K\xE4se"
+- dimensions: *id186
+  name: ch.blw.ursprungsbezeichnungen-kaese.wgs84
+  sources: [ch.blw.ursprungsbezeichnungen-kaese_cache_wgs84]
+  title: "GUB K\xE4se"
+- dimensions: *id186
+  name: ch.blw.ursprungsbezeichnungen-kaese.lv95
+  sources: [ch.blw.ursprungsbezeichnungen-kaese_cache_lv95]
+  title: "GUB K\xE4se"
+- dimensions: *id186
+  name: ch.blw.ursprungsbezeichnungen-kaese
+  sources: [ch.blw.ursprungsbezeichnungen-kaese_cache]
+  title: "GUB K\xE4se"
+- dimensions: &id187
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.ursprungsbezeichnungen-pflanzen.mercator
+  sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache_mercator]
+  title: GUB Pflanzliche Produkte
+- dimensions: *id187
+  name: ch.blw.ursprungsbezeichnungen-pflanzen.etrs89
+  sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache_etrs89]
+  title: GUB Pflanzliche Produkte
+- dimensions: *id187
+  name: ch.blw.ursprungsbezeichnungen-pflanzen.wgs84
+  sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache_wgs84]
+  title: GUB Pflanzliche Produkte
+- dimensions: *id187
+  name: ch.blw.ursprungsbezeichnungen-pflanzen.lv95
+  sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache_lv95]
+  title: GUB Pflanzliche Produkte
+- dimensions: *id187
+  name: ch.blw.ursprungsbezeichnungen-pflanzen
+  sources: [ch.blw.ursprungsbezeichnungen-pflanzen_cache]
+  title: GUB Pflanzliche Produkte
+- dimensions: &id188
+    Time:
+      default: '20081024'
+      values: ['20081024']
+  name: ch.blw.ursprungsbezeichnungen-spirituosen.mercator
+  sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache_mercator]
+  title: GUB Spirituosen
+- dimensions: *id188
+  name: ch.blw.ursprungsbezeichnungen-spirituosen.etrs89
+  sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache_etrs89]
+  title: GUB Spirituosen
+- dimensions: *id188
+  name: ch.blw.ursprungsbezeichnungen-spirituosen.wgs84
+  sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache_wgs84]
+  title: GUB Spirituosen
+- dimensions: *id188
+  name: ch.blw.ursprungsbezeichnungen-spirituosen.lv95
+  sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache_lv95]
+  title: GUB Spirituosen
+- dimensions: *id188
+  name: ch.blw.ursprungsbezeichnungen-spirituosen
+  sources: [ch.blw.ursprungsbezeichnungen-spirituosen_cache]
+  title: GUB Spirituosen
+- dimensions: &id189
+    Time:
+      default: '20120101'
+      values: ['20120101', '20110412']
+  name: ch.ensi.zonenplan-notfallschutz-kernanlagen.mercator
+  sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_mercator]
+  title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
+- dimensions: *id189
+  name: ch.ensi.zonenplan-notfallschutz-kernanlagen.etrs89
+  sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_etrs89]
+  title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
+- dimensions: *id189
+  name: ch.ensi.zonenplan-notfallschutz-kernanlagen.wgs84
+  sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_wgs84]
+  title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
+- dimensions: *id189
+  name: ch.ensi.zonenplan-notfallschutz-kernanlagen.lv95
+  sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache_lv95]
+  title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
+- dimensions: *id189
+  name: ch.ensi.zonenplan-notfallschutz-kernanlagen
+  sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_cache]
+  title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
+- dimensions: &id190
+    Time:
+      default: '20070101'
+      values: ['20070101']
+  name: ch.kantone.ivs-reg_loc.mercator
+  sources: [ch.kantone.ivs-reg_loc_cache_mercator]
+  title: IVS Kanton Bern
+- dimensions: *id190
+  name: ch.kantone.ivs-reg_loc.etrs89
+  sources: [ch.kantone.ivs-reg_loc_cache_etrs89]
+  title: IVS Kanton Bern
+- dimensions: *id190
+  name: ch.kantone.ivs-reg_loc.wgs84
+  sources: [ch.kantone.ivs-reg_loc_cache_wgs84]
+  title: IVS Kanton Bern
+- dimensions: *id190
+  name: ch.kantone.ivs-reg_loc.lv95
+  sources: [ch.kantone.ivs-reg_loc_cache_lv95]
+  title: IVS Kanton Bern
+- dimensions: *id190
+  name: ch.kantone.ivs-reg_loc
+  sources: [ch.kantone.ivs-reg_loc_cache]
+  title: IVS Kanton Bern
+- dimensions: &id191
+    Time:
+      default: '20131028'
+      values: ['20131028', '20121102', '20111216']
+  name: ch.swisstopo-vd.spannungsarme-gebiete.mercator
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache_mercator]
+  title: Spannungsarme Gebiete
+- dimensions: *id191
+  name: ch.swisstopo-vd.spannungsarme-gebiete.etrs89
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache_etrs89]
+  title: Spannungsarme Gebiete
+- dimensions: *id191
+  name: ch.swisstopo-vd.spannungsarme-gebiete.wgs84
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache_wgs84]
+  title: Spannungsarme Gebiete
+- dimensions: *id191
+  name: ch.swisstopo-vd.spannungsarme-gebiete.lv95
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache_lv95]
+  title: Spannungsarme Gebiete
+- dimensions: *id191
+  name: ch.swisstopo-vd.spannungsarme-gebiete
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_cache]
+  title: Spannungsarme Gebiete
+- dimensions: &id192
+    Time:
+      default: '20061231'
+      values: ['20061231']
+  name: ch.swisstopo.dreiecksvermaschung.mercator
+  sources: [ch.swisstopo.dreiecksvermaschung_cache_mercator]
+  title: LV95 Dreiecksvermaschung
+- dimensions: *id192
+  name: ch.swisstopo.dreiecksvermaschung.etrs89
+  sources: [ch.swisstopo.dreiecksvermaschung_cache_etrs89]
+  title: LV95 Dreiecksvermaschung
+- dimensions: *id192
+  name: ch.swisstopo.dreiecksvermaschung.wgs84
+  sources: [ch.swisstopo.dreiecksvermaschung_cache_wgs84]
+  title: LV95 Dreiecksvermaschung
+- dimensions: *id192
+  name: ch.swisstopo.dreiecksvermaschung.lv95
+  sources: [ch.swisstopo.dreiecksvermaschung_cache_lv95]
+  title: LV95 Dreiecksvermaschung
+- dimensions: *id192
+  name: ch.swisstopo.dreiecksvermaschung
+  sources: [ch.swisstopo.dreiecksvermaschung_cache]
+  title: LV95 Dreiecksvermaschung
+- dimensions: &id193
+    Time:
+      default: '20120622'
+      values: ['20120622', '20110509']
+  name: ch.swisstopo.fixpunkte-agnes.mercator
+  sources: [ch.swisstopo.fixpunkte-agnes_cache_mercator]
+  title: AGNES
+- dimensions: *id193
+  name: ch.swisstopo.fixpunkte-agnes.etrs89
+  sources: [ch.swisstopo.fixpunkte-agnes_cache_etrs89]
+  title: AGNES
+- dimensions: *id193
+  name: ch.swisstopo.fixpunkte-agnes.wgs84
+  sources: [ch.swisstopo.fixpunkte-agnes_cache_wgs84]
+  title: AGNES
+- dimensions: *id193
+  name: ch.swisstopo.fixpunkte-agnes.lv95
+  sources: [ch.swisstopo.fixpunkte-agnes_cache_lv95]
+  title: AGNES
+- dimensions: *id193
+  name: ch.swisstopo.fixpunkte-agnes
+  sources: [ch.swisstopo.fixpunkte-agnes_cache]
+  title: AGNES
+- dimensions: &id194
+    Time:
+      default: '20121212'
+      values: ['20121212']
+  name: ch.swisstopo.fixpunkte-hfp1.mercator
+  sources: [ch.swisstopo.fixpunkte-hfp1_cache_mercator]
+  title: "H\xF6henfixpunkte HFP1"
+- dimensions: *id194
+  name: ch.swisstopo.fixpunkte-hfp1.etrs89
+  sources: [ch.swisstopo.fixpunkte-hfp1_cache_etrs89]
+  title: "H\xF6henfixpunkte HFP1"
+- dimensions: *id194
+  name: ch.swisstopo.fixpunkte-hfp1.wgs84
+  sources: [ch.swisstopo.fixpunkte-hfp1_cache_wgs84]
+  title: "H\xF6henfixpunkte HFP1"
+- dimensions: *id194
+  name: ch.swisstopo.fixpunkte-hfp1.lv95
+  sources: [ch.swisstopo.fixpunkte-hfp1_cache_lv95]
+  title: "H\xF6henfixpunkte HFP1"
+- dimensions: *id194
+  name: ch.swisstopo.fixpunkte-hfp1
+  sources: [ch.swisstopo.fixpunkte-hfp1_cache]
+  title: "H\xF6henfixpunkte HFP1"
+- dimensions: &id195
+    Time:
+      default: '20121212'
+      values: ['20121212']
+  name: ch.swisstopo.fixpunkte-hfp2.mercator
+  sources: [ch.swisstopo.fixpunkte-hfp2_cache_mercator]
+  title: "H\xF6henfixpunkte HFP2"
+- dimensions: *id195
+  name: ch.swisstopo.fixpunkte-hfp2.etrs89
+  sources: [ch.swisstopo.fixpunkte-hfp2_cache_etrs89]
+  title: "H\xF6henfixpunkte HFP2"
+- dimensions: *id195
+  name: ch.swisstopo.fixpunkte-hfp2.wgs84
+  sources: [ch.swisstopo.fixpunkte-hfp2_cache_wgs84]
+  title: "H\xF6henfixpunkte HFP2"
+- dimensions: *id195
+  name: ch.swisstopo.fixpunkte-hfp2.lv95
+  sources: [ch.swisstopo.fixpunkte-hfp2_cache_lv95]
+  title: "H\xF6henfixpunkte HFP2"
+- dimensions: *id195
+  name: ch.swisstopo.fixpunkte-hfp2
+  sources: [ch.swisstopo.fixpunkte-hfp2_cache]
+  title: "H\xF6henfixpunkte HFP2"
+- dimensions: &id196
+    Time:
+      default: '20121212'
+      values: ['20121212']
+  name: ch.swisstopo.fixpunkte-lfp1.mercator
+  sources: [ch.swisstopo.fixpunkte-lfp1_cache_mercator]
+  title: Lagefixpunkte LFP1
+- dimensions: *id196
+  name: ch.swisstopo.fixpunkte-lfp1.etrs89
+  sources: [ch.swisstopo.fixpunkte-lfp1_cache_etrs89]
+  title: Lagefixpunkte LFP1
+- dimensions: *id196
+  name: ch.swisstopo.fixpunkte-lfp1.wgs84
+  sources: [ch.swisstopo.fixpunkte-lfp1_cache_wgs84]
+  title: Lagefixpunkte LFP1
+- dimensions: *id196
+  name: ch.swisstopo.fixpunkte-lfp1.lv95
+  sources: [ch.swisstopo.fixpunkte-lfp1_cache_lv95]
+  title: Lagefixpunkte LFP1
+- dimensions: *id196
+  name: ch.swisstopo.fixpunkte-lfp1
+  sources: [ch.swisstopo.fixpunkte-lfp1_cache]
+  title: Lagefixpunkte LFP1
+- dimensions: &id197
+    Time:
+      default: '20121212'
+      values: ['20121212']
+  name: ch.swisstopo.fixpunkte-lfp2.mercator
+  sources: [ch.swisstopo.fixpunkte-lfp2_cache_mercator]
+  title: Lagefixpunkte LFP2
+- dimensions: *id197
+  name: ch.swisstopo.fixpunkte-lfp2.etrs89
+  sources: [ch.swisstopo.fixpunkte-lfp2_cache_etrs89]
+  title: Lagefixpunkte LFP2
+- dimensions: *id197
+  name: ch.swisstopo.fixpunkte-lfp2.wgs84
+  sources: [ch.swisstopo.fixpunkte-lfp2_cache_wgs84]
+  title: Lagefixpunkte LFP2
+- dimensions: *id197
+  name: ch.swisstopo.fixpunkte-lfp2.lv95
+  sources: [ch.swisstopo.fixpunkte-lfp2_cache_lv95]
+  title: Lagefixpunkte LFP2
+- dimensions: *id197
+  name: ch.swisstopo.fixpunkte-lfp2
+  sources: [ch.swisstopo.fixpunkte-lfp2_cache]
+  title: Lagefixpunkte LFP2
+- dimensions: &id198
+    Time:
+      default: '20041231'
+      values: ['20041231']
+  name: ch.swisstopo.geoidmodell-ch1903.mercator
+  sources: [ch.swisstopo.geoidmodell-ch1903_cache_mercator]
+  title: Geoidmodell in CH1903
+- dimensions: *id198
+  name: ch.swisstopo.geoidmodell-ch1903.etrs89
+  sources: [ch.swisstopo.geoidmodell-ch1903_cache_etrs89]
+  title: Geoidmodell in CH1903
+- dimensions: *id198
+  name: ch.swisstopo.geoidmodell-ch1903.wgs84
+  sources: [ch.swisstopo.geoidmodell-ch1903_cache_wgs84]
+  title: Geoidmodell in CH1903
+- dimensions: *id198
+  name: ch.swisstopo.geoidmodell-ch1903.lv95
+  sources: [ch.swisstopo.geoidmodell-ch1903_cache_lv95]
+  title: Geoidmodell in CH1903
+- dimensions: *id198
+  name: ch.swisstopo.geoidmodell-ch1903
+  sources: [ch.swisstopo.geoidmodell-ch1903_cache]
+  title: Geoidmodell in CH1903
+- dimensions: &id199
+    Time:
+      default: '20041231'
+      values: ['20041231']
+  name: ch.swisstopo.geoidmodell-etrs89.mercator
+  sources: [ch.swisstopo.geoidmodell-etrs89_cache_mercator]
+  title: Geoidmodell in ETRS89
+- dimensions: *id199
+  name: ch.swisstopo.geoidmodell-etrs89.etrs89
+  sources: [ch.swisstopo.geoidmodell-etrs89_cache_etrs89]
+  title: Geoidmodell in ETRS89
+- dimensions: *id199
+  name: ch.swisstopo.geoidmodell-etrs89.wgs84
+  sources: [ch.swisstopo.geoidmodell-etrs89_cache_wgs84]
+  title: Geoidmodell in ETRS89
+- dimensions: *id199
+  name: ch.swisstopo.geoidmodell-etrs89.lv95
+  sources: [ch.swisstopo.geoidmodell-etrs89_cache_lv95]
+  title: Geoidmodell in ETRS89
+- dimensions: *id199
+  name: ch.swisstopo.geoidmodell-etrs89
+  sources: [ch.swisstopo.geoidmodell-etrs89_cache]
+  title: Geoidmodell in ETRS89
+- dimensions: &id200
+    Time:
+      default: '20081231'
+      values: ['20081231']
+  name: ch.swisstopo.geologie-eiszeit-lgm-raster.mercator
+  sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache_mercator]
+  title: Eiszeitliches Maximum
+- dimensions: *id200
+  name: ch.swisstopo.geologie-eiszeit-lgm-raster.etrs89
+  sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache_etrs89]
+  title: Eiszeitliches Maximum
+- dimensions: *id200
+  name: ch.swisstopo.geologie-eiszeit-lgm-raster.wgs84
+  sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache_wgs84]
+  title: Eiszeitliches Maximum
+- dimensions: *id200
+  name: ch.swisstopo.geologie-eiszeit-lgm-raster.lv95
+  sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache_lv95]
+  title: Eiszeitliches Maximum
+- dimensions: *id200
+  name: ch.swisstopo.geologie-eiszeit-lgm-raster
+  sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_cache]
+  title: Eiszeitliches Maximum
+- dimensions: &id201
+    Time:
+      default: '19641231'
+      values: ['19641231']
+  name: ch.swisstopo.geologie-generalkarte-ggk200.mercator
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache_mercator]
+  title: Geologische Generalkarte
+- dimensions: *id201
+  name: ch.swisstopo.geologie-generalkarte-ggk200.etrs89
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache_etrs89]
+  title: Geologische Generalkarte
+- dimensions: *id201
+  name: ch.swisstopo.geologie-generalkarte-ggk200.wgs84
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache_wgs84]
+  title: Geologische Generalkarte
+- dimensions: *id201
+  name: ch.swisstopo.geologie-generalkarte-ggk200.lv95
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache_lv95]
+  title: Geologische Generalkarte
+- dimensions: *id201
+  name: ch.swisstopo.geologie-generalkarte-ggk200
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_cache]
+  title: Geologische Generalkarte
+- dimensions: &id202
+    Time:
+      default: '19791231'
+      values: ['19791231']
+  name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien.mercator
+  sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_mercator]
+  title: Bouguer-Anomalien
+- dimensions: *id202
+  name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien.etrs89
+  sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_etrs89]
+  title: Bouguer-Anomalien
+- dimensions: *id202
+  name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien.wgs84
+  sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_wgs84]
+  title: Bouguer-Anomalien
+- dimensions: *id202
+  name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien.lv95
+  sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache_lv95]
+  title: Bouguer-Anomalien
+- dimensions: *id202
+  name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien
+  sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_cache]
+  title: Bouguer-Anomalien
+- dimensions: &id203
+    Time:
+      default: '19791231'
+      values: ['19791231']
+  name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien.mercator
+  sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_mercator]
+  title: Isostatische Anomalien
+- dimensions: *id203
+  name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien.etrs89
+  sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_etrs89]
+  title: Isostatische Anomalien
+- dimensions: *id203
+  name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien.wgs84
+  sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_wgs84]
+  title: Isostatische Anomalien
+- dimensions: *id203
+  name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien.lv95
+  sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache_lv95]
+  title: Isostatische Anomalien
+- dimensions: *id203
+  name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien
+  sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_cache]
+  title: Isostatische Anomalien
+- dimensions: &id204
+    Time:
+      default: '20070425'
+      values: ['20070425']
+  name: ch.swisstopo.geologie-geolkarten500.metadata.mercator
+  sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache_mercator]
+  title: Blatteinteilung GeoKarten 500
+- dimensions: *id204
+  name: ch.swisstopo.geologie-geolkarten500.metadata.etrs89
+  sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache_etrs89]
+  title: Blatteinteilung GeoKarten 500
+- dimensions: *id204
+  name: ch.swisstopo.geologie-geolkarten500.metadata.wgs84
+  sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache_wgs84]
+  title: Blatteinteilung GeoKarten 500
+- dimensions: *id204
+  name: ch.swisstopo.geologie-geolkarten500.metadata.lv95
+  sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache_lv95]
+  title: Blatteinteilung GeoKarten 500
+- dimensions: *id204
+  name: ch.swisstopo.geologie-geolkarten500.metadata
+  sources: [ch.swisstopo.geologie-geolkarten500.metadata_cache]
+  title: Blatteinteilung GeoKarten 500
+- dimensions: &id205
+    Time:
+      default: '20080630'
+      values: ['20080630', '20051231']
+  name: ch.swisstopo.geologie-geologische_karte.mercator
+  sources: [ch.swisstopo.geologie-geologische_karte_cache_mercator]
+  title: Geologie 1:500000
+- dimensions: *id205
+  name: ch.swisstopo.geologie-geologische_karte.etrs89
+  sources: [ch.swisstopo.geologie-geologische_karte_cache_etrs89]
+  title: Geologie 1:500000
+- dimensions: *id205
+  name: ch.swisstopo.geologie-geologische_karte.wgs84
+  sources: [ch.swisstopo.geologie-geologische_karte_cache_wgs84]
+  title: Geologie 1:500000
+- dimensions: *id205
+  name: ch.swisstopo.geologie-geologische_karte.lv95
+  sources: [ch.swisstopo.geologie-geologische_karte_cache_lv95]
+  title: Geologie 1:500000
+- dimensions: *id205
+  name: ch.swisstopo.geologie-geologische_karte
+  sources: [ch.swisstopo.geologie-geologische_karte_cache]
+  title: Geologie 1:500000
+- dimensions: &id206
+    Time:
+      default: '20131120'
+      values: ['20131120', '20120601', '20101221']
+  name: ch.swisstopo.geologie-geologischer_atlas.mercator
+  sources: [ch.swisstopo.geologie-geologischer_atlas_cache_mercator]
+  title: Geologischer Atlas 1:25000
+- dimensions: *id206
+  name: ch.swisstopo.geologie-geologischer_atlas.etrs89
+  sources: [ch.swisstopo.geologie-geologischer_atlas_cache_etrs89]
+  title: Geologischer Atlas 1:25000
+- dimensions: *id206
+  name: ch.swisstopo.geologie-geologischer_atlas.wgs84
+  sources: [ch.swisstopo.geologie-geologischer_atlas_cache_wgs84]
+  title: Geologischer Atlas 1:25000
+- dimensions: *id206
+  name: ch.swisstopo.geologie-geologischer_atlas.lv95
+  sources: [ch.swisstopo.geologie-geologischer_atlas_cache_lv95]
+  title: Geologischer Atlas 1:25000
+- dimensions: *id206
+  name: ch.swisstopo.geologie-geologischer_atlas
+  sources: [ch.swisstopo.geologie-geologischer_atlas_cache]
+  title: Geologischer Atlas 1:25000
+- dimensions: &id207
+    Time:
+      default: '19831231'
+      values: ['19831231']
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura.mercator
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_mercator]
+  title: Aeromagnetik Voralpen/Jura
+- dimensions: *id207
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura.etrs89
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_etrs89]
+  title: Aeromagnetik Voralpen/Jura
+- dimensions: *id207
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura.wgs84
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_wgs84]
+  title: Aeromagnetik Voralpen/Jura
+- dimensions: *id207
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura.lv95
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache_lv95]
+  title: Aeromagnetik Voralpen/Jura
+- dimensions: *id207
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_cache]
+  title: Aeromagnetik Voralpen/Jura
+- dimensions: &id208
+    Time:
+      default: '20120628'
+      values: ['20120628', '19821231']
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz.mercator
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_mercator]
+  title: Aeromagnetik
+- dimensions: *id208
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz.etrs89
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_etrs89]
+  title: Aeromagnetik
+- dimensions: *id208
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz.wgs84
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_wgs84]
+  title: Aeromagnetik
+- dimensions: *id208
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz.lv95
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache_lv95]
+  title: Aeromagnetik
+- dimensions: *id208
+  name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz
+  sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_cache]
+  title: Aeromagnetik
+- dimensions: &id209
+    Time:
+      default: '20011203'
+      values: ['20011203', '19791231']
+  name: ch.swisstopo.geologie-geophysik-deklination.mercator
+  sources: [ch.swisstopo.geologie-geophysik-deklination_cache_mercator]
+  title: Deklination
+- dimensions: *id209
+  name: ch.swisstopo.geologie-geophysik-deklination.etrs89
+  sources: [ch.swisstopo.geologie-geophysik-deklination_cache_etrs89]
+  title: Deklination
+- dimensions: *id209
+  name: ch.swisstopo.geologie-geophysik-deklination.wgs84
+  sources: [ch.swisstopo.geologie-geophysik-deklination_cache_wgs84]
+  title: Deklination
+- dimensions: *id209
+  name: ch.swisstopo.geologie-geophysik-deklination.lv95
+  sources: [ch.swisstopo.geologie-geophysik-deklination_cache_lv95]
+  title: Deklination
+- dimensions: *id209
+  name: ch.swisstopo.geologie-geophysik-deklination
+  sources: [ch.swisstopo.geologie-geophysik-deklination_cache]
+  title: Deklination
+- dimensions: &id210
+    Time:
+      default: '20111121'
+      values: ['20111121', '19821231']
+  name: ch.swisstopo.geologie-geophysik-geothermie.mercator
+  sources: [ch.swisstopo.geologie-geophysik-geothermie_cache_mercator]
+  title: Geothermie
+- dimensions: *id210
+  name: ch.swisstopo.geologie-geophysik-geothermie.etrs89
+  sources: [ch.swisstopo.geologie-geophysik-geothermie_cache_etrs89]
+  title: Geothermie
+- dimensions: *id210
+  name: ch.swisstopo.geologie-geophysik-geothermie.wgs84
+  sources: [ch.swisstopo.geologie-geophysik-geothermie_cache_wgs84]
+  title: Geothermie
+- dimensions: *id210
+  name: ch.swisstopo.geologie-geophysik-geothermie.lv95
+  sources: [ch.swisstopo.geologie-geophysik-geothermie_cache_lv95]
+  title: Geothermie
+- dimensions: *id210
+  name: ch.swisstopo.geologie-geophysik-geothermie
+  sources: [ch.swisstopo.geologie-geophysik-geothermie_cache]
+  title: Geothermie
+- dimensions: &id211
+    Time:
+      default: '20111128'
+      values: ['20111128', '19791231']
+  name: ch.swisstopo.geologie-geophysik-inklination.mercator
+  sources: [ch.swisstopo.geologie-geophysik-inklination_cache_mercator]
+  title: Inklination
+- dimensions: *id211
+  name: ch.swisstopo.geologie-geophysik-inklination.etrs89
+  sources: [ch.swisstopo.geologie-geophysik-inklination_cache_etrs89]
+  title: Inklination
+- dimensions: *id211
+  name: ch.swisstopo.geologie-geophysik-inklination.wgs84
+  sources: [ch.swisstopo.geologie-geophysik-inklination_cache_wgs84]
+  title: Inklination
+- dimensions: *id211
+  name: ch.swisstopo.geologie-geophysik-inklination.lv95
+  sources: [ch.swisstopo.geologie-geophysik-inklination_cache_lv95]
+  title: Inklination
+- dimensions: *id211
+  name: ch.swisstopo.geologie-geophysik-inklination
+  sources: [ch.swisstopo.geologie-geophysik-inklination_cache]
+  title: Inklination
+- dimensions: &id212
+    Time:
+      default: '19800101'
+      values: ['19800101', '19791231']
+  name: ch.swisstopo.geologie-geophysik-totalintensitaet.mercator
+  sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache_mercator]
+  title: "Magnetfeldst\xE4rke"
+- dimensions: *id212
+  name: ch.swisstopo.geologie-geophysik-totalintensitaet.etrs89
+  sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache_etrs89]
+  title: "Magnetfeldst\xE4rke"
+- dimensions: *id212
+  name: ch.swisstopo.geologie-geophysik-totalintensitaet.wgs84
+  sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache_wgs84]
+  title: "Magnetfeldst\xE4rke"
+- dimensions: *id212
+  name: ch.swisstopo.geologie-geophysik-totalintensitaet.lv95
+  sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache_lv95]
+  title: "Magnetfeldst\xE4rke"
+- dimensions: *id212
+  name: ch.swisstopo.geologie-geophysik-totalintensitaet
+  sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_cache]
+  title: "Magnetfeldst\xE4rke"
+- dimensions: &id213
+    Time:
+      default: '19670101'
+      values: ['19670101']
+  name: ch.swisstopo.geologie-geotechnik-gk200.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-gk200_cache_mercator]
+  title: Geotechnik Rohstoffe Gesteine
+- dimensions: *id213
+  name: ch.swisstopo.geologie-geotechnik-gk200.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-gk200_cache_etrs89]
+  title: Geotechnik Rohstoffe Gesteine
+- dimensions: *id213
+  name: ch.swisstopo.geologie-geotechnik-gk200.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-gk200_cache_wgs84]
+  title: Geotechnik Rohstoffe Gesteine
+- dimensions: *id213
+  name: ch.swisstopo.geologie-geotechnik-gk200.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-gk200_cache_lv95]
+  title: Geotechnik Rohstoffe Gesteine
+- dimensions: *id213
+  name: ch.swisstopo.geologie-geotechnik-gk200
+  sources: [ch.swisstopo.geologie-geotechnik-gk200_cache]
+  title: Geotechnik Rohstoffe Gesteine
+- dimensions: &id214
+    Time:
+      default: '20060304'
+      values: ['20060304', '20000101']
+  name: ch.swisstopo.geologie-geotechnik-gk500-genese.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache_mercator]
+  title: Entstehung der Gesteine
+- dimensions: *id214
+  name: ch.swisstopo.geologie-geotechnik-gk500-genese.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache_etrs89]
+  title: Entstehung der Gesteine
+- dimensions: *id214
+  name: ch.swisstopo.geologie-geotechnik-gk500-genese.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache_wgs84]
+  title: Entstehung der Gesteine
+- dimensions: *id214
+  name: ch.swisstopo.geologie-geotechnik-gk500-genese.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache_lv95]
+  title: Entstehung der Gesteine
+- dimensions: *id214
+  name: ch.swisstopo.geologie-geotechnik-gk500-genese
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_cache]
+  title: Entstehung der Gesteine
+- dimensions: &id215
+    Time:
+      default: '20060304'
+      values: ['20060304', '20000101']
+  name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_mercator]
+  title: Gesteinklassierung
+- dimensions: *id215
+  name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_etrs89]
+  title: Gesteinklassierung
+- dimensions: *id215
+  name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_wgs84]
+  title: Gesteinklassierung
+- dimensions: *id215
+  name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache_lv95]
+  title: Gesteinklassierung
+- dimensions: *id215
+  name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_cache]
+  title: Gesteinklassierung
+- dimensions: &id216
+    Time:
+      default: '20060304'
+      values: ['20060304', '20000101']
+  name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_mercator]
+  title: Lithologie-Hauptgruppen
+- dimensions: *id216
+  name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_etrs89]
+  title: Lithologie-Hauptgruppen
+- dimensions: *id216
+  name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_wgs84]
+  title: Lithologie-Hauptgruppen
+- dimensions: *id216
+  name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache_lv95]
+  title: Lithologie-Hauptgruppen
+- dimensions: *id216
+  name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen
+  sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_cache]
+  title: Lithologie-Hauptgruppen
+- dimensions: &id217
+    Time:
+      default: '19900101'
+      values: ['19900101']
+  name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_mercator]
+  title: Mineralische Rohstoffe
+- dimensions: *id217
+  name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_etrs89]
+  title: Mineralische Rohstoffe
+- dimensions: *id217
+  name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_wgs84]
+  title: Mineralische Rohstoffe
+- dimensions: *id217
+  name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache_lv95]
+  title: Mineralische Rohstoffe
+- dimensions: *id217
+  name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200
+  sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_cache]
+  title: Mineralische Rohstoffe
+- dimensions: &id218
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_mercator]
+  title: "Steinbr\xFCche 1915"
+- dimensions: *id218
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_etrs89]
+  title: "Steinbr\xFCche 1915"
+- dimensions: *id218
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_wgs84]
+  title: "Steinbr\xFCche 1915"
+- dimensions: *id218
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache_lv95]
+  title: "Steinbr\xFCche 1915"
+- dimensions: *id218
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_cache]
+  title: "Steinbr\xFCche 1915"
+- dimensions: &id219
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_mercator]
+  title: "Steinbr\xFCche 1965"
+- dimensions: *id219
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_etrs89]
+  title: "Steinbr\xFCche 1965"
+- dimensions: *id219
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_wgs84]
+  title: "Steinbr\xFCche 1965"
+- dimensions: *id219
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache_lv95]
+  title: "Steinbr\xFCche 1965"
+- dimensions: *id219
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_cache]
+  title: "Steinbr\xFCche 1965"
+- dimensions: &id220
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_mercator]
+  title: "Steinbr\xFCche 1980"
+- dimensions: *id220
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_etrs89]
+  title: "Steinbr\xFCche 1980"
+- dimensions: *id220
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_wgs84]
+  title: "Steinbr\xFCche 1980"
+- dimensions: *id220
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache_lv95]
+  title: "Steinbr\xFCche 1980"
+- dimensions: *id220
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_cache]
+  title: "Steinbr\xFCche 1980"
+- dimensions: &id221
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_mercator]
+  title: "Steinbr\xFCche 1995"
+- dimensions: *id221
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_etrs89]
+  title: "Steinbr\xFCche 1995"
+- dimensions: *id221
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_wgs84]
+  title: "Steinbr\xFCche 1995"
+- dimensions: *id221
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache_lv95]
+  title: "Steinbr\xFCche 1995"
+- dimensions: *id221
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_cache]
+  title: "Steinbr\xFCche 1995"
+- dimensions: &id222
+    Time:
+      default: '20130620'
+      values: ['20130620']
+  name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_mercator]
+  title: Steine an historischen Bauwerken
+- dimensions: *id222
+  name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_etrs89]
+  title: Steine an historischen Bauwerken
+- dimensions: *id222
+  name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_wgs84]
+  title: Steine an historischen Bauwerken
+- dimensions: *id222
+  name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache_lv95]
+  title: Steine an historischen Bauwerken
+- dimensions: *id222
+  name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke
+  sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_cache]
+  title: Steine an historischen Bauwerken
+- dimensions: &id223
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_mercator]
+  title: Zementindustrie 1965
+- dimensions: *id223
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_etrs89]
+  title: Zementindustrie 1965
+- dimensions: *id223
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_wgs84]
+  title: Zementindustrie 1965
+- dimensions: *id223
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache_lv95]
+  title: Zementindustrie 1965
+- dimensions: *id223
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_cache]
+  title: Zementindustrie 1965
+- dimensions: &id224
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_mercator]
+  title: Zementindustrie 1995
+- dimensions: *id224
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_etrs89]
+  title: Zementindustrie 1995
+- dimensions: *id224
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_wgs84]
+  title: Zementindustrie 1995
+- dimensions: *id224
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache_lv95]
+  title: Zementindustrie 1995
+- dimensions: *id224
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_cache]
+  title: Zementindustrie 1995
+- dimensions: &id225
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_mercator]
+  title: Ziegeleien 1907
+- dimensions: *id225
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_etrs89]
+  title: Ziegeleien 1907
+- dimensions: *id225
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_wgs84]
+  title: Ziegeleien 1907
+- dimensions: *id225
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache_lv95]
+  title: Ziegeleien 1907
+- dimensions: *id225
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_cache]
+  title: Ziegeleien 1907
+- dimensions: &id226
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_mercator]
+  title: Ziegeleien 1965
+- dimensions: *id226
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_etrs89]
+  title: Ziegeleien 1965
+- dimensions: *id226
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_wgs84]
+  title: Ziegeleien 1965
+- dimensions: *id226
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache_lv95]
+  title: Ziegeleien 1965
+- dimensions: *id226
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_cache]
+  title: Ziegeleien 1965
+- dimensions: &id227
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995.mercator
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_mercator]
+  title: Ziegeleien 1995
+- dimensions: *id227
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995.etrs89
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_etrs89]
+  title: Ziegeleien 1995
+- dimensions: *id227
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995.wgs84
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_wgs84]
+  title: Ziegeleien 1995
+- dimensions: *id227
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995.lv95
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache_lv95]
+  title: Ziegeleien 1995
+- dimensions: *id227
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_cache]
+  title: Ziegeleien 1995
+- dimensions: &id228
+    Time:
+      default: '20130107'
+      values: ['20130107', '20110201']
+  name: ch.swisstopo.geologie-geotope.mercator
+  sources: [ch.swisstopo.geologie-geotope_cache_mercator]
+  title: Schweizerische Geotope
+- dimensions: *id228
+  name: ch.swisstopo.geologie-geotope.etrs89
+  sources: [ch.swisstopo.geologie-geotope_cache_etrs89]
+  title: Schweizerische Geotope
+- dimensions: *id228
+  name: ch.swisstopo.geologie-geotope.wgs84
+  sources: [ch.swisstopo.geologie-geotope_cache_wgs84]
+  title: Schweizerische Geotope
+- dimensions: *id228
+  name: ch.swisstopo.geologie-geotope.lv95
+  sources: [ch.swisstopo.geologie-geotope_cache_lv95]
+  title: Schweizerische Geotope
+- dimensions: *id228
+  name: ch.swisstopo.geologie-geotope
+  sources: [ch.swisstopo.geologie-geotope_cache]
+  title: Schweizerische Geotope
+- dimensions: &id229
+    Time:
+      default: '20021231'
+      values: ['20021231']
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.mercator
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache_mercator]
+  title: Gravimetrischer Atlas
+- dimensions: *id229
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.etrs89
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache_etrs89]
+  title: Gravimetrischer Atlas
+- dimensions: *id229
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.wgs84
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache_wgs84]
+  title: Gravimetrischer Atlas
+- dimensions: *id229
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.lv95
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache_lv95]
+  title: Gravimetrischer Atlas
+- dimensions: *id229
+  name: ch.swisstopo.geologie-gravimetrischer_atlas
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas_cache]
+  title: Gravimetrischer Atlas
+- dimensions: &id230
+    Time:
+      default: '20021231'
+      values: ['20021231']
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata.mercator
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_mercator]
+  title: Einteilung gravimetrischer Atlas
+- dimensions: *id230
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata.etrs89
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_etrs89]
+  title: Einteilung gravimetrischer Atlas
+- dimensions: *id230
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata.wgs84
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_wgs84]
+  title: Einteilung gravimetrischer Atlas
+- dimensions: *id230
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata.lv95
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache_lv95]
+  title: Einteilung gravimetrischer Atlas
+- dimensions: *id230
+  name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata
+  sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_cache]
+  title: Einteilung gravimetrischer Atlas
+- dimensions: &id231
+    Time:
+      default: '20081103'
+      values: ['20081103', '20070101']
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen.mercator
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_mercator]
+  title: Grundwasservorkommen
+- dimensions: *id231
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen.etrs89
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_etrs89]
+  title: Grundwasservorkommen
+- dimensions: *id231
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen.wgs84
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_wgs84]
+  title: Grundwasservorkommen
+- dimensions: *id231
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen.lv95
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache_lv95]
+  title: Grundwasservorkommen
+- dimensions: *id231
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_cache]
+  title: Grundwasservorkommen
+- dimensions: &id232
+    Time:
+      default: '20081016'
+      values: ['20081016', '20070914']
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet.mercator
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_mercator]
+  title: "Grundwasservulnerabilit\xE4t"
+- dimensions: *id232
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet.etrs89
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_etrs89]
+  title: "Grundwasservulnerabilit\xE4t"
+- dimensions: *id232
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet.wgs84
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_wgs84]
+  title: "Grundwasservulnerabilit\xE4t"
+- dimensions: *id232
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet.lv95
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache_lv95]
+  title: "Grundwasservulnerabilit\xE4t"
+- dimensions: *id232
+  name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet
+  sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_cache]
+  title: "Grundwasservulnerabilit\xE4t"
+- dimensions: &id233
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale.mercator
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_mercator]
+  title: Industrieminerale
+- dimensions: *id233
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale.etrs89
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_etrs89]
+  title: Industrieminerale
+- dimensions: *id233
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale.wgs84
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_wgs84]
+  title: Industrieminerale
+- dimensions: *id233
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale.lv95
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache_lv95]
+  title: Industrieminerale
+- dimensions: *id233
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_cache]
+  title: Industrieminerale
+- dimensions: &id234
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas.mercator
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_mercator]
+  title: Mineralische Energierohstoffe
+- dimensions: *id234
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas.etrs89
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_etrs89]
+  title: Mineralische Energierohstoffe
+- dimensions: *id234
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas.wgs84
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_wgs84]
+  title: Mineralische Energierohstoffe
+- dimensions: *id234
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas.lv95
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache_lv95]
+  title: Mineralische Energierohstoffe
+- dimensions: *id234
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_cache]
+  title: Mineralische Energierohstoffe
+- dimensions: &id235
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen.mercator
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache_mercator]
+  title: Vererzungen
+- dimensions: *id235
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen.etrs89
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache_etrs89]
+  title: Vererzungen
+- dimensions: *id235
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen.wgs84
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache_wgs84]
+  title: Vererzungen
+- dimensions: *id235
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen.lv95
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache_lv95]
+  title: Vererzungen
+- dimensions: *id235
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_cache]
+  title: Vererzungen
+- dimensions: &id236
+    Time:
+      default: '20110101'
+      values: ['20110101']
+  name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata.mercator
+  sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_mercator]
+  title: Einteilung geol. Spezialkarten
+- dimensions: *id236
+  name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata.etrs89
+  sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_etrs89]
+  title: Einteilung geol. Spezialkarten
+- dimensions: *id236
+  name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata.wgs84
+  sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_wgs84]
+  title: Einteilung geol. Spezialkarten
+- dimensions: *id236
+  name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata.lv95
+  sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache_lv95]
+  title: Einteilung geol. Spezialkarten
+- dimensions: *id236
+  name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata
+  sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_cache]
+  title: Einteilung geol. Spezialkarten
+- dimensions: &id237
+    Time:
+      default: '20080522'
+      values: ['20080522', '20051231']
+  name: ch.swisstopo.geologie-tektonische_karte.mercator
+  sources: [ch.swisstopo.geologie-tektonische_karte_cache_mercator]
+  title: Tektonik 1:500000
+- dimensions: *id237
+  name: ch.swisstopo.geologie-tektonische_karte.etrs89
+  sources: [ch.swisstopo.geologie-tektonische_karte_cache_etrs89]
+  title: Tektonik 1:500000
+- dimensions: *id237
+  name: ch.swisstopo.geologie-tektonische_karte.wgs84
+  sources: [ch.swisstopo.geologie-tektonische_karte_cache_wgs84]
+  title: Tektonik 1:500000
+- dimensions: *id237
+  name: ch.swisstopo.geologie-tektonische_karte.lv95
+  sources: [ch.swisstopo.geologie-tektonische_karte_cache_lv95]
+  title: Tektonik 1:500000
+- dimensions: *id237
+  name: ch.swisstopo.geologie-tektonische_karte
+  sources: [ch.swisstopo.geologie-tektonische_karte_cache]
+  title: Tektonik 1:500000
+- dimensions: &id238
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.swisstopo.hangneigung-ueber_30.mercator
+  sources: [ch.swisstopo.hangneigung-ueber_30_cache_mercator]
+  title: "Hangneigungen ab 30\xB0"
+- dimensions: *id238
+  name: ch.swisstopo.hangneigung-ueber_30.etrs89
+  sources: [ch.swisstopo.hangneigung-ueber_30_cache_etrs89]
+  title: "Hangneigungen ab 30\xB0"
+- dimensions: *id238
+  name: ch.swisstopo.hangneigung-ueber_30.wgs84
+  sources: [ch.swisstopo.hangneigung-ueber_30_cache_wgs84]
+  title: "Hangneigungen ab 30\xB0"
+- dimensions: *id238
+  name: ch.swisstopo.hangneigung-ueber_30.lv95
+  sources: [ch.swisstopo.hangneigung-ueber_30_cache_lv95]
+  title: "Hangneigungen ab 30\xB0"
+- dimensions: *id238
+  name: ch.swisstopo.hangneigung-ueber_30
+  sources: [ch.swisstopo.hangneigung-ueber_30_cache]
+  title: "Hangneigungen ab 30\xB0"
+- dimensions: &id239
+    Time:
+      default: '18450101'
+      values: ['18450101']
+  name: ch.swisstopo.hiks-dufour.mercator
+  sources: [ch.swisstopo.hiks-dufour_cache_mercator]
+  title: Dufourkarte Erstausgabe
+- dimensions: *id239
+  name: ch.swisstopo.hiks-dufour.etrs89
+  sources: [ch.swisstopo.hiks-dufour_cache_etrs89]
+  title: Dufourkarte Erstausgabe
+- dimensions: *id239
+  name: ch.swisstopo.hiks-dufour.wgs84
+  sources: [ch.swisstopo.hiks-dufour_cache_wgs84]
+  title: Dufourkarte Erstausgabe
+- dimensions: *id239
+  name: ch.swisstopo.hiks-dufour.lv95
+  sources: [ch.swisstopo.hiks-dufour_cache_lv95]
+  title: Dufourkarte Erstausgabe
+- dimensions: *id239
+  name: ch.swisstopo.hiks-dufour
+  sources: [ch.swisstopo.hiks-dufour_cache]
+  title: Dufourkarte Erstausgabe
+- dimensions: &id240
+    Time:
+      default: '19391231'
+      values: ['19391231', '19381231', '19371231', '19361231', '19351231', '19341231',
+        '19331231', '19321231', '19311231', '19301231', '19291231', '19281231', '19271231',
+        '19261231', '19251231', '19241231', '19231231', '19221231', '19211231', '19201231',
+        '19191231', '19181231', '19171231', '19161231', '19151231', '19141231', '19131231',
+        '19121231', '19111231', '19101231', '19091231', '19081231', '19071231', '19061231',
+        '19051231', '19041231', '19031231', '19021231', '19011231', '19001231', '18991231',
+        '18981231', '18971231', '18961231', '18951231', '18941231', '18931231', '18921231',
+        '18911231', '18901231', '18891231', '18881231', '18871231', '18861231', '18851231',
+        '18841231', '18831231', '18821231', '18811231', '18801231', '18791231', '18781231',
+        '18771231', '18761231', '18751231', '18741231', '18731231', '18721231', '18711231',
+        '18701231', '18691231', '18681231', '18671231', '18661231', '18651231', '18641231',
+        '18631231', '18621231', '18611231', '18601231', '18591231', '18581231', '18571231',
+        '18561231', '18551231', '18541231', '18531231', '18521231', '18511231', '18501231',
+        '18491231', '18481231', '18471231', '18461231', '18451231', '18441231']
+  name: ch.swisstopo.hiks-dufour-timeseries.mercator
+  sources: [ch.swisstopo.hiks-dufour-timeseries_cache_mercator]
+  title: ch.swisstopo.hiks-dufour-timeseries
+- dimensions: *id240
+  name: ch.swisstopo.hiks-dufour-timeseries.etrs89
+  sources: [ch.swisstopo.hiks-dufour-timeseries_cache_etrs89]
+  title: ch.swisstopo.hiks-dufour-timeseries
+- dimensions: *id240
+  name: ch.swisstopo.hiks-dufour-timeseries.wgs84
+  sources: [ch.swisstopo.hiks-dufour-timeseries_cache_wgs84]
+  title: ch.swisstopo.hiks-dufour-timeseries
+- dimensions: *id240
+  name: ch.swisstopo.hiks-dufour-timeseries.lv95
+  sources: [ch.swisstopo.hiks-dufour-timeseries_cache_lv95]
+  title: ch.swisstopo.hiks-dufour-timeseries
+- dimensions: *id240
+  name: ch.swisstopo.hiks-dufour-timeseries
+  sources: [ch.swisstopo.hiks-dufour-timeseries_cache]
+  title: ch.swisstopo.hiks-dufour-timeseries
+- dimensions: &id241
+    Time:
+      default: '18700101'
+      values: ['18700101']
+  name: ch.swisstopo.hiks-siegfried.mercator
+  sources: [ch.swisstopo.hiks-siegfried_cache_mercator]
+  title: Siegfriedkarte Erstausgabe
+- dimensions: *id241
+  name: ch.swisstopo.hiks-siegfried.etrs89
+  sources: [ch.swisstopo.hiks-siegfried_cache_etrs89]
+  title: Siegfriedkarte Erstausgabe
+- dimensions: *id241
+  name: ch.swisstopo.hiks-siegfried.wgs84
+  sources: [ch.swisstopo.hiks-siegfried_cache_wgs84]
+  title: Siegfriedkarte Erstausgabe
+- dimensions: *id241
+  name: ch.swisstopo.hiks-siegfried.lv95
+  sources: [ch.swisstopo.hiks-siegfried_cache_lv95]
+  title: Siegfriedkarte Erstausgabe
+- dimensions: *id241
+  name: ch.swisstopo.hiks-siegfried
+  sources: [ch.swisstopo.hiks-siegfried_cache]
+  title: Siegfriedkarte Erstausgabe
+- dimensions: &id242
+    Time:
+      default: '19491231'
+      values: ['19491231', '19481231', '19471231', '19461231', '19451231', '19441231',
+        '19431231', '19421231', '19411231', '19401231', '19391231', '19381231', '19371231',
+        '19361231', '19351231', '19341231', '19331231', '19321231', '19311231', '19301231',
+        '19291231', '19281231', '19271231', '19261231', '19251231', '19241231', '19231231',
+        '19221231', '19211231', '19201231', '19191231', '19181231', '19171231', '19161231',
+        '19151231', '19141231', '19131231', '19121231', '19111231', '19101231', '19091231',
+        '19081231', '19071231', '19061231', '19051231', '19041231', '19031231', '19021231',
+        '19011231', '19001231', '18991231', '18981231', '18971231', '18961231', '18951231',
+        '18941231', '18931231', '18921231', '18911231', '18901231', '18891231', '18881231',
+        '18871231', '18861231', '18851231', '18841231', '18831231', '18821231', '18811231',
+        '18801231', '18791231', '18781231', '18771231', '18761231', '18751231', '18741231',
+        '18731231', '18721231', '18711231', '18701231']
+  name: ch.swisstopo.hiks-siegfried-ta25.mercator
+  sources: [ch.swisstopo.hiks-siegfried-ta25_cache_mercator]
+  title: ch.swisstopo.hiks-siegfried-ta25
+- dimensions: *id242
+  name: ch.swisstopo.hiks-siegfried-ta25.etrs89
+  sources: [ch.swisstopo.hiks-siegfried-ta25_cache_etrs89]
+  title: ch.swisstopo.hiks-siegfried-ta25
+- dimensions: *id242
+  name: ch.swisstopo.hiks-siegfried-ta25.wgs84
+  sources: [ch.swisstopo.hiks-siegfried-ta25_cache_wgs84]
+  title: ch.swisstopo.hiks-siegfried-ta25
+- dimensions: *id242
+  name: ch.swisstopo.hiks-siegfried-ta25.lv95
+  sources: [ch.swisstopo.hiks-siegfried-ta25_cache_lv95]
+  title: ch.swisstopo.hiks-siegfried-ta25
+- dimensions: *id242
+  name: ch.swisstopo.hiks-siegfried-ta25
+  sources: [ch.swisstopo.hiks-siegfried-ta25_cache]
+  title: ch.swisstopo.hiks-siegfried-ta25
+- dimensions: &id243
+    Time:
+      default: '19491231'
+      values: ['19491231', '19481231', '19471231', '19461231', '19451231', '19441231',
+        '19431231', '19421231', '19411231', '19401231', '19391231', '19381231', '19371231',
+        '19361231', '19351231', '19341231', '19331231', '19321231', '19311231', '19301231',
+        '19291231', '19281231', '19271231', '19261231', '19251231', '19241231', '19231231',
+        '19221231', '19211231', '19201231', '19191231', '19181231', '19171231', '19161231',
+        '19151231', '19141231', '19131231', '19121231', '19111231', '19101231', '19091231',
+        '19081231', '19071231', '19061231', '19051231', '19041231', '19031231', '19021231',
+        '19011231', '19001231', '18991231', '18981231', '18971231', '18961231', '18951231',
+        '18941231', '18931231', '18921231', '18911231', '18901231', '18891231', '18881231',
+        '18871231', '18861231', '18851231', '18841231', '18831231', '18821231', '18811231',
+        '18801231', '18791231', '18781231', '18771231', '18761231', '18751231', '18741231',
+        '18731231', '18721231', '18711231', '18701231']
+  name: ch.swisstopo.hiks-siegfried-ta50.mercator
+  sources: [ch.swisstopo.hiks-siegfried-ta50_cache_mercator]
+  title: ch.swisstopo.hiks-siegfried-ta50
+- dimensions: *id243
+  name: ch.swisstopo.hiks-siegfried-ta50.etrs89
+  sources: [ch.swisstopo.hiks-siegfried-ta50_cache_etrs89]
+  title: ch.swisstopo.hiks-siegfried-ta50
+- dimensions: *id243
+  name: ch.swisstopo.hiks-siegfried-ta50.wgs84
+  sources: [ch.swisstopo.hiks-siegfried-ta50_cache_wgs84]
+  title: ch.swisstopo.hiks-siegfried-ta50
+- dimensions: *id243
+  name: ch.swisstopo.hiks-siegfried-ta50.lv95
+  sources: [ch.swisstopo.hiks-siegfried-ta50_cache_lv95]
+  title: ch.swisstopo.hiks-siegfried-ta50
+- dimensions: *id243
+  name: ch.swisstopo.hiks-siegfried-ta50
+  sources: [ch.swisstopo.hiks-siegfried-ta50_cache]
+  title: ch.swisstopo.hiks-siegfried-ta50
+- dimensions: &id244
+    Time:
+      default: '20061231'
+      values: ['20061231']
+  name: ch.swisstopo.koordinatenaenderung.mercator
+  sources: [ch.swisstopo.koordinatenaenderung_cache_mercator]
+  title: "LV95 Koordinaten\xE4nderung"
+- dimensions: *id244
+  name: ch.swisstopo.koordinatenaenderung.etrs89
+  sources: [ch.swisstopo.koordinatenaenderung_cache_etrs89]
+  title: "LV95 Koordinaten\xE4nderung"
+- dimensions: *id244
+  name: ch.swisstopo.koordinatenaenderung.wgs84
+  sources: [ch.swisstopo.koordinatenaenderung_cache_wgs84]
+  title: "LV95 Koordinaten\xE4nderung"
+- dimensions: *id244
+  name: ch.swisstopo.koordinatenaenderung.lv95
+  sources: [ch.swisstopo.koordinatenaenderung_cache_lv95]
+  title: "LV95 Koordinaten\xE4nderung"
+- dimensions: *id244
+  name: ch.swisstopo.koordinatenaenderung
+  sources: [ch.swisstopo.koordinatenaenderung_cache]
+  title: "LV95 Koordinaten\xE4nderung"
+- dimensions: &id245
+    Time:
+      default: '99991231'
+      values: ['99991231', '20091231', '20081231', '20071231', '20061231', '20051231',
+        '20041231', '20031231', '20021231', '20011231', '20001231', '19991231', '19981231',
+        '19971231', '19961231', '19951231', '19941231', '19931231', '19921231', '19911231',
+        '19901231', '19891231']
+  name: ch.swisstopo.lubis-luftbilder-dritte-firmen.mercator
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_mercator]
+  title: Luftbilder Privater
+- dimensions: *id245
+  name: ch.swisstopo.lubis-luftbilder-dritte-firmen.etrs89
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_etrs89]
+  title: Luftbilder Privater
+- dimensions: *id245
+  name: ch.swisstopo.lubis-luftbilder-dritte-firmen.wgs84
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_wgs84]
+  title: Luftbilder Privater
+- dimensions: *id245
+  name: ch.swisstopo.lubis-luftbilder-dritte-firmen.lv95
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache_lv95]
+  title: Luftbilder Privater
+- dimensions: *id245
+  name: ch.swisstopo.lubis-luftbilder-dritte-firmen
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_cache]
+  title: Luftbilder Privater
+- dimensions: &id246
+    Time:
+      default: '99991231'
+      values: ['99991231', '20131231', '20121231', '20111231', '20091231', '19841231',
+        '19671231', '19661231', '19651231', '19641231', '19631231', '19621231']
+  name: ch.swisstopo.lubis-luftbilder-dritte-kantone.mercator
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_mercator]
+  title: Luftbilder Kantone
+- dimensions: *id246
+  name: ch.swisstopo.lubis-luftbilder-dritte-kantone.etrs89
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_etrs89]
+  title: Luftbilder Kantone
+- dimensions: *id246
+  name: ch.swisstopo.lubis-luftbilder-dritte-kantone.wgs84
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_wgs84]
+  title: Luftbilder Kantone
+- dimensions: *id246
+  name: ch.swisstopo.lubis-luftbilder-dritte-kantone.lv95
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache_lv95]
+  title: Luftbilder Kantone
+- dimensions: *id246
+  name: ch.swisstopo.lubis-luftbilder-dritte-kantone
+  sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_cache]
+  title: Luftbilder Kantone
+- dimensions: &id247
+    Time:
+      default: '99991231'
+      values: ['99991231', '20101231', '20091231', '20081231', '20071231', '20061231',
+        '20051231', '20041231', '20031231', '20021231', '20011231', '20001231', '19991231',
+        '19981231', '19971231', '19961231', '19951231', '19941231', '19931231', '19921231',
+        '19911231', '19901231', '19891231', '19881231', '19871231', '19861231', '19851231',
+        '19841231', '19831231', '19821231', '19811231']
+  name: ch.swisstopo.lubis-luftbilder_farbe.mercator
+  sources: [ch.swisstopo.lubis-luftbilder_farbe_cache_mercator]
+  title: Luftbilder swisstopo farbig
+- dimensions: *id247
+  name: ch.swisstopo.lubis-luftbilder_farbe.etrs89
+  sources: [ch.swisstopo.lubis-luftbilder_farbe_cache_etrs89]
+  title: Luftbilder swisstopo farbig
+- dimensions: *id247
+  name: ch.swisstopo.lubis-luftbilder_farbe.wgs84
+  sources: [ch.swisstopo.lubis-luftbilder_farbe_cache_wgs84]
+  title: Luftbilder swisstopo farbig
+- dimensions: *id247
+  name: ch.swisstopo.lubis-luftbilder_farbe.lv95
+  sources: [ch.swisstopo.lubis-luftbilder_farbe_cache_lv95]
+  title: Luftbilder swisstopo farbig
+- dimensions: *id247
+  name: ch.swisstopo.lubis-luftbilder_farbe
+  sources: [ch.swisstopo.lubis-luftbilder_farbe_cache]
+  title: Luftbilder swisstopo farbig
+- dimensions: &id248
+    Time:
+      default: '99991231'
+      values: ['99991231', '20091231', '20081231', '20071231', '20061231', '20051231',
+        '20041231', '20031231', '20021231', '20011231', '20001231', '19991231', '19981231',
+        '19971231', '19961231', '19951231', '19941231', '19931231', '19921231', '19911231',
+        '19901231', '19891231', '19881231', '19871231', '19861231', '19851231', '19841231',
+        '19831231', '19811231']
+  name: ch.swisstopo.lubis-luftbilder_infrarot.mercator
+  sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache_mercator]
+  title: Luftbilder swisstopo infrarot
+- dimensions: *id248
+  name: ch.swisstopo.lubis-luftbilder_infrarot.etrs89
+  sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache_etrs89]
+  title: Luftbilder swisstopo infrarot
+- dimensions: *id248
+  name: ch.swisstopo.lubis-luftbilder_infrarot.wgs84
+  sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache_wgs84]
+  title: Luftbilder swisstopo infrarot
+- dimensions: *id248
+  name: ch.swisstopo.lubis-luftbilder_infrarot.lv95
+  sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache_lv95]
+  title: Luftbilder swisstopo infrarot
+- dimensions: *id248
+  name: ch.swisstopo.lubis-luftbilder_infrarot
+  sources: [ch.swisstopo.lubis-luftbilder_infrarot_cache]
+  title: Luftbilder swisstopo infrarot
+- dimensions: &id249
+    Time:
+      default: '99991231'
+      values: ['99991231', '20101231', '20091231', '20081231', '20071231', '20061231',
+        '20051231', '20041231', '20031231', '20021231', '20011231', '20001231', '19991231',
+        '19981231', '19971231', '19961231', '19951231', '19941231', '19931231', '19921231',
+        '19911231', '19901231', '19891231', '19881231', '19871231', '19861231', '19851231',
+        '19841231', '19831231', '19821231', '19811231', '19801231', '19791231', '19781231',
+        '19771231', '19761231', '19751231', '19741231', '19731231', '19721231', '19711231',
+        '19701231', '19691231', '19681231', '19671231', '19661231', '19651231', '19641231',
+        '19631231', '19621231', '19611231', '19601231', '19591231', '19581231', '19571231',
+        '19561231', '19551231', '19541231', '19531231', '19521231', '19511231', '19501231',
+        '19491231', '19481231', '19471231', '19461231', '19451231', '19441231', '19431231',
+        '19421231', '19411231', '19401231', '19391231', '19381231', '19371231', '19361231',
+        '19351231', '19341231', '19331231', '19321231', '19311231', '19301231', '19291231',
+        '19281231']
+  name: ch.swisstopo.lubis-luftbilder_schwarzweiss.mercator
+  sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_mercator]
+  title: Luftbilder swisstopo s/w
+- dimensions: *id249
+  name: ch.swisstopo.lubis-luftbilder_schwarzweiss.etrs89
+  sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_etrs89]
+  title: Luftbilder swisstopo s/w
+- dimensions: *id249
+  name: ch.swisstopo.lubis-luftbilder_schwarzweiss.wgs84
+  sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_wgs84]
+  title: Luftbilder swisstopo s/w
+- dimensions: *id249
+  name: ch.swisstopo.lubis-luftbilder_schwarzweiss.lv95
+  sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache_lv95]
+  title: Luftbilder swisstopo s/w
+- dimensions: *id249
+  name: ch.swisstopo.lubis-luftbilder_schwarzweiss
+  sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_cache]
+  title: Luftbilder swisstopo s/w
+- dimensions: &id250
+    Time:
+      default: '20140520'
+      values: ['20140520', '20140106', '20130903', '20130213', '20120809', '20111206',
+        '20111027', '20110401']
+  name: ch.swisstopo.pixelkarte-farbe.mercator
+  sources: [ch.swisstopo.pixelkarte-farbe_cache_mercator]
+  title: Karte farbig
+- dimensions: *id250
+  name: ch.swisstopo.pixelkarte-farbe.etrs89
+  sources: [ch.swisstopo.pixelkarte-farbe_cache_etrs89]
+  title: Karte farbig
+- dimensions: *id250
+  name: ch.swisstopo.pixelkarte-farbe.wgs84
+  sources: [ch.swisstopo.pixelkarte-farbe_cache_wgs84]
+  title: Karte farbig
+- dimensions: *id250
+  name: ch.swisstopo.pixelkarte-farbe.lv95
+  sources: [ch.swisstopo.pixelkarte-farbe_cache_lv95]
+  title: Karte farbig
+- dimensions: *id250
+  name: ch.swisstopo.pixelkarte-farbe
+  sources: [ch.swisstopo.pixelkarte-farbe_cache]
+  title: Karte farbig
+- dimensions: &id251
+    Time:
+      default: '20140106'
+      values: ['20140106', '20130903', '20130213', '20120809', '20111206', '20111027']
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale.mercator
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_mercator]
+  title: Landeskarte 1:100'000
+- dimensions: *id251
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale.etrs89
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_etrs89]
+  title: Landeskarte 1:100'000
+- dimensions: *id251
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale.wgs84
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_wgs84]
+  title: Landeskarte 1:100'000
+- dimensions: *id251
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale.lv95
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache_lv95]
+  title: Landeskarte 1:100'000
+- dimensions: *id251
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_cache]
+  title: Landeskarte 1:100'000
+- dimensions: &id252
+    Time:
+      default: '20140106'
+      values: ['20140106', '20120809', '20111027']
+  name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale.mercator
+  sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_mercator]
+  title: Landeskarte 1:1 Mio.
+- dimensions: *id252
+  name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale.etrs89
+  sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_etrs89]
+  title: Landeskarte 1:1 Mio.
+- dimensions: *id252
+  name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale.wgs84
+  sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_wgs84]
+  title: Landeskarte 1:1 Mio.
+- dimensions: *id252
+  name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale.lv95
+  sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache_lv95]
+  title: Landeskarte 1:1 Mio.
+- dimensions: *id252
+  name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_cache]
+  title: Landeskarte 1:1 Mio.
+- dimensions: &id253
+    Time:
+      default: '20111027'
+      values: ['20111027']
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale.mercator
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_mercator]
+  title: Landeskarte 1:200'000
+- dimensions: *id253
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale.etrs89
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_etrs89]
+  title: Landeskarte 1:200'000
+- dimensions: *id253
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale.wgs84
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_wgs84]
+  title: Landeskarte 1:200'000
+- dimensions: *id253
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale.lv95
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache_lv95]
+  title: Landeskarte 1:200'000
+- dimensions: *id253
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_cache]
+  title: Landeskarte 1:200'000
+- dimensions: &id254
+    Time:
+      default: '20140520'
+      values: ['20140520', '20140106', '20130903', '20130213', '20120809', '20111027']
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale.mercator
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_mercator]
+  title: Landeskarte 1:25'000
+- dimensions: *id254
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale.etrs89
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_etrs89]
+  title: Landeskarte 1:25'000
+- dimensions: *id254
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale.wgs84
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_wgs84]
+  title: Landeskarte 1:25'000
+- dimensions: *id254
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale.lv95
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache_lv95]
+  title: Landeskarte 1:25'000
+- dimensions: *id254
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_cache]
+  title: Landeskarte 1:25'000
+- dimensions: &id255
+    Time:
+      default: '20140520'
+      values: ['20140520', '20140106', '20130903', '20130213', '20120809', '20111027']
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale.mercator
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_mercator]
+  title: Landeskarte 1:50'000
+- dimensions: *id255
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale.etrs89
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_etrs89]
+  title: Landeskarte 1:50'000
+- dimensions: *id255
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale.wgs84
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_wgs84]
+  title: Landeskarte 1:50'000
+- dimensions: *id255
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale.lv95
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache_lv95]
+  title: Landeskarte 1:50'000
+- dimensions: *id255
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_cache]
+  title: Landeskarte 1:50'000
+- dimensions: &id256
+    Time:
+      default: '20111027'
+      values: ['20111027']
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale.mercator
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_mercator]
+  title: Landeskarte 1:500'000
+- dimensions: *id256
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale.etrs89
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_etrs89]
+  title: Landeskarte 1:500'000
+- dimensions: *id256
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale.wgs84
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_wgs84]
+  title: Landeskarte 1:500'000
+- dimensions: *id256
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale.lv95
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache_lv95]
+  title: Landeskarte 1:500'000
+- dimensions: *id256
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_cache]
+  title: Landeskarte 1:500'000
+- dimensions: &id257
+    Time:
+      default: '20140520'
+      values: ['20140520', '20140106', '20130903', '20130213', '20120809', '20111206',
+        '20111027', '20110401']
+  name: ch.swisstopo.pixelkarte-grau.mercator
+  sources: [ch.swisstopo.pixelkarte-grau_cache_mercator]
+  title: Karte SW
+- dimensions: *id257
+  name: ch.swisstopo.pixelkarte-grau.etrs89
+  sources: [ch.swisstopo.pixelkarte-grau_cache_etrs89]
+  title: Karte SW
+- dimensions: *id257
+  name: ch.swisstopo.pixelkarte-grau.wgs84
+  sources: [ch.swisstopo.pixelkarte-grau_cache_wgs84]
+  title: Karte SW
+- dimensions: *id257
+  name: ch.swisstopo.pixelkarte-grau.lv95
+  sources: [ch.swisstopo.pixelkarte-grau_cache_lv95]
+  title: Karte SW
+- dimensions: *id257
+  name: ch.swisstopo.pixelkarte-grau
+  sources: [ch.swisstopo.pixelkarte-grau_cache]
+  title: Karte SW
+- dimensions: &id258
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20110101', '20000101']
+  name: ch.swisstopo.swissalti3d-reliefschattierung.mercator
+  sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache_mercator]
+  title: swissALTI3D Reliefschattierung
+- dimensions: *id258
+  name: ch.swisstopo.swissalti3d-reliefschattierung.etrs89
+  sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache_etrs89]
+  title: swissALTI3D Reliefschattierung
+- dimensions: *id258
+  name: ch.swisstopo.swissalti3d-reliefschattierung.wgs84
+  sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache_wgs84]
+  title: swissALTI3D Reliefschattierung
+- dimensions: *id258
+  name: ch.swisstopo.swissalti3d-reliefschattierung.lv95
+  sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache_lv95]
+  title: swissALTI3D Reliefschattierung
+- dimensions: *id258
+  name: ch.swisstopo.swissalti3d-reliefschattierung
+  sources: [ch.swisstopo.swissalti3d-reliefschattierung_cache]
+  title: swissALTI3D Reliefschattierung
+- dimensions: &id259
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101']
+  name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill.mercator
+  sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_mercator]
+  title: Bezirksgrenzen
+- dimensions: *id259
+  name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill.etrs89
+  sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_etrs89]
+  title: Bezirksgrenzen
+- dimensions: *id259
+  name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill.wgs84
+  sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_wgs84]
+  title: Bezirksgrenzen
+- dimensions: *id259
+  name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill.lv95
+  sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache_lv95]
+  title: Bezirksgrenzen
+- dimensions: *id259
+  name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill
+  sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_cache]
+  title: Bezirksgrenzen
+- dimensions: &id260
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101']
+  name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill.mercator
+  sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_mercator]
+  title: Gemeindegrenzen
+- dimensions: *id260
+  name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill.etrs89
+  sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_etrs89]
+  title: Gemeindegrenzen
+- dimensions: *id260
+  name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill.wgs84
+  sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_wgs84]
+  title: Gemeindegrenzen
+- dimensions: *id260
+  name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill.lv95
+  sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache_lv95]
+  title: Gemeindegrenzen
+- dimensions: *id260
+  name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
+  sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_cache]
+  title: Gemeindegrenzen
+- dimensions: &id261
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101']
+  name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill.mercator
+  sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_mercator]
+  title: Kantonsgrenzen
+- dimensions: *id261
+  name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill.etrs89
+  sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_etrs89]
+  title: Kantonsgrenzen
+- dimensions: *id261
+  name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill.wgs84
+  sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_wgs84]
+  title: Kantonsgrenzen
+- dimensions: *id261
+  name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill.lv95
+  sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache_lv95]
+  title: Kantonsgrenzen
+- dimensions: *id261
+  name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill
+  sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_cache]
+  title: Kantonsgrenzen
+- dimensions: &id262
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20120101']
+  name: ch.swisstopo.swissboundaries3d-land-flaeche.fill.mercator
+  sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_mercator]
+  title: Landesgrenzen
+- dimensions: *id262
+  name: ch.swisstopo.swissboundaries3d-land-flaeche.fill.etrs89
+  sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_etrs89]
+  title: Landesgrenzen
+- dimensions: *id262
+  name: ch.swisstopo.swissboundaries3d-land-flaeche.fill.wgs84
+  sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_wgs84]
+  title: Landesgrenzen
+- dimensions: *id262
+  name: ch.swisstopo.swissboundaries3d-land-flaeche.fill.lv95
+  sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache_lv95]
+  title: Landesgrenzen
+- dimensions: *id262
+  name: ch.swisstopo.swissboundaries3d-land-flaeche.fill
+  sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_cache]
+  title: Landesgrenzen
+- dimensions: &id263
+    Time:
+      default: '19980101'
+      values: ['19980101']
+  name: ch.swisstopo.swissbuildings3d.mercator
+  sources: [ch.swisstopo.swissbuildings3d_cache_mercator]
+  title: "Vereinfachte 3D-Geb\xE4ude"
+- dimensions: *id263
+  name: ch.swisstopo.swissbuildings3d.etrs89
+  sources: [ch.swisstopo.swissbuildings3d_cache_etrs89]
+  title: "Vereinfachte 3D-Geb\xE4ude"
+- dimensions: *id263
+  name: ch.swisstopo.swissbuildings3d.wgs84
+  sources: [ch.swisstopo.swissbuildings3d_cache_wgs84]
+  title: "Vereinfachte 3D-Geb\xE4ude"
+- dimensions: *id263
+  name: ch.swisstopo.swissbuildings3d.lv95
+  sources: [ch.swisstopo.swissbuildings3d_cache_lv95]
+  title: "Vereinfachte 3D-Geb\xE4ude"
+- dimensions: *id263
+  name: ch.swisstopo.swissbuildings3d
+  sources: [ch.swisstopo.swissbuildings3d_cache]
+  title: "Vereinfachte 3D-Geb\xE4ude"
+- dimensions: &id264
+    Time:
+      default: '20131107'
+      values: ['20131107', '20130916', '20130422', '20120809', '20120225', '20110914',
+        '20110228']
+  name: ch.swisstopo.swissimage.mercator
+  sources: [ch.swisstopo.swissimage_cache_mercator]
+  title: SWISSIMAGE
+- dimensions: *id264
+  name: ch.swisstopo.swissimage.etrs89
+  sources: [ch.swisstopo.swissimage_cache_etrs89]
+  title: SWISSIMAGE
+- dimensions: *id264
+  name: ch.swisstopo.swissimage.wgs84
+  sources: [ch.swisstopo.swissimage_cache_wgs84]
+  title: SWISSIMAGE
+- dimensions: *id264
+  name: ch.swisstopo.swissimage.lv95
+  sources: [ch.swisstopo.swissimage_cache_lv95]
+  title: SWISSIMAGE
+- dimensions: *id264
+  name: ch.swisstopo.swissimage
+  sources: [ch.swisstopo.swissimage_cache]
+  title: SWISSIMAGE
+- dimensions: &id265
+    Time:
+      default: '20140401'
+      values: ['20140401']
+  name: ch.swisstopo.swisstlm3d-karte-farbe.mercator
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_mercator]
+  title: Karte swissTLM (farbig)
+- dimensions: *id265
+  name: ch.swisstopo.swisstlm3d-karte-farbe.etrs89
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_etrs89]
+  title: Karte swissTLM (farbig)
+- dimensions: *id265
+  name: ch.swisstopo.swisstlm3d-karte-farbe.wgs84
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_wgs84]
+  title: Karte swissTLM (farbig)
+- dimensions: *id265
+  name: ch.swisstopo.swisstlm3d-karte-farbe.lv95
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_lv95]
+  title: Karte swissTLM (farbig)
+- dimensions: *id265
+  name: ch.swisstopo.swisstlm3d-karte-farbe
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache]
+  title: Karte swissTLM (farbig)
+- dimensions: &id266
+    Time:
+      default: '20140401'
+      values: ['20140401']
+  name: ch.swisstopo.swisstlm3d-karte-farbe.mercator
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_mercator]
+  title: Karte swissTLM (farbig)
+- dimensions: *id266
+  name: ch.swisstopo.swisstlm3d-karte-farbe.etrs89
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_etrs89]
+  title: Karte swissTLM (farbig)
+- dimensions: *id266
+  name: ch.swisstopo.swisstlm3d-karte-farbe.wgs84
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_wgs84]
+  title: Karte swissTLM (farbig)
+- dimensions: *id266
+  name: ch.swisstopo.swisstlm3d-karte-farbe.lv95
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache_lv95]
+  title: Karte swissTLM (farbig)
+- dimensions: *id266
+  name: ch.swisstopo.swisstlm3d-karte-farbe
+  sources: [ch.swisstopo.swisstlm3d-karte-farbe_cache]
+  title: Karte swissTLM (farbig)
+- dimensions: &id267
+    Time:
+      default: '20140401'
+      values: ['20140401']
+  name: ch.swisstopo.swisstlm3d-karte-grau.mercator
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_mercator]
+  title: Karte swissTLM (grau)
+- dimensions: *id267
+  name: ch.swisstopo.swisstlm3d-karte-grau.etrs89
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_etrs89]
+  title: Karte swissTLM (grau)
+- dimensions: *id267
+  name: ch.swisstopo.swisstlm3d-karte-grau.wgs84
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_wgs84]
+  title: Karte swissTLM (grau)
+- dimensions: *id267
+  name: ch.swisstopo.swisstlm3d-karte-grau.lv95
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_lv95]
+  title: Karte swissTLM (grau)
+- dimensions: *id267
+  name: ch.swisstopo.swisstlm3d-karte-grau
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache]
+  title: Karte swissTLM (grau)
+- dimensions: &id268
+    Time:
+      default: '20140401'
+      values: ['20140401']
+  name: ch.swisstopo.swisstlm3d-karte-grau.mercator
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_mercator]
+  title: Karte swissTLM (grau)
+- dimensions: *id268
+  name: ch.swisstopo.swisstlm3d-karte-grau.etrs89
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_etrs89]
+  title: Karte swissTLM (grau)
+- dimensions: *id268
+  name: ch.swisstopo.swisstlm3d-karte-grau.wgs84
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_wgs84]
+  title: Karte swissTLM (grau)
+- dimensions: *id268
+  name: ch.swisstopo.swisstlm3d-karte-grau.lv95
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache_lv95]
+  title: Karte swissTLM (grau)
+- dimensions: *id268
+  name: ch.swisstopo.swisstlm3d-karte-grau
+  sources: [ch.swisstopo.swisstlm3d-karte-grau_cache]
+  title: Karte swissTLM (grau)
+- dimensions: &id269
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101']
+  name: ch.swisstopo.swisstlm3d-wanderwege.mercator
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_cache_mercator]
+  title: Wanderwege
+- dimensions: *id269
+  name: ch.swisstopo.swisstlm3d-wanderwege.etrs89
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_cache_etrs89]
+  title: Wanderwege
+- dimensions: *id269
+  name: ch.swisstopo.swisstlm3d-wanderwege.wgs84
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_cache_wgs84]
+  title: Wanderwege
+- dimensions: *id269
+  name: ch.swisstopo.swisstlm3d-wanderwege.lv95
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_cache_lv95]
+  title: Wanderwege
+- dimensions: *id269
+  name: ch.swisstopo.swisstlm3d-wanderwege
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_cache]
+  title: Wanderwege
+- dimensions: &id270
+    Time:
+      default: '20131028'
+      values: ['20131028', '20100531']
+  name: ch.swisstopo.transformationsgenauigkeit.mercator
+  sources: [ch.swisstopo.transformationsgenauigkeit_cache_mercator]
+  title: LV95 Transformationsgenauigkeit
+- dimensions: *id270
+  name: ch.swisstopo.transformationsgenauigkeit.etrs89
+  sources: [ch.swisstopo.transformationsgenauigkeit_cache_etrs89]
+  title: LV95 Transformationsgenauigkeit
+- dimensions: *id270
+  name: ch.swisstopo.transformationsgenauigkeit.wgs84
+  sources: [ch.swisstopo.transformationsgenauigkeit_cache_wgs84]
+  title: LV95 Transformationsgenauigkeit
+- dimensions: *id270
+  name: ch.swisstopo.transformationsgenauigkeit.lv95
+  sources: [ch.swisstopo.transformationsgenauigkeit_cache_lv95]
+  title: LV95 Transformationsgenauigkeit
+- dimensions: *id270
+  name: ch.swisstopo.transformationsgenauigkeit
+  sources: [ch.swisstopo.transformationsgenauigkeit_cache]
+  title: LV95 Transformationsgenauigkeit
+- dimensions: &id271
+    Time:
+      default: '20130815'
+      values: ['20130815', '20120606']
+  name: ch.swisstopo.treasurehunt.mercator
+  sources: [ch.swisstopo.treasurehunt_cache_mercator]
+  title: Schatzkarte
+- dimensions: *id271
+  name: ch.swisstopo.treasurehunt.etrs89
+  sources: [ch.swisstopo.treasurehunt_cache_etrs89]
+  title: Schatzkarte
+- dimensions: *id271
+  name: ch.swisstopo.treasurehunt.wgs84
+  sources: [ch.swisstopo.treasurehunt_cache_wgs84]
+  title: Schatzkarte
+- dimensions: *id271
+  name: ch.swisstopo.treasurehunt.lv95
+  sources: [ch.swisstopo.treasurehunt_cache_lv95]
+  title: Schatzkarte
+- dimensions: *id271
+  name: ch.swisstopo.treasurehunt
+  sources: [ch.swisstopo.treasurehunt_cache]
+  title: Schatzkarte
+- dimensions: &id272
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-adminboundaries-protectedarea.mercator
+  sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache_mercator]
+  title: Schutzgebiete VECTOR200
+- dimensions: *id272
+  name: ch.swisstopo.vec200-adminboundaries-protectedarea.etrs89
+  sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache_etrs89]
+  title: Schutzgebiete VECTOR200
+- dimensions: *id272
+  name: ch.swisstopo.vec200-adminboundaries-protectedarea.wgs84
+  sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache_wgs84]
+  title: Schutzgebiete VECTOR200
+- dimensions: *id272
+  name: ch.swisstopo.vec200-adminboundaries-protectedarea.lv95
+  sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache_lv95]
+  title: Schutzgebiete VECTOR200
+- dimensions: *id272
+  name: ch.swisstopo.vec200-adminboundaries-protectedarea
+  sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_cache]
+  title: Schutzgebiete VECTOR200
+- dimensions: &id273
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-building.mercator
+  sources: [ch.swisstopo.vec200-building_cache_mercator]
+  title: "Einzelgeb\xE4ude gen. VECTOR200"
+- dimensions: *id273
+  name: ch.swisstopo.vec200-building.etrs89
+  sources: [ch.swisstopo.vec200-building_cache_etrs89]
+  title: "Einzelgeb\xE4ude gen. VECTOR200"
+- dimensions: *id273
+  name: ch.swisstopo.vec200-building.wgs84
+  sources: [ch.swisstopo.vec200-building_cache_wgs84]
+  title: "Einzelgeb\xE4ude gen. VECTOR200"
+- dimensions: *id273
+  name: ch.swisstopo.vec200-building.lv95
+  sources: [ch.swisstopo.vec200-building_cache_lv95]
+  title: "Einzelgeb\xE4ude gen. VECTOR200"
+- dimensions: *id273
+  name: ch.swisstopo.vec200-building
+  sources: [ch.swisstopo.vec200-building_cache]
+  title: "Einzelgeb\xE4ude gen. VECTOR200"
+- dimensions: &id274
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-hydrography.mercator
+  sources: [ch.swisstopo.vec200-hydrography_cache_mercator]
+  title: "Gew\xE4ssernetz VECTOR200"
+- dimensions: *id274
+  name: ch.swisstopo.vec200-hydrography.etrs89
+  sources: [ch.swisstopo.vec200-hydrography_cache_etrs89]
+  title: "Gew\xE4ssernetz VECTOR200"
+- dimensions: *id274
+  name: ch.swisstopo.vec200-hydrography.wgs84
+  sources: [ch.swisstopo.vec200-hydrography_cache_wgs84]
+  title: "Gew\xE4ssernetz VECTOR200"
+- dimensions: *id274
+  name: ch.swisstopo.vec200-hydrography.lv95
+  sources: [ch.swisstopo.vec200-hydrography_cache_lv95]
+  title: "Gew\xE4ssernetz VECTOR200"
+- dimensions: *id274
+  name: ch.swisstopo.vec200-hydrography
+  sources: [ch.swisstopo.vec200-hydrography_cache]
+  title: "Gew\xE4ssernetz VECTOR200"
+- dimensions: &id275
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-landcover.mercator
+  sources: [ch.swisstopo.vec200-landcover_cache_mercator]
+  title: Prim. Bodenbedeckung VECTOR200
+- dimensions: *id275
+  name: ch.swisstopo.vec200-landcover.etrs89
+  sources: [ch.swisstopo.vec200-landcover_cache_etrs89]
+  title: Prim. Bodenbedeckung VECTOR200
+- dimensions: *id275
+  name: ch.swisstopo.vec200-landcover.wgs84
+  sources: [ch.swisstopo.vec200-landcover_cache_wgs84]
+  title: Prim. Bodenbedeckung VECTOR200
+- dimensions: *id275
+  name: ch.swisstopo.vec200-landcover.lv95
+  sources: [ch.swisstopo.vec200-landcover_cache_lv95]
+  title: Prim. Bodenbedeckung VECTOR200
+- dimensions: *id275
+  name: ch.swisstopo.vec200-landcover
+  sources: [ch.swisstopo.vec200-landcover_cache]
+  title: Prim. Bodenbedeckung VECTOR200
+- dimensions: &id276
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.swisstopo.vec200-landcover-wald.mercator
+  sources: [ch.swisstopo.vec200-landcover-wald_cache_mercator]
+  title: "Waldfl\xE4chen"
+- dimensions: *id276
+  name: ch.swisstopo.vec200-landcover-wald.etrs89
+  sources: [ch.swisstopo.vec200-landcover-wald_cache_etrs89]
+  title: "Waldfl\xE4chen"
+- dimensions: *id276
+  name: ch.swisstopo.vec200-landcover-wald.wgs84
+  sources: [ch.swisstopo.vec200-landcover-wald_cache_wgs84]
+  title: "Waldfl\xE4chen"
+- dimensions: *id276
+  name: ch.swisstopo.vec200-landcover-wald.lv95
+  sources: [ch.swisstopo.vec200-landcover-wald_cache_lv95]
+  title: "Waldfl\xE4chen"
+- dimensions: *id276
+  name: ch.swisstopo.vec200-landcover-wald
+  sources: [ch.swisstopo.vec200-landcover-wald_cache]
+  title: "Waldfl\xE4chen"
+- dimensions: &id277
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-miscellaneous.mercator
+  sources: [ch.swisstopo.vec200-miscellaneous_cache_mercator]
+  title: Einzelobjekte VECTOR200
+- dimensions: *id277
+  name: ch.swisstopo.vec200-miscellaneous.etrs89
+  sources: [ch.swisstopo.vec200-miscellaneous_cache_etrs89]
+  title: Einzelobjekte VECTOR200
+- dimensions: *id277
+  name: ch.swisstopo.vec200-miscellaneous.wgs84
+  sources: [ch.swisstopo.vec200-miscellaneous_cache_wgs84]
+  title: Einzelobjekte VECTOR200
+- dimensions: *id277
+  name: ch.swisstopo.vec200-miscellaneous.lv95
+  sources: [ch.swisstopo.vec200-miscellaneous_cache_lv95]
+  title: Einzelobjekte VECTOR200
+- dimensions: *id277
+  name: ch.swisstopo.vec200-miscellaneous
+  sources: [ch.swisstopo.vec200-miscellaneous_cache]
+  title: Einzelobjekte VECTOR200
+- dimensions: &id278
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-miscellaneous-geodpoint.mercator
+  sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache_mercator]
+  title: "H\xF6henkoten VECTOR200"
+- dimensions: *id278
+  name: ch.swisstopo.vec200-miscellaneous-geodpoint.etrs89
+  sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache_etrs89]
+  title: "H\xF6henkoten VECTOR200"
+- dimensions: *id278
+  name: ch.swisstopo.vec200-miscellaneous-geodpoint.wgs84
+  sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache_wgs84]
+  title: "H\xF6henkoten VECTOR200"
+- dimensions: *id278
+  name: ch.swisstopo.vec200-miscellaneous-geodpoint.lv95
+  sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache_lv95]
+  title: "H\xF6henkoten VECTOR200"
+- dimensions: *id278
+  name: ch.swisstopo.vec200-miscellaneous-geodpoint
+  sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_cache]
+  title: "H\xF6henkoten VECTOR200"
+- dimensions: &id279
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-names-namedlocation.mercator
+  sources: [ch.swisstopo.vec200-names-namedlocation_cache_mercator]
+  title: Namen VECTOR200
+- dimensions: *id279
+  name: ch.swisstopo.vec200-names-namedlocation.etrs89
+  sources: [ch.swisstopo.vec200-names-namedlocation_cache_etrs89]
+  title: Namen VECTOR200
+- dimensions: *id279
+  name: ch.swisstopo.vec200-names-namedlocation.wgs84
+  sources: [ch.swisstopo.vec200-names-namedlocation_cache_wgs84]
+  title: Namen VECTOR200
+- dimensions: *id279
+  name: ch.swisstopo.vec200-names-namedlocation.lv95
+  sources: [ch.swisstopo.vec200-names-namedlocation_cache_lv95]
+  title: Namen VECTOR200
+- dimensions: *id279
+  name: ch.swisstopo.vec200-names-namedlocation
+  sources: [ch.swisstopo.vec200-names-namedlocation_cache]
+  title: Namen VECTOR200
+- dimensions: &id280
+    Time:
+      default: '20130101'
+      values: ['20130101', '20100101']
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr.mercator
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_mercator]
+  title: "\xD6ffentlicher Verkehr VECTOR200"
+- dimensions: *id280
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr.etrs89
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_etrs89]
+  title: "\xD6ffentlicher Verkehr VECTOR200"
+- dimensions: *id280
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr.wgs84
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_wgs84]
+  title: "\xD6ffentlicher Verkehr VECTOR200"
+- dimensions: *id280
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr.lv95
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache_lv95]
+  title: "\xD6ffentlicher Verkehr VECTOR200"
+- dimensions: *id280
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_cache]
+  title: "\xD6ffentlicher Verkehr VECTOR200"
+- dimensions: &id281
+    Time:
+      default: '20140101'
+      values: ['20140101', '20130101', '20100101']
+  name: ch.swisstopo.vec200-transportation-strassennetz.mercator
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_cache_mercator]
+  title: Strassennetz VECTOR200
+- dimensions: *id281
+  name: ch.swisstopo.vec200-transportation-strassennetz.etrs89
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_cache_etrs89]
+  title: Strassennetz VECTOR200
+- dimensions: *id281
+  name: ch.swisstopo.vec200-transportation-strassennetz.wgs84
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_cache_wgs84]
+  title: Strassennetz VECTOR200
+- dimensions: *id281
+  name: ch.swisstopo.vec200-transportation-strassennetz.lv95
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_cache_lv95]
+  title: Strassennetz VECTOR200
+- dimensions: *id281
+  name: ch.swisstopo.vec200-transportation-strassennetz
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_cache]
+  title: Strassennetz VECTOR200
+- dimensions: &id282
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-anlagen.mercator
+  sources: [ch.swisstopo.vec25-anlagen_cache_mercator]
+  title: Anlagen VECTOR25
+- dimensions: *id282
+  name: ch.swisstopo.vec25-anlagen.etrs89
+  sources: [ch.swisstopo.vec25-anlagen_cache_etrs89]
+  title: Anlagen VECTOR25
+- dimensions: *id282
+  name: ch.swisstopo.vec25-anlagen.wgs84
+  sources: [ch.swisstopo.vec25-anlagen_cache_wgs84]
+  title: Anlagen VECTOR25
+- dimensions: *id282
+  name: ch.swisstopo.vec25-anlagen.lv95
+  sources: [ch.swisstopo.vec25-anlagen_cache_lv95]
+  title: Anlagen VECTOR25
+- dimensions: *id282
+  name: ch.swisstopo.vec25-anlagen
+  sources: [ch.swisstopo.vec25-anlagen_cache]
+  title: Anlagen VECTOR25
+- dimensions: &id283
+    Time:
+      default: '19980101'
+      values: ['19980101']
+  name: ch.swisstopo.vec25-einzelobjekte.mercator
+  sources: [ch.swisstopo.vec25-einzelobjekte_cache_mercator]
+  title: Einzelobjekte VECTOR25
+- dimensions: *id283
+  name: ch.swisstopo.vec25-einzelobjekte.etrs89
+  sources: [ch.swisstopo.vec25-einzelobjekte_cache_etrs89]
+  title: Einzelobjekte VECTOR25
+- dimensions: *id283
+  name: ch.swisstopo.vec25-einzelobjekte.wgs84
+  sources: [ch.swisstopo.vec25-einzelobjekte_cache_wgs84]
+  title: Einzelobjekte VECTOR25
+- dimensions: *id283
+  name: ch.swisstopo.vec25-einzelobjekte.lv95
+  sources: [ch.swisstopo.vec25-einzelobjekte_cache_lv95]
+  title: Einzelobjekte VECTOR25
+- dimensions: *id283
+  name: ch.swisstopo.vec25-einzelobjekte
+  sources: [ch.swisstopo.vec25-einzelobjekte_cache]
+  title: Einzelobjekte VECTOR25
+- dimensions: &id284
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-eisenbahnnetz.mercator
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_cache_mercator]
+  title: Eisenbahnnetz VECTOR25
+- dimensions: *id284
+  name: ch.swisstopo.vec25-eisenbahnnetz.etrs89
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_cache_etrs89]
+  title: Eisenbahnnetz VECTOR25
+- dimensions: *id284
+  name: ch.swisstopo.vec25-eisenbahnnetz.wgs84
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_cache_wgs84]
+  title: Eisenbahnnetz VECTOR25
+- dimensions: *id284
+  name: ch.swisstopo.vec25-eisenbahnnetz.lv95
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_cache_lv95]
+  title: Eisenbahnnetz VECTOR25
+- dimensions: *id284
+  name: ch.swisstopo.vec25-eisenbahnnetz
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_cache]
+  title: Eisenbahnnetz VECTOR25
+- dimensions: &id285
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-gebaeude.mercator
+  sources: [ch.swisstopo.vec25-gebaeude_cache_mercator]
+  title: "Geb\xE4ude VECTOR25"
+- dimensions: *id285
+  name: ch.swisstopo.vec25-gebaeude.etrs89
+  sources: [ch.swisstopo.vec25-gebaeude_cache_etrs89]
+  title: "Geb\xE4ude VECTOR25"
+- dimensions: *id285
+  name: ch.swisstopo.vec25-gebaeude.wgs84
+  sources: [ch.swisstopo.vec25-gebaeude_cache_wgs84]
+  title: "Geb\xE4ude VECTOR25"
+- dimensions: *id285
+  name: ch.swisstopo.vec25-gebaeude.lv95
+  sources: [ch.swisstopo.vec25-gebaeude_cache_lv95]
+  title: "Geb\xE4ude VECTOR25"
+- dimensions: *id285
+  name: ch.swisstopo.vec25-gebaeude
+  sources: [ch.swisstopo.vec25-gebaeude_cache]
+  title: "Geb\xE4ude VECTOR25"
+- dimensions: &id286
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-gewaessernetz.mercator
+  sources: [ch.swisstopo.vec25-gewaessernetz_cache_mercator]
+  title: "Gew\xE4ssernetz VECTOR25"
+- dimensions: *id286
+  name: ch.swisstopo.vec25-gewaessernetz.etrs89
+  sources: [ch.swisstopo.vec25-gewaessernetz_cache_etrs89]
+  title: "Gew\xE4ssernetz VECTOR25"
+- dimensions: *id286
+  name: ch.swisstopo.vec25-gewaessernetz.wgs84
+  sources: [ch.swisstopo.vec25-gewaessernetz_cache_wgs84]
+  title: "Gew\xE4ssernetz VECTOR25"
+- dimensions: *id286
+  name: ch.swisstopo.vec25-gewaessernetz.lv95
+  sources: [ch.swisstopo.vec25-gewaessernetz_cache_lv95]
+  title: "Gew\xE4ssernetz VECTOR25"
+- dimensions: *id286
+  name: ch.swisstopo.vec25-gewaessernetz
+  sources: [ch.swisstopo.vec25-gewaessernetz_cache]
+  title: "Gew\xE4ssernetz VECTOR25"
+- dimensions: &id287
+    Time:
+      default: '19980101'
+      values: ['19980101']
+  name: ch.swisstopo.vec25-heckenbaeume.mercator
+  sources: [ch.swisstopo.vec25-heckenbaeume_cache_mercator]
+  title: "Hecken und B\xE4ume VECTOR25"
+- dimensions: *id287
+  name: ch.swisstopo.vec25-heckenbaeume.etrs89
+  sources: [ch.swisstopo.vec25-heckenbaeume_cache_etrs89]
+  title: "Hecken und B\xE4ume VECTOR25"
+- dimensions: *id287
+  name: ch.swisstopo.vec25-heckenbaeume.wgs84
+  sources: [ch.swisstopo.vec25-heckenbaeume_cache_wgs84]
+  title: "Hecken und B\xE4ume VECTOR25"
+- dimensions: *id287
+  name: ch.swisstopo.vec25-heckenbaeume.lv95
+  sources: [ch.swisstopo.vec25-heckenbaeume_cache_lv95]
+  title: "Hecken und B\xE4ume VECTOR25"
+- dimensions: *id287
+  name: ch.swisstopo.vec25-heckenbaeume
+  sources: [ch.swisstopo.vec25-heckenbaeume_cache]
+  title: "Hecken und B\xE4ume VECTOR25"
+- dimensions: &id288
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-primaerflaechen.mercator
+  sources: [ch.swisstopo.vec25-primaerflaechen_cache_mercator]
+  title: "Prim\xE4rfl\xE4chen VECTOR25"
+- dimensions: *id288
+  name: ch.swisstopo.vec25-primaerflaechen.etrs89
+  sources: [ch.swisstopo.vec25-primaerflaechen_cache_etrs89]
+  title: "Prim\xE4rfl\xE4chen VECTOR25"
+- dimensions: *id288
+  name: ch.swisstopo.vec25-primaerflaechen.wgs84
+  sources: [ch.swisstopo.vec25-primaerflaechen_cache_wgs84]
+  title: "Prim\xE4rfl\xE4chen VECTOR25"
+- dimensions: *id288
+  name: ch.swisstopo.vec25-primaerflaechen.lv95
+  sources: [ch.swisstopo.vec25-primaerflaechen_cache_lv95]
+  title: "Prim\xE4rfl\xE4chen VECTOR25"
+- dimensions: *id288
+  name: ch.swisstopo.vec25-primaerflaechen
+  sources: [ch.swisstopo.vec25-primaerflaechen_cache]
+  title: "Prim\xE4rfl\xE4chen VECTOR25"
+- dimensions: &id289
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-strassennetz.mercator
+  sources: [ch.swisstopo.vec25-strassennetz_cache_mercator]
+  title: Strassennetz VECTOR25
+- dimensions: *id289
+  name: ch.swisstopo.vec25-strassennetz.etrs89
+  sources: [ch.swisstopo.vec25-strassennetz_cache_etrs89]
+  title: Strassennetz VECTOR25
+- dimensions: *id289
+  name: ch.swisstopo.vec25-strassennetz.wgs84
+  sources: [ch.swisstopo.vec25-strassennetz_cache_wgs84]
+  title: Strassennetz VECTOR25
+- dimensions: *id289
+  name: ch.swisstopo.vec25-strassennetz.lv95
+  sources: [ch.swisstopo.vec25-strassennetz_cache_lv95]
+  title: Strassennetz VECTOR25
+- dimensions: *id289
+  name: ch.swisstopo.vec25-strassennetz
+  sources: [ch.swisstopo.vec25-strassennetz_cache]
+  title: Strassennetz VECTOR25
+- dimensions: &id290
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-uebrigerverkehr.mercator
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_cache_mercator]
+  title: "\xDCbriger Verkehr VECTOR25"
+- dimensions: *id290
+  name: ch.swisstopo.vec25-uebrigerverkehr.etrs89
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_cache_etrs89]
+  title: "\xDCbriger Verkehr VECTOR25"
+- dimensions: *id290
+  name: ch.swisstopo.vec25-uebrigerverkehr.wgs84
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_cache_wgs84]
+  title: "\xDCbriger Verkehr VECTOR25"
+- dimensions: *id290
+  name: ch.swisstopo.vec25-uebrigerverkehr.lv95
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_cache_lv95]
+  title: "\xDCbriger Verkehr VECTOR25"
+- dimensions: *id290
+  name: ch.swisstopo.vec25-uebrigerverkehr
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_cache]
+  title: "\xDCbriger Verkehr VECTOR25"
+- dimensions: &id291
+    Time:
+      default: '20061231'
+      values: ['20061231']
+  name: ch.swisstopo.verschiebungsvektoren-tsp1.mercator
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache_mercator]
+  title: LV95 Verschiebungsvektoren TSP1
+- dimensions: *id291
+  name: ch.swisstopo.verschiebungsvektoren-tsp1.etrs89
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache_etrs89]
+  title: LV95 Verschiebungsvektoren TSP1
+- dimensions: *id291
+  name: ch.swisstopo.verschiebungsvektoren-tsp1.wgs84
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache_wgs84]
+  title: LV95 Verschiebungsvektoren TSP1
+- dimensions: *id291
+  name: ch.swisstopo.verschiebungsvektoren-tsp1.lv95
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache_lv95]
+  title: LV95 Verschiebungsvektoren TSP1
+- dimensions: *id291
+  name: ch.swisstopo.verschiebungsvektoren-tsp1
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp1_cache]
+  title: LV95 Verschiebungsvektoren TSP1
+- dimensions: &id292
+    Time:
+      default: '20070101'
+      values: ['20070101']
+  name: ch.swisstopo.verschiebungsvektoren-tsp2.mercator
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache_mercator]
+  title: LV95 Verschiebungsvektoren TSP2
+- dimensions: *id292
+  name: ch.swisstopo.verschiebungsvektoren-tsp2.etrs89
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache_etrs89]
+  title: LV95 Verschiebungsvektoren TSP2
+- dimensions: *id292
+  name: ch.swisstopo.verschiebungsvektoren-tsp2.wgs84
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache_wgs84]
+  title: LV95 Verschiebungsvektoren TSP2
+- dimensions: *id292
+  name: ch.swisstopo.verschiebungsvektoren-tsp2.lv95
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache_lv95]
+  title: LV95 Verschiebungsvektoren TSP2
+- dimensions: *id292
+  name: ch.swisstopo.verschiebungsvektoren-tsp2
+  sources: [ch.swisstopo.verschiebungsvektoren-tsp2_cache]
+  title: LV95 Verschiebungsvektoren TSP2
+- dimensions: &id293
+    Time:
+      default: '20121231'
+      values: ['20121231', '20111231', '20101231', '20091231', '20081231', '20071231',
+        '20061231', '20051231', '20041231', '20031231', '20021231', '20011231', '20001231',
+        '19991231', '19981231', '19971231', '19961231', '19951231', '19941231', '19931231',
+        '19921231', '19911231', '19901231', '19891231', '19881231', '19871231', '19861231',
+        '19851231', '19841231', '19831231', '19821231', '19811231', '19801231', '19791231',
+        '19781231', '19771231', '19761231', '19751231', '19741231', '19731231', '19721231',
+        '19711231', '19701231', '19691231', '19681231', '19671231', '19661231', '19651231',
+        '19641231', '19631231', '19621231', '19611231', '19601231', '19591231', '19581231',
+        '19571231', '19561231', '19551231', '19541231', '19531231', '19521231', '19511231',
+        '19501231', '19491231', '19481231', '19471231', '19461231', '19451231', '19441231',
+        '19431231', '19421231', '19411231', '19401231', '19391231', '19381231', '19371231',
+        '19361231', '19351231', '19341231', '19331231', '19321231', '19311231', '19301231',
+        '19291231', '19281231', '19271231', '19261231', '19251231', '19241231', '19231231',
+        '19221231', '19211231', '19201231', '19191231', '19181231', '19171231', '19161231',
+        '19151231', '19141231', '19131231', '19121231', '19111231', '19101231', '19091231',
+        '19081231', '19071231', '19061231', '19051231', '19041231', '19031231', '19021231',
+        '19011231', '19001231', '18991231', '18981231', '18971231', '18961231', '18951231',
+        '18941231', '18931231', '18921231', '18911231', '18901231', '18891231', '18881231',
+        '18871231', '18861231', '18851231', '18841231', '18831231', '18821231', '18811231',
+        '18801231', '18791231', '18781231', '18771231', '18761231', '18751231', '18741231',
+        '18731231', '18721231', '18711231', '18701231', '18691231', '18681231', '18671231',
+        '18661231', '18651231', '18641231', '18631231', '18621231', '18611231', '18601231',
+        '18591231', '18581231', '18571231', '18561231', '18551231', '18541231', '18531231',
+        '18521231', '18511231', '18501231', '18491231', '18481231', '18471231', '18461231',
+        '18451231', '18441231']
+  name: ch.swisstopo.zeitreihen.mercator
+  sources: [ch.swisstopo.zeitreihen_cache_mercator]
+  title: Karten - Zeitreise
+- dimensions: *id293
+  name: ch.swisstopo.zeitreihen.etrs89
+  sources: [ch.swisstopo.zeitreihen_cache_etrs89]
+  title: Karten - Zeitreise
+- dimensions: *id293
+  name: ch.swisstopo.zeitreihen.wgs84
+  sources: [ch.swisstopo.zeitreihen_cache_wgs84]
+  title: Karten - Zeitreise
+- dimensions: *id293
+  name: ch.swisstopo.zeitreihen.lv95
+  sources: [ch.swisstopo.zeitreihen_cache_lv95]
+  title: Karten - Zeitreise
+- dimensions: *id293
+  name: ch.swisstopo.zeitreihen
+  sources: [ch.swisstopo.zeitreihen_cache]
+  title: Karten - Zeitreise
+- dimensions: &id294
+    Time:
+      default: '20110501'
+      values: ['20110501']
+  name: ch.vbs.territorialregionen.mercator
+  sources: [ch.vbs.territorialregionen_cache_mercator]
+  title: Territorialregionen
+- dimensions: *id294
+  name: ch.vbs.territorialregionen.etrs89
+  sources: [ch.vbs.territorialregionen_cache_etrs89]
+  title: Territorialregionen
+- dimensions: *id294
+  name: ch.vbs.territorialregionen.wgs84
+  sources: [ch.vbs.territorialregionen_cache_wgs84]
+  title: Territorialregionen
+- dimensions: *id294
+  name: ch.vbs.territorialregionen.lv95
+  sources: [ch.vbs.territorialregionen_cache_lv95]
+  title: Territorialregionen
+- dimensions: *id294
+  name: ch.vbs.territorialregionen
+  sources: [ch.vbs.territorialregionen_cache]
+  title: Territorialregionen
+services:
+  demo: null
+  kml: null
+  wms:
+    image_formats: [image/jpeg, image/png]
+    md:
+      abstract: GeoAdmin geodata
+      access_constraints: License
+      contact: {address: Seftigenstrasse 264, city: Wabern, country: Schweiz, email: webgis@swisstopo.ch,
+        fax: +41 (0)31 / 963 24, organization: "Bundesamt f\xFCr Landestopografie\
+          \ swisstopo", person: webgis@swisstopo.ch, phone: +41 (0)31 / 963 21 11,
+        postcode: 3084}
+      fees: This service cant be used without permission
+      online_resource: http://api3.geo.admin.ch/mapproxy/service?
+      title: GeoAdmin MapProxy WMS
+    srs: ['EPSG:4326', 'EPSG:21781', 'EPSG:4258', 'EPSG:3857']
+  wmts: {kvp: false, restful: true, restful_template: '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.{Format}'}
 sources:
-  swissimage-tiles:
-    type: tile
-    grid: swisstopo-swissimage
-    http:
-      headers:
-        Referer: http://www.geoportail.gouv.fr/
-    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20131107/21781/%(z)d/%(y)d/%(x)d.jpeg
-  pixelkarte-farbe-tiles:
-    type: tile
+  ch.are.agglomerationen_isolierte_staedte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
     grid: swisstopo-pixelkarte
     http:
-      headers:
-        Referer: http://www.geoportail.gouv.fr/
-    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140106/21781/%(z)d/%(y)d/%(x)d.jpeg
-  osm_tms:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
     type: tile
-    grid: global_mercator_osm
-    url: http://c.tile.openstreetmap.org/%(tms_path)s.png
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.agglomerationen_isolierte_staedte/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.alpenkonvention:
     coverage:
-      bbox: [420000,30000,900000,350000]
+      bbox: [420000, 30000, 900000, 350000]
       bbox_srs: EPSG:21781
-  tlm-tiles:
-    type: tile
-    grid: swisstopo-tlm
-    transparent: true
-    on_error:
-      other:
-        response: transparent
-        cache: false
+    grid: swisstopo-pixelkarte
     http:
-      headers:
-        Referer: http://map.geo.admin.ch/
-    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swisstlm3d-karte-farbe/default/20130401/21781/%(z)d/%(y)d/%(x)d.png
-
-grids:
-  swisstopo-swissimage:
-    res: [4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5,0.25]
-    bbox: [420000,30000,900000,350000]
-    bbox_srs: EPSG:21781
-    srs: EPSG:21781
-    origin: nw
-    stretch_factor: 1.0
-  swisstopo-pixelkarte:
-    res: [4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5]
-    bbox: [420000,30000,900000,350000]
-    bbox_srs: EPSG:21781
-    srs: EPSG:21781
-    origin: nw
-    stretch_factor: 1.0
-  global_mercator_osm:
-    base: GLOBAL_MERCATOR
-    num_levels: 18
-    origin: nw
-  swisstopo-tlm:
-    res: [4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5]
-    bbox: [420000,30000,900000,350000]
-    bbox_srs: EPSG:21781
-    srs: EPSG:21781
-    origin: nw
-    stretch_factor: 1.0
-
-globals:
-  cache:
-    # use parallel requests to the WMTS sources
-    concurrent_tile_creators: 32
-
-  image:
-      resampling_method: bicubic
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.alpenkonvention/default/20090101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.bauzonen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.bauzonen/default/20120101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.belastung-gueterverkehr-bahn-2008:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.belastung-gueterverkehr-bahn-2008/default/20080101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.belastung-gueterverkehr-strasse-2008:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.belastung-gueterverkehr-strasse-2008/default/20080101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.belastung-personenverkehr-bahn-2008:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.belastung-personenverkehr-bahn-2008/default/20080101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.belastung-personenverkehr-strasse-2008:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.belastung-personenverkehr-strasse-2008/default/20080101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.beschaeftigtendichte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.beschaeftigtendichte/default/20111231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.bevoelkerungsdichte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.bevoelkerungsdichte/default/20121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.gemeindetypen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.gemeindetypen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.gueteklassen_oev:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.gueteklassen_oev/default/20131231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.landschaftstypen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.landschaftstypen/default/20100831/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.reisezeit-miv:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.reisezeit-miv/default/20121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.are.reisezeit-oev:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.are.reisezeit-oev/default/20121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.astra.ausnahmetransportrouten:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.astra.ausnahmetransportrouten/default/20111010/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.astra.ivs-gelaendekarte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.astra.ivs-gelaendekarte/default/19980816/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.astra.ivs-nat:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.astra.ivs-nat/default/20100416/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.astra.ivs-nat-verlaeufe:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.astra.ivs-nat-verlaeufe/default/20100416/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.astra.ivs-nat_abgrenzungen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.astra.ivs-nat_abgrenzungen/default/20100414/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.astra.ivs-nat_wegbegleiter:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.astra.ivs-nat_wegbegleiter/default/20100414/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.astra.ivs-reg_loc:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.astra.ivs-reg_loc/default/20100416/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.babs.kulturgueter:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.babs.kulturgueter/default/20140120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.aquaprotect_050:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.aquaprotect_050/default/20081218/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.aquaprotect_100:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.aquaprotect_100/default/20081218/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.aquaprotect_250:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.aquaprotect_250/default/20081218/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.aquaprotect_500:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.aquaprotect_500/default/20081218/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.biogeographische_regionen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.biogeographische_regionen/default/20040302/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-amphibien:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-amphibien/default/20070702/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-amphibien_anhang4:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-amphibien_anhang4/default/20111205/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-amphibien_anhoerung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-amphibien_anhoerung/default/20140505/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-amphibien_wanderobjekte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-amphibien_wanderobjekte/default/20070702/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung/default/20140505/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-auen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-auen/default/20070701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-auen_anhoerung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-auen_anhoerung/default/20140505/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-bln:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-bln/default/20010809/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-flachmoore:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-flachmoore/default/20100623/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-flachmoore_anhoerung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-flachmoore_anhoerung/default/20140505/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-flachmoore_regional:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-flachmoore_regional/default/20070731/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-hochmoore:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-hochmoore/default/20080721/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-hochmoore_anhoerung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-hochmoore_anhoerung/default/20140505/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-jagdbanngebiete:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-jagdbanngebiete/default/20131202/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-moorlandschaften:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-moorlandschaften/default/20070701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-moorlandschaften_anhoerung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-moorlandschaften_anhoerung/default/20140505/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-trockenwiesen_trockenweiden/default/20130624/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2/default/20120111/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung/default/20140505/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-vogelreservate:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-vogelreservate/default/20090617/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fauna-steinbockkolonien:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fauna-steinbockkolonien/default/20020114/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fauna-vernetzungsachsen_national:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fauna-vernetzungsachsen_national/default/20130528/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fauna-wildtierkorridor_national:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fauna-wildtierkorridor_national/default/20130528/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fischerei-aeschen_kernzonen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fischerei-aeschen_kernzonen/default/20110829/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fischerei-aeschen_laichplaetze:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fischerei-aeschen_laichplaetze/default/20110829/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fischerei-aeschen_larvenhabitate:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fischerei-aeschen_larvenhabitate/default/20110829/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fischerei-aeschen_verbreitungsgebiet:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fischerei-aeschen_verbreitungsgebiet/default/20110905/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fischerei-krebspest:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fischerei-krebspest/default/20110107/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fischerei-nasenlaichplaetze:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fischerei-nasenlaichplaetze/default/20060220/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.fischerei-proliferative_nierenkrankheit:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.fischerei-proliferative_nierenkrankheit/default/20140120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.flora-schwingrasen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.flora-schwingrasen/default/19920822/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.flora-verbreitungskarten:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.flora-verbreitungskarten/default/20080612/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.flora-weltensutter_atlas:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.flora-weltensutter_atlas/default/20080612/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.gefahren-baugrundklassen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.gefahren-baugrundklassen/default/20140314/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.gefahren-gefaehrdungszonen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.gefahren-gefaehrdungszonen/default/20030102/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.gefahren-historische_erdbeben:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.gefahren-historische_erdbeben/default/20110428/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.gefahren-mikrozonierung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.gefahren-mikrozonierung/default/20121219/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.gefahren-spektral:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.gefahren-spektral/default/20140314/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.holznutzung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.holznutzung/default/20100310/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.holzvorrat:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.holzvorrat/default/20100310/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.holzzuwachs:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.holzzuwachs/default/20100310/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.hydrologie-gewaesserzustandsmessstationen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.hydrologie-gewaesserzustandsmessstationen/default/20130301/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.hydrologie-hydromessstationen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.hydrologie-hydromessstationen/default/20081201/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.hydrologie-wassertemperaturmessstationen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.hydrologie-wassertemperaturmessstationen/default/20130322/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.laerm-bahnlaerm_nacht:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.laerm-bahnlaerm_nacht/default/20061231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.laerm-bahnlaerm_tag:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.laerm-bahnlaerm_tag/default/20061231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.laerm-strassenlaerm_nacht:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.laerm-strassenlaerm_nacht/default/20101231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.laerm-strassenlaerm_tag:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.laerm-strassenlaerm_tag/default/20101231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.landesforstinventar-baumarten:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.landesforstinventar-baumarten/default/20100310/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.landesforstinventar-totholz:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.landesforstinventar-totholz/default/20100310/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.landesforstinventar-waldanteil:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.landesforstinventar-waldanteil/default/20100310/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.moose:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.moose/default/20120416/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.nabelstationen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.nabelstationen/default/20110309/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.naqua-grundwasser_nitrat:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.naqua-grundwasser_nitrat/default/20130305/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.naqua-grundwasser_psm:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.naqua-grundwasser_psm/default/20130305/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.naqua-grundwasser_voc:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.naqua-grundwasser_voc/default/20130305/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.oekomorphologie-f_abschnitte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.oekomorphologie-f_abschnitte/default/20080913/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.oekomorphologie-f_abstuerze:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.oekomorphologie-f_abstuerze/default/20110912/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.oekomorphologie-f_bauwerke:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.oekomorphologie-f_bauwerke/default/20110912/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.permafrost:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.permafrost/default/20110317/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.ren-extensive_landwirtschaftsgebiete:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.ren-extensive_landwirtschaftsgebiete/default/20110214/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.ren-feuchtgebiete:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.ren-feuchtgebiete/default/20110214/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.ren-fliessgewaesser_seen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.ren-fliessgewaesser_seen/default/20110214/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.ren-trockenstandorte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.ren-trockenstandorte/default/20110214/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.ren-wald:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.ren-wald/default/20110214/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.schutzgebiete-biosphaerenreservate:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.schutzgebiete-biosphaerenreservate/default/20120109/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.schutzgebiete-luftfahrt:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.schutzgebiete-luftfahrt/default/20110818/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.schutzgebiete-paerke_nationaler_bedeutung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.schutzgebiete-paerke_nationaler_bedeutung/default/20140402/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.schutzgebiete-ramsar:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.schutzgebiete-ramsar/default/20110830/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.schutzgebiete-schweizerischer_nationalpark:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.schutzgebiete-schweizerischer_nationalpark/default/20010117/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.schutzgebiete-smaragd:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.schutzgebiete-smaragd/default/20090917/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_hochwasser:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_hochwasser/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_lawinen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_lawinen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_rutschungen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_rutschungen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_sturzprozesse:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_sturzprozesse/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_hochwasser:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_hochwasser/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_lawinen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_lawinen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_rutschungen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_rutschungen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_sturzprozesse:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_sturzprozesse/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.silvaprotect-hangmuren:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.silvaprotect-hangmuren/default/20060701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.silvaprotect-lawinen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.silvaprotect-lawinen/default/20060701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.silvaprotect-murgang:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.silvaprotect-murgang/default/20060701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.silvaprotect-sturz:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.silvaprotect-sturz/default/20060701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.silvaprotect-uebersarung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.silvaprotect-uebersarung/default/20080501/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.swissprtr:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.swissprtr/default/20140213/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.unesco-weltnaturerbe:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.unesco-weltnaturerbe/default/20080724/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.waldschadenflaechen-lothar:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.waldschadenflaechen-lothar/default/20001001/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.waldschadenflaechen-vivian:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.waldschadenflaechen-vivian/default/19920115/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wasser-entnahme:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wasser-entnahme/default/20040101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wasser-gebietsauslaesse:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wasser-gebietsauslaesse/default/20120701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wasser-leitungen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wasser-leitungen/default/20040101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wasser-rueckgabe:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wasser-rueckgabe/default/20040101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wasser-teileinzugsgebiete_2:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wasser-teileinzugsgebiete_2/default/20120701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wasser-teileinzugsgebiete_40:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wasser-teileinzugsgebiete_40/default/20120701/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wasser-vorfluter:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wasser-vorfluter/default/20120702/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wege-wildruhezonen-jagdbanngebiete:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wege-wildruhezonen-jagdbanngebiete/default/20111129/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wildruhezonen-jagdbanngebiete:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wildruhezonen-jagdbanngebiete/default/20111129/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wrz-jagdbanngebiete_select:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wrz-jagdbanngebiete_select/default/20140107/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wrz-wildruhezonen-jagdbanngebiete-wege-routen/default/20140107/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wrz-wildruhezonen_portal:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bafu.wrz-wildruhezonen_portal/default/20131118/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bag.zecken-fsme-faelle:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bag.zecken-fsme-faelle/default/20140220/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bag.zecken-fsme-impfung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bag.zecken-fsme-impfung/default/20140220/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bag.zecken-lyme:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bag.zecken-lyme/default/20110613/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bak.bundesinventar-schuetzenswerte-ortsbilder:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/default/20131113/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bak.schutzgebiete-unesco_weltkulturerbe:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bak.schutzgebiete-unesco_weltkulturerbe/default/20120203/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.versorgungsgebiet-tv:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bakom.versorgungsgebiet-tv/default/20070704/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.versorgungsgebiet-ukw:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bakom.versorgungsgebiet-ukw/default/20070704/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bav.laerm-emissionplan_eisenbahn_2015:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bav.laerm-emissionplan_eisenbahn_2015/default/20101109/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bazl.heliports-gebirgslandeplaetze:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bazl.heliports-gebirgslandeplaetze/default/20110926/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bazl.landschaftsruhezonen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bazl.landschaftsruhezonen/default/20110101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bazl.luftfahrtkarten-icao:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bazl.luftfahrtkarten-icao/default/20140306/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bazl.points-of-interest:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bazl.points-of-interest/default/20120829/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bazl.projektierungszonen-flughafenanlagen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bazl.projektierungszonen-flughafenanlagen/default/20130822/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bazl.segelflugkarte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bazl.segelflugkarte/default/20140306/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfe.kernkraftwerke:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfe.kernkraftwerke/default/20120911/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfe.kleinwasserkraftpotentiale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfe.kleinwasserkraftpotentiale/default/20120531/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-1985:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-1985/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-1997:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-1997/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-bodenbedeckung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-bodenbedeckung/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-bodenbedeckung-1985:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-bodenbedeckung-1985/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-bodenbedeckung-1997:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-bodenbedeckung-1997/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-bodennutzung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-bodennutzung/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-bodennutzung-1985:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-bodennutzung-1985/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-bodennutzung-1997:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-bodennutzung-1997/default/20131121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-hintergrund:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-hintergrund/default/20070116/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.arealstatistik-waldmischungsgrad:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.arealstatistik-waldmischungsgrad/default/19970901/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bfs.gebaeude_wohnungs_register:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.bfs.gebaeude_wohnungs_register/default/20130212/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.alpprodukte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.alpprodukte/default/20130531/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bergprodukte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bergprodukte/default/20130531/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bewaesserungsbeduerftigkeit:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bewaesserungsbeduerftigkeit/default/20091110/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-gruendigkeit:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-gruendigkeit/default/20120601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-kulturland:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-kulturland/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-kulturtyp:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-kulturtyp/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-naehrstoffspeichervermoegen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-naehrstoffspeichervermoegen/default/20120601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-skelettgehalt:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-skelettgehalt/default/20120601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-vernaessung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-vernaessung/default/20120601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-wasserdurchlaessigkeit:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-wasserdurchlaessigkeit/default/20120601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.bodeneignung-wasserspeichervermoegen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.bodeneignung-wasserspeichervermoegen/default/20120601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.erosion:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.erosion/default/20100103/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.erosion-mit_bergzonen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.erosion-mit_bergzonen/default/20100103/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.erosion-quantitativ:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.erosion-quantitativ/default/20100601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.feldblockkarte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.feldblockkarte/default/20120601/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.gewaesseranschlusskarte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.gewaesseranschlusskarte/default/20121201/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.gewaesseranschlusskarte-direkt:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.gewaesseranschlusskarte-direkt/default/20121201/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.hang_steillagen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.hang_steillagen/default/20121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-futterbau:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-futterbau/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-getreidebau:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-getreidebau/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-kartoffeln:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-kartoffeln/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-koernermais:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-koernermais/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-kulturland:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-kulturland/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-spezialkulturen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-spezialkulturen/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-typ:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-typ/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.klimaeignung-zwischenfruchtbau:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.klimaeignung-zwischenfruchtbau/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.landwirtschaftliche-zonengrenzen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.landwirtschaftliche-zonengrenzen/default/20140417/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.niederschlagshaushalt:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.niederschlagshaushalt/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.steil_terrassenlagen_rebbau:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.steil_terrassenlagen_rebbau/default/20121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.ursprungsbezeichnungen-fleisch:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.ursprungsbezeichnungen-fleisch/default/20110805/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.ursprungsbezeichnungen-kaese:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.ursprungsbezeichnungen-kaese/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.ursprungsbezeichnungen-pflanzen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.ursprungsbezeichnungen-pflanzen/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.ursprungsbezeichnungen-spirituosen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.blw.ursprungsbezeichnungen-spirituosen/default/20081024/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.ensi.zonenplan-notfallschutz-kernanlagen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.ensi.zonenplan-notfallschutz-kernanlagen/default/20120101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.kantone.ivs-reg_loc:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.kantone.ivs-reg_loc/default/20070101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo-vd.spannungsarme-gebiete:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo-vd.spannungsarme-gebiete/default/20131028/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.dreiecksvermaschung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.dreiecksvermaschung/default/20061231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.fixpunkte-agnes:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.fixpunkte-agnes/default/20120622/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.fixpunkte-hfp1:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.fixpunkte-hfp1/default/20121212/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.fixpunkte-hfp2:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.fixpunkte-hfp2/default/20121212/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.fixpunkte-lfp1:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.fixpunkte-lfp1/default/20121212/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.fixpunkte-lfp2:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.fixpunkte-lfp2/default/20121212/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geoidmodell-ch1903:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geoidmodell-ch1903/default/20041231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geoidmodell-etrs89:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geoidmodell-etrs89/default/20041231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-eiszeit-lgm-raster:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-eiszeit-lgm-raster/default/20081231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-generalkarte-ggk200:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-generalkarte-ggk200/default/19641231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geodaesie-bouguer_anomalien:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geodaesie-bouguer_anomalien/default/19791231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geodaesie-isostatische_anomalien:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geodaesie-isostatische_anomalien/default/19791231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geolkarten500.metadata:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geolkarten500.metadata/default/20070425/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geologische_karte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geologische_karte/default/20080630/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geologischer_atlas:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geologischer_atlas/default/20131120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura/default/19831231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz/default/20120628/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geophysik-deklination:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geophysik-deklination/default/20011203/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geophysik-geothermie:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geophysik-geothermie/default/20111121/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geophysik-inklination:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geophysik-inklination/default/20111128/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geophysik-totalintensitaet:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geophysik-totalintensitaet/default/19800101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-gk200:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-gk200/default/19670101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-gk500-genese:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-gk500-genese/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200/default/19900101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1915:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-steinbrueche_1915/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1965:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-steinbrueche_1965/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1980:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-steinbrueche_1980/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-steinbrueche_1995:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-steinbrueche_1995/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke/default/20130620/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1965:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-zementindustrie_1965/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-zementindustrie_1995:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-zementindustrie_1995/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1907:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-ziegeleien_1907/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1965:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-ziegeleien_1965/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotechnik-ziegeleien_1995:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotechnik-ziegeleien_1995/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-geotope:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-geotope/default/20130107/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-gravimetrischer_atlas:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-gravimetrischer_atlas/default/20021231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-gravimetrischer_atlas.metadata:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-gravimetrischer_atlas.metadata/default/20021231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen/default/20081103/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet/default/20081016/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-rohstoffe-industrieminerale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-rohstoffe-industrieminerale/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-rohstoffe-vererzungen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-rohstoffe-vererzungen/default/20060304/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-spezialkarten_schweiz.metadata:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-spezialkarten_schweiz.metadata/default/20110101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.geologie-tektonische_karte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.geologie-tektonische_karte/default/20080522/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.hangneigung-ueber_30:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.hangneigung-ueber_30/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.hiks-dufour:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.hiks-dufour/default/18450101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.hiks-dufour-timeseries:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.hiks-dufour-timeseries/default/19391231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.hiks-siegfried:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.hiks-siegfried/default/18700101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.hiks-siegfried-ta25:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.hiks-siegfried-ta25/default/19491231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.hiks-siegfried-ta50:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.hiks-siegfried-ta50/default/19491231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.koordinatenaenderung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.koordinatenaenderung/default/20061231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.lubis-luftbilder-dritte-firmen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.lubis-luftbilder-dritte-firmen/default/99991231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.lubis-luftbilder-dritte-kantone:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.lubis-luftbilder-dritte-kantone/default/99991231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.lubis-luftbilder_farbe:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.lubis-luftbilder_farbe/default/99991231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.lubis-luftbilder_infrarot:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.lubis-luftbilder_infrarot/default/99991231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.lubis-luftbilder_schwarzweiss:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.lubis-luftbilder_schwarzweiss/default/99991231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-farbe:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-farbe-pk100.noscale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe-pk100.noscale/default/20140106/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-farbe-pk1000.noscale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe-pk1000.noscale/default/20140106/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-farbe-pk200.noscale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe-pk200.noscale/default/20111027/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-farbe-pk25.noscale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe-pk25.noscale/default/20140520/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-farbe-pk50.noscale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe-pk50.noscale/default/20140520/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-farbe-pk500.noscale:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe-pk500.noscale/default/20111027/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.pixelkarte-grau:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/20140520/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissalti3d-reliefschattierung:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissalti3d-reliefschattierung/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissboundaries3d-kanton-flaeche.fill:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissboundaries3d-kanton-flaeche.fill/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissboundaries3d-land-flaeche.fill:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissboundaries3d-land-flaeche.fill/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissbuildings3d:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissbuildings3d/default/19980101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissimage:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20131107/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swisstlm3d-karte-farbe:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swisstlm3d-karte-farbe/default/20140401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swisstlm3d-karte-grau:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swisstlm3d-karte-grau/default/20140401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swisstlm3d-wanderwege:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.swisstlm3d-wanderwege/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.transformationsgenauigkeit:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.transformationsgenauigkeit/default/20131028/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.treasurehunt:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.treasurehunt/default/20130815/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-adminboundaries-protectedarea:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-adminboundaries-protectedarea/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-building:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-building/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-hydrography:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-hydrography/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-landcover:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-landcover/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-landcover-wald:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-landcover-wald/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-miscellaneous:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-miscellaneous/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-miscellaneous-geodpoint:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-miscellaneous-geodpoint/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-names-namedlocation:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-names-namedlocation/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-transportation-oeffentliche-verkehr:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-transportation-oeffentliche-verkehr/default/20130101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec200-transportation-strassennetz:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec200-transportation-strassennetz/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-anlagen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-anlagen/default/20090401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-einzelobjekte:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-einzelobjekte/default/19980101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-eisenbahnnetz:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-eisenbahnnetz/default/20090401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-gebaeude:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-gebaeude/default/20090401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-gewaessernetz:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-gewaessernetz/default/20090401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-heckenbaeume:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-heckenbaeume/default/19980101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-primaerflaechen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-primaerflaechen/default/20090401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-strassennetz:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-strassennetz/default/20090401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.vec25-uebrigerverkehr:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.vec25-uebrigerverkehr/default/20090401/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.verschiebungsvektoren-tsp1:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.verschiebungsvektoren-tsp1/default/20061231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.verschiebungsvektoren-tsp2:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.verschiebungsvektoren-tsp2/default/20070101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.vbs.territorialregionen:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    type: tile
+    url: http://wmts3.geo.admin.ch/1.0.0/ch.vbs.territorialregionen/default/20110501/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  osm_tms:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: global_mercator_osm
+    type: tile
+    url: http://c.tile.openstreetmap.org/%(tms_path)s.png

--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+"""
+mapproxyfy.py Script to generate a MapProxy config file from a layer list.
+
+"""
+
+import os, sys, codecs
+import cgi
+
+import yaml
+import json
+
+from babel import support, Locale
+
+try:
+    import psycopg2
+    import psycopg2.extras
+    from psycopg2.extensions import register_type, UNICODE, connection
+except ImportError:
+    print 'You need psycopg2 to run this script. Try to install it with \'easy_install psycopg2\''
+    sys.exit()
+
+DEBUG = False
+
+
+
+def get_conn():
+    try:
+        dsn = "dbname='bod' port=5432  host='pgcluster0t.bgdi.admin.ch'" 
+        conn=psycopg2.connect(dsn)
+        print 'Database connection established'
+    except:
+        print 'Critical Error: Unable to connect to the database. Have set your PGUSER and PGPASSWD ?\nExit'
+        sys.exit()
+    register_type(UNICODE)
+    conn.set_client_encoding('UTF8')
+
+    return conn
+
+
+
+def get_layers(conn, sql="select * from re3.view_layers_js"):
+
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    cur.execute("select * from re3.view_layers_js")
+
+    return cur.fetchall()
+
+
+try:
+    with open(os.path.abspath('mapproxy/templates/mapproxy.tpl')) as f:
+            y = yaml.load(f.read())
+
+except EnvironmentError:
+    print 'Critical error. Unable to open/read the mapproxy template file. Exit.'
+
+
+
+# Translation
+tr = support.Translations.load('chsdi/locale',locales=['de'], domain='chsdi')
+
+
+conn = get_conn()
+
+rows = get_layers(conn)
+
+
+
+for row in rows:
+    if row['layertype'] == 'wmts' and row['timestamps'] is not None:
+        print row
+        bod_layer_id = row['bod_layer_id']
+        wmts_source_name = bod_layer_id
+        wmts_cache_name = "%s_cache" % bod_layer_id
+        layer_source_name = "%s_source" % bod_layer_id
+
+        current_timestamp = row['timestamps'][0]
+        
+        dimensions = {'Time': {'default': current_timestamp, 'values': row['timestamps']}}
+        title = cgi.escape(tr.ugettext(bod_layer_id))
+
+        for matrix in ['mercator', 'etrs89', 'wgs84', 'lv95']:
+            cache_name = "%s_cache_%s" % (bod_layer_id, matrix)
+            layer_name = "%s.%s" % (bod_layer_id, matrix)
+
+            grid_name = "lowres_%s" % matrix
+
+            #layer config: one layer and one cache per each projection
+            layer = {'name': layer_name, 'title': title, 'dimensions': dimensions, 'sources': [cache_name] }
+
+            cache = {"sources": [wmts_cache_name], "format": "image/%s" %row['image_format'], "grids": [grid_name], "disable_storage": True, "meta_size": [4,4]}
+
+
+            y['layers'].append(layer)
+            y['caches'][cache_name] = cache
+
+        # original source (one for all projection)
+        wmts_url = "http://wmts3.geo.admin.ch/1.0.0/"+row['server_layername'] +"/default/"+current+"/21781/%(z)d/%(y)d/%(x)d.%(format)s"
+
+        wmts_source = {"url": wmts_url, "type": "tile", "grid": "swisstopo-pixelkarte","http": {"headers": {"Referer": "http://mapproxy.geo.admin.ch"}}, \
+                    "coverage": {   "bbox": [ 420000, 30000, 900000,350000 ], "bbox_srs": "EPSG:21781" } }
+
+        wmts_cache = {"sources": [wmts_source_name], "format": "image/%s" %row['image_format'], "grids": ["swisstopo-pixelkarte"], "disable_storage": True}
+
+
+        wmts_layer = {'name': bod_layer_id, 'title': title, 'dimensions': dimensions, 'sources': [wmts_cache_name] }
+
+
+        if DEBUG:
+            print layer
+
+        y['layers'].append(wmts_layer)
+        y['caches'][wmts_cache_name] = wmts_cache
+        y['sources'][wmts_source_name] = wmts_source
+
+if DEBUG:
+    print json.dumps(y, sort_keys = False, indent = 4)
+
+# outfile
+with open('mapproxy/mapproxy.yaml', 'w') as o:
+    o.write(yaml.safe_dump(y, encoding=None))
+


### PR DESCRIPTION
The aim of this PR is to provide WMTS tiles for other _projection_ than the used by map.geo.admin.ch using _MapProxy. The ultimate goal would be to use the same RESTful patten for _TileMatrixSet_ like ETRS89, WG89, LV95 and the ubiquitous spherical mercator.

_http://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/{Time}/{TileMatrixSet}/16/1/5.jpeg_

The config file for _MapProxy, `mapproxy.yaml` is generated by a script reading the layers list from the BOD.
1. Using a WMTS source is no issue for MapProxy, but we have to define a new _layer_ for each _projection_, for instance `pixelkarte`is the original name, `pixelkarte.mercator` would be the name for the reprojected layer in mercator, which is redondand.
2. It is now not possible to forward dimensions to sources other than WMS one. 
3. The Mapproxy demo page does not support dimension (nice to test, but irrelevant for the service itself)
