### PR TITLE
Allow services for bots

### DIFF
--- a/chsdi/static/robots_prod.txt
+++ b/chsdi/static/robots_prod.txt
@@ -5,5 +5,6 @@ Disallow: /testi18n
 Disallow: /checker
 Disallow: /checker_dev
 Disallow: /snapshot
-Disallow: /rest/services
+Disallow: /mapproxy
+Disallow: /owschecker
 


### PR DESCRIPTION
This is in preparation to use the full page rendering of google bots in the future. For this to fully work for map.geo.admin.ch, the bots needs to be able to access our services (via CORS). This PR assures that.
