### PR TITLE
Filter search results by bbox if present

### DIFF
--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -152,7 +152,7 @@ class TestSearchServiceView(TestsBase):
         self.failUnless(resp.json['results'][0]['attrs']['feature_id'] == '43543')
 
     def test_features_time(self):
-        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'locations', 'bbox': '542200,206800,542200,206800', 'timeInstant': '1981'}, status=200)
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'locations', 'bbox': '542199,206799,542201,206801', 'timeInstant': '1981'}, status=200)
         self.failUnless(resp.content_type == 'application/json')
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
 
@@ -178,7 +178,8 @@ class TestSearchServiceView(TestsBase):
         self.failUnless(len(resp.json['results']) != 0)
 
     def test_featuressearch_geodist(self):
-        resp = self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'gen', 'features': 'ch.babs.kulturgueter', 'type': 'featuresearch', 'bbox': '688301,166874,688301,166874'})
+        resp = self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'gen', 'features': 'ch.babs.kulturgueter', 'type': 'featuresearch', 'bbox': '688290,166864,688309,166884'})
         self.failUnless(resp.content_type == 'application/json')
+        self.failUnless(len(resp.json['results']) == 1)
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
         self.failUnless(resp.json['results'][0]['attrs']['detail'] == 'general-suworow-denkmal')


### PR DESCRIPTION
Put bbox filtering into service to avoid clients to filter their results themselves. This will only be applied if a bbox is specified in the request.

Note: this reduces the number of results heavily! Thus reducing traffic

https://github.com/geoadmin/mf-chsdi3/issues/804
