### PR TITLE
API Loader will be cached in backend. Newly cached on each build/deploy

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -94,6 +94,13 @@ WSGIScriptAlias /${vars:apache_base_path} ${buildout:directory/buildout/parts/mo
     WSGIApplicationGroup %{GLOBAL}
 </Location>
 
+# We rewrite loader to versioned loader, which is cached
+RewriteRule ^${apache_entry_path}loader.js$ ${apache_entry_path}${app_version}/uncached_loader.js [P]
+<LocationMatch ^${apache_entry_path}loader.js>
+    Header unset Cache-Control
+    Header merge Cache-Control "no-cache"
+</LocationMatch>
+
 # If URI has numbers at the start, we cache a year
 # This allows a client to create their own cache and
 # update at his discretion
@@ -101,7 +108,7 @@ RewriteRule ^${apache_entry_path}[0-9]+/(.*)$ ${apache_entry_path}$1 [E=${vars:a
 Header merge Cache-Control "max-age=31536013, public" env=${vars:apache_base_path}setyearcache
 
 # Non cached access
-RewriteRule ^${apache_entry_path}(qrcodegenerator|owschecker|iipimage|luftbilder|search|index|genindex|examples|img|js|css|releasenotes|services|_sources|_static|api|rest/services|ogcproxy|testi18n|loader.js|snapshot|checker|checker_dev|static|print|dev|feedback)(.*)$ /${vars:apache_base_path}/$1$2 [PT]
+RewriteRule ^${apache_entry_path}(qrcodegenerator|owschecker|iipimage|luftbilder|search|index|genindex|examples|img|js|css|releasenotes|services|_sources|_static|api|rest/services|ogcproxy|testi18n|uncached_loader.js|snapshot|checker|checker_dev|static|print|dev|feedback)(.*)$ /${vars:apache_base_path}/$1$2 [PT]
 
 # Some services are not "free": control is done at varnish level
 <LocationMatch /${vars:apache_base_path}/rest/(height|profile)>

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -58,7 +58,7 @@ def main(global_config, **settings):
     # Static config
     config.add_route('home', '/')
     config.add_route('dev', '/dev')
-    config.add_route('ga_api', '/loader.js')
+    config.add_route('ga_api', '/uncached_loader.js')
     config.add_route('testi18n', '/testi18n')
     config.add_view(route_name='home', renderer='chsdi:static/doc/build/index.html', http_cache=3600)
     config.add_view(route_name='dev', renderer='chsdi:templates/index.pt', http_cache=0)


### PR DESCRIPTION
This will add caching for the loader.js file. The cache will be automatically renewed on each build/deploy.

Note: this PR is for @procrastinatio branch.
