### PR TITLE
Keyword filtering should be case insensitive

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -261,7 +261,7 @@ class Search(SearchValidation):
         if len(self.searchText) > 0:
             PARCEL_KEYWORDS = ('parzelle', 'parcelle', 'parcella', 'parcel')
             ADDRESS_KEYWORDS = ('addresse', 'adresse', 'indirizzo', 'address')
-            firstWord = self.searchText[0]
+            firstWord = self.searchText[0].lower()
             if firstWord in PARCEL_KEYWORDS:
                 # As one cannot apply filters on string attributes, we use the rank information
                 self.sphinx.SetFilter('rank', [10])


### PR DESCRIPTION
This is to address an issue that has been discussed in https://github.com/geoadmin/mf-chsdi3/issues/777

@cedricmoullet 
I think it would be nice to have it for the deploy.
