### PR TITLE
fix wrong attribute name in template

### DIFF
--- a/chsdi/templates/htmlpopup/geocover_point_info.mako
+++ b/chsdi/templates/htmlpopup/geocover_point_info.mako
@@ -1,6 +1,6 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c,lang)">
-    <tr><td class="cell-left">${_('geocover_id_geol')}</td><td>${c['attributes']['id_geol'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('geocover_basisdatensatz')}</td><td>${c['attributes']['basisdatensatz'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('geocover_description')}</td><td>${c['attributes']['description'] or '-'}</td></tr>
 </%def>


### PR DESCRIPTION
fixes http://api3.geo.admin.ch/1410241912/rest/services/ech/MapServer/ch.swisstopo.geologie-geocover/607526/htmlPopup?imageDisplay=1624,1028,96&lang=de&mapExtent=583557.0155328292,191761.06718554336,587617.0155328292,194331.06718554336
