### PR TITLE
Assure node_modules directory exists in build

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -216,6 +216,7 @@ cmds =
 recipe = collective.recipe.cmd
 on_install = true
 cmds =
+    mkdir -p node_modules
     npm install less@1.5.0
 
 [lessc]


### PR DESCRIPTION
Because of [1], it's possible that less compiler is installed in a parent directory instead of the project directory. This PR assures that a node_moduels directory will be created before installing the node modules.

[1] http://stackoverflow.com/questions/18566048/npm-installs-package-outside-current-directory
