### PR TITLE
Caching all URL with number as first resource

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -94,6 +94,13 @@ WSGIScriptAlias /${vars:apache_base_path}/wsgi ${buildout:directory/buildout/par
     WSGIApplicationGroup %{GLOBAL}
 </Location>
 
+# If URI has numbers at the start, we cache a year
+# This allows a client to create their own cache and
+# update at his discretion
+RewriteRule ^${apache_entry_path}[0-9]+/(.*)$ ${apache_entry_path}$1 [E=setyearcache:true]
+Header merge Cache-Control "public,max-age=31536001" env=setyearcache
+
+# Non cached access
 RewriteRule ^${apache_entry_path}(qrcodegenerator|owschecker|iipimage|luftbilder|search|index|genindex|examples|img|js|css|releasenotes|services|_sources|_static|api|rest/services|ogcproxy|testi18n|loader.js|snapshot|checker|checker_dev|static|print|dev|feedback)(.*)$ /${vars:apache_base_path}/wsgi/$1$2 [PT]
 
 


### PR DESCRIPTION
Cache all URI's starting with a combination of numbers. e.g `*chsdi3.geo.admin.ch/234234/*` will be cached 1 year.

This is also valid for all user-specific accounts: `*chsdi3.geo.admin.ch/ltjeg/234234/*` will also be cached 1 year also.
