### PR TITLE
Make env variable unique for versioned caching

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -96,8 +96,8 @@ WSGIScriptAlias /${vars:apache_base_path}/wsgi ${buildout:directory/buildout/par
 # If URI has numbers at the start, we cache a year
 # This allows a client to create their own cache and
 # update at his discretion
-RewriteRule ^${apache_entry_path}[0-9]+/(.*)$ ${apache_entry_path}$1 [E=setyearcache:true]
-Header merge Cache-Control "public,max-age=31536001" env=setyearcache
+RewriteRule ^${apache_entry_path}[0-9]+/(.*)$ ${apache_entry_path}$1 [E=${vars:apache_base_path}setyearcache:true]
+Header merge Cache-Control "max-age=31536013, public" env=${vars:apache_base_path}setyearcache
 
 # Non cached access
 RewriteRule ^${apache_entry_path}(qrcodegenerator|owschecker|iipimage|luftbilder|search|index|genindex|examples|img|js|css|releasenotes|services|_sources|_static|api|rest/services|ogcproxy|testi18n|loader.js|snapshot|checker|checker_dev|static|print|dev|feedback)(.*)$ /${vars:apache_base_path}/wsgi/$1$2 [PT]


### PR DESCRIPTION
This fixes a small isue only apparent in dev. The enviroment variable was named the same for all users, therefore the Header was added once for each user. With this fix, the header is added only once.

Also, it adapt the formatting of the header a little bit.
