### PR TITLE
Add umask definition for deploydev script

### DIFF
--- a/deploydev.sh
+++ b/deploydev.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# set correct umask to assure proper rights after build
+umask 0002
+
 #bail out on any error
 set -o errexit
 


### PR DESCRIPTION
As @loicgasser found out, our jenkins user as rightfully a more strict umask. This led to permission problems in our main directory when jenkins updates the build using the ./deploydev.sh script.

Hopefully, with this fix, the correct umask is used by Jenkins.
