### PR TITLE
Adding address sitemaps

### DIFF
--- a/chsdi/lib/validation/sitemaps.py
+++ b/chsdi/lib/validation/sitemaps.py
@@ -7,12 +7,13 @@ class SiteMapValidation(object):
 
     def __init__(self):
         self._content = None
-        self.contents = [
+        self._multi_sitemaps = ['addresses']
+        self._multi_part = None
+        self._contents = [
             'index',
             'base',
             'topics',
-            'layers'
-        ]
+            'layers'] + self._multi_sitemaps
 
     @property
     def content(self):
@@ -22,9 +23,25 @@ class SiteMapValidation(object):
     def content(self, value):
         if value is None:
             raise HTTPBadRequest('Please provide the parameter content  (Required)')
-        if value not in self.contents:
+        clist = value.split('_')
+        value = clist[0]
+        if value not in self._contents:
             raise HTTPNotFound('Please provide a valid content parameter')
+        if len(clist) > 2:
+            raise HTTPBadRequest('Malformed content parameter')
+        if len(clist) == 2:
+            try:
+                self._multi_part = int(clist[1])
+            except:
+                raise HTTPBadRequest('Content parameter should have integer index value')
+            if self._multi_part < 0:
+                raise HTTPBadRequest('Content parameter should have integer greater zero')
         self._content = value
 
+    @property
     def contents(self):
-        return self.contents
+        return self._contents
+
+    @property
+    def multi_part(self):
+        return self._multi_part

--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -144,3 +144,12 @@ class FIXPUNKTE_HFP2(Base, Vector):
     bgdi_created = Column('bgdi_created', Text)
 
 register('ch.swisstopo.fixpunkte-hfp2', FIXPUNKTE_HFP2)
+
+
+# This address model is just used in the sitemap service
+# It contains different attributes than the standard
+# Gebaeuderegister model for the layer 'ch.bfs.gebaeude_wohnungs_register'
+# This model is not registered
+class SitemapGebaeuderegister(Gebaeuderegister):
+    X = Column('gkody', Numeric)
+    Y = Column('gkodx', Numeric)

--- a/chsdi/templates/index.pt
+++ b/chsdi/templates/index.pt
@@ -34,6 +34,8 @@
           <a href="sitemap?content=base">Base page</a> <br>
           <a href="sitemap?content=topics">Topics page</a> <br>
           <a href="sitemap?content=layers">Layers page</a> <br>
+          <a href="sitemap?content=addresses">Address index page</a> <br>
+          <a href="sitemap?content=addresses_33">Sample address index</a> <br>
       <h2 id="checkers">Checkers</h2>
           <a href="checker">Checker for home page</a> <br>
           <a href="checker_dev">Checker for dev page</a> <br> 

--- a/chsdi/tests/integration/test_sitemap.py
+++ b/chsdi/tests/integration/test_sitemap.py
@@ -87,3 +87,42 @@ class TestSitemapView(TestsBase):
         self.failUnless(self.testapp.app.registry.settings.get('geoadminhost') in resp.body)
         # validate scheme
         self.failUnless(0 == _validate_scheme('sitemap.xsd', resp.body))
+
+    def test_bad_multi_files(self):
+        # multipart (after _) must be integer
+        resp = self.testapp.get('/sitemap?content=addresses_other', status=400)
+        # mutiipart can't be empty
+        resp = self.testapp.get('/sitemap?content=addresses_', status=400)
+        # multipart muast be >= 0
+        resp = self.testapp.get('/sitemap?content=addresses_-1', status=400)
+
+    def test_addresses_index_file(self):
+        resp = self.testapp.get('/sitemap?content=addresses', status=200)
+        resp.content_type == 'application/xml'
+        # shouldn't contain empty
+        self.failUnless('sitemap_addresses.xml' not in resp.body)
+        self.failUnless('sitemap_addresses_.xml' not in resp.body)
+        # shouldn't contain too big (this might theoreticyll fail if address db grew
+        self.failUnless('sitemap_addresses_500.xml' not in resp.body)
+        # check for first link
+        resp.mustcontain('sitemap_addresses_0.xml')
+        # check for last link (this might change depending on size of db
+        resp.mustcontain('sitemap_addresses_387.xml')
+        # contains correct domain
+        self.failUnless(self.testapp.app.registry.settings.get('geoadminhost') in resp.body)
+        # validate scheme
+        self.failUnless(0 == _validate_scheme('siteindex.xsd', resp.body))
+
+    def test_addresses_file(self):
+        resp = self.testapp.get('/sitemap?content=addresses_387', status=200)
+        resp = self.testapp.get('/sitemap?content=addresses_0', status=200)
+        resp.content_type == 'application/xml'
+        # some checks on content
+        resp.mustcontain('ch.bfs.gebaeude_wohnungs_register=')
+        resp.mustcontain('X=')
+        resp.mustcontain('Y=')
+        resp.mustcontain('zoom=')
+        # contains correct domain
+        self.failUnless(self.testapp.app.registry.settings.get('geoadminhost') in resp.body)
+        # validate scheme
+        self.failUnless(0 == _validate_scheme('sitemap.xsd', resp.body))

--- a/chsdi/views/sitemaps.py
+++ b/chsdi/views/sitemaps.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
 import json
+import math
 from sqlalchemy.orm import scoped_session, sessionmaker
-
 from pyramid.view import view_config
-from pyramid.renderers import render_to_response
 from pyramid.httpexceptions import HTTPNotFound, HTTPInternalServerError
+from pyramid.renderers import render_to_response
 from pyramid.request import Request
 
-from chsdi.models.bod import Catalog
 from chsdi.lib.validation.sitemaps import SiteMapValidation
 from chsdi.lib.filters import *
 
-__AMPERSAND__ = '&amp;'
+from chsdi.models.vector.kogis import SitemapGebaeuderegister
+from chsdi.models.bod import Catalog
 
 
 class SiteMaps(SiteMapValidation):
@@ -26,6 +26,10 @@ class SiteMaps(SiteMapValidation):
         self.request = request
         self.langs = ['de', 'fr', 'it', 'rm', 'en']
 
+# Maximum number of urls allowed in multi-files
+__MAX_NUM_URLS__ = 5000
+__AMPERSAND__ = '&amp;'
+
 
 @view_config(route_name='sitemap')
 def sitemap(request):
@@ -34,7 +38,8 @@ def sitemap(request):
         'index': index,
         'base': base,
         'topics': topics,
-        'layers': layers
+        'layers': layers,
+        'addresses': addresses
     }
     if params.content not in funcs:
         raise HTTPNotFound('Missing function definition')
@@ -77,7 +82,7 @@ def topics(params):
 
 def layers(params):
     buildlink = lambda x: '?topic=' + topic['id'] + __AMPERSAND__ + 'layers=' + x.layerBodId
-    session = scoped_session(sessionmaker())
+    session = params.request.db
     paths = []
     topics = getTopics(params)
     for topic in topics:
@@ -87,7 +92,47 @@ def layers(params):
         query = filter_by_geodata_staging(query, Catalog.staging, params.staging)
         layerlinks = map(buildlink, query.all())
         paths.extend(toAllLanguages(topic['langs'].split(','), layerlinks, __AMPERSAND__, ''))
-    session.close()
+
+    return asXml(params, paths)
+
+
+def addresses(params):
+    # index file
+    if params.multi_part is None:
+        return address_index(params)
+    else:
+        return address_part(params)
+
+
+def address_index(params):
+    session = params.request.db
+    count = session.query(SitemapGebaeuderegister).count()
+    max_index = int(math.ceil(count / __MAX_NUM_URLS__))
+    names = lambda x: params.basename + '_addresses_' + str(x) + '.xml'
+    data = {
+        'host': params.host,
+        'sitemaps': map(names, range(max_index))
+    }
+    response = render_to_response(
+        'chsdi:templates/sitemapindex.mako',
+        data,
+        request=params.request)
+    response.content_type = 'application/xml'
+    return response
+
+
+def address_part(params):
+    session = params.request.db
+    query = (session.query(SitemapGebaeuderegister)
+             .order_by(SitemapGebaeuderegister.id)
+             .offset(params.multi_part)
+             .limit(__MAX_NUM_URLS__))
+    paths = []
+    for res in query.all():
+        paths.append('?' + res.__bodId__ + '=' + res.id + __AMPERSAND__ +
+                     'X=' + str(int(res.X)) + __AMPERSAND__ +
+                     'Y=' + str(int(res.Y)) + __AMPERSAND__ +
+                     'zoom=9')
     return asXml(params, paths)
 
 


### PR DESCRIPTION
**This should not be merged now.** I first want to test the general sitemap service in production before merging this.

Anyhow, this is ready to be reviewed. It basically replaces https://github.com/geoadmin/mf-geoadmin3/pull/1448/files 
1. Sitemaps containing all adresses of our wohnungsregister layers. It contains links as [1]. These xml files have 5000 links each (~1MB raw, ~50KB gzipped)
2. Replaces `&` with `&amp;` to have fully valid xml
3. Removes priority from all sitemaps

[1] http://map.geo.admin.ch/?ch.bfs.gebaeude_wohnungs_register=1761259_0&X=199101.00&Y=626766.00&zoom=9
