### PR TITLE
Stateless print by using results from shared filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ MANIFEST
 buildout_branch.cfg
 deploy/deploy-branch.cfg
 deploy/conf/00-branch.conf
+print/WEB-INF/web.xml

--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -3,18 +3,20 @@
     Allow from all
 </Proxy>
 
-# Stateful cookies
-<LocationMatch ${apache_entry_path}/print/>
-    Header set Set-Cookie "SRV=${hostname-digest}; path=${apache_entry_path}/print/"
-</LocationMatch>
-
-ProxyPass ${apache_entry_path}/print/ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/
+# JSON print requests to print server
+ProxyPassMatch ${apache_entry_path}/print/(info|create)\.json$ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/$1.json
 ProxyPassReverse ${apache_entry_path}/print/ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/
 
-# Try to force IE to open the PDF in a new window
-# overriding what set by the print server
-SetEnvIf Request_URI "\.pdf$" PDF=pdf
-SetEnvIf User-Agent .*MSIE.* IE=ie
-Header set Content-Disposition "inline" env=IE
-Header set Content-Type "application/octet-stream" env=PDF
+# Get resulting files directly from filesystem
+AliasMatch ^${apache_entry_path}/print/([0-9]+\.pdf\.printout)$ ${print_temp_dir}/mapfish-print$1
+
+<LocationMatch ^${apache_entry_path}/print/([0-9]+\.pdf\.printout)$ >
+  Header set Content-Disposition "attachment; filename=map.geo.admin.ch.pdf"
+  # Try to force IE to open the PDF in a new window
+  # overriding what set by the print server
+  SetEnvIf Request_URI "\.pdf$" PDF=pdf
+  SetEnvIf User-Agent .*MSIE.* IE=ie
+  Header set Content-Disposition "inline" env=IE
+  Header set Content-Type "application/octet-stream" env=PDF
+</LocationMatch>
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -108,8 +108,6 @@ geodata_staging = prod
 # the Unix user under which the modwsgi daemon processes are executed,
 # can be overriden in development-specific buildout config files
 modwsgi_user = www-data
-# cookie session secret
-authtkt_secret = __import__('uuid').uuid4().hex
 # database host
 dbhost = localhost
 # database port
@@ -128,6 +126,8 @@ robots_file = robots.txt
 deploy_target = prod
 #wsgi daemon threads
 wsgi_threads=30
+# print files directory
+print_temp_dir = /var/cache/print
 
 [mapproxy]
 recipe = collective.recipe.cmd
@@ -170,10 +170,7 @@ config-file = ${buildout:directory}/production.ini
 recipe = z3c.recipe.filetemplate
 source-directory = .
 exclude-directories = buildout
-interpreted-options = authtkt_secret
 interpreted-options = app_version = __import__('time').strftime('%s')
-                      hostname = __import__('socket').gethostname()
-                      hostname-digest = __import__('hashlib').md5(options.get('hostname')).hexdigest()
                       apache_entry_path = '' if options.get('apache_base_path') == 'main' else ('/' + options.get('apache_base_path'))
                       git_branch = __import__('subprocess').check_output(['git', 'rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']).rstrip()
 
@@ -276,7 +273,6 @@ cmds =
 [nosetest-ini]
 recipe = z3c.recipe.filetemplate
 files = production.ini development.ini
-interpreted-options = authtkt_secret
 interpreted-options = app_version = __import__('time').strftime('%s')
                       apache_entry_path = '' if options.get('apache_base_path') == 'main' else ('/' + options.get('apache_base_path'))
 extends = vars

--- a/print/WEB-INF/web.xml.in
+++ b/print/WEB-INF/web.xml.in
@@ -59,7 +59,7 @@
     </init-param>
     <init-param>
       <param-name>tempdir</param-name>
-      <param-value>/var/cache/print</param-value>
+      <param-value>${print_temp_dir}</param-value>
     </init-param>
   </servlet>
   <servlet-mapping>

--- a/print/config.yaml
+++ b/print/config.yaml
@@ -17,8 +17,6 @@ hosts:
 #
 scales: [2500000, 1500000, 1000000, 500000, 200000, 100000, 50000, 25000, 20000, 10000, 5000, 2500, 1000, 500]
 
-outputFilename: 'map.geo.admin.ch.pdf'
-
 globalParallelFetches: 32
 perHostParallelFetches: 32
 connectionTimeout: 30000


### PR DESCRIPTION
This removes the stateful print. It gets the resulting file directly from the filesystem. In our case, the filesystem must point to a directory shared by all instances. We have this in the VPC with Zadara.

Only merge/test together with PR in ga3.
Only merge when we are fully in the VPC (this won't work on the classic instances)

When it's merged, we can remove the stateful configuration from our varnishes.
