### PR TITLE
Enable creation of snapshots from branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ deploy process is done.
 
 `./deploydev.sh -s`
 
+Alternatively use the following command to create a snapshot from a branch (Only for emergency deploy)
+
+`./deploydev.sh -s somebranchname`
+
 This updates the source in /var/www...to the latest master branch from github,
 creates a snapshot and runs nosetests against the test db. The snapshot directory
 will be shown when the script is done. *Note*: you can omit the `-s` parameter if

--- a/deploydev.sh
+++ b/deploydev.sh
@@ -8,19 +8,21 @@ umask 0002
 #bail out on any error
 set -o errexit
 
-# adapt these for emergency deploy coming from branches
-GITBRANCH=master
-
 # set some variables
 DEPLOYDIR=/var/www/vhosts/mf-chsdi3/private/chsdi/
 SNAPSHOT=`date '+%Y%m%d%H%M'`
 SNAPSHOTDIR=/var/www/vhosts/mf-chsdi3/private/snapshots/$SNAPSHOT
 
 # parse parameter (if -n is specified, no snapshot will be created)
+GITBRANCH=master
 CREATE_SNAPSHOT='false'
 if [ "$1" == "-s" ]
 then
   CREATE_SNAPSHOT='true'
+  if [ -n "$2" ]
+  then
+    GITBRANCH=$2
+  fi
 fi
 
 # build latest 'master' version on dev


### PR DESCRIPTION
Basic usage hasn't changed

If no param is provided then deploy master to test without snapshot
If `-s` is provided then deploy to dev and create a snapshot

<pre>
./deploydev.sh -s somebranch
</pre>

deploys a branch to dev and creates a snapshot
