### PR TITLE
Print configuration only in tomcat relevant part

### DIFF
--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -5,7 +5,7 @@
 
 # Stateful cookies
 <LocationMatch /${vars:apache_base_path}/(wsgi)?/print/>
-    Header set Set-Cookie "SRV=${hostname-digest}; path=${apache_entry_path}print/"
+    Header set Set-Cookie "SRV=${hostname-digest}; path=/${vars:apache_base_path}/print/"
 </LocationMatch>
 
 


### PR DESCRIPTION
This is needed to make the print work in IE9. Apparently, the path of the cookie is more important there than elsewhere and it has to correspond to the original request in map.geo.admin.ch.

Note: I've tested this **on `int` main** (together with https://github.com/geoadmin/mf-geoadmin3/pull/1534) and it **works in chrome and IE9**. It's still deployed on integration.

Note: This **does not work in dev and IE9** because of some remaining IE9 specific header settings _somewhere_. We need to track these down later on.

Please review and test.
