### PR TITLE
Rewriting clean versioned API url

### DIFF
--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -4,13 +4,13 @@
 </Proxy>
 
 # Stateful cookies
-<LocationMatch /${vars:apache_base_path}/(wsgi)?/print/>
-    Header set Set-Cookie "SRV=${hostname-digest}; path=/${vars:apache_base_path}/print/"
+<LocationMatch ^${apache_entry_path}print/>
+    Header set Set-Cookie "SRV=${hostname-digest}; path=${apache_entry_path}print/"
 </LocationMatch>
 
 
-ProxyPass /${vars:apache_base_path}/wsgi/print/ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/
-ProxyPassReverse /${vars:apache_base_path}/wsgi/print/ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/
+ProxyPass ${apache_entry_path}print/ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/
+ProxyPassReverse ${apache_entry_path}print/ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/
 
 # Try to force IE to open the PDF in a new window
 # overriding what set by the print server

--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -29,41 +29,44 @@ AddOutputFilterByType DEFLATE text/html text/plain text/xml
 WSGIPassAuthorization On
 
 # Static files with aggressive cache:
-RewriteRule ^/${vars:apache_base_path}/wsgi/[0-9a-fA-F]*/(static)/(.*)$  ${buildout:directory/chsdi/$1/$2}
-RewriteRule ^/${vars:apache_base_path}/wsgi/(static)/(.*)$  ${buildout:directory/chsdi/$1/$2}
+RewriteRule ^${apache_entry_path}[0-9\/]*static/(.*)$  ${buildout:directory/chsdi/static/$1}
+
+# Entry for doc
+RewriteRule ^${apache_entry_path}?$  ${apache_entry_path}doc [R,QSA]
+RewriteRule ^${apache_entry_path}doc/examples(.*)$  ${buildout:directory}/chsdi/static/doc/examples$1 [S=1]
+RewriteRule ^${apache_entry_path}doc(.*)$  ${buildout:directory}/chsdi/static/doc/build/$1
 
 <IfModule mod_headers.c>
   Header set X-UA-Compatible "IE=Edge"
 </IfModule>
 
-<LocationMatch "/${vars:apache_base_path}/wsgi/[0-9a-fA-F]*/(static)/">
+<LocationMatch "^${apache_entry_path}[0-9]+/static/">
     ExpiresDefault "now plus 1 year"
     Header merge Cache-Control "public"
     Header unset Etag
 </LocationMatch>
 
 # Static for cross domain flash/arcgis
-<LocationMatch "/${vars:apache_base_path}/wsgi/static/(crossdomain.xml|clientaccesspolicy.xml)">
+<LocationMatch "^${apache_entry_path}static/(crossdomain.xml|clientaccesspolicy.xml)">
     Header set Content-type "text/x-cross-domain-policy"
 </LocationMatch>
-RewriteRule ^${apache_entry_path}(crossdomain.xml|clientaccesspolicy.xml) /${vars:apache_base_path}/wsgi/static/$1 [PT]
+RewriteRule ^${apache_entry_path}(crossdomain.xml|clientaccesspolicy.xml) ${apache_entry_path}static/$1 [PT]
 
 # Robots static files
-<LocationMatch "/${vars:apache_base_path}/wsgi/static/(robots.txt|robots_prod.txt)">
+<LocationMatch "^${apache_entry_path}static/(robots.txt|robots_prod.txt)">
     Header set Content-type "text/plain"
 </LocationMatch>
-RewriteRule ^${apache_entry_path}robots.txt /${vars:apache_base_path}/wsgi/static/${robots_file} [PT]
+RewriteRule ^${apache_entry_path}robots.txt ${apache_entry_path}static/${robots_file} [PT]
 
 
 # WMTS
-RewriteRule ^${apache_entry_path}1.0.0/WMTSCapabilities\.xml$ /${vars:apache_base_path}/wsgi/rest/services/api/1.0.0/WMTSCapabilities.xml [PT,NC,QSA,L]
+RewriteRule ^${apache_entry_path}1.0.0/WMTSCapabilities\.xml$ ${apache_entry_path}rest/services/api/1.0.0/WMTSCapabilities.xml [PT,NC,QSA,L]
 
 # Frozen Capabilities, for swissmaponline 
 RewriteCond %{QUERY_STRING} lang=(de|fr|it|en) [NC] 
 RewriteRule ^${apache_entry_path}1.0.0/WMTSCapabilities_v([0-9]{8})\.xml$ ${buildout:directory}/chsdi/static/capabilities/$1/WMTSCapabilities.%1.xml [NC,QSA,L]
 RewriteRule ^${apache_entry_path}1.0.0/WMTSCapabilities_v([0-9]{8})\.xml$ ${buildout:directory}/chsdi/static/capabilities/$1/WMTSCapabilities.de.xml [NC,QSA,L]
 
-RewriteRule ^${apache_entry_path}$ /${vars:apache_base_path}/wsgi/ [PT]
 
 # Proxy pass pointing on api.geo.admin.ch project
 RewriteRule ^${apache_entry_path}(shorten|shorten.json)(.*)$ http://api.geo.admin.ch/$1$2 [P]
@@ -71,10 +74,11 @@ RewriteRule ^${apache_entry_path}(shorten|shorten.json)(.*)$ http://api.geo.admi
 # Proxy pass for geodesy services
 RewriteRule ^${apache_entry_path}reframe/lv03tolv95(.*)$ http://tc-geodesy.bgdi.admin.ch/reframe/lv03tolv95$1 [P]
 
-<Location ${apache_entry_path}>
-    Order allow,deny
-    Allow from all
-</Location>
+# If URI has numbers at the start, we cache a year
+# This allows a client to create their own cache and
+# update at his discretion
+RewriteRule ^${apache_entry_path}[0-9]+/(.*)$ ${apache_entry_path}$1 [PT,E=${vars:apache_base_path}setyearcache:true] 
+Header merge Cache-Control "max-age=31536013, public" env=${vars:apache_base_path}setyearcache
 
 
 # define a process group
@@ -82,29 +86,34 @@ RewriteRule ^${apache_entry_path}reframe/lv03tolv95(.*)$ http://tc-geodesy.bgdi.
 WSGIDaemonProcess mf-chsdi3:${vars:apache_base_path} display-name=%{GROUP} user=${vars:modwsgi_user} threads=${vars:wsgi_threads}
 
 # define the path to the WSGI app
-WSGIScriptAlias /${vars:apache_base_path}/wsgi ${buildout:directory/buildout/parts/modwsgi/wsgi}
+WSGIScriptAlias ${apache_entry_path} ${buildout:directory}/buildout/parts/modwsgi/wsgi
 
 # assign the WSGI app instance the process group defined aboven, we put the WSGI
 # app instance in the global application group so it is always executed within
 # the main interpreter
-<Location /${vars:apache_base_path}/wsgi>
+<LocationMatch ^${apache_entry_path}>
     # WSGIProcessGroup must be commented/removed when running the project on windows
     WSGIProcessGroup mf-chsdi3:${vars:apache_base_path}
     WSGIApplicationGroup %{GLOBAL}
-</Location>
 
-# If URI has numbers at the start, we cache a year
-# This allows a client to create their own cache and
-# update at his discretion
-RewriteRule ^${apache_entry_path}[0-9]+/(.*)$ ${apache_entry_path}$1 [E=${vars:apache_base_path}setyearcache:true]
-Header merge Cache-Control "max-age=31536013, public" env=${vars:apache_base_path}setyearcache
+    Order allow,deny
+    Allow from all
+</LocationMatch>
 
-# Non cached access
-RewriteRule ^${apache_entry_path}(qrcodegenerator|owschecker|iipimage|luftbilder|search|index|genindex|examples|img|js|css|releasenotes|services|_sources|_static|api|rest/services|ogcproxy|testi18n|loader.js|snapshot|checker|checker_dev|static|print|dev|feedback|sitemap)(.*)$ /${vars:apache_base_path}/wsgi/$1$2 [PT]
+# We rewrite loader to versioned loader, which is cached
+RewriteRule ^${apache_entry_path}loader.js$ ${apache_entry_path}${app_version}/uncached_loader.js [P]
+<LocationMatch ^${apache_entry_path}loader.js>
+    Header unset Cache-Control
+    Header merge Cache-Control "no-cache"
+</LocationMatch>
+
+# Big & ugly regex to match everything that is handled by pylons (everything!) in this 'apache_entry_path'
+RewriteRule ^${apache_entry_path}[0-9\/]*(qrcodegenerator|owschecker|iipimage|luftbilder|search|index|genindex|examples|img|js|css|releasenotes|services|_sources|_static|api|rest/services|ogcproxy|testi18n|uncached_loader.js|loader.js|snapshot|checker|checker_dev|static|print|dev|feedback|sitemap|doc)(.*)$ ${apache_entry_path}$1$2 [PT]
+
 
 
 # Some services are not "free": control is done at varnish level
-<LocationMatch /${vars:apache_base_path}/wsgi/rest/(height|profile)>
+<LocationMatch ^${apache_entry_path}rest/(height|profile)>
    Order Deny,Allow
    Allow from all
 </LocationMatch>

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -169,7 +169,7 @@ recipe = z3c.recipe.filetemplate
 source-directory = .
 exclude-directories = buildout
 interpreted-options = authtkt_secret
-interpreted-options = app_version = __import__('uuid').uuid4().hex[:5]
+interpreted-options = app_version = __import__('time').strftime('%s')
                       hostname = __import__('socket').gethostname()
                       hostname-digest = __import__('hashlib').md5(options.get('hostname')).hexdigest()
                       apache_entry_path = '/' if options.get('apache_base_path') == 'main' else ('/' + options.get('apache_base_path') + '/')

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -58,7 +58,7 @@ def main(global_config, **settings):
     # Static config
     config.add_route('home', '/')
     config.add_route('dev', '/dev')
-    config.add_route('ga_api', '/loader.js')
+    config.add_route('ga_api', '/uncached_loader.js')
     config.add_route('testi18n', '/testi18n')
     config.add_view(route_name='home', renderer='chsdi:static/doc/build/index.html', http_cache=3600)
     config.add_view(route_name='dev', renderer='chsdi:templates/index.pt', http_cache=0)
@@ -106,8 +106,8 @@ def main(global_config, **settings):
     config.add_static_view('static/js', 'chsdi:static/js', cache_max_age=datetime.timedelta(days=365))
     config.add_static_view('static/images', 'chsdi:static/images', cache_max_age=datetime.timedelta(days=365))
     config.add_static_view('img', 'chsdi:static/images', cache_max_age=datetime.timedelta(days=365))
-    config.add_static_view('examples', 'chsdi:static/doc/examples', cache_max_age=datetime.timedelta(days=365))
     # Static view for sphinx
-    config.add_static_view('/', 'chsdi:static/doc/build', cache_max_age=datetime.timedelta(days=365))
+    config.add_static_view('doc/examples', 'chsdi:static/doc/examples')
+    config.add_static_view('doc', 'chsdi:static/doc/build')
 
     return config.make_wsgi_app()

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -12,8 +12,9 @@ def versioned(path):
     if version is not None:
         agnosticPath = make_agnostic(path)
         # Only resources with wsgi are versioned
+        # WSGI has not clue what is done at apache level
         if '/wsgi' in agnosticPath:
-            return agnosticPath.replace('wsgi', 'wsgi/' + version)
+            return agnosticPath.replace('wsgi', version)
         return agnosticPath
     else:
         return path

--- a/chsdi/static/doc/examples/geoadmin_catalog.html
+++ b/chsdi/static/doc/examples/geoadmin_catalog.html
@@ -122,7 +122,7 @@
     <script type="text/javascript" src="/static/js/jquery-2.0.3.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.2/jquery.xdomainrequest.min.js"></script>
     <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="//api3.geo.admin.ch/loader.js"></script>
+    <script type="text/javascript" src="../../uncached_loader.js"></script>
     <script type="text/javascript" src="//code.jquery.com/jquery-latest.js"></script>
     <script type="text/javascript" src="geoadmin_catalog.js"></script>
   </body>

--- a/chsdi/static/doc/examples/geoadmin_geocoder.html
+++ b/chsdi/static/doc/examples/geoadmin_geocoder.html
@@ -15,7 +15,7 @@
     <div id="map" style="width=100%;height:350px;"></div>
     This examples presents the usage of the geocoder.<br>
     <a href="geoadmin_geocoder.js">See the code</a>
-    <script src="../loader.js" type="text/javascript"></script>
+    <script src="../../uncached_loader.js" type="text/javascript"></script>
     <script src="geoadmin_geocoder.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_kml.html
+++ b/chsdi/static/doc/examples/geoadmin_kml.html
@@ -34,7 +34,7 @@
     The KML file has to be compliant with the KML standard. KML can be validated <a href="http://www.kmlvalidator.com/home.htm">here.</a>
     <script src="//code.jquery.com/jquery-1.10.1.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-    <script src="../loader.js" type="text/javascript"></script> 
+    <script src="../../uncached_loader.js" type="text/javascript"></script> 
     <script src="geoadmin_kml.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_mapoverlay.html
+++ b/chsdi/static/doc/examples/geoadmin_mapoverlay.html
@@ -15,7 +15,7 @@
     <div id="map" style="width=100%;height:350px;"></div>
     This examples presents a simple map with an AGNES layer. You can click on the AGNES station in order to get the attributive information.<br>
     <a href="geoadmin_mapoverlay.js">See the code</a>
-    <script src="../loader.js" type="text/javascript"></script>
+    <script src="../../uncached_loader.js" type="text/javascript"></script>
     <script src="geoadmin_mapoverlay.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_rectangle.html
+++ b/chsdi/static/doc/examples/geoadmin_rectangle.html
@@ -58,7 +58,7 @@
     <br> This example shows to draw and delete a rectangle over the map.</br>
     <a href="geoadmin_rectangle.js">See the code</a> now jquery is used for the homelibrary js and not jquery.com.<br>  
     <script src="/static/js/jquery-2.0.3.min.js"></script>
-    <script src="../loader.js" type="text/javascript"></script>
+    <script src="../../uncached_loader.js" type="text/javascript"></script>
     <script type="text/javascript" src="geoadmin_rectangle.js"></script>   
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_search.html
+++ b/chsdi/static/doc/examples/geoadmin_search.html
@@ -101,7 +101,7 @@
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.2/jquery.xdomainrequest.min.js"></script>
     <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="//twitter.github.io/typeahead.js/releases/latest/typeahead.bundle.js"></script> 
-    <script type="text/javascript" src="../loader.js"></script>
+    <script type="text/javascript" src="../../uncached_loader.js"></script>
     <script type="text/javascript" src="geoadmin_search.js"></script>
   </body>
 </html>

--- a/chsdi/static/doc/source/index.rst
+++ b/chsdi/static/doc/source/index.rst
@@ -26,7 +26,7 @@ Use the GeoAdmin API Forum to ask questions: http://groups.google.com/group/geoa
   </style>
   <body>
     <div id="map"></div>
-    <script type="text/javascript" src="../../../loader.js"></script>
+    <script type="text/javascript" src="../uncached_loader.js"></script>
     <script type="text/javascript">
       var layer = ga.layer.create('ch.swisstopo.pixelkarte-farbe');
       var map = new ga.Map({


### PR DESCRIPTION
- Using the same version tag as in _mf-geoadmin3_ , i.e. `date '+%s'` (hex are not cached by apache)
- Removing the pesky _wsgi_ from pathes
- uncached_loader.js/loader.js
- generated doc to its own directory
