### PR TITLE
Fetch only the required branch

### DIFF
--- a/deploybranch.sh
+++ b/deploybranch.sh
@@ -16,7 +16,7 @@ fi
 
 cd $CODE_DIR
 git checkout $GIT_BRANCH
-git fetch --all
+git fetch origin $GIT_BRANCH
 git reset --hard origin/$GIT_BRANCH
 # This creates the branch configuration
 buildout/bin/buildout -c buildout_dev.cfg


### PR DESCRIPTION
I think that fetching only the required branch is better.
