### PR TITLE
Protect featureidentify and featuresearch services.

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -317,7 +317,7 @@ class Search(SearchValidation):
 
     def _parse_address(self, res):
         if not (self.varnish_authorized and self.returnGeometry):
-            attrs2Del = ['x', 'y', 'lon', 'lat', 'geom_st_box2d', 'featureId']
+            attrs2Del = ['x', 'y', 'lon', 'lat', 'geom_st_box2d']
             popAtrrs = lambda x: res.pop(x) if x in res else x
             map(popAtrrs, attrs2Del)
             return res
@@ -354,6 +354,8 @@ class Search(SearchValidation):
                 for res in results[i]['matches']:
                     if 'feature_id' in res['attrs']:
                         res['attrs']['featureId'] = res['attrs']['feature_id']
+                    if res['attrs']['layer'] == 'ch.bfs.gebaeude_wohnungs_register':
+                        res['attrs'] = self._parse_address(res['attrs'])
                     if self.typeInfo == 'featuresearch' or not self.bbox or \
                             self._bbox_intersection(self.bbox, res['attrs']['geom_st_box2d']):
                         self.results['results'].append(res)


### PR DESCRIPTION
`/rest/services/api/SearchServer?type=locations&searchText=chaussee%20du%20canal%2068%201897%20bouveret%206154%20port-v
alais%20ch%20vs`

authorized:

<pre>
{
    "results": [
        {
            "id": 1644673,
            "weight": 12,
            "attrs": {
                "origin": "address",
                "geom_quadindex": "023001222011332120133",
                "layerBodId": "ch.bfs.gebaeude_wohnungs_register",
                "featureId": "190446068_0",
                "detail": "chaussee du canal 68 1897 bouveret 6154 port-valais ch vs",
                "rank": 6,
                "num": 68,
                "label": "Chauss\u00e9e du Canal 68 <b>1897 Bouveret</b>"
            }
        }
    ]
}
</pre>


unauthorized:

<pre>
{
    "results": [
        {
            "id": 1644673,
            "weight": 12,
            "attrs": {
                "origin": "address",
                "geom_quadindex": "023001222011332120133",
                "layerBodId": "ch.bfs.gebaeude_wohnungs_register",
                "featureId": "190446068_0",
                "lon": 6.865394115447998,
                "detail": "chaussee du canal 68 1897 bouveret 6154 port-valais ch vs",
                "rank": 6,
                "geom_st_box2d": "BOX(555897 136661,555897 136661)",
                "lat": 46.37986373901367,
                "num": 68,
                "y": 555897.0,
                "x": 136661.0,
                "label": "Chauss\u00e9e du Canal 68 <b>1897 Bouveret</b>"
            }
        }
    ]
}
</pre>


All service with `rest/services` will soon be protected using the same principle. (see Marc email)

[Varnish refrence](https://gitweb.prod.bgdi.ch/gitweb/?p=puppetmaster-stable/.git;a=blob;f=site-modules/chtopo/files/etc/varnish/varnish.vcl;h=fb600879fc940e3793da00c271b618bf04f08468;hb=HEAD)

featureId is back since geometry will be blocked at the `Get Feature` level.
