### PR TITLE
Remove link_tests for nose test runs on deploy

### DIFF
--- a/deploy/hooks/pre-create-code.in
+++ b/deploy/hooks/pre-create-code.in
@@ -12,6 +12,6 @@ echo "running unit tests (wd: '$(pwd)')"
 
 buildout/bin/nosetests chsdi/tests/functional
 
-buildout/bin/nosetests # > /dev/null 2>&1
+buildout/bin/nosetests -e test_external_links # > /dev/null 2>&1
 
 exit $?

--- a/nose_run.sh
+++ b/nose_run.sh
@@ -22,7 +22,7 @@ shift $((OPTIND-1))
 mv -f production.ini production.ini.bup
 mv -f development.ini development.ini.bup
 
-buildout/bin/buildout -c $conf_to_use install nosetest-ini && buildout/bin/nosetests
+buildout/bin/buildout -c $conf_to_use install nosetest-ini && buildout/bin/nosetests -e test_external_links
 
 rc=$?
 


### PR DESCRIPTION
This exclude the link_tests nosetests from nosetests run at deployment time. Those links are quite unstable and fail often when building with jenkins as well.

They can always be run manually.
