### PR TITLE
fixes server error when searching for parcel keyword only (parzelle,

### DIFF
--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -160,6 +160,11 @@ class TestSearchServiceView(TestsBase):
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'parcel')
 
+    def test_search_locations_parcel_keyword_only(self):
+        params = {'searchText': 'parzelle', 'type': 'locations'}
+        resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
+        self.failUnless(len(resp.json['results']) == 0)
+
     def test_search_locations_with_bbox(self):
         params = {'type': 'locations', 'searchText': 'buechli tegerfelden', 'bbox': '664100,268443,664150,268643'}
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -109,11 +109,15 @@ class Search(SearchValidation):
             searchTextFinal = '(' + searchList[0] + ') & (' + searchList[1] + ')'
         elif len(searchList) == 1:
             searchTextFinal = searchList[0]
-        try:
-            temp = self.sphinx.Query(searchTextFinal, index='swisssearch')
-        except IOError:
-            raise exc.HTTPGatewayTimeout()
-        temp = temp['matches'] if temp is not None else temp
+
+        if len(searchList) != 0:
+            try:
+                temp = self.sphinx.Query(searchTextFinal, index='swisssearch')
+            except IOError:
+                raise exc.HTTPGatewayTimeout()
+            temp = temp['matches'] if temp is not None else temp
+        else:
+            temp = []
         if temp is not None and len(temp) != 0:
             self._parse_location_results(temp)
 


### PR DESCRIPTION
see #925 

When searching for "parzelle" only [1] there is the following error:

```
[Mon Aug 11 07:23:46 2014] [error] [client 10.35.188.159]   File "/var/www/vhosts/mf-chsdi3/private/chsdi/chsdi/views/search.py", line 113, in _swiss_search
[Mon Aug 11 07:23:46 2014] [error] [client 10.35.188.159]     temp = self.sphinx.Query(searchTextFinal, index='swisssearch')
[Mon Aug 11 07:23:46 2014] [error] [client 10.35.188.159] UnboundLocalError: local variable 'searchTextFinal' referenced before assignment
```

@loicgasser please have a look at this pr, i could not find any side-effect.

[1] http://api3.geo.admin.ch/rest/services/api/SearchServer?searchText=parzelle&type=locations
