### PR TITLE
Fix Shapely version

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ In order to reinitialize your project and remove unused eggs do the following co
 
 `buildout_cleaner.cfg` will move all the unused eggs into `buildout/old-eggs/`, remove all the `*.mo` translation files, uninstall all the templates and remove all the `*.pyc` files.
 
+If buildout failed previously, you might need to bootstrap the project again, use the following command after the buildout cleaner:
+
+    python bootstrap.py --version 1.5.2 --distribute --download-base http://pypi.camptocamp.net/distribute-0.6.22_fix-issue-227/ --setup-source http://pypi.camptocamp.net/distribute-0.6.22_fix-issue-227/distribute_setup.py
+
 # Python Code Styling
 
 We are currently using the PEP 8 convention for Python code.

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -71,6 +71,7 @@ PyYAML = 3.10
 qrcode = 4.0.4
 regex = 2014.02.19
 repoze.lru = 0.6
+shapely = 1.3.3
 simplejson = 3.1.0
 six = 1.3.0
 sphinx = 1.2.3


### PR DESCRIPTION
The latest version of Shapely (1.4.0) is not compatible with our current configuration and therefore the project installation fails.

This PR fixes this issue by telling buildout to use version 1.3.3 of Shapely.

Please merge ASAP
