### PR TITLE
Use same GeoRaster instances for height and profile

### DIFF
--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from chsdi.renderers import EsriJSON, CSVRenderer
 from chsdi.models import initialize_sql
 from papyrus.renderers import GeoJSON
+from chsdi.lib.raster.georaster import init_rasterfiles
 
 
 def db(request):
@@ -30,6 +31,9 @@ def main(global_config, **settings):
     app_version = settings.get('app_version')
     settings['app_version'] = app_version
     config = Configurator(settings=settings)
+
+    # init raster files for height/profile and preload COMB file
+    init_rasterfiles(settings.get('data_path'), ['COMB'])
 
     # configure 'locale' dir as the translation dir for chsdi app
     config.add_translation_dirs('chsdi:locale/')

--- a/chsdi/lib/raster/georaster.py
+++ b/chsdi/lib/raster/georaster.py
@@ -4,6 +4,29 @@ import shputils
 from os.path import dirname
 from struct import unpack
 
+# cache of GeoRaster instances in function of the layer name
+_rasters = {}
+_rasterfiles = {}
+
+def get_raster(name):
+    global _rasters
+    result = _rasters.get(name, None)
+    if not result:
+        result = GeoRaster(_rasterfiles[name])
+        _rasters[name] = result
+    return result
+
+def init_rasterfiles(datapath, preloadtypes):
+    base_path = 'bund/swisstopo/'
+    global _rasterfiles
+    _rasterfiles = {
+        'DTM25': datapath + base_path + 'dhm25_25_matrix/mm0001.shp',
+        'DTM2': datapath + base_path + 'swissalti3d/2m/index.shp',
+        'COMB': datapath + base_path + 'swissalti3d/kombo_2m_dhm25/index.shp'
+    }
+    for pt in preloadtypes:
+        get_raster(pt)
+
 class Tile(object):
     def __init__(self, minX, minY, maxX, maxY, filename):
         self.minX=minX

--- a/chsdi/views/height.py
+++ b/chsdi/views/height.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from chsdi.lib.validation.height import HeightValidation
-from chsdi.lib.raster.georaster import GeoRaster
+from chsdi.lib.raster.georaster import get_raster
 
 from pyramid.view import view_config
-
-# cache of GeoRaster instances in function of the layer name
-_rasters = {}
 
 
 class Height(HeightValidation):
@@ -31,30 +28,10 @@ class Height(HeightValidation):
 
     @view_config(route_name='height', renderer='jsonp', http_cache=0)
     def height(self):
-        rasters = [self._get_raster(layer) for layer in self.layers]
+        rasters = [get_raster(layer) for layer in self.layers]
         alt = self._filter_alt(rasters[0].getVal(self.lon, self.lat))
 
         return {'height': str(alt)}
-
-    def _get_raster(self, layer):
-        result = _rasters.get(layer, None)
-        if not result:
-            result = GeoRaster(self._get_raster_files()[layer])
-            _rasters[layer] = result
-        return result
-
-    def _get_raster_files(self):
-        """Returns the raster filename in function of its layer name"""
-        base_path = 'bund/swisstopo/'
-        return {
-            'DTM25': self.request.registry.settings[
-                'data_path'] + base_path + 'dhm25_25_matrix/mm0001.shp',
-            'DTM2': self.request.registry.settings[
-                'data_path'] + base_path + 'swissalti3d/2m/index.shp',
-            'COMB': self.request.registry.settings[
-                'data_path'] + base_path +
-            'swissalti3d/kombo_2m_dhm25/index.shp'
-        }
 
     def _filter_alt(self, alt):
         if alt is not None and alt > 0.0:


### PR DESCRIPTION
Height and profile used to different instances of GeoRaster (representing the shapefile), which resulted in unneeded duplication of code and memory overhead.

This PR assures that the same GeoRaster is used for both services.

In addition, we now pre-load the COMB file on start of the application. This reduces the response time on the first call to height or profile considerably.
