### PR TITLE
Use buildout eggs cleaner extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ apache/mapproxy.conf
 apache/tomcat-print.conf
 buildout/bin/
 buildout/develop-eggs/
+buildout/old-eggs/
 buildout/eggs/
 buildout/parts/
 chsdi.egg-info

--- a/README.md
+++ b/README.md
@@ -122,8 +122,14 @@ To run against dev/test environment:
 To run against your private environment:
 `./buildout/bin/nosetests`
 
+# Clean project
+In order to reinitialize your project and remove unused eggs do the following commands:
+<pre>
+buildout/bin/buildout -c buildout_cleaner.cfg
+buildout/bin/buildout -c buildout_<username>.cfg
+</pre>
 
-
+`buildout_cleaner.cfg` will move all the unused eggs into `buildout/old-eggs/`, remove all the `*.mo` translation files, uninstall all the templates and remove all the `*.pyc` files.
 
 # Python Code Styling
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -270,13 +270,6 @@ cmds =
     cp ${buildout:directory}/chsdi/static/js/ol3/build/EPSG* ${buildout:directory}/chsdi/static/js/ &&
     cp ${buildout:directory}/chsdi/static/js/ol3/build/proj4js-com* ${buildout:directory}/chsdi/static/js
 
-[clean-project]
-recipe = collective.recipe.cmd
-on_install = true
-cmds =
-    find . -name "*.pyc" -delete -print
-    find . -name "*.in" |  sed -r 's/(.*)\.in/\1/' | xargs -I {} rm -v "{}"
-
 [nosetest-ini]
 recipe = z3c.recipe.filetemplate
 files = production.ini development.ini

--- a/buildout_cleaner.cfg
+++ b/buildout_cleaner.cfg
@@ -1,0 +1,17 @@
+[buildout]
+extends = buildout.cfg
+parts -= activate
+        template
+        modwsgi
+        mapproxy
+        print-config
+        print-war
+        po2mo
+        validate-py
+        doc
+        node-modules
+        lessc
+        ol3-install
+        ol3-serverconfig
+extensions += buildout.eggscleaner
+old-eggs-directory = buildout/old-eggs

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ README = open(os.path.join(here, 'README.md')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
 
 requires = [
+    'zc.buildout',
     'webtest',
     'pyramid',
     'pyramid_debugtoolbar',


### PR DESCRIPTION
Make sure our eggs directory only contains 'used' eggs.

https://pypi.python.org/pypi/buildout.eggscleaner/0.1.6
