### PR TITLE
beautify report-structure output

### DIFF
--- a/chsdi/templates/htmlpopup/gisgeol.mako
+++ b/chsdi/templates/htmlpopup/gisgeol.mako
@@ -10,7 +10,7 @@
     <tr><td class="cell-left">${_('sgd_nr')}</td><td>${c['attributes']['sgd_nr']}</td></tr>
     <tr><td class="cell-left">${_('title')}</td><td>${c['attributes']['title'] | br }</td></tr>
     <tr><td class="cell-left">${_('author')}</td><td>${c['attributes']['author']}</td></tr>
-    <tr><td class="cell-left">${_('report_structure')}</td><td>${c['attributes']['report_structure']}</td></tr>
+    <tr><td class="cell-left">${_('report_structure')}</td><td>${c['attributes']['report_structure'] | br }</td></tr>
     <tr><td class="cell-left">${_('auxiliary_information')}</td><td>${c['attributes']['aux_info'] | br }</td></tr>
     <tr><td class="cell-left">${_('doccreation_date')}</td><td>${c['attributes']['doccreation']}</td></tr>
     <tr><td class="cell-left">${_('copy_avail')}</td><td>${c['attributes']['copy_avail']}</td></tr>


### PR DESCRIPTION
replaces linefeeds `\n` from postgres into html tags `<br/>` for report_structure field
