### PR TITLE
fullres preview will only be visible if the database is up to date

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -227,7 +227,7 @@ viewer_url = get_viewer_url(request, params)
   </div>
   <br>
 
-% if preview_url != "":
+% if preview_url != "" and c['attributes']['image_width']:
   <span class="chsdi-no-print">${_('tt_luftbilderOL')}<a href="${viewer_url}" target="_blank" alt="Fullscreen">(fullscreen)</a></span>
   <div class="chsdi-map-container table-with-border">
     <div id="lubismap"></div>
@@ -266,7 +266,7 @@ viewer_url = get_viewer_url(request, params)
       map.highlightFeature('${c['layerBodId']}', '${c['featureId']}');
       map.recenterFeature('${c['layerBodId']}', '${c['featureId']}');
 
-% if preview_url != "":
+% if preview_url != "" and c['attributes']['image_width']:
       ${lubis_map.init_map(c['featureId'], image_width, image_height, 0, 'lubismap')}
 %endif
 


### PR DESCRIPTION
Since the gis center is now creating the lubis fullres tiles continuosly, our catalog will be out of date soon.
the current implementation of the lubis tooltip mako is showing the fullres viewer in the extended tooltip when the 0 tile and the quickview exists.
this pr adds an addional test, the database has to be up to date, means the width information has to be there.

So this
**example 1: Image has been created (0tile and quickview exist but our table is out of date):**
http://api3.geo.admin.ch/rest/services/swisstopo/MapServer/ch.swisstopo.lubis-luftbilder_schwarzweiss/19821070043961/extendedHtmlPopup?lang=de

will be changed to this:
**example 2: Image has not yet been created**
http://api3.geo.admin.ch/rest/services/swisstopo/MapServer/ch.swisstopo.lubis-luftbilder_schwarzweiss/20090660026102/extendedHtmlPopup?lang=de
