### PR TITLE
[WIP] Add script to run nosetests on any db target

### DIFF
--- a/nose_run.sh
+++ b/nose_run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Adapt your ~/.pgpass file for this to work
+
+# A POSIX variable
+OPTIND=1         # Reset in case getopts has been used previously in the shell.
+
+cluster_to_use="pgcluster0t"
+
+while getopts "ip" opt; do
+  case "$opt" in
+  i) cluster_to_use="pgcluster0i"
+     ;;
+  p) cluster_to_use="pgcluster0"
+     ;;
+  esac
+done
+
+shift $((OPTIND-1))
+[ "$1" = "--" ] && shift
+
+cp -f production.ini production.ini.bup
+
+sed -i "s/pgcluster0t/$cluster_to_use/g" production.ini && buildout/bin/nosetests
+
+rc=$?
+
+mv -f production.ini.bup production.ini
+
+exit $rc
+


### PR DESCRIPTION
This PR adds a script to be able to run the integration tests on any db cluster (test, integration or production).

This wasn't put as a buildout part because we need to assure that the configuration is reset after the command. The `collective.recipe.cmd` would not allow that.

Note: this should only be used in your working directory and it's in preparation to do deploys directly from the working directory.

**For this to work, you need to adapt your personal ~/.pgpass file. It has to include access information for all clusters (add `pgcluster0i` and `pgcluster0`)**

Usage:

To run against test cluster: `./nose_run.sh` (same as `buildout/bin/nosetests`)
To run versus integration cluster: `./nose_run.sh -i`
To run versus production cluster: `./nose_run.sh -p`
