### PR TITLE
made ows:Metadata link to the geocat metadata for the given layer in WMT...

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -171,6 +171,7 @@ class GetCap(object):
     zoomlevel_max = Column('zoomlevel_max', Integer)
     maps = Column('topics', Text)  # the topics
     chargeable = Column('chargeable', Boolean)
+    idGeoCat = Column('idgeocat', Text)
 
 
 class GetCapFr(Base, GetCap):

--- a/chsdi/templates/wmtscapabilities.mako
+++ b/chsdi/templates/wmtscapabilities.mako
@@ -56,7 +56,7 @@
                 <ows:UpperCorner>11.47757 48.230651</ows:UpperCorner>
             </ows:WGS84BoundingBox>
             <ows:Identifier>${layer.id|x,trim}</ows:Identifier>
-            <ows:Metadata xlink:href="http://www.swisstopo.admin.ch/SITiled/world/AdminBoundaries/metadata.htm"/>
+            <ows:Metadata xlink:href="http://www.geocat.ch/geonetwork/srv/deu/metadata.show?uuid=${layer.idGeoCat}"/>
             <Style>
                 <ows:Title>${layer.kurzbezeichnung|x,trim}</ows:Title>
                 <ows:Identifier>${layer.id|x,trim}</ows:Identifier>


### PR DESCRIPTION
made ows:Metadata link to the geocat metadata for the given layer in WMTS GetCap

fixes issue https://github.com/geoadmin/mf-chsdi3/issues/1041

I had to add a column in re3.view_bod_wmts_getcapabilities_*, but it's working fine
