### PR TITLE
Remove addresses sitemap from sitemap index

### DIFF
--- a/chsdi/lib/validation/sitemaps.py
+++ b/chsdi/lib/validation/sitemaps.py
@@ -7,13 +7,10 @@ class SiteMapValidation(object):
 
     def __init__(self):
         self._content = None
+        self._in_index = ['base', 'topics', 'layers']
         self._multi_sitemaps = ['addresses']
         self._multi_part = None
-        self._contents = [
-            'index',
-            'base',
-            'topics',
-            'layers'] + self._multi_sitemaps
+        self._contents = ['index'] + self._in_index + self._multi_sitemaps
 
     @property
     def content(self):
@@ -39,8 +36,8 @@ class SiteMapValidation(object):
         self._content = value
 
     @property
-    def contents(self):
-        return self._contents
+    def in_index(self):
+        return self._in_index
 
     @property
     def multi_part(self):

--- a/chsdi/tests/integration/test_sitemap.py
+++ b/chsdi/tests/integration/test_sitemap.py
@@ -22,6 +22,7 @@ class TestSitemapView(TestsBase):
     def __init__(self, other):
         super(TestsBase, self).__init__(other)
         self.sitemaps_with_urls = ['base', 'topics', 'layers']
+        self.sitemaps_notin_index = ['index', 'addresses']
 
     def test_no_parameter_failure(self):
         resp = self.testapp.get('/sitemap', status=400)
@@ -41,6 +42,10 @@ class TestSitemapView(TestsBase):
         # contains all links
         for urlbase in self.sitemaps_with_urls:
             resp.mustcontain('sitemap_' + urlbase + '.xml')
+        # does not contain
+        for urlbase in self.sitemaps_notin_index:
+            self.failUnless('sitemap_' + urlbase + '.xml' not in resp.body)
+
         # contains correct domain
         self.failUnless(self.testapp.app.registry.settings.get('geoadminhost') in resp.body)
         # validate scheme

--- a/chsdi/views/sitemaps.py
+++ b/chsdi/views/sitemaps.py
@@ -48,12 +48,10 @@ def sitemap(request):
 
 
 def index(params):
-    # We don't want to include a self-reference
-    filteredlist = filter(lambda x: x != 'index', params.contents)
     buildFileNames = lambda x: params.basename + '_' + x + '.xml'
     data = {
         'host': params.host,
-        'sitemaps': map(buildFileNames, filteredlist)
+        'sitemaps': map(buildFileNames, params.in_index)
     }
 
     response = render_to_response(


### PR DESCRIPTION
As sitemaps indices are not allowed to have other sitemap indices, we need to adapt our sitemap service to reflect that. See https://productforums.google.com/forum/#!topic/webmasters/6UyJ3pfRXZk and the related PR @ https://github.com/geoadmin/mf-geoadmin3/pull/1566
