### PR TITLE
Adding Jenkins build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 mf-chsdi3
 =========
 
-next generation of api.geo.admin.ch
+next generation of api3.geo.admin.ch
 
+Jenkins Build Status: [![Jenkins Build Status](https://jenkins.dev.bgdi.ch/buildStatus/icon?job=chsdi3)](https://jenkins.dev.bgdi.ch/job/chsdi3/)
 
 # Getting started
 


### PR DESCRIPTION
This adds a jenkins build status icon to the README page.
