### PR TITLE
Deploy with tests to corresponding db cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Add .pgpass to your environment
 Open .pgpass and Add
 
     pgcluster0t.bgdi.admin.ch:5432:*:${username}:${pass}
+    pgcluster0i.bgdi.admin.ch:5432:*:${username}:${pass}
+    pgcluster0.bgdi.admin.ch:5432:*:${username}:${pass}
 
 Make sure PGUSER and PGPASS is set in your .bashrc (for nosetests, potranslate and sphinx)
 
@@ -51,6 +53,33 @@ that points to your working directory. If all is well, you can reach your pages 
 
     http://mf-chsdi3.dev.bgdi.ch/<username>/
 
+# Deploying to dev, int and prod
+
+Do the following commands **inside your working directory**. Here's how a standard
+deploy process is done.
+
+`.\deploydev.sh -s`
+
+This updates the source in /var/www...to the latest master branch from github,
+creates a snapshot and runs nosetests against the test db. The snapshot directory
+will be shown when the script is done. *Note*: you can omit the `-s` parameter if
+you don't want to create a snapshot e.g. for intermediate releases on dev main.
+
+Once a snapshot has been created, you are able to deploy this snapshot to a
+desired target. For integration, do
+
+`.\deploysnapshot 201407031411 int`
+
+This will run the full nose tests **from inside the 201407031411 snapshot directory** against the integration db cluster. Only if these tests are successfull, the snapshot is deployed to the integration cluster.
+
+`.\deploysnapshot 201407031411 prod`
+
+This will do the corresponding thing for prod
+
+*Note*: older snapshots don't contain the nose_run.sh scripts. To use the above
+commands, you have to manually copy the nose_run.sh script into the snapshot code
+directory.
+
 # Deploying a branch
 
 Call the `.\deploybranch.sh` script **in your working directory** to deploy your current 
@@ -76,7 +105,10 @@ want to change that, adapt the `geoadminhost` variable in the
 `buildout_branch.cfg.in` input file and commit it in *your branch*.
 
 ## Run nosetests manual on different enviroments
-We are able to run our integration tests against different staging environments:
+We are able to run our integration tests against different staging environments
+
+**For this to work, you need to adapt your personal ~/.pgpass file. It has to
+include access information for all clusters (add pgcluster0i and pgcluster0)**
 
 To run against prod environment:
 `./nose_run.sh -p`
@@ -89,6 +121,8 @@ To run against dev/test environment:
 
 To run against your private environment:
 `./buildout/bin/nosetests`
+
+
 
 
 # Python Code Styling

--- a/deploydev.sh
+++ b/deploydev.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#bail out on any error
+set -o errexit
+
+# adapt these for emergency deploy coming from branches
+GITBRANCH=master
+
+# set some variables
+DEPLOYDIR=/var/www/vhosts/mf-chsdi3/private/chsdi/
+SNAPSHOT=`date '+%Y%m%d%H%M'`
+SNAPSHOTDIR=/var/www/vhosts/mf-chsdi3/private/snapshots/$SNAPSHOT
+
+# parse parameter (if -n is specified, no snapshot will be created)
+CREATE_SNAPSHOT='false'
+if [ "$1" == "-s" ]
+then
+  CREATE_SNAPSHOT='true'
+fi
+
+# build latest 'master' version on dev
+cd $DEPLOYDIR
+
+# remove all local changes and get latest GITBRANCH from remote
+git fetch --all && git reset --hard && git checkout $GITBRANCH && git reset --hard origin/$GITBRANCH
+
+# build the project
+buildout/bin/buildout -c buildout_dev.cfg
+
+# restart apache
+sudo apache2ctl graceful
+
+echo "Deployed branch $GITBRANCH to dev main."
+
+# create a snapshot
+if [ $CREATE_SNAPSHOT == 'true' ]; then
+  sudo -u deploy deploy -c deploy/deploy.cfg $SNAPSHOTDIR
+  echo "Snapshot of branch $GITBRANCH created at $SNAPSHOTDIR"
+else
+  echo "NO Snapshot created. Specify '-s' parameter got create snapshot."
+fi
+

--- a/deploysnapshot.sh
+++ b/deploysnapshot.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#bail out on any error
+set -o errexit
+
+# Check if snapshot parameter is supplied and there are 2 parameters
+if [ "$2" != "int" ] && [ "$2" != "prod" ]
+then
+  echo "Error: Please specify 1) snapshot directoy and 2) target."
+  exit 1
+fi
+
+SNAPSHOTDIR=/var/www/vhosts/mf-chsdi3/private/snapshots/$1
+
+cwd=$(pwd)
+
+# Go into snapshot directory to run nose-tests
+cd $SNAPSHOTDIR/chsdi3/code/chsdi3
+
+# Run nose tests with target cluster db
+if [ "$2" == "int" ]
+then
+  echo "Running nose tests with integration cluster in $SNAPSHOTDIR"
+  ./nose_run.sh -i
+fi
+
+if [ "$2" == "prod" ]
+then
+  echo "Running nose tests with production cluster in $SNAPSHOTDIR"
+  ./nose_run.sh -p
+fi
+
+# back to working directory for the deploy command
+cd $cwd
+sudo -u deploy deploy -r deploy/deploy.cfg $2 $SNAPSHOTDIR
+


### PR DESCRIPTION
This PR adds new deploy scripts. With these, it will be possible to
- deploy the project to any target from inside the working directory
- run the nosetests against the db cluster corresponding to the target.

This removes the need to be inside /var/www to do deploys. It replaces our chsdi3 deploy scripts from https://github.com/geoadmin/deploy
