### PR TITLE
Rely on the same information for topic filtering

### DIFF
--- a/chsdi/lib/validation/__init__.py
+++ b/chsdi/lib/validation/__init__.py
@@ -11,10 +11,8 @@ class MapNameValidation(object):
         availableMaps = [q[0] for q in db.query(Topics.id)]
         # FIXME add this info in DB
         availableMaps.append('all')
-        availableMaps.append('api')
         availableMaps.append('api-free')
         availableMaps.append('api-notfree')
-        availableMaps.append('swissmaponline')
 
         if mapName not in availableMaps:
             raise HTTPBadRequest('The map you provided does not exist')

--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -15,7 +15,8 @@ class Bod(object):
     idGeoCat = Column('geocat_uuid', Text)
     name = Column('kurzbezeichnung', Text)
     fullName = Column('bezeichnung', Text)
-    maps = Column('projekte', Text)  # The topics
+    maps = Column('topics', Text)  # The topics
+    chargeable = Column('chargeable', Boolean)
     dataOwner = Column('datenherr', Text)
     abstract = Column('abstract', Text)
     dataStatus = Column('datenstand', Text)
@@ -74,6 +75,7 @@ class LayersConfig(Base):
     timestamps = Column('timestamps', postgresql.ARRAY(Text))
     timeBehaviour = Column('time_behaviour', Text)
     maps = Column('topics', Text)
+    chargeable = Column('chargeable', Boolean)
     staging = Column('staging', Text)
     wmsLayers = Column('wms_layers', Text)
     wmsUrl = Column('wms_url', Text)
@@ -166,6 +168,8 @@ class GetCap(object):
     wms_kontakt_name = Column('wms_kontakt_name', Text)
     zoomlevel_min = Column('zoomlevel_min', Integer)
     zoomlevel_max = Column('zoomlevel_max', Integer)
+    maps = Column('topics', Text)  # the topics
+    chargeable = Column('chargeable', Boolean)
 
 
 class GetCapFr(Base, GetCap):

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -138,7 +138,7 @@ def get_layers_metadata_for_params(params, query, model, layerIds=None):
     layer metadata dictionaries. '''
     query = filter_by_map_name(
         query,
-        model.maps,
+        model,
         params.mapName
     )
     query = filter_by_geodata_staging(
@@ -159,16 +159,11 @@ def get_layers_config_for_params(params, query, model, layerIds=None):
     ''' Returns a generator function that yields
     layer config dictionaries. '''
     model = LayersConfig
-    bgLayers = True
-    if params.mapName != 'all':
-        clauses = [model.maps.ilike('%%%s%%' % params.mapName), model.background == bgLayers]
-        # we also want to always include all 'ech' layers (except for api's)
-        if (params.mapName != 'api-notfree' and
-                params.mapName != 'api-free' and
-                params.mapName != 'api'):
-            clauses.append(model.maps.ilike('%%%s%%' % 'ech'))
-        query = query.filter(or_(*clauses))
-
+    query = filter_by_map_name(
+        query,
+        model,
+        params.mapName
+    )
     query = filter_by_geodata_staging(
         query,
         model.staging,

--- a/chsdi/views/wmtscapabilities.py
+++ b/chsdi/views/wmtscapabilities.py
@@ -29,8 +29,7 @@ class WMTSCapabilites(MapNameValidation):
 
         layers_query = self.request.db.query(self.models['GetCap'])
         if self.mapName != 'all':
-            layers_query = layers_query.filter(self.models['GetCap']
-                                               .projekte.ilike('%%%s%%' % self.mapName))
+            layers_query = filter_by_map_name(query, self.models['GetCap'], self.mapName)
         layers = layers_query.all()
 
         if hasattr(self.models['GetCapThemes'], 'oberthema_id'):


### PR DESCRIPTION
This PR reflects the changes operated in the BOD.
See:
https://github.com/geoadmin/mf-chsdi3/issues/891

Now all the services use a unique method for topic filtering.

Flat topics `api` and `swissmaponline` have been added to the table topics.

`api-free`, `api-notfree` topics don't exist anymore, they are simulated in `filter_by_map_name`

Please test, twice rather than once.
