### PR TITLE
CadastralWebMap WMTS form WMS

### DIFF
--- a/apache/mapproxy.conf.in
+++ b/apache/mapproxy.conf.in
@@ -9,7 +9,7 @@ ExpiresActive On
 RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.EPSG.(\d+).xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,PT]
 RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml [L,PT]
 
-RewriteRule ^${apache_entry_path}/1.0.0/(.*)/default/(\d+)/(\d+)/(.*)   ${apache_entry_path}/mapproxy/wmts/1.0.0/$1_$2/default/$2/epsg_$3/$4 [L,PT]
+RewriteRule ^${apache_entry_path}/1.0.0/(.*)/default/(\d+|current|default)/(\d+)/(.*)   ${apache_entry_path}/mapproxy/wmts/1.0.0/$1_$2/default/$2/epsg_$3/$4 [L,PT]
 
 WSGIDaemonProcess mf-chsdi3:${vars:apache_base_path}-mapproxy display-name=%{GROUP} user=${vars:modwsgi_user} ${vars:mapproxy_wsgi_options}
 
@@ -32,8 +32,8 @@ WSGIScriptAliasMatch ^${apache_entry_path}/mapproxy ${buildout:directory}/buildo
     Allow from all
 </Location>
 
-# Cache for timestamp keyword 'default'
-<LocationMatch "default/default/(.*)(jpg|jpeg|png)$">
+# Cache for timestamp keyword 'default', 'current' and '00000000' (cadastralwebmap)
+<LocationMatch "default/(current|default|00000000)/(.*)(jpg|jpeg|png)$">
     Header set Cache-Control "max-age=3600, public"
 </LocationMatch>
 

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -43,7 +43,7 @@ def main(global_config, **settings):
     # renderers
     config.add_renderer('.html', mako_renderer_factory)
     config.add_renderer('.js', mako_renderer_factory)
-    config.add_renderer('jsonp', JSONP(param_name='callback', indent=None, separators=(',',':')))
+    config.add_renderer('jsonp', JSONP(param_name='callback', indent=None, separators=(',', ':')))
     config.add_renderer('geojson', GeoJSON(jsonp_param_name='callback'))
     config.add_renderer('esrijson', EsriJSON(jsonp_param_name='callback'))
     config.add_renderer('csv', CSVRenderer)

--- a/chsdi/static/doc/examples/cadastralwebmap.html
+++ b/chsdi/static/doc/examples/cadastralwebmap.html
@@ -1,0 +1,47 @@
+<!--[if HTML5]><![endif]-->
+<!DOCTYPE html>
+  <head>
+    <!--[if !HTML5]>
+    <meta http-equiv="X-UA-Compatible" content="IE=9,IE=10,IE=edge,chrome=1"/>
+    <![endif]-->    
+    <meta charset="utf-8">    
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css">
+    <title>Cadastralwebmap as WMTS</title>
+    <style>
+        .ol-logo {
+            display: none;
+        }
+    </style>
+  </head>
+  <body>
+
+     <div class="container">
+
+    <h1>Cadastralwebmap as WMTS</h1>
+      <div class="row">
+        <div class="col-md-12">
+          
+          <h3>WMTS</h3>
+          <div id="map-left" style="width:100%; height:450px;"></div>
+          This examples shows how to use geo.admin.ch CadastralWebMap WMTS layers. The WMTS tiles are generated <em>on-the-fly</em>
+          by a MapProxy service and hold in cache for one hour. The only value for the <em>timestamp</em> dimension is <em>current</em>. Not other values
+          are possible as outlined in  the <a href="../1.0.0/WMTSCapabilities.xml" target="_blank">WMTS GetCapabilities</a>.<br>
+          <a href="cadastralwebmap.js">See the code</a><br>
+        </div>
+      <div class="row">
+        <div class="col-md-12">
+          <h3>Tiled WMS</h3>
+          <div id="map-right" style="width:100%; height:450px;"></div>
+          For comparison, the same layer and area, but as tiled WMS.<br>
+        </div>
+   </div>
+     <script src="/static/js/jquery-2.0.3.min.js"></script>
+     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
+    <script src="../uncached_loader.js" type="text/javascript"></script> 
+    <script src="cadastralwebmap.js" type="text/javascript"></script>
+  </body>
+</html>
+    

--- a/chsdi/static/doc/examples/cadastralwebmap.js
+++ b/chsdi/static/doc/examples/cadastralwebmap.js
@@ -1,0 +1,90 @@
+function qualifyURL(url) {
+  var a = document.createElement('a');
+  a.href = url;
+  return a.cloneNode(false).href;
+}
+
+var attributions = [new ol.Attribution({
+        html: '&copy; ' +
+            '<a href="http://www.geo.admin.ch/internet/geoportal/' +
+            'en/home.html">' +
+            'swisstopo / Amtliche Vermessung Schweiz/FL</a>'
+      })];
+
+var RESOLUTIONS = [
+  4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
+  1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5, 0.25, 0.1
+];
+var wmtsSource = function(layer, options) {
+  var resolutions = options.resolutions ? options.resolutions : RESOLUTIONS;
+  var tileGrid = new ol.tilegrid.WMTS({
+    origin: [420000, 350000],
+    resolutions: resolutions,
+    matrixIds: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+      17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]
+  });
+  var extension = options.format || 'png';
+  var timestamp = options['timestamps'];
+  return new ol.source.WMTS(({
+    //crossOrigin: 'anonymous',
+    attributions: attributions,
+    url: (qualifyURL('..') + '1.0.0/{Layer}/default/' +
+        timestamp + '/21781/' + '{TileMatrix}/{TileCol}/{TileRow}.') + extension,
+    tileGrid: tileGrid,
+    layer: options['serverLayerName'] ? options['serverLayerName'] : layer,
+    requestEncoding: 'REST'
+  }));
+};
+
+
+
+var wmtsCadastre = new ol.layer.Tile({
+    source: wmtsSource('ch.kantone.cadastralwebmap-farbe_wmts',
+        {
+            timestamps: ['current'],
+            format: 'png'
+        }
+      )
+});
+
+
+var extent = [420000, 30000, 900000, 350000];
+
+
+var wmsCadastre = new ol.layer.Tile({
+    extent: extent,
+    source: new ol.source.TileWMS({
+       url: 'http://wms.geo.admin.ch/',
+      //crossOrigin: 'anonymous',
+      attributions: attributions,
+      params: {
+        'LAYERS': 'ch.kantone.cadastralwebmap-farbe',
+        'FORMAT': 'image/png',
+        'TILED': true
+      },
+      serverType: 'mapserver'
+    })
+  });
+
+
+
+ var map_left = new ga.Map({
+    target: 'map-left',
+    layers: [wmtsCadastre],
+    view: new ol.View2D({
+      resolution: 1.0,
+     center: [502160, 125800]
+    })
+});
+
+var map_right = new ol.Map({
+  controls: ol.control.defaults({
+    attributionOptions: ({
+      collapsible: false
+    })
+  }),
+  layers: [wmsCadastre],
+  target: 'map-right'
+});
+
+map_right.bindTo('view', map_left);

--- a/chsdi/static/doc/source/api/examples.rst
+++ b/chsdi/static/doc/source/api/examples.rst
@@ -18,6 +18,7 @@ GeoAdmin Examples
 - `Catalog <../examples/geoadmin_catalog.html>`_
 - `Localisation <../examples/geoadmin_localisation.html>`_
 - `Pseudo-Mercator projection <../examples/ol3_mercator.html>`_
+- `CadastralWebMap as WMTS <../examples/cadastralwebmap.html>`_
 
 OpenLayers Examples
 -------------------

--- a/chsdi/templates/wmtscapabilities.mako
+++ b/chsdi/templates/wmtscapabilities.mako
@@ -4,7 +4,7 @@
   metadata = pageargs['metadata']
   themes = pageargs['themes']
   scheme = pageargs['scheme']
-  onlineressource = pageargs['onlineressource']
+  onlineressources = pageargs['onlineressources']
   tilematrixset = pageargs['tilematrixset']
   epsg = tilematrixset
   TileMatrixSet_epsg = "TileMatrixSet_%s.mako" % epsg
@@ -21,7 +21,7 @@
         <ows:Operation name="GetCapabilities">
             <ows:DCP>
                 <ows:HTTP>
-                    <ows:Get xlink:href="${onlineressource}1.0.0/WMTSCapabilities.xml">
+                    <ows:Get xlink:href="${onlineressources['s3']}1.0.0/WMTSCapabilities.xml">
                         <ows:Constraint name="GetEncoding">
                             <ows:AllowedValues>
                                 <ows:Value>REST</ows:Value>
@@ -34,7 +34,7 @@
         <ows:Operation name="GetTile">
             <ows:DCP>
                 <ows:HTTP>
-                    <ows:Get xlink:href="${onlineressource}">
+                    <ows:Get xlink:href="${onlineressources['s3']}">
                         <ows:Constraint name="GetEncoding">
                             <ows:AllowedValues>
                                 <ows:Value>REST</ows:Value>
@@ -48,6 +48,13 @@
     <Contents>
   ## Main loop
    % for layer in layers:
+<%
+if layer.id == 'ch.kantone.cadastralwebmap-farbe':
+     layer.timestamp='current'
+     onlineressource = onlineressources['mapproxy']
+else:
+     onlineressource = onlineressources['s3']
+%>
         <Layer>
             <ows:Title>${layer.kurzbezeichnung|x,trim}</ows:Title>
             <ows:Abstract>${layer.abstract|x,trim}</ows:Abstract>
@@ -73,6 +80,9 @@
             <Dimension>
                 <ows:Identifier>Time</ows:Identifier>
                 <Default>${str(layer.timestamp).split(',')[0]}</Default>
+                % if layer.id == 'ch.kantone.cadastralwebmap-farbe':
+                <Current>true</Current>
+                % endif
                 % for timestamp in layer.timestamp.split(','):
                 <Value>${timestamp}</Value>
                 % endfor

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -225,7 +225,7 @@ class TestSearchServiceView(TestsBase):
 
     def test_features_mix_timeinstant_timestamps(self):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features':
-        'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeInstant': '1952', 'timeStamps': '1946'}, status=400)
+                                                                           'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeInstant': '1952', 'timeStamps': '1946'}, status=400)
 
     def test_features_wrong_timestamps(self):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeStamps': '19522'}, status=400)

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -221,7 +221,6 @@ class Search(SearchValidation):
         if self.timeInstant is not None and self.timeStamps is not None:
             raise exc.HTTPBadRequest('You are not allowed to mix timeStamps and timeInstant parameters')
 
-
     def _get_geoanchor_from_bbox(self):
         centerX = (self.bbox[2] + self.bbox[0]) / 2
         centerY = (self.bbox[3] + self.bbox[1]) / 2
@@ -230,7 +229,7 @@ class Search(SearchValidation):
 
     def _feature_bbox_search(self):
         self._check_timeparameters()
-        
+
         timeFilter = {
             'type': None,
             'years': []

--- a/chsdi/views/wmtscapabilities.py
+++ b/chsdi/views/wmtscapabilities.py
@@ -40,8 +40,8 @@ class WMTSCapabilites(MapNameValidation):
         apache_base_path = self.request.registry.settings['apache_base_path']
         apache_entry_point = '/' if apache_base_path == 'main' else '/' + apache_base_path
 
-        onlineressource = "%s://%s%s/" % (scheme, host, apache_entry_point) if self.tileMatrixSet != '21781'\
-            else "%s://wmts.geo.admin.ch/" % scheme
+        # Default ressource
+        onlineressources = {'mapproxy': "%s://%s%s/" % (scheme, host, apache_entry_point), 's3': "%s://wmts.geo.admin.ch/" % scheme}
 
         layers_query = self.request.db.query(self.models['GetCap'])
         layers_query = filter_by_geodata_staging(
@@ -67,7 +67,7 @@ class WMTSCapabilites(MapNameValidation):
             'themes': themes,
             'metadata': metadata,
             'scheme': scheme,
-            'onlineressource': onlineressource,
+            'onlineressources': onlineressources,
             'tilematrixset': self.tileMatrixSet
         }
         response = render_to_response(

--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -1345,6 +1345,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache]
+  ch.bafu.wrz-wildruhezonen_portal_20141105_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_source]
+  ch.bafu.wrz-wildruhezonen_portal_20141105_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id019
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache]
   ch.bag.zecken-fsme-faelle_20121231_cache:
     disable_storage: true
     format: image/png
@@ -3649,6 +3661,12 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
+  ch.kantone.cadastralwebmap-farbe_wms_cache:
+    disable_storage: true
+    format: image/png
+    grids: [epsg_21781, epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    meta_size: [1, 1]
+    sources: [ch.kantone.cadastralwebmap-farbe_wms_source]
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache:
     disable_storage: true
     format: image/png
@@ -3757,6 +3775,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache]
+  ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_source]
+  ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id053
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   ch.swisstopo.dreiecksvermaschung_20061231_cache:
     disable_storage: true
     format: image/png
@@ -9847,6 +9877,14 @@ grids:
       1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5]
     srs: EPSG:2056
     stretch_factor: 1.0
+  epsg_21781:
+    bbox: [420000, 30000, 900000, 350000]
+    bbox_srs: EPSG:21781
+    origin: nw
+    res: [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250, 2000, 1750, 1500, 1250,
+      1000, 750, 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5, 0.25, 0.1]
+    srs: EPSG:21781
+    stretch_factor: 1.0
   epsg_3857: {base: GLOBAL_MERCATOR, num_levels: 18, origin: nw}
   epsg_4258:
     bbox: [420000, 30000, 900000, 350000]
@@ -9887,6 +9925,13 @@ layers:
 - name: osm
   sources: [osm_cache]
   title: OpenStreetMap
+- dimensions:
+    Time:
+      default: current
+      values: [current]
+  name: ch.kantone.cadastralwebmap-farbe_wmts_current
+  sources: [ch.kantone.cadastralwebmap-farbe_wms_cache]
+  title: CadastralWebMap
 - dimensions: &id100
     Time:
       default: '20140101'
@@ -11324,8453 +11369,8475 @@ layers:
   title: Teileinzugsgebiete 40km2
 - dimensions: &id209
     Time:
+      default: '20141105'
+      values: ['20141105']
+  name: ch.bafu.wrz-wildruhezonen_portal_20141105
+  sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache_out]
+  title: Wildruhezonen
+- dimensions: *id209
+  name: ch.bafu.wrz-wildruhezonen_portal
+  sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache]
+  title: Wildruhezonen
+- dimensions: *id209
+  name: ch.bafu.wrz-wildruhezonen_portal_20141105_source
+  sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache]
+  title: Wildruhezonen
+- dimensions: &id210
+    Time:
       default: '20140107'
       values: ['20140107']
   name: ch.bafu.wrz-wildruhezonen_portal_20140107
   sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache_out]
   title: Wildruhezonen
-- dimensions: *id209
-  name: ch.bafu.wrz-wildruhezonen_portal
-  sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache]
-  title: Wildruhezonen
-- dimensions: *id209
+- dimensions: *id210
   name: ch.bafu.wrz-wildruhezonen_portal_20140107_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache]
   title: Wildruhezonen
-- dimensions: &id210
+- dimensions: &id211
     Time:
       default: '20131118'
       values: ['20131118']
   name: ch.bafu.wrz-wildruhezonen_portal_20131118
   sources: [ch.bafu.wrz-wildruhezonen_portal_20131118_cache_out]
   title: Wildruhezonen
-- dimensions: *id210
+- dimensions: *id211
   name: ch.bafu.wrz-wildruhezonen_portal_20131118_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20131118_cache]
   title: Wildruhezonen
-- dimensions: &id211
+- dimensions: &id212
     Time:
       default: '20130111'
       values: ['20130111']
   name: ch.bafu.wrz-wildruhezonen_portal_20130111
   sources: [ch.bafu.wrz-wildruhezonen_portal_20130111_cache_out]
   title: Wildruhezonen
-- dimensions: *id211
+- dimensions: *id212
   name: ch.bafu.wrz-wildruhezonen_portal_20130111_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20130111_cache]
   title: Wildruhezonen
-- dimensions: &id212
+- dimensions: &id213
     Time:
       default: '20140220'
       values: ['20140220']
   name: ch.bag.zecken-fsme-faelle_20140220
   sources: [ch.bag.zecken-fsme-faelle_20140220_cache_out]
   title: "FSME - Lokale H\xE4ufungen"
-- dimensions: *id212
+- dimensions: *id213
   name: ch.bag.zecken-fsme-faelle
   sources: [ch.bag.zecken-fsme-faelle_20140220_cache]
   title: "FSME - Lokale H\xE4ufungen"
-- dimensions: *id212
+- dimensions: *id213
   name: ch.bag.zecken-fsme-faelle_20140220_source
   sources: [ch.bag.zecken-fsme-faelle_20140220_cache]
   title: "FSME - Lokale H\xE4ufungen"
-- dimensions: &id213
+- dimensions: &id214
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.bag.zecken-fsme-faelle_20121231
   sources: [ch.bag.zecken-fsme-faelle_20121231_cache_out]
   title: "FSME - Lokale H\xE4ufungen"
-- dimensions: *id213
+- dimensions: *id214
   name: ch.bag.zecken-fsme-faelle_20121231_source
   sources: [ch.bag.zecken-fsme-faelle_20121231_cache]
   title: "FSME - Lokale H\xE4ufungen"
-- dimensions: &id214
+- dimensions: &id215
     Time:
       default: '20140220'
       values: ['20140220']
   name: ch.bag.zecken-fsme-impfung_20140220
   sources: [ch.bag.zecken-fsme-impfung_20140220_cache_out]
   title: FSME - Impfempfehlung
-- dimensions: *id214
+- dimensions: *id215
   name: ch.bag.zecken-fsme-impfung
   sources: [ch.bag.zecken-fsme-impfung_20140220_cache]
   title: FSME - Impfempfehlung
-- dimensions: *id214
+- dimensions: *id215
   name: ch.bag.zecken-fsme-impfung_20140220_source
   sources: [ch.bag.zecken-fsme-impfung_20140220_cache]
   title: FSME - Impfempfehlung
-- dimensions: &id215
+- dimensions: &id216
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.bag.zecken-fsme-impfung_20121231
   sources: [ch.bag.zecken-fsme-impfung_20121231_cache_out]
   title: FSME - Impfempfehlung
-- dimensions: *id215
+- dimensions: *id216
   name: ch.bag.zecken-fsme-impfung_20121231_source
   sources: [ch.bag.zecken-fsme-impfung_20121231_cache]
   title: FSME - Impfempfehlung
-- dimensions: &id216
+- dimensions: &id217
     Time:
       default: '20110613'
       values: ['20110613']
   name: ch.bag.zecken-lyme_20110613
   sources: [ch.bag.zecken-lyme_20110613_cache_out]
   title: Borreliose Risikogebiete
-- dimensions: *id216
+- dimensions: *id217
   name: ch.bag.zecken-lyme
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete
-- dimensions: *id216
+- dimensions: *id217
   name: ch.bag.zecken-lyme_20110613_source
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete
-- dimensions: &id217
+- dimensions: &id218
     Time:
       default: '20140801'
       values: ['20140801']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache_out]
   title: Bundesinventar ISOS
-- dimensions: *id217
+- dimensions: *id218
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache]
   title: Bundesinventar ISOS
-- dimensions: *id217
+- dimensions: *id218
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache]
   title: Bundesinventar ISOS
-- dimensions: &id218
+- dimensions: &id219
     Time:
       default: '20131113'
       values: ['20131113']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache_out]
   title: Bundesinventar ISOS
-- dimensions: *id218
+- dimensions: *id219
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache]
   title: Bundesinventar ISOS
-- dimensions: &id219
+- dimensions: &id220
     Time:
       default: '20121218'
       values: ['20121218']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache_out]
   title: Bundesinventar ISOS
-- dimensions: *id219
+- dimensions: *id220
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache]
   title: Bundesinventar ISOS
-- dimensions: &id220
+- dimensions: &id221
     Time:
       default: '20120510'
       values: ['20120510']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache_out]
   title: Bundesinventar ISOS
-- dimensions: *id220
+- dimensions: *id221
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache]
   title: Bundesinventar ISOS
-- dimensions: &id221
+- dimensions: &id222
     Time:
       default: '20110915'
       values: ['20110915']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache_out]
   title: Bundesinventar ISOS
-- dimensions: *id221
+- dimensions: *id222
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache]
   title: Bundesinventar ISOS
-- dimensions: &id222
+- dimensions: &id223
     Time:
       default: '20120203'
       values: ['20120203']
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache_out]
   title: "UNESCO-Welterbe Kulturst\xE4tten"
-- dimensions: *id222
+- dimensions: *id223
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten"
-- dimensions: *id222
+- dimensions: *id223
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_source
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten"
-- dimensions: &id223
+- dimensions: &id224
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anbieter-eigenes_festnetz_20141021
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache_out]
   title: Anzahl Leitungsanbieter
-- dimensions: *id223
+- dimensions: *id224
   name: ch.bakom.anbieter-eigenes_festnetz
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache]
   title: Anzahl Leitungsanbieter
-- dimensions: *id223
+- dimensions: *id224
   name: ch.bakom.anbieter-eigenes_festnetz_20141021_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache]
   title: Anzahl Leitungsanbieter
-- dimensions: &id224
+- dimensions: &id225
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anbieter-eigenes_festnetz_20140625
   sources: [ch.bakom.anbieter-eigenes_festnetz_20140625_cache_out]
   title: Anzahl Leitungsanbieter
-- dimensions: *id224
+- dimensions: *id225
   name: ch.bakom.anbieter-eigenes_festnetz_20140625_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20140625_cache]
   title: Anzahl Leitungsanbieter
-- dimensions: &id225
+- dimensions: &id226
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anbieter-eigenes_festnetz_20131212
   sources: [ch.bakom.anbieter-eigenes_festnetz_20131212_cache_out]
   title: Anzahl Leitungsanbieter
-- dimensions: *id225
+- dimensions: *id226
   name: ch.bakom.anbieter-eigenes_festnetz_20131212_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20131212_cache]
   title: Anzahl Leitungsanbieter
-- dimensions: &id226
+- dimensions: &id227
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anbieter-eigenes_festnetz_20130901
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130901_cache_out]
   title: Anzahl Leitungsanbieter
-- dimensions: *id226
+- dimensions: *id227
   name: ch.bakom.anbieter-eigenes_festnetz_20130901_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130901_cache]
   title: Anzahl Leitungsanbieter
-- dimensions: &id227
+- dimensions: &id228
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anbieter-eigenes_festnetz_20130601
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130601_cache_out]
   title: Anzahl Leitungsanbieter
-- dimensions: *id227
+- dimensions: *id228
   name: ch.bakom.anbieter-eigenes_festnetz_20130601_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130601_cache]
   title: Anzahl Leitungsanbieter
-- dimensions: &id228
+- dimensions: &id229
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anbieter-eigenes_festnetz_20121222
   sources: [ch.bakom.anbieter-eigenes_festnetz_20121222_cache_out]
   title: Anzahl Leitungsanbieter
-- dimensions: *id228
+- dimensions: *id229
   name: ch.bakom.anbieter-eigenes_festnetz_20121222_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20121222_cache]
   title: Anzahl Leitungsanbieter
-- dimensions: &id229
+- dimensions: &id230
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-glasfaser_20141021
   sources: [ch.bakom.anschlussart-glasfaser_20141021_cache_out]
   title: Glasfaser
-- dimensions: *id229
+- dimensions: *id230
   name: ch.bakom.anschlussart-glasfaser
   sources: [ch.bakom.anschlussart-glasfaser_20141021_cache]
   title: Glasfaser
-- dimensions: *id229
+- dimensions: *id230
   name: ch.bakom.anschlussart-glasfaser_20141021_source
   sources: [ch.bakom.anschlussart-glasfaser_20141021_cache]
   title: Glasfaser
-- dimensions: &id230
+- dimensions: &id231
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-glasfaser_20140625
   sources: [ch.bakom.anschlussart-glasfaser_20140625_cache_out]
   title: Glasfaser
-- dimensions: *id230
+- dimensions: *id231
   name: ch.bakom.anschlussart-glasfaser_20140625_source
   sources: [ch.bakom.anschlussart-glasfaser_20140625_cache]
   title: Glasfaser
-- dimensions: &id231
+- dimensions: &id232
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-glasfaser_20131212
   sources: [ch.bakom.anschlussart-glasfaser_20131212_cache_out]
   title: Glasfaser
-- dimensions: *id231
+- dimensions: *id232
   name: ch.bakom.anschlussart-glasfaser_20131212_source
   sources: [ch.bakom.anschlussart-glasfaser_20131212_cache]
   title: Glasfaser
-- dimensions: &id232
+- dimensions: &id233
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-glasfaser_20130901
   sources: [ch.bakom.anschlussart-glasfaser_20130901_cache_out]
   title: Glasfaser
-- dimensions: *id232
+- dimensions: *id233
   name: ch.bakom.anschlussart-glasfaser_20130901_source
   sources: [ch.bakom.anschlussart-glasfaser_20130901_cache]
   title: Glasfaser
-- dimensions: &id233
+- dimensions: &id234
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-glasfaser_20130601
   sources: [ch.bakom.anschlussart-glasfaser_20130601_cache_out]
   title: Glasfaser
-- dimensions: *id233
+- dimensions: *id234
   name: ch.bakom.anschlussart-glasfaser_20130601_source
   sources: [ch.bakom.anschlussart-glasfaser_20130601_cache]
   title: Glasfaser
-- dimensions: &id234
+- dimensions: &id235
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-glasfaser_20121222
   sources: [ch.bakom.anschlussart-glasfaser_20121222_cache_out]
   title: Glasfaser
-- dimensions: *id234
+- dimensions: *id235
   name: ch.bakom.anschlussart-glasfaser_20121222_source
   sources: [ch.bakom.anschlussart-glasfaser_20121222_cache]
   title: Glasfaser
-- dimensions: &id235
+- dimensions: &id236
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-koaxialkabel_20141021
   sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache_out]
   title: Koaxial-Kabel
-- dimensions: *id235
+- dimensions: *id236
   name: ch.bakom.anschlussart-koaxialkabel
   sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache]
   title: Koaxial-Kabel
-- dimensions: *id235
+- dimensions: *id236
   name: ch.bakom.anschlussart-koaxialkabel_20141021_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache]
   title: Koaxial-Kabel
-- dimensions: &id236
+- dimensions: &id237
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-koaxialkabel_20140625
   sources: [ch.bakom.anschlussart-koaxialkabel_20140625_cache_out]
   title: Koaxial-Kabel
-- dimensions: *id236
+- dimensions: *id237
   name: ch.bakom.anschlussart-koaxialkabel_20140625_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20140625_cache]
   title: Koaxial-Kabel
-- dimensions: &id237
+- dimensions: &id238
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-koaxialkabel_20131212
   sources: [ch.bakom.anschlussart-koaxialkabel_20131212_cache_out]
   title: Koaxial-Kabel
-- dimensions: *id237
+- dimensions: *id238
   name: ch.bakom.anschlussart-koaxialkabel_20131212_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20131212_cache]
   title: Koaxial-Kabel
-- dimensions: &id238
+- dimensions: &id239
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-koaxialkabel_20130901
   sources: [ch.bakom.anschlussart-koaxialkabel_20130901_cache_out]
   title: Koaxial-Kabel
-- dimensions: *id238
+- dimensions: *id239
   name: ch.bakom.anschlussart-koaxialkabel_20130901_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20130901_cache]
   title: Koaxial-Kabel
-- dimensions: &id239
+- dimensions: &id240
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-koaxialkabel_20130601
   sources: [ch.bakom.anschlussart-koaxialkabel_20130601_cache_out]
   title: Koaxial-Kabel
-- dimensions: *id239
+- dimensions: *id240
   name: ch.bakom.anschlussart-koaxialkabel_20130601_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20130601_cache]
   title: Koaxial-Kabel
-- dimensions: &id240
+- dimensions: &id241
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-koaxialkabel_20121222
   sources: [ch.bakom.anschlussart-koaxialkabel_20121222_cache_out]
   title: Koaxial-Kabel
-- dimensions: *id240
+- dimensions: *id241
   name: ch.bakom.anschlussart-koaxialkabel_20121222_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20121222_cache]
   title: Koaxial-Kabel
-- dimensions: &id241
+- dimensions: &id242
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-kupferdraht_20141021
   sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache_out]
   title: Kupfer-Draht
-- dimensions: *id241
+- dimensions: *id242
   name: ch.bakom.anschlussart-kupferdraht
   sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache]
   title: Kupfer-Draht
-- dimensions: *id241
+- dimensions: *id242
   name: ch.bakom.anschlussart-kupferdraht_20141021_source
   sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache]
   title: Kupfer-Draht
-- dimensions: &id242
+- dimensions: &id243
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-kupferdraht_20140625
   sources: [ch.bakom.anschlussart-kupferdraht_20140625_cache_out]
   title: Kupfer-Draht
-- dimensions: *id242
+- dimensions: *id243
   name: ch.bakom.anschlussart-kupferdraht_20140625_source
   sources: [ch.bakom.anschlussart-kupferdraht_20140625_cache]
   title: Kupfer-Draht
-- dimensions: &id243
+- dimensions: &id244
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-kupferdraht_20131212
   sources: [ch.bakom.anschlussart-kupferdraht_20131212_cache_out]
   title: Kupfer-Draht
-- dimensions: *id243
+- dimensions: *id244
   name: ch.bakom.anschlussart-kupferdraht_20131212_source
   sources: [ch.bakom.anschlussart-kupferdraht_20131212_cache]
   title: Kupfer-Draht
-- dimensions: &id244
+- dimensions: &id245
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-kupferdraht_20130901
   sources: [ch.bakom.anschlussart-kupferdraht_20130901_cache_out]
   title: Kupfer-Draht
-- dimensions: *id244
+- dimensions: *id245
   name: ch.bakom.anschlussart-kupferdraht_20130901_source
   sources: [ch.bakom.anschlussart-kupferdraht_20130901_cache]
   title: Kupfer-Draht
-- dimensions: &id245
+- dimensions: &id246
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-kupferdraht_20130601
   sources: [ch.bakom.anschlussart-kupferdraht_20130601_cache_out]
   title: Kupfer-Draht
-- dimensions: *id245
+- dimensions: *id246
   name: ch.bakom.anschlussart-kupferdraht_20130601_source
   sources: [ch.bakom.anschlussart-kupferdraht_20130601_cache]
   title: Kupfer-Draht
-- dimensions: &id246
+- dimensions: &id247
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-kupferdraht_20121222
   sources: [ch.bakom.anschlussart-kupferdraht_20121222_cache_out]
   title: Kupfer-Draht
-- dimensions: *id246
+- dimensions: *id247
   name: ch.bakom.anschlussart-kupferdraht_20121222_source
   sources: [ch.bakom.anschlussart-kupferdraht_20121222_cache]
   title: Kupfer-Draht
-- dimensions: &id247
+- dimensions: &id248
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink1_20141021
   sources: [ch.bakom.downlink1_20141021_cache_out]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: *id247
+- dimensions: *id248
   name: ch.bakom.downlink1
   sources: [ch.bakom.downlink1_20141021_cache]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: *id247
+- dimensions: *id248
   name: ch.bakom.downlink1_20141021_source
   sources: [ch.bakom.downlink1_20141021_cache]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: &id248
+- dimensions: &id249
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink1_20140625
   sources: [ch.bakom.downlink1_20140625_cache_out]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: *id248
+- dimensions: *id249
   name: ch.bakom.downlink1_20140625_source
   sources: [ch.bakom.downlink1_20140625_cache]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: &id249
+- dimensions: &id250
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink1_20131212
   sources: [ch.bakom.downlink1_20131212_cache_out]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: *id249
+- dimensions: *id250
   name: ch.bakom.downlink1_20131212_source
   sources: [ch.bakom.downlink1_20131212_cache]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: &id250
+- dimensions: &id251
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink1_20130901
   sources: [ch.bakom.downlink1_20130901_cache_out]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: *id250
+- dimensions: *id251
   name: ch.bakom.downlink1_20130901_source
   sources: [ch.bakom.downlink1_20130901_cache]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: &id251
+- dimensions: &id252
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink1_20130601
   sources: [ch.bakom.downlink1_20130601_cache_out]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: *id251
+- dimensions: *id252
   name: ch.bakom.downlink1_20130601_source
   sources: [ch.bakom.downlink1_20130601_cache]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: &id252
+- dimensions: &id253
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink1_20121222
   sources: [ch.bakom.downlink1_20121222_cache_out]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: *id252
+- dimensions: *id253
   name: ch.bakom.downlink1_20121222_source
   sources: [ch.bakom.downlink1_20121222_cache]
   title: "Download \u2265 1 Mbit/s"
-- dimensions: &id253
+- dimensions: &id254
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink10_20141021
   sources: [ch.bakom.downlink10_20141021_cache_out]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: *id253
+- dimensions: *id254
   name: ch.bakom.downlink10
   sources: [ch.bakom.downlink10_20141021_cache]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: *id253
+- dimensions: *id254
   name: ch.bakom.downlink10_20141021_source
   sources: [ch.bakom.downlink10_20141021_cache]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: &id254
+- dimensions: &id255
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink10_20140625
   sources: [ch.bakom.downlink10_20140625_cache_out]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: *id254
+- dimensions: *id255
   name: ch.bakom.downlink10_20140625_source
   sources: [ch.bakom.downlink10_20140625_cache]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: &id255
+- dimensions: &id256
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink10_20131212
   sources: [ch.bakom.downlink10_20131212_cache_out]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: *id255
+- dimensions: *id256
   name: ch.bakom.downlink10_20131212_source
   sources: [ch.bakom.downlink10_20131212_cache]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: &id256
+- dimensions: &id257
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink10_20130901
   sources: [ch.bakom.downlink10_20130901_cache_out]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: *id256
+- dimensions: *id257
   name: ch.bakom.downlink10_20130901_source
   sources: [ch.bakom.downlink10_20130901_cache]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: &id257
+- dimensions: &id258
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink10_20130601
   sources: [ch.bakom.downlink10_20130601_cache_out]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: *id257
+- dimensions: *id258
   name: ch.bakom.downlink10_20130601_source
   sources: [ch.bakom.downlink10_20130601_cache]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: &id258
+- dimensions: &id259
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink10_20121222
   sources: [ch.bakom.downlink10_20121222_cache_out]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: *id258
+- dimensions: *id259
   name: ch.bakom.downlink10_20121222_source
   sources: [ch.bakom.downlink10_20121222_cache]
   title: "Download \u2265 10 Mbit/s"
-- dimensions: &id259
+- dimensions: &id260
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink100_20141021
   sources: [ch.bakom.downlink100_20141021_cache_out]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: *id259
+- dimensions: *id260
   name: ch.bakom.downlink100
   sources: [ch.bakom.downlink100_20141021_cache]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: *id259
+- dimensions: *id260
   name: ch.bakom.downlink100_20141021_source
   sources: [ch.bakom.downlink100_20141021_cache]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: &id260
+- dimensions: &id261
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink100_20140625
   sources: [ch.bakom.downlink100_20140625_cache_out]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: *id260
+- dimensions: *id261
   name: ch.bakom.downlink100_20140625_source
   sources: [ch.bakom.downlink100_20140625_cache]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: &id261
+- dimensions: &id262
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink100_20131212
   sources: [ch.bakom.downlink100_20131212_cache_out]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: *id261
+- dimensions: *id262
   name: ch.bakom.downlink100_20131212_source
   sources: [ch.bakom.downlink100_20131212_cache]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: &id262
+- dimensions: &id263
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink100_20130901
   sources: [ch.bakom.downlink100_20130901_cache_out]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: *id262
+- dimensions: *id263
   name: ch.bakom.downlink100_20130901_source
   sources: [ch.bakom.downlink100_20130901_cache]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: &id263
+- dimensions: &id264
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink100_20130601
   sources: [ch.bakom.downlink100_20130601_cache_out]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: *id263
+- dimensions: *id264
   name: ch.bakom.downlink100_20130601_source
   sources: [ch.bakom.downlink100_20130601_cache]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: &id264
+- dimensions: &id265
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink100_20121222
   sources: [ch.bakom.downlink100_20121222_cache_out]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: *id264
+- dimensions: *id265
   name: ch.bakom.downlink100_20121222_source
   sources: [ch.bakom.downlink100_20121222_cache]
   title: "Download \u2265 100 Mbit/s"
-- dimensions: &id265
+- dimensions: &id266
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink2_20141021
   sources: [ch.bakom.downlink2_20141021_cache_out]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: *id265
+- dimensions: *id266
   name: ch.bakom.downlink2
   sources: [ch.bakom.downlink2_20141021_cache]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: *id265
+- dimensions: *id266
   name: ch.bakom.downlink2_20141021_source
   sources: [ch.bakom.downlink2_20141021_cache]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: &id266
+- dimensions: &id267
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink2_20140625
   sources: [ch.bakom.downlink2_20140625_cache_out]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: *id266
+- dimensions: *id267
   name: ch.bakom.downlink2_20140625_source
   sources: [ch.bakom.downlink2_20140625_cache]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: &id267
+- dimensions: &id268
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink2_20131212
   sources: [ch.bakom.downlink2_20131212_cache_out]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: *id267
+- dimensions: *id268
   name: ch.bakom.downlink2_20131212_source
   sources: [ch.bakom.downlink2_20131212_cache]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: &id268
+- dimensions: &id269
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink2_20130901
   sources: [ch.bakom.downlink2_20130901_cache_out]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: *id268
+- dimensions: *id269
   name: ch.bakom.downlink2_20130901_source
   sources: [ch.bakom.downlink2_20130901_cache]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: &id269
+- dimensions: &id270
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink2_20130601
   sources: [ch.bakom.downlink2_20130601_cache_out]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: *id269
+- dimensions: *id270
   name: ch.bakom.downlink2_20130601_source
   sources: [ch.bakom.downlink2_20130601_cache]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: &id270
+- dimensions: &id271
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink2_20121222
   sources: [ch.bakom.downlink2_20121222_cache_out]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: *id270
+- dimensions: *id271
   name: ch.bakom.downlink2_20121222_source
   sources: [ch.bakom.downlink2_20121222_cache]
   title: "Download \u2265 2 Mbit/s"
-- dimensions: &id271
+- dimensions: &id272
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink20_20141021
   sources: [ch.bakom.downlink20_20141021_cache_out]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: *id271
+- dimensions: *id272
   name: ch.bakom.downlink20
   sources: [ch.bakom.downlink20_20141021_cache]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: *id271
+- dimensions: *id272
   name: ch.bakom.downlink20_20141021_source
   sources: [ch.bakom.downlink20_20141021_cache]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: &id272
+- dimensions: &id273
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink20_20140625
   sources: [ch.bakom.downlink20_20140625_cache_out]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: *id272
+- dimensions: *id273
   name: ch.bakom.downlink20_20140625_source
   sources: [ch.bakom.downlink20_20140625_cache]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: &id273
+- dimensions: &id274
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink20_20131212
   sources: [ch.bakom.downlink20_20131212_cache_out]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: *id273
+- dimensions: *id274
   name: ch.bakom.downlink20_20131212_source
   sources: [ch.bakom.downlink20_20131212_cache]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: &id274
+- dimensions: &id275
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink20_20130901
   sources: [ch.bakom.downlink20_20130901_cache_out]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: *id274
+- dimensions: *id275
   name: ch.bakom.downlink20_20130901_source
   sources: [ch.bakom.downlink20_20130901_cache]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: &id275
+- dimensions: &id276
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink20_20130601
   sources: [ch.bakom.downlink20_20130601_cache_out]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: *id275
+- dimensions: *id276
   name: ch.bakom.downlink20_20130601_source
   sources: [ch.bakom.downlink20_20130601_cache]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: &id276
+- dimensions: &id277
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink20_20121222
   sources: [ch.bakom.downlink20_20121222_cache_out]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: *id276
+- dimensions: *id277
   name: ch.bakom.downlink20_20121222_source
   sources: [ch.bakom.downlink20_20121222_cache]
   title: "Download \u2265 20 Mbit/s"
-- dimensions: &id277
+- dimensions: &id278
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink50_20141021
   sources: [ch.bakom.downlink50_20141021_cache_out]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: *id277
+- dimensions: *id278
   name: ch.bakom.downlink50
   sources: [ch.bakom.downlink50_20141021_cache]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: *id277
+- dimensions: *id278
   name: ch.bakom.downlink50_20141021_source
   sources: [ch.bakom.downlink50_20141021_cache]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: &id278
+- dimensions: &id279
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink50_20140625
   sources: [ch.bakom.downlink50_20140625_cache_out]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: *id278
+- dimensions: *id279
   name: ch.bakom.downlink50_20140625_source
   sources: [ch.bakom.downlink50_20140625_cache]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: &id279
+- dimensions: &id280
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink50_20131212
   sources: [ch.bakom.downlink50_20131212_cache_out]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: *id279
+- dimensions: *id280
   name: ch.bakom.downlink50_20131212_source
   sources: [ch.bakom.downlink50_20131212_cache]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: &id280
+- dimensions: &id281
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink50_20130901
   sources: [ch.bakom.downlink50_20130901_cache_out]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: *id280
+- dimensions: *id281
   name: ch.bakom.downlink50_20130901_source
   sources: [ch.bakom.downlink50_20130901_cache]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: &id281
+- dimensions: &id282
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink50_20130601
   sources: [ch.bakom.downlink50_20130601_cache_out]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: *id281
+- dimensions: *id282
   name: ch.bakom.downlink50_20130601_source
   sources: [ch.bakom.downlink50_20130601_cache]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: &id282
+- dimensions: &id283
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink50_20121222
   sources: [ch.bakom.downlink50_20121222_cache_out]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: *id282
+- dimensions: *id283
   name: ch.bakom.downlink50_20121222_source
   sources: [ch.bakom.downlink50_20121222_cache]
   title: "Download \u2265 50 Mbit/s"
-- dimensions: &id283
+- dimensions: &id284
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink1_20141021
   sources: [ch.bakom.uplink1_20141021_cache_out]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: *id283
+- dimensions: *id284
   name: ch.bakom.uplink1
   sources: [ch.bakom.uplink1_20141021_cache]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: *id283
+- dimensions: *id284
   name: ch.bakom.uplink1_20141021_source
   sources: [ch.bakom.uplink1_20141021_cache]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: &id284
+- dimensions: &id285
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink1_20140625
   sources: [ch.bakom.uplink1_20140625_cache_out]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: *id284
+- dimensions: *id285
   name: ch.bakom.uplink1_20140625_source
   sources: [ch.bakom.uplink1_20140625_cache]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: &id285
+- dimensions: &id286
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink1_20131212
   sources: [ch.bakom.uplink1_20131212_cache_out]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: *id285
+- dimensions: *id286
   name: ch.bakom.uplink1_20131212_source
   sources: [ch.bakom.uplink1_20131212_cache]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: &id286
+- dimensions: &id287
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink1_20130901
   sources: [ch.bakom.uplink1_20130901_cache_out]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: *id286
+- dimensions: *id287
   name: ch.bakom.uplink1_20130901_source
   sources: [ch.bakom.uplink1_20130901_cache]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: &id287
+- dimensions: &id288
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink1_20130601
   sources: [ch.bakom.uplink1_20130601_cache_out]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: *id287
+- dimensions: *id288
   name: ch.bakom.uplink1_20130601_source
   sources: [ch.bakom.uplink1_20130601_cache]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: &id288
+- dimensions: &id289
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink1_20121222
   sources: [ch.bakom.uplink1_20121222_cache_out]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: *id288
+- dimensions: *id289
   name: ch.bakom.uplink1_20121222_source
   sources: [ch.bakom.uplink1_20121222_cache]
   title: "Upload \u2265 1 Mbit/s"
-- dimensions: &id289
+- dimensions: &id290
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink10_20141021
   sources: [ch.bakom.uplink10_20141021_cache_out]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: *id289
+- dimensions: *id290
   name: ch.bakom.uplink10
   sources: [ch.bakom.uplink10_20141021_cache]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: *id289
+- dimensions: *id290
   name: ch.bakom.uplink10_20141021_source
   sources: [ch.bakom.uplink10_20141021_cache]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: &id290
+- dimensions: &id291
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink10_20140625
   sources: [ch.bakom.uplink10_20140625_cache_out]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: *id290
+- dimensions: *id291
   name: ch.bakom.uplink10_20140625_source
   sources: [ch.bakom.uplink10_20140625_cache]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: &id291
+- dimensions: &id292
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink10_20131212
   sources: [ch.bakom.uplink10_20131212_cache_out]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: *id291
+- dimensions: *id292
   name: ch.bakom.uplink10_20131212_source
   sources: [ch.bakom.uplink10_20131212_cache]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: &id292
+- dimensions: &id293
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink10_20130901
   sources: [ch.bakom.uplink10_20130901_cache_out]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: *id292
+- dimensions: *id293
   name: ch.bakom.uplink10_20130901_source
   sources: [ch.bakom.uplink10_20130901_cache]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: &id293
+- dimensions: &id294
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink10_20130601
   sources: [ch.bakom.uplink10_20130601_cache_out]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: *id293
+- dimensions: *id294
   name: ch.bakom.uplink10_20130601_source
   sources: [ch.bakom.uplink10_20130601_cache]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: &id294
+- dimensions: &id295
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink10_20121222
   sources: [ch.bakom.uplink10_20121222_cache_out]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: *id294
+- dimensions: *id295
   name: ch.bakom.uplink10_20121222_source
   sources: [ch.bakom.uplink10_20121222_cache]
   title: "Upload \u2265 10 Mbit/s"
-- dimensions: &id295
+- dimensions: &id296
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink100_20141021
   sources: [ch.bakom.uplink100_20141021_cache_out]
   title: ch.bakom.uplink100
-- dimensions: *id295
+- dimensions: *id296
   name: ch.bakom.uplink100
   sources: [ch.bakom.uplink100_20141021_cache]
   title: ch.bakom.uplink100
-- dimensions: *id295
+- dimensions: *id296
   name: ch.bakom.uplink100_20141021_source
   sources: [ch.bakom.uplink100_20141021_cache]
   title: ch.bakom.uplink100
-- dimensions: &id296
+- dimensions: &id297
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink100_20140625
   sources: [ch.bakom.uplink100_20140625_cache_out]
   title: ch.bakom.uplink100
-- dimensions: *id296
+- dimensions: *id297
   name: ch.bakom.uplink100_20140625_source
   sources: [ch.bakom.uplink100_20140625_cache]
   title: ch.bakom.uplink100
-- dimensions: &id297
+- dimensions: &id298
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink100_20131212
   sources: [ch.bakom.uplink100_20131212_cache_out]
   title: ch.bakom.uplink100
-- dimensions: *id297
+- dimensions: *id298
   name: ch.bakom.uplink100_20131212_source
   sources: [ch.bakom.uplink100_20131212_cache]
   title: ch.bakom.uplink100
-- dimensions: &id298
+- dimensions: &id299
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink100_20130901
   sources: [ch.bakom.uplink100_20130901_cache_out]
   title: ch.bakom.uplink100
-- dimensions: *id298
+- dimensions: *id299
   name: ch.bakom.uplink100_20130901_source
   sources: [ch.bakom.uplink100_20130901_cache]
   title: ch.bakom.uplink100
-- dimensions: &id299
+- dimensions: &id300
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink100_20130601
   sources: [ch.bakom.uplink100_20130601_cache_out]
   title: ch.bakom.uplink100
-- dimensions: *id299
+- dimensions: *id300
   name: ch.bakom.uplink100_20130601_source
   sources: [ch.bakom.uplink100_20130601_cache]
   title: ch.bakom.uplink100
-- dimensions: &id300
+- dimensions: &id301
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink100_20121222
   sources: [ch.bakom.uplink100_20121222_cache_out]
   title: ch.bakom.uplink100
-- dimensions: *id300
+- dimensions: *id301
   name: ch.bakom.uplink100_20121222_source
   sources: [ch.bakom.uplink100_20121222_cache]
   title: ch.bakom.uplink100
-- dimensions: &id301
+- dimensions: &id302
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink2_20141021
   sources: [ch.bakom.uplink2_20141021_cache_out]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: *id301
+- dimensions: *id302
   name: ch.bakom.uplink2
   sources: [ch.bakom.uplink2_20141021_cache]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: *id301
+- dimensions: *id302
   name: ch.bakom.uplink2_20141021_source
   sources: [ch.bakom.uplink2_20141021_cache]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: &id302
+- dimensions: &id303
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink2_20140625
   sources: [ch.bakom.uplink2_20140625_cache_out]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: *id302
+- dimensions: *id303
   name: ch.bakom.uplink2_20140625_source
   sources: [ch.bakom.uplink2_20140625_cache]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: &id303
+- dimensions: &id304
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink2_20131212
   sources: [ch.bakom.uplink2_20131212_cache_out]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: *id303
+- dimensions: *id304
   name: ch.bakom.uplink2_20131212_source
   sources: [ch.bakom.uplink2_20131212_cache]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: &id304
+- dimensions: &id305
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink2_20130901
   sources: [ch.bakom.uplink2_20130901_cache_out]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: *id304
+- dimensions: *id305
   name: ch.bakom.uplink2_20130901_source
   sources: [ch.bakom.uplink2_20130901_cache]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: &id305
+- dimensions: &id306
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink2_20130601
   sources: [ch.bakom.uplink2_20130601_cache_out]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: *id305
+- dimensions: *id306
   name: ch.bakom.uplink2_20130601_source
   sources: [ch.bakom.uplink2_20130601_cache]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: &id306
+- dimensions: &id307
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink2_20121222
   sources: [ch.bakom.uplink2_20121222_cache_out]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: *id306
+- dimensions: *id307
   name: ch.bakom.uplink2_20121222_source
   sources: [ch.bakom.uplink2_20121222_cache]
   title: "Upload \u2265 2 Mbit/s"
-- dimensions: &id307
+- dimensions: &id308
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink20_20141021
   sources: [ch.bakom.uplink20_20141021_cache_out]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: *id307
+- dimensions: *id308
   name: ch.bakom.uplink20
   sources: [ch.bakom.uplink20_20141021_cache]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: *id307
+- dimensions: *id308
   name: ch.bakom.uplink20_20141021_source
   sources: [ch.bakom.uplink20_20141021_cache]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: &id308
+- dimensions: &id309
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink20_20140625
   sources: [ch.bakom.uplink20_20140625_cache_out]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: *id308
+- dimensions: *id309
   name: ch.bakom.uplink20_20140625_source
   sources: [ch.bakom.uplink20_20140625_cache]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: &id309
+- dimensions: &id310
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink20_20131212
   sources: [ch.bakom.uplink20_20131212_cache_out]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: *id309
+- dimensions: *id310
   name: ch.bakom.uplink20_20131212_source
   sources: [ch.bakom.uplink20_20131212_cache]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: &id310
+- dimensions: &id311
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink20_20130901
   sources: [ch.bakom.uplink20_20130901_cache_out]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: *id310
+- dimensions: *id311
   name: ch.bakom.uplink20_20130901_source
   sources: [ch.bakom.uplink20_20130901_cache]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: &id311
+- dimensions: &id312
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink20_20130601
   sources: [ch.bakom.uplink20_20130601_cache_out]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: *id311
+- dimensions: *id312
   name: ch.bakom.uplink20_20130601_source
   sources: [ch.bakom.uplink20_20130601_cache]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: &id312
+- dimensions: &id313
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink20_20121222
   sources: [ch.bakom.uplink20_20121222_cache_out]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: *id312
+- dimensions: *id313
   name: ch.bakom.uplink20_20121222_source
   sources: [ch.bakom.uplink20_20121222_cache]
   title: "Upload \u2265 20 Mbit/s"
-- dimensions: &id313
+- dimensions: &id314
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink50_20141021
   sources: [ch.bakom.uplink50_20141021_cache_out]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: *id313
+- dimensions: *id314
   name: ch.bakom.uplink50
   sources: [ch.bakom.uplink50_20141021_cache]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: *id313
+- dimensions: *id314
   name: ch.bakom.uplink50_20141021_source
   sources: [ch.bakom.uplink50_20141021_cache]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: &id314
+- dimensions: &id315
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink50_20140625
   sources: [ch.bakom.uplink50_20140625_cache_out]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: *id314
+- dimensions: *id315
   name: ch.bakom.uplink50_20140625_source
   sources: [ch.bakom.uplink50_20140625_cache]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: &id315
+- dimensions: &id316
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink50_20131212
   sources: [ch.bakom.uplink50_20131212_cache_out]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: *id315
+- dimensions: *id316
   name: ch.bakom.uplink50_20131212_source
   sources: [ch.bakom.uplink50_20131212_cache]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: &id316
+- dimensions: &id317
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink50_20130901
   sources: [ch.bakom.uplink50_20130901_cache_out]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: *id316
+- dimensions: *id317
   name: ch.bakom.uplink50_20130901_source
   sources: [ch.bakom.uplink50_20130901_cache]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: &id317
+- dimensions: &id318
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink50_20130601
   sources: [ch.bakom.uplink50_20130601_cache_out]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: *id317
+- dimensions: *id318
   name: ch.bakom.uplink50_20130601_source
   sources: [ch.bakom.uplink50_20130601_cache]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: &id318
+- dimensions: &id319
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink50_20121222
   sources: [ch.bakom.uplink50_20121222_cache_out]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: *id318
+- dimensions: *id319
   name: ch.bakom.uplink50_20121222_source
   sources: [ch.bakom.uplink50_20121222_cache]
   title: "Upload \u2265 50 Mbit/s"
-- dimensions: &id319
+- dimensions: &id320
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.verfuegbarkeit-hdtv_20141021
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: *id319
+- dimensions: *id320
   name: ch.bakom.verfuegbarkeit-hdtv
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: *id319
+- dimensions: *id320
   name: ch.bakom.verfuegbarkeit-hdtv_20141021_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: &id320
+- dimensions: &id321
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.verfuegbarkeit-hdtv_20140625
   sources: [ch.bakom.verfuegbarkeit-hdtv_20140625_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: *id320
+- dimensions: *id321
   name: ch.bakom.verfuegbarkeit-hdtv_20140625_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20140625_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: &id321
+- dimensions: &id322
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.verfuegbarkeit-hdtv_20131212
   sources: [ch.bakom.verfuegbarkeit-hdtv_20131212_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: *id321
+- dimensions: *id322
   name: ch.bakom.verfuegbarkeit-hdtv_20131212_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20131212_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: &id322
+- dimensions: &id323
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.verfuegbarkeit-hdtv_20130901
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130901_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: *id322
+- dimensions: *id323
   name: ch.bakom.verfuegbarkeit-hdtv_20130901_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130901_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: &id323
+- dimensions: &id324
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.verfuegbarkeit-hdtv_20130601
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130601_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: *id323
+- dimensions: *id324
   name: ch.bakom.verfuegbarkeit-hdtv_20130601_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130601_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: &id324
+- dimensions: &id325
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.verfuegbarkeit-hdtv_20121222
   sources: [ch.bakom.verfuegbarkeit-hdtv_20121222_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: *id324
+- dimensions: *id325
   name: ch.bakom.verfuegbarkeit-hdtv_20121222_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20121222_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz"
-- dimensions: &id325
+- dimensions: &id326
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.verfuegbarkeit-tv_20141021
   sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: *id325
+- dimensions: *id326
   name: ch.bakom.verfuegbarkeit-tv
   sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: *id325
+- dimensions: *id326
   name: ch.bakom.verfuegbarkeit-tv_20141021_source
   sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: &id326
+- dimensions: &id327
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.verfuegbarkeit-tv_20140625
   sources: [ch.bakom.verfuegbarkeit-tv_20140625_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: *id326
+- dimensions: *id327
   name: ch.bakom.verfuegbarkeit-tv_20140625_source
   sources: [ch.bakom.verfuegbarkeit-tv_20140625_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: &id327
+- dimensions: &id328
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.verfuegbarkeit-tv_20131212
   sources: [ch.bakom.verfuegbarkeit-tv_20131212_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: *id327
+- dimensions: *id328
   name: ch.bakom.verfuegbarkeit-tv_20131212_source
   sources: [ch.bakom.verfuegbarkeit-tv_20131212_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: &id328
+- dimensions: &id329
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.verfuegbarkeit-tv_20130901
   sources: [ch.bakom.verfuegbarkeit-tv_20130901_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: *id328
+- dimensions: *id329
   name: ch.bakom.verfuegbarkeit-tv_20130901_source
   sources: [ch.bakom.verfuegbarkeit-tv_20130901_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: &id329
+- dimensions: &id330
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.verfuegbarkeit-tv_20130601
   sources: [ch.bakom.verfuegbarkeit-tv_20130601_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: *id329
+- dimensions: *id330
   name: ch.bakom.verfuegbarkeit-tv_20130601_source
   sources: [ch.bakom.verfuegbarkeit-tv_20130601_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: &id330
+- dimensions: &id331
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.verfuegbarkeit-tv_20121222
   sources: [ch.bakom.verfuegbarkeit-tv_20121222_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: *id330
+- dimensions: *id331
   name: ch.bakom.verfuegbarkeit-tv_20121222_source
   sources: [ch.bakom.verfuegbarkeit-tv_20121222_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz"
-- dimensions: &id331
+- dimensions: &id332
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-tv_20070704
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache_out]
   title: Versorgungsgebiete TV
-- dimensions: *id331
+- dimensions: *id332
   name: ch.bakom.versorgungsgebiet-tv
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV
-- dimensions: *id331
+- dimensions: *id332
   name: ch.bakom.versorgungsgebiet-tv_20070704_source
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV
-- dimensions: &id332
+- dimensions: &id333
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-ukw_20070704
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache_out]
   title: Versorgungsgebiete Radio
-- dimensions: *id332
+- dimensions: *id333
   name: ch.bakom.versorgungsgebiet-ukw
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio
-- dimensions: *id332
+- dimensions: *id333
   name: ch.bakom.versorgungsgebiet-ukw_20070704_source
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio
-- dimensions: &id333
+- dimensions: &id334
     Time:
       default: '20101109'
       values: ['20101109']
   name: ch.bav.laerm-emissionplan_eisenbahn_2015_20101109
   sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache_out]
   title: Emissionsplan Eisenbahn 2015
-- dimensions: *id333
+- dimensions: *id334
   name: ch.bav.laerm-emissionplan_eisenbahn_2015
   sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache]
   title: Emissionsplan Eisenbahn 2015
-- dimensions: *id333
+- dimensions: *id334
   name: ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_source
   sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache]
   title: Emissionsplan Eisenbahn 2015
-- dimensions: &id334
+- dimensions: &id335
     Time:
       default: '20140306'
       values: ['20140306']
   name: ch.bazl.luftfahrtkarten-icao_20140306
   sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache_out]
   title: Luftfahrtkarte ICAO
-- dimensions: *id334
+- dimensions: *id335
   name: ch.bazl.luftfahrtkarten-icao
   sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache]
   title: Luftfahrtkarte ICAO
-- dimensions: *id334
+- dimensions: *id335
   name: ch.bazl.luftfahrtkarten-icao_20140306_source
   sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache]
   title: Luftfahrtkarte ICAO
-- dimensions: &id335
+- dimensions: &id336
     Time:
       default: '20130307'
       values: ['20130307']
   name: ch.bazl.luftfahrtkarten-icao_20130307
   sources: [ch.bazl.luftfahrtkarten-icao_20130307_cache_out]
   title: Luftfahrtkarte ICAO
-- dimensions: *id335
+- dimensions: *id336
   name: ch.bazl.luftfahrtkarten-icao_20130307_source
   sources: [ch.bazl.luftfahrtkarten-icao_20130307_cache]
   title: Luftfahrtkarte ICAO
-- dimensions: &id336
+- dimensions: &id337
     Time:
       default: '20120308'
       values: ['20120308']
   name: ch.bazl.luftfahrtkarten-icao_20120308
   sources: [ch.bazl.luftfahrtkarten-icao_20120308_cache_out]
   title: Luftfahrtkarte ICAO
-- dimensions: *id336
+- dimensions: *id337
   name: ch.bazl.luftfahrtkarten-icao_20120308_source
   sources: [ch.bazl.luftfahrtkarten-icao_20120308_cache]
   title: Luftfahrtkarte ICAO
-- dimensions: &id337
+- dimensions: &id338
     Time:
       default: '20110310'
       values: ['20110310']
   name: ch.bazl.luftfahrtkarten-icao_20110310
   sources: [ch.bazl.luftfahrtkarten-icao_20110310_cache_out]
   title: Luftfahrtkarte ICAO
-- dimensions: *id337
+- dimensions: *id338
   name: ch.bazl.luftfahrtkarten-icao_20110310_source
   sources: [ch.bazl.luftfahrtkarten-icao_20110310_cache]
   title: Luftfahrtkarte ICAO
-- dimensions: &id338
+- dimensions: &id339
     Time:
       default: '20130822'
       values: ['20130822']
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache_out]
   title: "Projektierungszonen: Flugh\xE4fen"
-- dimensions: *id338
+- dimensions: *id339
   name: ch.bazl.projektierungszonen-flughafenanlagen
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen"
-- dimensions: *id338
+- dimensions: *id339
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822_source
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen"
-- dimensions: &id339
+- dimensions: &id340
     Time:
       default: '20140306'
       values: ['20140306']
   name: ch.bazl.segelflugkarte_20140306
   sources: [ch.bazl.segelflugkarte_20140306_cache_out]
   title: Segelflugkarte
-- dimensions: *id339
+- dimensions: *id340
   name: ch.bazl.segelflugkarte
   sources: [ch.bazl.segelflugkarte_20140306_cache]
   title: Segelflugkarte
-- dimensions: *id339
+- dimensions: *id340
   name: ch.bazl.segelflugkarte_20140306_source
   sources: [ch.bazl.segelflugkarte_20140306_cache]
   title: Segelflugkarte
-- dimensions: &id340
+- dimensions: &id341
     Time:
       default: '20130307'
       values: ['20130307']
   name: ch.bazl.segelflugkarte_20130307
   sources: [ch.bazl.segelflugkarte_20130307_cache_out]
   title: Segelflugkarte
-- dimensions: *id340
+- dimensions: *id341
   name: ch.bazl.segelflugkarte_20130307_source
   sources: [ch.bazl.segelflugkarte_20130307_cache]
   title: Segelflugkarte
-- dimensions: &id341
+- dimensions: &id342
     Time:
       default: '20120308'
       values: ['20120308']
   name: ch.bazl.segelflugkarte_20120308
   sources: [ch.bazl.segelflugkarte_20120308_cache_out]
   title: Segelflugkarte
-- dimensions: *id341
+- dimensions: *id342
   name: ch.bazl.segelflugkarte_20120308_source
   sources: [ch.bazl.segelflugkarte_20120308_cache]
   title: Segelflugkarte
-- dimensions: &id342
+- dimensions: &id343
     Time:
       default: '20120911'
       values: ['20120911']
   name: ch.bfe.kernkraftwerke_20120911
   sources: [ch.bfe.kernkraftwerke_20120911_cache_out]
   title: Kernkraftwerke
-- dimensions: *id342
+- dimensions: *id343
   name: ch.bfe.kernkraftwerke
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke
-- dimensions: *id342
+- dimensions: *id343
   name: ch.bfe.kernkraftwerke_20120911_source
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke
-- dimensions: &id343
+- dimensions: &id344
     Time:
       default: '20120531'
       values: ['20120531']
   name: ch.bfe.kleinwasserkraftpotentiale_20120531
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache_out]
   title: Kleinwasserkraftpotentiale
-- dimensions: *id343
+- dimensions: *id344
   name: ch.bfe.kleinwasserkraftpotentiale
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale
-- dimensions: *id343
+- dimensions: *id344
   name: ch.bfe.kleinwasserkraftpotentiale_20120531_source
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale
-- dimensions: &id344
+- dimensions: &id345
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik_20131121
   sources: [ch.bfs.arealstatistik_20131121_cache_out]
   title: Arealstatistik 2004/09 NOAS04
-- dimensions: *id344
+- dimensions: *id345
   name: ch.bfs.arealstatistik
   sources: [ch.bfs.arealstatistik_20131121_cache]
   title: Arealstatistik 2004/09 NOAS04
-- dimensions: *id344
+- dimensions: *id345
   name: ch.bfs.arealstatistik_20131121_source
   sources: [ch.bfs.arealstatistik_20131121_cache]
   title: Arealstatistik 2004/09 NOAS04
-- dimensions: &id345
+- dimensions: &id346
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-1985_20131121
   sources: [ch.bfs.arealstatistik-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOAS04
-- dimensions: *id345
+- dimensions: *id346
   name: ch.bfs.arealstatistik-1985
   sources: [ch.bfs.arealstatistik-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOAS04
-- dimensions: *id345
+- dimensions: *id346
   name: ch.bfs.arealstatistik-1985_20131121_source
   sources: [ch.bfs.arealstatistik-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOAS04
-- dimensions: &id346
+- dimensions: &id347
     Time:
       default: '19790101'
       values: ['19790101']
   name: ch.bfs.arealstatistik-1985_19790101
   sources: [ch.bfs.arealstatistik-1985_19790101_cache_out]
   title: Arealstatistik 1979/85 NOAS04
-- dimensions: *id346
+- dimensions: *id347
   name: ch.bfs.arealstatistik-1985_19790101_source
   sources: [ch.bfs.arealstatistik-1985_19790101_cache]
   title: Arealstatistik 1979/85 NOAS04
-- dimensions: &id347
+- dimensions: &id348
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-1997_20131121
   sources: [ch.bfs.arealstatistik-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOAS04
-- dimensions: *id347
+- dimensions: *id348
   name: ch.bfs.arealstatistik-1997
   sources: [ch.bfs.arealstatistik-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOAS04
-- dimensions: *id347
+- dimensions: *id348
   name: ch.bfs.arealstatistik-1997_20131121_source
   sources: [ch.bfs.arealstatistik-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOAS04
-- dimensions: &id348
+- dimensions: &id349
     Time:
       default: '19920101'
       values: ['19920101']
   name: ch.bfs.arealstatistik-1997_19920101
   sources: [ch.bfs.arealstatistik-1997_19920101_cache_out]
   title: Arealstatistik 1992/97 NOAS04
-- dimensions: *id348
+- dimensions: *id349
   name: ch.bfs.arealstatistik-1997_19920101_source
   sources: [ch.bfs.arealstatistik-1997_19920101_cache]
   title: Arealstatistik 1992/97 NOAS04
-- dimensions: &id349
+- dimensions: &id350
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache_out]
   title: Arealstatistik 2004/09 NOLC04
-- dimensions: *id349
+- dimensions: *id350
   name: ch.bfs.arealstatistik-bodenbedeckung
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04
-- dimensions: *id349
+- dimensions: *id350
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04
-- dimensions: &id350
+- dimensions: &id351
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLC04
-- dimensions: *id350
+- dimensions: *id351
   name: ch.bfs.arealstatistik-bodenbedeckung-1985
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04
-- dimensions: *id350
+- dimensions: *id351
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04
-- dimensions: &id351
+- dimensions: &id352
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLC04
-- dimensions: *id351
+- dimensions: *id352
   name: ch.bfs.arealstatistik-bodenbedeckung-1997
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04
-- dimensions: *id351
+- dimensions: *id352
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04
-- dimensions: &id352
+- dimensions: &id353
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache_out]
   title: 'Arealstatistik 2004/09 NOLU04 '
-- dimensions: *id352
+- dimensions: *id353
   name: ch.bfs.arealstatistik-bodennutzung
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: 'Arealstatistik 2004/09 NOLU04 '
-- dimensions: *id352
+- dimensions: *id353
   name: ch.bfs.arealstatistik-bodennutzung_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: 'Arealstatistik 2004/09 NOLU04 '
-- dimensions: &id353
+- dimensions: &id354
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLU04
-- dimensions: *id353
+- dimensions: *id354
   name: ch.bfs.arealstatistik-bodennutzung-1985
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04
-- dimensions: *id353
+- dimensions: *id354
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04
-- dimensions: &id354
+- dimensions: &id355
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLU04
-- dimensions: *id354
+- dimensions: *id355
   name: ch.bfs.arealstatistik-bodennutzung-1997
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04
-- dimensions: *id354
+- dimensions: *id355
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04
-- dimensions: &id355
+- dimensions: &id356
     Time:
       default: '20070116'
       values: ['20070116']
   name: ch.bfs.arealstatistik-hintergrund_20070116
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache_out]
   title: Vereinfachte Bodennutzung
-- dimensions: *id355
+- dimensions: *id356
   name: ch.bfs.arealstatistik-hintergrund
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
   title: Vereinfachte Bodennutzung
-- dimensions: *id355
+- dimensions: *id356
   name: ch.bfs.arealstatistik-hintergrund_20070116_source
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
   title: Vereinfachte Bodennutzung
-- dimensions: &id356
+- dimensions: &id357
     Time:
       default: '19970901'
       values: ['19970901']
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache_out]
   title: Waldmischungsgrad 1990/1992
-- dimensions: *id356
+- dimensions: *id357
   name: ch.bfs.arealstatistik-waldmischungsgrad
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992
-- dimensions: *id356
+- dimensions: *id357
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901_source
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992
-- dimensions: &id357
+- dimensions: &id358
     Time:
       default: '20130212'
       values: ['20130212']
   name: ch.bfs.gebaeude_wohnungs_register_20130212
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache_out]
   title: "Geb\xE4ude- und Wohnungsregister"
-- dimensions: *id357
+- dimensions: *id358
   name: ch.bfs.gebaeude_wohnungs_register
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
   title: "Geb\xE4ude- und Wohnungsregister"
-- dimensions: *id357
+- dimensions: *id358
   name: ch.bfs.gebaeude_wohnungs_register_20130212_source
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
   title: "Geb\xE4ude- und Wohnungsregister"
-- dimensions: &id358
+- dimensions: &id359
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.alpprodukte_20130531
   sources: [ch.blw.alpprodukte_20130531_cache_out]
   title: Alpprodukte
-- dimensions: *id358
+- dimensions: *id359
   name: ch.blw.alpprodukte
   sources: [ch.blw.alpprodukte_20130531_cache]
   title: Alpprodukte
-- dimensions: *id358
+- dimensions: *id359
   name: ch.blw.alpprodukte_20130531_source
   sources: [ch.blw.alpprodukte_20130531_cache]
   title: Alpprodukte
-- dimensions: &id359
+- dimensions: &id360
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.alpprodukte_20081024
   sources: [ch.blw.alpprodukte_20081024_cache_out]
   title: Alpprodukte
-- dimensions: *id359
+- dimensions: *id360
   name: ch.blw.alpprodukte_20081024_source
   sources: [ch.blw.alpprodukte_20081024_cache]
   title: Alpprodukte
-- dimensions: &id360
+- dimensions: &id361
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.bergprodukte_20130531
   sources: [ch.blw.bergprodukte_20130531_cache_out]
   title: Bergprodukte
-- dimensions: *id360
+- dimensions: *id361
   name: ch.blw.bergprodukte
   sources: [ch.blw.bergprodukte_20130531_cache]
   title: Bergprodukte
-- dimensions: *id360
+- dimensions: *id361
   name: ch.blw.bergprodukte_20130531_source
   sources: [ch.blw.bergprodukte_20130531_cache]
   title: Bergprodukte
-- dimensions: &id361
+- dimensions: &id362
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bergprodukte_20081024
   sources: [ch.blw.bergprodukte_20081024_cache_out]
   title: Bergprodukte
-- dimensions: *id361
+- dimensions: *id362
   name: ch.blw.bergprodukte_20081024_source
   sources: [ch.blw.bergprodukte_20081024_cache]
   title: Bergprodukte
-- dimensions: &id362
+- dimensions: &id363
     Time:
       default: '20091110'
       values: ['20091110']
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache_out]
   title: "Bew\xE4sserungsbed\xFCrftigkeit"
-- dimensions: *id362
+- dimensions: *id363
   name: ch.blw.bewaesserungsbeduerftigkeit
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit"
-- dimensions: *id362
+- dimensions: *id363
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110_source
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit"
-- dimensions: &id363
+- dimensions: &id364
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-gruendigkeit_20120601
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache_out]
   title: "Gr\xFCndigkeit"
-- dimensions: *id363
+- dimensions: *id364
   name: ch.blw.bodeneignung-gruendigkeit
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit"
-- dimensions: *id363
+- dimensions: *id364
   name: ch.blw.bodeneignung-gruendigkeit_20120601_source
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit"
-- dimensions: &id364
+- dimensions: &id365
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturland_20081024
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache_out]
   title: "Bodeneignung f\xFCr Kulturland"
-- dimensions: *id364
+- dimensions: *id365
   name: ch.blw.bodeneignung-kulturland
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland"
-- dimensions: *id364
+- dimensions: *id365
   name: ch.blw.bodeneignung-kulturland_20081024_source
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland"
-- dimensions: &id365
+- dimensions: &id366
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturtyp_20081024
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache_out]
   title: 'Bodeneignung: Kulturtyp'
-- dimensions: *id365
+- dimensions: *id366
   name: ch.blw.bodeneignung-kulturtyp
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp'
-- dimensions: *id365
+- dimensions: *id366
   name: ch.blw.bodeneignung-kulturtyp_20081024_source
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp'
-- dimensions: &id366
+- dimensions: &id367
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache_out]
   title: "N\xE4hrstoffspeicherverm\xF6gen"
-- dimensions: *id366
+- dimensions: *id367
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen"
-- dimensions: *id366
+- dimensions: *id367
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen"
-- dimensions: &id367
+- dimensions: &id368
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-skelettgehalt_20120601
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache_out]
   title: Skelettgehalt
-- dimensions: *id367
+- dimensions: *id368
   name: ch.blw.bodeneignung-skelettgehalt
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt
-- dimensions: *id367
+- dimensions: *id368
   name: ch.blw.bodeneignung-skelettgehalt_20120601_source
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt
-- dimensions: &id368
+- dimensions: &id369
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-vernaessung_20120601
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache_out]
   title: "Vern\xE4ssung"
-- dimensions: *id368
+- dimensions: *id369
   name: ch.blw.bodeneignung-vernaessung
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung"
-- dimensions: *id368
+- dimensions: *id369
   name: ch.blw.bodeneignung-vernaessung_20120601_source
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung"
-- dimensions: &id369
+- dimensions: &id370
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache_out]
   title: "Wasserdurchl\xE4ssigkeit"
-- dimensions: *id369
+- dimensions: *id370
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit"
-- dimensions: *id369
+- dimensions: *id370
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_source
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit"
-- dimensions: &id370
+- dimensions: &id371
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache_out]
   title: "Wasserspeicherverm\xF6gen"
-- dimensions: *id370
+- dimensions: *id371
   name: ch.blw.bodeneignung-wasserspeichervermoegen
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen"
-- dimensions: *id370
+- dimensions: *id371
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen"
-- dimensions: &id371
+- dimensions: &id372
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion_20100103
   sources: [ch.blw.erosion_20100103_cache_out]
   title: Erosionsrisiko qualitativ 1
-- dimensions: *id371
+- dimensions: *id372
   name: ch.blw.erosion
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1
-- dimensions: *id371
+- dimensions: *id372
   name: ch.blw.erosion_20100103_source
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1
-- dimensions: &id372
+- dimensions: &id373
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion-mit_bergzonen_20100103
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache_out]
   title: Erosionsrisiko qualitativ 2
-- dimensions: *id372
+- dimensions: *id373
   name: ch.blw.erosion-mit_bergzonen
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2
-- dimensions: *id372
+- dimensions: *id373
   name: ch.blw.erosion-mit_bergzonen_20100103_source
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2
-- dimensions: &id373
+- dimensions: &id374
     Time:
       default: '20100601'
       values: ['20100601']
   name: ch.blw.erosion-quantitativ_20100601
   sources: [ch.blw.erosion-quantitativ_20100601_cache_out]
   title: Erosionsrisiko quantitativ
-- dimensions: *id373
+- dimensions: *id374
   name: ch.blw.erosion-quantitativ
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ
-- dimensions: *id373
+- dimensions: *id374
   name: ch.blw.erosion-quantitativ_20100601_source
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ
-- dimensions: &id374
+- dimensions: &id375
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.feldblockkarte_20120601
   sources: [ch.blw.feldblockkarte_20120601_cache_out]
   title: Feldblockkarte
-- dimensions: *id374
+- dimensions: *id375
   name: ch.blw.feldblockkarte
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte
-- dimensions: *id374
+- dimensions: *id375
   name: ch.blw.feldblockkarte_20120601_source
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte
-- dimensions: &id375
+- dimensions: &id376
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte_20121201
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache_out]
   title: "Gew\xE4sseranschluss"
-- dimensions: *id375
+- dimensions: *id376
   name: ch.blw.gewaesseranschlusskarte
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss"
-- dimensions: *id375
+- dimensions: *id376
   name: ch.blw.gewaesseranschlusskarte_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss"
-- dimensions: &id376
+- dimensions: &id377
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache_out]
   title: "Gew\xE4sseranschluss erweitert"
-- dimensions: *id376
+- dimensions: *id377
   name: ch.blw.gewaesseranschlusskarte-direkt
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert"
-- dimensions: *id376
+- dimensions: *id377
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert"
-- dimensions: &id377
+- dimensions: &id378
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.hang_steillagen_20121231
   sources: [ch.blw.hang_steillagen_20121231_cache_out]
   title: Hanglagen
-- dimensions: *id377
+- dimensions: *id378
   name: ch.blw.hang_steillagen
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen
-- dimensions: *id377
+- dimensions: *id378
   name: ch.blw.hang_steillagen_20121231_source
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen
-- dimensions: &id378
+- dimensions: &id379
     Time:
       default: '20100501'
       values: ['20100501']
   name: ch.blw.hang_steillagen_20100501
   sources: [ch.blw.hang_steillagen_20100501_cache_out]
   title: Hanglagen
-- dimensions: *id378
+- dimensions: *id379
   name: ch.blw.hang_steillagen_20100501_source
   sources: [ch.blw.hang_steillagen_20100501_cache]
   title: Hanglagen
-- dimensions: &id379
+- dimensions: &id380
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-futterbau_20081024
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache_out]
   title: Klimaeignung Futterbau
-- dimensions: *id379
+- dimensions: *id380
   name: ch.blw.klimaeignung-futterbau
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau
-- dimensions: *id379
+- dimensions: *id380
   name: ch.blw.klimaeignung-futterbau_20081024_source
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau
-- dimensions: &id380
+- dimensions: &id381
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-getreidebau_20081024
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache_out]
   title: Klimaeignung Getreidebau
-- dimensions: *id380
+- dimensions: *id381
   name: ch.blw.klimaeignung-getreidebau
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau
-- dimensions: *id380
+- dimensions: *id381
   name: ch.blw.klimaeignung-getreidebau_20081024_source
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau
-- dimensions: &id381
+- dimensions: &id382
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kartoffeln_20081024
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache_out]
   title: Klimaeignung Kartoffeln
-- dimensions: *id381
+- dimensions: *id382
   name: ch.blw.klimaeignung-kartoffeln
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln
-- dimensions: *id381
+- dimensions: *id382
   name: ch.blw.klimaeignung-kartoffeln_20081024_source
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln
-- dimensions: &id382
+- dimensions: &id383
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-koernermais_20081024
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache_out]
   title: "Klimaeignung K\xF6rnermais"
-- dimensions: *id382
+- dimensions: *id383
   name: ch.blw.klimaeignung-koernermais
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais"
-- dimensions: *id382
+- dimensions: *id383
   name: ch.blw.klimaeignung-koernermais_20081024_source
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais"
-- dimensions: &id383
+- dimensions: &id384
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kulturland_20081024
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache_out]
   title: Klimaeignung Kulturland
-- dimensions: *id383
+- dimensions: *id384
   name: ch.blw.klimaeignung-kulturland
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland
-- dimensions: *id383
+- dimensions: *id384
   name: ch.blw.klimaeignung-kulturland_20081024_source
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland
-- dimensions: &id384
+- dimensions: &id385
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-spezialkulturen_20081024
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache_out]
   title: Klimaeignung Spezialkulturen
-- dimensions: *id384
+- dimensions: *id385
   name: ch.blw.klimaeignung-spezialkulturen
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen
-- dimensions: *id384
+- dimensions: *id385
   name: ch.blw.klimaeignung-spezialkulturen_20081024_source
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen
-- dimensions: &id385
+- dimensions: &id386
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-typ_20081024
   sources: [ch.blw.klimaeignung-typ_20081024_cache_out]
   title: "Klimaeignung \xDCbersicht"
-- dimensions: *id385
+- dimensions: *id386
   name: ch.blw.klimaeignung-typ
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht"
-- dimensions: *id385
+- dimensions: *id386
   name: ch.blw.klimaeignung-typ_20081024_source
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht"
-- dimensions: &id386
+- dimensions: &id387
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache_out]
   title: Klimaeignung Zwischenfruchtbau
-- dimensions: *id386
+- dimensions: *id387
   name: ch.blw.klimaeignung-zwischenfruchtbau
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau
-- dimensions: *id386
+- dimensions: *id387
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024_source
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau
-- dimensions: &id387
+- dimensions: &id388
     Time:
       default: '20140418'
       values: ['20140418']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140418
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache_out]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: *id387
+- dimensions: *id388
   name: ch.blw.landwirtschaftliche-zonengrenzen
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: *id387
+- dimensions: *id388
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140418_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: &id388
+- dimensions: &id389
     Time:
       default: '20140417'
       values: ['20140417']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140417
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache_out]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: *id388
+- dimensions: *id389
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140417_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: &id389
+- dimensions: &id390
     Time:
       default: '20140108'
       values: ['20140108']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140108
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache_out]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: *id389
+- dimensions: *id390
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140108_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: &id390
+- dimensions: &id391
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20130531
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache_out]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: *id390
+- dimensions: *id391
   name: ch.blw.landwirtschaftliche-zonengrenzen_20130531_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: &id391
+- dimensions: &id392
     Time:
       default: '20111214'
       values: ['20111214']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111214
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache_out]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: *id391
+- dimensions: *id392
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111214_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: &id392
+- dimensions: &id393
     Time:
       default: '20111010'
       values: ['20111010']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111010
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache_out]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: *id392
+- dimensions: *id393
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111010_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache]
   title: Landwirtschaftliche Zonengrenzen
-- dimensions: &id393
+- dimensions: &id394
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.niederschlagshaushalt_20081024
   sources: [ch.blw.niederschlagshaushalt_20081024_cache_out]
   title: Niederschlagshaushalt
-- dimensions: *id393
+- dimensions: *id394
   name: ch.blw.niederschlagshaushalt
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt
-- dimensions: *id393
+- dimensions: *id394
   name: ch.blw.niederschlagshaushalt_20081024_source
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt
-- dimensions: &id394
+- dimensions: &id395
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.steil_terrassenlagen_rebbau_20121231
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache_out]
   title: "Rebfl\xE4chen in Hanglagen"
-- dimensions: *id394
+- dimensions: *id395
   name: ch.blw.steil_terrassenlagen_rebbau
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen"
-- dimensions: *id394
+- dimensions: *id395
   name: ch.blw.steil_terrassenlagen_rebbau_20121231_source
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen"
-- dimensions: &id395
+- dimensions: &id396
     Time:
       default: '20100501'
       values: ['20100501']
   name: ch.blw.steil_terrassenlagen_rebbau_20100501
   sources: [ch.blw.steil_terrassenlagen_rebbau_20100501_cache_out]
   title: "Rebfl\xE4chen in Hanglagen"
-- dimensions: *id395
+- dimensions: *id396
   name: ch.blw.steil_terrassenlagen_rebbau_20100501_source
   sources: [ch.blw.steil_terrassenlagen_rebbau_20100501_cache]
   title: "Rebfl\xE4chen in Hanglagen"
-- dimensions: &id396
+- dimensions: &id397
     Time:
       default: '20110805'
       values: ['20110805']
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache_out]
   title: GGA Fleischware
-- dimensions: *id396
+- dimensions: *id397
   name: ch.blw.ursprungsbezeichnungen-fleisch
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware
-- dimensions: *id396
+- dimensions: *id397
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805_source
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware
-- dimensions: &id397
+- dimensions: &id398
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-fleisch_20081024
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache_out]
   title: GGA Fleischware
-- dimensions: *id397
+- dimensions: *id398
   name: ch.blw.ursprungsbezeichnungen-fleisch_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache]
   title: GGA Fleischware
-- dimensions: &id398
+- dimensions: &id399
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache_out]
   title: "GUB K\xE4se"
-- dimensions: *id398
+- dimensions: *id399
   name: ch.blw.ursprungsbezeichnungen-kaese
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se"
-- dimensions: *id398
+- dimensions: *id399
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se"
-- dimensions: &id399
+- dimensions: &id400
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache_out]
   title: GUB Pflanzliche Produkte
-- dimensions: *id399
+- dimensions: *id400
   name: ch.blw.ursprungsbezeichnungen-pflanzen
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte
-- dimensions: *id399
+- dimensions: *id400
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte
-- dimensions: &id400
+- dimensions: &id401
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache_out]
   title: GUB Spirituosen
-- dimensions: *id400
+- dimensions: *id401
   name: ch.blw.ursprungsbezeichnungen-spirituosen
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen
-- dimensions: *id400
+- dimensions: *id401
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen
-- dimensions: &id401
+- dimensions: &id402
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache_out]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
-- dimensions: *id401
+- dimensions: *id402
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
-- dimensions: *id401
+- dimensions: *id402
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_source
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
-- dimensions: &id402
+- dimensions: &id403
     Time:
       default: '20110412'
       values: ['20110412']
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache_out]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
-- dimensions: *id402
+- dimensions: *id403
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_source
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz"
-- dimensions: &id403
+- dimensions: &id404
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.kantone.cadastralwebmap-farbe_20121201
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache_out]
   title: CadastralWebMap
-- dimensions: *id403
+- dimensions: *id404
   name: ch.kantone.cadastralwebmap-farbe
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
   title: CadastralWebMap
-- dimensions: *id403
+- dimensions: *id404
   name: ch.kantone.cadastralwebmap-farbe_20121201_source
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
   title: CadastralWebMap
-- dimensions: &id404
+- dimensions: &id405
     Time:
       default: '20131101'
       values: ['20131101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache_out]
   title: PLZ und Ortschaften
-- dimensions: *id404
+- dimensions: *id405
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften
-- dimensions: *id404
+- dimensions: *id405
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften
-- dimensions: &id405
+- dimensions: &id406
     Time:
       default: '20130501'
       values: ['20130501']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache_out]
   title: PLZ und Ortschaften
-- dimensions: *id405
+- dimensions: *id406
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache]
   title: PLZ und Ortschaften
-- dimensions: &id406
+- dimensions: &id407
     Time:
       default: '20121102'
       values: ['20121102']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache_out]
   title: PLZ und Ortschaften
-- dimensions: *id406
+- dimensions: *id407
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache]
   title: PLZ und Ortschaften
-- dimensions: &id407
+- dimensions: &id408
     Time:
       default: '20120501'
       values: ['20120501']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache_out]
   title: PLZ und Ortschaften
-- dimensions: *id407
+- dimensions: *id408
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache]
   title: PLZ und Ortschaften
-- dimensions: &id408
+- dimensions: &id409
     Time:
       default: '20111101'
       values: ['20111101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache_out]
   title: PLZ und Ortschaften
-- dimensions: *id408
+- dimensions: *id409
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache]
   title: PLZ und Ortschaften
-- dimensions: &id409
+- dimensions: &id410
     Time:
       default: '20110502'
       values: ['20110502']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache_out]
   title: PLZ und Ortschaften
-- dimensions: *id409
+- dimensions: *id410
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache]
   title: PLZ und Ortschaften
-- dimensions: &id410
+- dimensions: &id411
+    Time:
+      default: '20141101'
+      values: ['20141101']
+  name: ch.swisstopo-vd.spannungsarme-gebiete_20141101
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache_out]
+  title: Spannungsarme Gebiete
+- dimensions: *id411
+  name: ch.swisstopo-vd.spannungsarme-gebiete
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
+  title: Spannungsarme Gebiete
+- dimensions: *id411
+  name: ch.swisstopo-vd.spannungsarme-gebiete_20141101_source
+  sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
+  title: Spannungsarme Gebiete
+- dimensions: &id412
     Time:
       default: '20131028'
       values: ['20131028']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20131028
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache_out]
   title: Spannungsarme Gebiete
-- dimensions: *id410
-  name: ch.swisstopo-vd.spannungsarme-gebiete
-  sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache]
-  title: Spannungsarme Gebiete
-- dimensions: *id410
+- dimensions: *id412
   name: ch.swisstopo-vd.spannungsarme-gebiete_20131028_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache]
   title: Spannungsarme Gebiete
-- dimensions: &id411
+- dimensions: &id413
     Time:
       default: '20121102'
       values: ['20121102']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20121102
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache_out]
   title: Spannungsarme Gebiete
-- dimensions: *id411
+- dimensions: *id413
   name: ch.swisstopo-vd.spannungsarme-gebiete_20121102_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache]
   title: Spannungsarme Gebiete
-- dimensions: &id412
+- dimensions: &id414
     Time:
       default: '20111216'
       values: ['20111216']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20111216
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache_out]
   title: Spannungsarme Gebiete
-- dimensions: *id412
+- dimensions: *id414
   name: ch.swisstopo-vd.spannungsarme-gebiete_20111216_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache]
   title: Spannungsarme Gebiete
-- dimensions: &id413
+- dimensions: &id415
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.dreiecksvermaschung_20061231
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache_out]
   title: LV95 Dreiecksvermaschung
-- dimensions: *id413
+- dimensions: *id415
   name: ch.swisstopo.dreiecksvermaschung
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung
-- dimensions: *id413
+- dimensions: *id415
   name: ch.swisstopo.dreiecksvermaschung_20061231_source
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung
-- dimensions: &id414
+- dimensions: &id416
     Time:
       default: '20140924'
       values: ['20140924']
   name: ch.swisstopo.fixpunkte-agnes_20140924
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache_out]
   title: AGNES
-- dimensions: *id414
+- dimensions: *id416
   name: ch.swisstopo.fixpunkte-agnes
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES
-- dimensions: *id414
+- dimensions: *id416
   name: ch.swisstopo.fixpunkte-agnes_20140924_source
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES
-- dimensions: &id415
+- dimensions: &id417
     Time:
       default: '20120622'
       values: ['20120622']
   name: ch.swisstopo.fixpunkte-agnes_20120622
   sources: [ch.swisstopo.fixpunkte-agnes_20120622_cache_out]
   title: AGNES
-- dimensions: *id415
+- dimensions: *id417
   name: ch.swisstopo.fixpunkte-agnes_20120622_source
   sources: [ch.swisstopo.fixpunkte-agnes_20120622_cache]
   title: AGNES
-- dimensions: &id416
+- dimensions: &id418
     Time:
       default: '20110509'
       values: ['20110509']
   name: ch.swisstopo.fixpunkte-agnes_20110509
   sources: [ch.swisstopo.fixpunkte-agnes_20110509_cache_out]
   title: AGNES
-- dimensions: *id416
+- dimensions: *id418
   name: ch.swisstopo.fixpunkte-agnes_20110509_source
   sources: [ch.swisstopo.fixpunkte-agnes_20110509_cache]
   title: AGNES
-- dimensions: &id417
+- dimensions: &id419
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp1_20121212
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP1"
-- dimensions: *id417
+- dimensions: *id419
   name: ch.swisstopo.fixpunkte-hfp1
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1"
-- dimensions: *id417
+- dimensions: *id419
   name: ch.swisstopo.fixpunkte-hfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1"
-- dimensions: &id418
+- dimensions: &id420
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp2_20121212
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP2"
-- dimensions: *id418
+- dimensions: *id420
   name: ch.swisstopo.fixpunkte-hfp2
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2"
-- dimensions: *id418
+- dimensions: *id420
   name: ch.swisstopo.fixpunkte-hfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2"
-- dimensions: &id419
+- dimensions: &id421
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp1_20121212
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache_out]
   title: Lagefixpunkte LFP1
-- dimensions: *id419
+- dimensions: *id421
   name: ch.swisstopo.fixpunkte-lfp1
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1
-- dimensions: *id419
+- dimensions: *id421
   name: ch.swisstopo.fixpunkte-lfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1
-- dimensions: &id420
+- dimensions: &id422
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp2_20121212
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache_out]
   title: Lagefixpunkte LFP2
-- dimensions: *id420
+- dimensions: *id422
   name: ch.swisstopo.fixpunkte-lfp2
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2
-- dimensions: *id420
+- dimensions: *id422
   name: ch.swisstopo.fixpunkte-lfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2
-- dimensions: &id421
+- dimensions: &id423
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-ch1903_20041231
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache_out]
   title: Geoidmodell in CH1903
-- dimensions: *id421
+- dimensions: *id423
   name: ch.swisstopo.geoidmodell-ch1903
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903
-- dimensions: *id421
+- dimensions: *id423
   name: ch.swisstopo.geoidmodell-ch1903_20041231_source
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903
-- dimensions: &id422
+- dimensions: &id424
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-etrs89_20041231
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache_out]
   title: Geoidmodell in ETRS89
-- dimensions: *id422
+- dimensions: *id424
   name: ch.swisstopo.geoidmodell-etrs89
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89
-- dimensions: *id422
+- dimensions: *id424
   name: ch.swisstopo.geoidmodell-etrs89_20041231_source
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89
-- dimensions: &id423
+- dimensions: &id425
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache_out]
   title: Eiszeitliches Maximum
-- dimensions: *id423
+- dimensions: *id425
   name: ch.swisstopo.geologie-eiszeit-lgm-raster
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Eiszeitliches Maximum
-- dimensions: *id423
+- dimensions: *id425
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_source
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Eiszeitliches Maximum
-- dimensions: &id424
+- dimensions: &id426
     Time:
       default: '20140601'
       values: ['20140601']
   name: ch.swisstopo.geologie-geocover_20140601
   sources: [ch.swisstopo.geologie-geocover_20140601_cache_out]
   title: GeoCover
-- dimensions: *id424
+- dimensions: *id426
   name: ch.swisstopo.geologie-geocover
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: GeoCover
-- dimensions: *id424
+- dimensions: *id426
   name: ch.swisstopo.geologie-geocover_20140601_source
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: GeoCover
-- dimensions: &id425
+- dimensions: &id427
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache_out]
   title: Bouguer-Anomalien
-- dimensions: *id425
+- dimensions: *id427
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache]
   title: Bouguer-Anomalien
-- dimensions: *id425
+- dimensions: *id427
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache]
   title: Bouguer-Anomalien
-- dimensions: &id426
+- dimensions: &id428
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache_out]
   title: Isostatische Anomalien
-- dimensions: *id426
+- dimensions: *id428
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien
-- dimensions: *id426
+- dimensions: *id428
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien
-- dimensions: &id427
+- dimensions: &id429
     Time:
       default: '20070425'
       values: ['20070425']
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache_out]
   title: Blatteinteilung GeoKarten 500
-- dimensions: *id427
+- dimensions: *id429
   name: ch.swisstopo.geologie-geolkarten500.metadata
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500
-- dimensions: *id427
+- dimensions: *id429
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425_source
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500
-- dimensions: &id428
+- dimensions: &id430
     Time:
       default: '20080630'
       values: ['20080630']
   name: ch.swisstopo.geologie-geologische_karte_20080630
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache_out]
   title: Geologie 1:500000
-- dimensions: *id428
+- dimensions: *id430
   name: ch.swisstopo.geologie-geologische_karte
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologie 1:500000
-- dimensions: *id428
+- dimensions: *id430
   name: ch.swisstopo.geologie-geologische_karte_20080630_source
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologie 1:500000
-- dimensions: &id429
+- dimensions: &id431
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.geologie-geologische_karte_20051231
   sources: [ch.swisstopo.geologie-geologische_karte_20051231_cache_out]
   title: Geologie 1:500000
-- dimensions: *id429
+- dimensions: *id431
   name: ch.swisstopo.geologie-geologische_karte_20051231_source
   sources: [ch.swisstopo.geologie-geologische_karte_20051231_cache]
   title: Geologie 1:500000
-- dimensions: &id430
+- dimensions: &id432
     Time:
       default: '20131120'
       values: ['20131120']
   name: ch.swisstopo.geologie-geologischer_atlas_20131120
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache_out]
   title: Geologischer Atlas 1:25000
-- dimensions: *id430
+- dimensions: *id432
   name: ch.swisstopo.geologie-geologischer_atlas
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geologischer Atlas 1:25000
-- dimensions: *id430
+- dimensions: *id432
   name: ch.swisstopo.geologie-geologischer_atlas_20131120_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geologischer Atlas 1:25000
-- dimensions: &id431
+- dimensions: &id433
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.swisstopo.geologie-geologischer_atlas_20120601
   sources: [ch.swisstopo.geologie-geologischer_atlas_20120601_cache_out]
   title: Geologischer Atlas 1:25000
-- dimensions: *id431
+- dimensions: *id433
   name: ch.swisstopo.geologie-geologischer_atlas_20120601_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20120601_cache]
   title: Geologischer Atlas 1:25000
-- dimensions: &id432
+- dimensions: &id434
     Time:
       default: '20101221'
       values: ['20101221']
   name: ch.swisstopo.geologie-geologischer_atlas_20101221
   sources: [ch.swisstopo.geologie-geologischer_atlas_20101221_cache_out]
   title: Geologischer Atlas 1:25000
-- dimensions: *id432
+- dimensions: *id434
   name: ch.swisstopo.geologie-geologischer_atlas_20101221_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20101221_cache]
   title: Geologischer Atlas 1:25000
-- dimensions: &id433
+- dimensions: &id435
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache_out]
   title: Aeromagnetik Voralpen/Jura
-- dimensions: *id433
+- dimensions: *id435
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Voralpen/Jura
-- dimensions: *id433
+- dimensions: *id435
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Voralpen/Jura
-- dimensions: &id434
+- dimensions: &id436
     Time:
       default: '20120628'
       values: ['20120628']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache_out]
   title: Aeromagnetik
-- dimensions: *id434
+- dimensions: *id436
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik
-- dimensions: *id434
+- dimensions: *id436
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik
-- dimensions: &id435
+- dimensions: &id437
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache_out]
   title: Aeromagnetik
-- dimensions: *id435
+- dimensions: *id437
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache]
   title: Aeromagnetik
-- dimensions: &id436
+- dimensions: &id438
     Time:
       default: '20011203'
       values: ['20011203']
   name: ch.swisstopo.geologie-geophysik-deklination_20011203
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache_out]
   title: Deklination
-- dimensions: *id436
+- dimensions: *id438
   name: ch.swisstopo.geologie-geophysik-deklination
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination
-- dimensions: *id436
+- dimensions: *id438
   name: ch.swisstopo.geologie-geophysik-deklination_20011203_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination
-- dimensions: &id437
+- dimensions: &id439
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-deklination_19791231
   sources: [ch.swisstopo.geologie-geophysik-deklination_19791231_cache_out]
   title: Deklination
-- dimensions: *id437
+- dimensions: *id439
   name: ch.swisstopo.geologie-geophysik-deklination_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_19791231_cache]
   title: Deklination
-- dimensions: &id438
+- dimensions: &id440
     Time:
       default: '20111121'
       values: ['20111121']
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache_out]
   title: Geothermie
-- dimensions: *id438
+- dimensions: *id440
   name: ch.swisstopo.geologie-geophysik-geothermie
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: Geothermie
-- dimensions: *id438
+- dimensions: *id440
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: Geothermie
-- dimensions: &id439
+- dimensions: &id441
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.geologie-geophysik-geothermie_19821231
   sources: [ch.swisstopo.geologie-geophysik-geothermie_19821231_cache_out]
   title: Geothermie
-- dimensions: *id439
+- dimensions: *id441
   name: ch.swisstopo.geologie-geophysik-geothermie_19821231_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_19821231_cache]
   title: Geothermie
-- dimensions: &id440
+- dimensions: &id442
     Time:
       default: '20111128'
       values: ['20111128']
   name: ch.swisstopo.geologie-geophysik-inklination_20111128
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache_out]
   title: Inklination
-- dimensions: *id440
+- dimensions: *id442
   name: ch.swisstopo.geologie-geophysik-inklination
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination
-- dimensions: *id440
+- dimensions: *id442
   name: ch.swisstopo.geologie-geophysik-inklination_20111128_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination
-- dimensions: &id441
+- dimensions: &id443
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-inklination_19791231
   sources: [ch.swisstopo.geologie-geophysik-inklination_19791231_cache_out]
   title: Inklination
-- dimensions: *id441
+- dimensions: *id443
   name: ch.swisstopo.geologie-geophysik-inklination_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_19791231_cache]
   title: Inklination
-- dimensions: &id442
+- dimensions: &id444
     Time:
       default: '19800101'
       values: ['19800101']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache_out]
   title: "Magnetfeldst\xE4rke"
-- dimensions: *id442
+- dimensions: *id444
   name: ch.swisstopo.geologie-geophysik-totalintensitaet
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke"
-- dimensions: *id442
+- dimensions: *id444
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke"
-- dimensions: &id443
+- dimensions: &id445
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19791231
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache_out]
   title: "Magnetfeldst\xE4rke"
-- dimensions: *id443
+- dimensions: *id445
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache]
   title: "Magnetfeldst\xE4rke"
-- dimensions: &id444
+- dimensions: &id446
     Time:
       default: '19670101'
       values: ['19670101']
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache_out]
   title: Geotechnik und Gesteine
-- dimensions: *id444
+- dimensions: *id446
   name: ch.swisstopo.geologie-geotechnik-gk200
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnik und Gesteine
-- dimensions: *id444
+- dimensions: *id446
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnik und Gesteine
-- dimensions: &id445
+- dimensions: &id447
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache_out]
   title: Entstehung der Gesteine
-- dimensions: *id445
+- dimensions: *id447
   name: ch.swisstopo.geologie-geotechnik-gk500-genese
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine
-- dimensions: *id445
+- dimensions: *id447
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine
-- dimensions: &id446
+- dimensions: &id448
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache_out]
   title: Entstehung der Gesteine
-- dimensions: *id446
+- dimensions: *id448
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache]
   title: Entstehung der Gesteine
-- dimensions: &id447
+- dimensions: &id449
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache_out]
   title: Gesteinklassierung
-- dimensions: *id447
+- dimensions: *id449
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinklassierung
-- dimensions: *id447
+- dimensions: *id449
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinklassierung
-- dimensions: &id448
+- dimensions: &id450
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache_out]
   title: Gesteinklassierung
-- dimensions: *id448
+- dimensions: *id450
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache]
   title: Gesteinklassierung
-- dimensions: &id449
+- dimensions: &id451
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache_out]
   title: Lithologie-Hauptgruppen
-- dimensions: *id449
+- dimensions: *id451
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie-Hauptgruppen
-- dimensions: *id449
+- dimensions: *id451
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie-Hauptgruppen
-- dimensions: &id450
+- dimensions: &id452
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache_out]
   title: Lithologie-Hauptgruppen
-- dimensions: *id450
+- dimensions: *id452
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache]
   title: Lithologie-Hauptgruppen
-- dimensions: &id451
+- dimensions: &id453
     Time:
       default: '19900101'
       values: ['19900101']
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache_out]
   title: Mineralische Rohstoffe
-- dimensions: *id451
+- dimensions: *id453
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe
-- dimensions: *id451
+- dimensions: *id453
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_source
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe
-- dimensions: &id452
+- dimensions: &id454
     Time:
       default: '20130620'
       values: ['20130620']
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache_out]
   title: Steine an historischen Bauwerken
-- dimensions: *id452
+- dimensions: *id454
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an historischen Bauwerken
-- dimensions: *id452
+- dimensions: *id454
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_source
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an historischen Bauwerken
-- dimensions: &id453
+- dimensions: &id455
     Time:
       default: '20130107'
       values: ['20130107']
   name: ch.swisstopo.geologie-geotope_20130107
   sources: [ch.swisstopo.geologie-geotope_20130107_cache_out]
   title: Schweizerische Geotope
-- dimensions: *id453
+- dimensions: *id455
   name: ch.swisstopo.geologie-geotope
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Schweizerische Geotope
-- dimensions: *id453
+- dimensions: *id455
   name: ch.swisstopo.geologie-geotope_20130107_source
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Schweizerische Geotope
-- dimensions: &id454
+- dimensions: &id456
     Time:
       default: '20110201'
       values: ['20110201']
   name: ch.swisstopo.geologie-geotope_20110201
   sources: [ch.swisstopo.geologie-geotope_20110201_cache_out]
   title: Schweizerische Geotope
-- dimensions: *id454
+- dimensions: *id456
   name: ch.swisstopo.geologie-geotope_20110201_source
   sources: [ch.swisstopo.geologie-geotope_20110201_cache]
   title: Schweizerische Geotope
-- dimensions: &id455
+- dimensions: &id457
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache_out]
   title: Gravimetrischer Atlas
-- dimensions: *id455
+- dimensions: *id457
   name: ch.swisstopo.geologie-gravimetrischer_atlas
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas
-- dimensions: *id455
+- dimensions: *id457
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas
-- dimensions: &id456
+- dimensions: &id458
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache_out]
   title: Einteilung gravimetrischer Atlas
-- dimensions: *id456
+- dimensions: *id458
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravimetrischer Atlas
-- dimensions: *id456
+- dimensions: *id458
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravimetrischer Atlas
-- dimensions: &id457
+- dimensions: &id459
     Time:
       default: '20081103'
       values: ['20081103']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache_out]
   title: Grundwasservorkommen
-- dimensions: *id457
+- dimensions: *id459
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen
-- dimensions: *id457
+- dimensions: *id459
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen
-- dimensions: &id458
+- dimensions: &id460
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache_out]
   title: Grundwasservorkommen
-- dimensions: *id458
+- dimensions: *id460
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache]
   title: Grundwasservorkommen
-- dimensions: &id459
+- dimensions: &id461
     Time:
       default: '20081016'
       values: ['20081016']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache_out]
   title: "Grundwasservulnerabilit\xE4t"
-- dimensions: *id459
+- dimensions: *id461
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t"
-- dimensions: *id459
+- dimensions: *id461
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t"
-- dimensions: &id460
+- dimensions: &id462
     Time:
       default: '20070914'
       values: ['20070914']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache_out]
   title: "Grundwasservulnerabilit\xE4t"
-- dimensions: *id460
+- dimensions: *id462
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache]
   title: "Grundwasservulnerabilit\xE4t"
-- dimensions: &id461
+- dimensions: &id463
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache_out]
   title: Einteilung geol. Spezialkarten
-- dimensions: *id461
+- dimensions: *id463
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten
-- dimensions: *id461
+- dimensions: *id463
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_source
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten
-- dimensions: &id462
+- dimensions: &id464
     Time:
       default: '20080522'
       values: ['20080522']
   name: ch.swisstopo.geologie-tektonische_karte_20080522
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache_out]
   title: Tektonik 1:500000
-- dimensions: *id462
+- dimensions: *id464
   name: ch.swisstopo.geologie-tektonische_karte
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonik 1:500000
-- dimensions: *id462
+- dimensions: *id464
   name: ch.swisstopo.geologie-tektonische_karte_20080522_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonik 1:500000
-- dimensions: &id463
+- dimensions: &id465
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.geologie-tektonische_karte_20051231
   sources: [ch.swisstopo.geologie-tektonische_karte_20051231_cache_out]
   title: Tektonik 1:500000
-- dimensions: *id463
+- dimensions: *id465
   name: ch.swisstopo.geologie-tektonische_karte_20051231_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20051231_cache]
   title: Tektonik 1:500000
-- dimensions: &id464
+- dimensions: &id466
     Time:
       default: '18650101'
       values: ['18650101']
   name: ch.swisstopo.hiks-dufour_18650101
   sources: [ch.swisstopo.hiks-dufour_18650101_cache_out]
   title: Dufourkarte Erstausgabe
-- dimensions: *id464
+- dimensions: *id466
   name: ch.swisstopo.hiks-dufour
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe
-- dimensions: *id464
+- dimensions: *id466
   name: ch.swisstopo.hiks-dufour_18650101_source
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe
-- dimensions: &id465
+- dimensions: &id467
     Time:
       default: '19260101'
       values: ['19260101']
   name: ch.swisstopo.hiks-siegfried_19260101
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache_out]
   title: Siegfriedkarte Erstausgabe
-- dimensions: *id465
+- dimensions: *id467
   name: ch.swisstopo.hiks-siegfried
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe
-- dimensions: *id465
+- dimensions: *id467
   name: ch.swisstopo.hiks-siegfried_19260101_source
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe
-- dimensions: &id466
+- dimensions: &id468
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.hiks-siegfried-ta25_19491231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19491231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id466
+- dimensions: *id468
   name: ch.swisstopo.hiks-siegfried-ta25
   sources: [ch.swisstopo.hiks-siegfried-ta25_19491231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id466
+- dimensions: *id468
   name: ch.swisstopo.hiks-siegfried-ta25_19491231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19491231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id467
+- dimensions: &id469
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.hiks-siegfried-ta25_19481231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19481231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id467
+- dimensions: *id469
   name: ch.swisstopo.hiks-siegfried-ta25_19481231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19481231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id468
+- dimensions: &id470
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.hiks-siegfried-ta25_19471231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19471231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id468
+- dimensions: *id470
   name: ch.swisstopo.hiks-siegfried-ta25_19471231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19471231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id469
+- dimensions: &id471
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.hiks-siegfried-ta25_19461231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19461231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id469
+- dimensions: *id471
   name: ch.swisstopo.hiks-siegfried-ta25_19461231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19461231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id470
+- dimensions: &id472
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.hiks-siegfried-ta25_19451231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19451231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id470
+- dimensions: *id472
   name: ch.swisstopo.hiks-siegfried-ta25_19451231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19451231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id471
+- dimensions: &id473
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.hiks-siegfried-ta25_19441231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19441231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id471
+- dimensions: *id473
   name: ch.swisstopo.hiks-siegfried-ta25_19441231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19441231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id472
+- dimensions: &id474
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.hiks-siegfried-ta25_19431231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19431231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id472
+- dimensions: *id474
   name: ch.swisstopo.hiks-siegfried-ta25_19431231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19431231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id473
+- dimensions: &id475
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.hiks-siegfried-ta25_19421231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19421231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id473
+- dimensions: *id475
   name: ch.swisstopo.hiks-siegfried-ta25_19421231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19421231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id474
+- dimensions: &id476
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.hiks-siegfried-ta25_19411231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19411231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id474
+- dimensions: *id476
   name: ch.swisstopo.hiks-siegfried-ta25_19411231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19411231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id475
+- dimensions: &id477
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.hiks-siegfried-ta25_19401231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19401231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id475
+- dimensions: *id477
   name: ch.swisstopo.hiks-siegfried-ta25_19401231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19401231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id476
+- dimensions: &id478
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.hiks-siegfried-ta25_19391231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19391231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id476
+- dimensions: *id478
   name: ch.swisstopo.hiks-siegfried-ta25_19391231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19391231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id477
+- dimensions: &id479
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.hiks-siegfried-ta25_19381231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19381231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id477
+- dimensions: *id479
   name: ch.swisstopo.hiks-siegfried-ta25_19381231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19381231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id478
+- dimensions: &id480
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.hiks-siegfried-ta25_19371231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19371231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id478
+- dimensions: *id480
   name: ch.swisstopo.hiks-siegfried-ta25_19371231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19371231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id479
+- dimensions: &id481
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.hiks-siegfried-ta25_19361231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19361231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id479
+- dimensions: *id481
   name: ch.swisstopo.hiks-siegfried-ta25_19361231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19361231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id480
+- dimensions: &id482
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.hiks-siegfried-ta25_19351231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19351231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id480
+- dimensions: *id482
   name: ch.swisstopo.hiks-siegfried-ta25_19351231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19351231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id481
+- dimensions: &id483
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.hiks-siegfried-ta25_19341231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19341231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id481
+- dimensions: *id483
   name: ch.swisstopo.hiks-siegfried-ta25_19341231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19341231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id482
+- dimensions: &id484
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.hiks-siegfried-ta25_19331231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19331231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id482
+- dimensions: *id484
   name: ch.swisstopo.hiks-siegfried-ta25_19331231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19331231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id483
+- dimensions: &id485
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.hiks-siegfried-ta25_19321231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19321231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id483
+- dimensions: *id485
   name: ch.swisstopo.hiks-siegfried-ta25_19321231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19321231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id484
+- dimensions: &id486
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.hiks-siegfried-ta25_19311231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19311231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id484
+- dimensions: *id486
   name: ch.swisstopo.hiks-siegfried-ta25_19311231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19311231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id485
+- dimensions: &id487
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.hiks-siegfried-ta25_19301231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19301231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id485
+- dimensions: *id487
   name: ch.swisstopo.hiks-siegfried-ta25_19301231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19301231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id486
+- dimensions: &id488
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.hiks-siegfried-ta25_19291231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19291231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id486
+- dimensions: *id488
   name: ch.swisstopo.hiks-siegfried-ta25_19291231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19291231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id487
+- dimensions: &id489
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.hiks-siegfried-ta25_19281231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19281231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id487
+- dimensions: *id489
   name: ch.swisstopo.hiks-siegfried-ta25_19281231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19281231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id488
+- dimensions: &id490
     Time:
       default: '19271231'
       values: ['19271231']
   name: ch.swisstopo.hiks-siegfried-ta25_19271231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19271231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id488
+- dimensions: *id490
   name: ch.swisstopo.hiks-siegfried-ta25_19271231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19271231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id489
+- dimensions: &id491
     Time:
       default: '19261231'
       values: ['19261231']
   name: ch.swisstopo.hiks-siegfried-ta25_19261231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19261231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id489
+- dimensions: *id491
   name: ch.swisstopo.hiks-siegfried-ta25_19261231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19261231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id490
+- dimensions: &id492
     Time:
       default: '19251231'
       values: ['19251231']
   name: ch.swisstopo.hiks-siegfried-ta25_19251231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19251231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id490
+- dimensions: *id492
   name: ch.swisstopo.hiks-siegfried-ta25_19251231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19251231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id491
+- dimensions: &id493
     Time:
       default: '19241231'
       values: ['19241231']
   name: ch.swisstopo.hiks-siegfried-ta25_19241231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19241231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id491
+- dimensions: *id493
   name: ch.swisstopo.hiks-siegfried-ta25_19241231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19241231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id492
+- dimensions: &id494
     Time:
       default: '19231231'
       values: ['19231231']
   name: ch.swisstopo.hiks-siegfried-ta25_19231231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19231231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id492
+- dimensions: *id494
   name: ch.swisstopo.hiks-siegfried-ta25_19231231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19231231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id493
+- dimensions: &id495
     Time:
       default: '19221231'
       values: ['19221231']
   name: ch.swisstopo.hiks-siegfried-ta25_19221231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19221231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id493
+- dimensions: *id495
   name: ch.swisstopo.hiks-siegfried-ta25_19221231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19221231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id494
+- dimensions: &id496
     Time:
       default: '19211231'
       values: ['19211231']
   name: ch.swisstopo.hiks-siegfried-ta25_19211231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19211231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id494
+- dimensions: *id496
   name: ch.swisstopo.hiks-siegfried-ta25_19211231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19211231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id495
+- dimensions: &id497
     Time:
       default: '19201231'
       values: ['19201231']
   name: ch.swisstopo.hiks-siegfried-ta25_19201231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19201231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id495
+- dimensions: *id497
   name: ch.swisstopo.hiks-siegfried-ta25_19201231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19201231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id496
+- dimensions: &id498
     Time:
       default: '19191231'
       values: ['19191231']
   name: ch.swisstopo.hiks-siegfried-ta25_19191231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19191231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id496
+- dimensions: *id498
   name: ch.swisstopo.hiks-siegfried-ta25_19191231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19191231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id497
+- dimensions: &id499
     Time:
       default: '19181231'
       values: ['19181231']
   name: ch.swisstopo.hiks-siegfried-ta25_19181231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19181231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id497
+- dimensions: *id499
   name: ch.swisstopo.hiks-siegfried-ta25_19181231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19181231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id498
+- dimensions: &id500
     Time:
       default: '19171231'
       values: ['19171231']
   name: ch.swisstopo.hiks-siegfried-ta25_19171231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19171231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id498
+- dimensions: *id500
   name: ch.swisstopo.hiks-siegfried-ta25_19171231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19171231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id499
+- dimensions: &id501
     Time:
       default: '19161231'
       values: ['19161231']
   name: ch.swisstopo.hiks-siegfried-ta25_19161231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19161231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id499
+- dimensions: *id501
   name: ch.swisstopo.hiks-siegfried-ta25_19161231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19161231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id500
+- dimensions: &id502
     Time:
       default: '19151231'
       values: ['19151231']
   name: ch.swisstopo.hiks-siegfried-ta25_19151231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19151231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id500
+- dimensions: *id502
   name: ch.swisstopo.hiks-siegfried-ta25_19151231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19151231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id501
+- dimensions: &id503
     Time:
       default: '19141231'
       values: ['19141231']
   name: ch.swisstopo.hiks-siegfried-ta25_19141231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19141231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id501
+- dimensions: *id503
   name: ch.swisstopo.hiks-siegfried-ta25_19141231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19141231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id502
+- dimensions: &id504
     Time:
       default: '19131231'
       values: ['19131231']
   name: ch.swisstopo.hiks-siegfried-ta25_19131231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19131231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id502
+- dimensions: *id504
   name: ch.swisstopo.hiks-siegfried-ta25_19131231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19131231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id503
+- dimensions: &id505
     Time:
       default: '19121231'
       values: ['19121231']
   name: ch.swisstopo.hiks-siegfried-ta25_19121231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19121231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id503
+- dimensions: *id505
   name: ch.swisstopo.hiks-siegfried-ta25_19121231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19121231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id504
+- dimensions: &id506
     Time:
       default: '19111231'
       values: ['19111231']
   name: ch.swisstopo.hiks-siegfried-ta25_19111231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19111231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id504
+- dimensions: *id506
   name: ch.swisstopo.hiks-siegfried-ta25_19111231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19111231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id505
+- dimensions: &id507
     Time:
       default: '19101231'
       values: ['19101231']
   name: ch.swisstopo.hiks-siegfried-ta25_19101231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19101231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id505
+- dimensions: *id507
   name: ch.swisstopo.hiks-siegfried-ta25_19101231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19101231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id506
+- dimensions: &id508
     Time:
       default: '19091231'
       values: ['19091231']
   name: ch.swisstopo.hiks-siegfried-ta25_19091231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19091231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id506
+- dimensions: *id508
   name: ch.swisstopo.hiks-siegfried-ta25_19091231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19091231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id507
+- dimensions: &id509
     Time:
       default: '19081231'
       values: ['19081231']
   name: ch.swisstopo.hiks-siegfried-ta25_19081231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19081231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id507
+- dimensions: *id509
   name: ch.swisstopo.hiks-siegfried-ta25_19081231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19081231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id508
+- dimensions: &id510
     Time:
       default: '19071231'
       values: ['19071231']
   name: ch.swisstopo.hiks-siegfried-ta25_19071231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19071231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id508
+- dimensions: *id510
   name: ch.swisstopo.hiks-siegfried-ta25_19071231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19071231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id509
+- dimensions: &id511
     Time:
       default: '19061231'
       values: ['19061231']
   name: ch.swisstopo.hiks-siegfried-ta25_19061231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19061231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id509
+- dimensions: *id511
   name: ch.swisstopo.hiks-siegfried-ta25_19061231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19061231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id510
+- dimensions: &id512
     Time:
       default: '19051231'
       values: ['19051231']
   name: ch.swisstopo.hiks-siegfried-ta25_19051231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19051231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id510
+- dimensions: *id512
   name: ch.swisstopo.hiks-siegfried-ta25_19051231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19051231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id511
+- dimensions: &id513
     Time:
       default: '19041231'
       values: ['19041231']
   name: ch.swisstopo.hiks-siegfried-ta25_19041231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19041231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id511
+- dimensions: *id513
   name: ch.swisstopo.hiks-siegfried-ta25_19041231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19041231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id512
+- dimensions: &id514
     Time:
       default: '19031231'
       values: ['19031231']
   name: ch.swisstopo.hiks-siegfried-ta25_19031231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19031231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id512
+- dimensions: *id514
   name: ch.swisstopo.hiks-siegfried-ta25_19031231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19031231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id513
+- dimensions: &id515
     Time:
       default: '19021231'
       values: ['19021231']
   name: ch.swisstopo.hiks-siegfried-ta25_19021231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19021231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id513
+- dimensions: *id515
   name: ch.swisstopo.hiks-siegfried-ta25_19021231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19021231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id514
+- dimensions: &id516
     Time:
       default: '19011231'
       values: ['19011231']
   name: ch.swisstopo.hiks-siegfried-ta25_19011231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19011231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id514
+- dimensions: *id516
   name: ch.swisstopo.hiks-siegfried-ta25_19011231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19011231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id515
+- dimensions: &id517
     Time:
       default: '19001231'
       values: ['19001231']
   name: ch.swisstopo.hiks-siegfried-ta25_19001231
   sources: [ch.swisstopo.hiks-siegfried-ta25_19001231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id515
+- dimensions: *id517
   name: ch.swisstopo.hiks-siegfried-ta25_19001231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_19001231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id516
+- dimensions: &id518
     Time:
       default: '18991231'
       values: ['18991231']
   name: ch.swisstopo.hiks-siegfried-ta25_18991231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18991231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id516
+- dimensions: *id518
   name: ch.swisstopo.hiks-siegfried-ta25_18991231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18991231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id517
+- dimensions: &id519
     Time:
       default: '18981231'
       values: ['18981231']
   name: ch.swisstopo.hiks-siegfried-ta25_18981231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18981231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id517
+- dimensions: *id519
   name: ch.swisstopo.hiks-siegfried-ta25_18981231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18981231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id518
+- dimensions: &id520
     Time:
       default: '18971231'
       values: ['18971231']
   name: ch.swisstopo.hiks-siegfried-ta25_18971231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18971231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id518
+- dimensions: *id520
   name: ch.swisstopo.hiks-siegfried-ta25_18971231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18971231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id519
+- dimensions: &id521
     Time:
       default: '18961231'
       values: ['18961231']
   name: ch.swisstopo.hiks-siegfried-ta25_18961231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18961231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id519
+- dimensions: *id521
   name: ch.swisstopo.hiks-siegfried-ta25_18961231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18961231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id520
+- dimensions: &id522
     Time:
       default: '18951231'
       values: ['18951231']
   name: ch.swisstopo.hiks-siegfried-ta25_18951231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18951231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id520
+- dimensions: *id522
   name: ch.swisstopo.hiks-siegfried-ta25_18951231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18951231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id521
+- dimensions: &id523
     Time:
       default: '18941231'
       values: ['18941231']
   name: ch.swisstopo.hiks-siegfried-ta25_18941231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18941231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id521
+- dimensions: *id523
   name: ch.swisstopo.hiks-siegfried-ta25_18941231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18941231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id522
+- dimensions: &id524
     Time:
       default: '18931231'
       values: ['18931231']
   name: ch.swisstopo.hiks-siegfried-ta25_18931231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18931231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id522
+- dimensions: *id524
   name: ch.swisstopo.hiks-siegfried-ta25_18931231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18931231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id523
+- dimensions: &id525
     Time:
       default: '18921231'
       values: ['18921231']
   name: ch.swisstopo.hiks-siegfried-ta25_18921231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18921231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id523
+- dimensions: *id525
   name: ch.swisstopo.hiks-siegfried-ta25_18921231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18921231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id524
+- dimensions: &id526
     Time:
       default: '18911231'
       values: ['18911231']
   name: ch.swisstopo.hiks-siegfried-ta25_18911231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18911231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id524
+- dimensions: *id526
   name: ch.swisstopo.hiks-siegfried-ta25_18911231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18911231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id525
+- dimensions: &id527
     Time:
       default: '18901231'
       values: ['18901231']
   name: ch.swisstopo.hiks-siegfried-ta25_18901231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18901231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id525
+- dimensions: *id527
   name: ch.swisstopo.hiks-siegfried-ta25_18901231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18901231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id526
+- dimensions: &id528
     Time:
       default: '18891231'
       values: ['18891231']
   name: ch.swisstopo.hiks-siegfried-ta25_18891231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18891231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id526
+- dimensions: *id528
   name: ch.swisstopo.hiks-siegfried-ta25_18891231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18891231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id527
+- dimensions: &id529
     Time:
       default: '18881231'
       values: ['18881231']
   name: ch.swisstopo.hiks-siegfried-ta25_18881231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18881231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id527
+- dimensions: *id529
   name: ch.swisstopo.hiks-siegfried-ta25_18881231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18881231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id528
+- dimensions: &id530
     Time:
       default: '18871231'
       values: ['18871231']
   name: ch.swisstopo.hiks-siegfried-ta25_18871231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18871231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id528
+- dimensions: *id530
   name: ch.swisstopo.hiks-siegfried-ta25_18871231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18871231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id529
+- dimensions: &id531
     Time:
       default: '18861231'
       values: ['18861231']
   name: ch.swisstopo.hiks-siegfried-ta25_18861231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18861231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id529
+- dimensions: *id531
   name: ch.swisstopo.hiks-siegfried-ta25_18861231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18861231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id530
+- dimensions: &id532
     Time:
       default: '18851231'
       values: ['18851231']
   name: ch.swisstopo.hiks-siegfried-ta25_18851231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18851231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id530
+- dimensions: *id532
   name: ch.swisstopo.hiks-siegfried-ta25_18851231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18851231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id531
+- dimensions: &id533
     Time:
       default: '18841231'
       values: ['18841231']
   name: ch.swisstopo.hiks-siegfried-ta25_18841231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18841231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id531
+- dimensions: *id533
   name: ch.swisstopo.hiks-siegfried-ta25_18841231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18841231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id532
+- dimensions: &id534
     Time:
       default: '18831231'
       values: ['18831231']
   name: ch.swisstopo.hiks-siegfried-ta25_18831231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18831231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id532
+- dimensions: *id534
   name: ch.swisstopo.hiks-siegfried-ta25_18831231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18831231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id533
+- dimensions: &id535
     Time:
       default: '18821231'
       values: ['18821231']
   name: ch.swisstopo.hiks-siegfried-ta25_18821231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18821231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id533
+- dimensions: *id535
   name: ch.swisstopo.hiks-siegfried-ta25_18821231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18821231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id534
+- dimensions: &id536
     Time:
       default: '18811231'
       values: ['18811231']
   name: ch.swisstopo.hiks-siegfried-ta25_18811231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18811231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id534
+- dimensions: *id536
   name: ch.swisstopo.hiks-siegfried-ta25_18811231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18811231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id535
+- dimensions: &id537
     Time:
       default: '18801231'
       values: ['18801231']
   name: ch.swisstopo.hiks-siegfried-ta25_18801231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18801231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id535
+- dimensions: *id537
   name: ch.swisstopo.hiks-siegfried-ta25_18801231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18801231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id536
+- dimensions: &id538
     Time:
       default: '18791231'
       values: ['18791231']
   name: ch.swisstopo.hiks-siegfried-ta25_18791231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18791231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id536
+- dimensions: *id538
   name: ch.swisstopo.hiks-siegfried-ta25_18791231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18791231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id537
+- dimensions: &id539
     Time:
       default: '18781231'
       values: ['18781231']
   name: ch.swisstopo.hiks-siegfried-ta25_18781231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18781231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id537
+- dimensions: *id539
   name: ch.swisstopo.hiks-siegfried-ta25_18781231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18781231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id538
+- dimensions: &id540
     Time:
       default: '18771231'
       values: ['18771231']
   name: ch.swisstopo.hiks-siegfried-ta25_18771231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18771231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id538
+- dimensions: *id540
   name: ch.swisstopo.hiks-siegfried-ta25_18771231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18771231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id539
+- dimensions: &id541
     Time:
       default: '18761231'
       values: ['18761231']
   name: ch.swisstopo.hiks-siegfried-ta25_18761231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18761231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id539
+- dimensions: *id541
   name: ch.swisstopo.hiks-siegfried-ta25_18761231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18761231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id540
+- dimensions: &id542
     Time:
       default: '18751231'
       values: ['18751231']
   name: ch.swisstopo.hiks-siegfried-ta25_18751231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18751231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id540
+- dimensions: *id542
   name: ch.swisstopo.hiks-siegfried-ta25_18751231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18751231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id541
+- dimensions: &id543
     Time:
       default: '18741231'
       values: ['18741231']
   name: ch.swisstopo.hiks-siegfried-ta25_18741231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18741231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id541
+- dimensions: *id543
   name: ch.swisstopo.hiks-siegfried-ta25_18741231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18741231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id542
+- dimensions: &id544
     Time:
       default: '18731231'
       values: ['18731231']
   name: ch.swisstopo.hiks-siegfried-ta25_18731231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18731231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id542
+- dimensions: *id544
   name: ch.swisstopo.hiks-siegfried-ta25_18731231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18731231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id543
+- dimensions: &id545
     Time:
       default: '18721231'
       values: ['18721231']
   name: ch.swisstopo.hiks-siegfried-ta25_18721231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18721231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id543
+- dimensions: *id545
   name: ch.swisstopo.hiks-siegfried-ta25_18721231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18721231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id544
+- dimensions: &id546
     Time:
       default: '18711231'
       values: ['18711231']
   name: ch.swisstopo.hiks-siegfried-ta25_18711231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18711231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id544
+- dimensions: *id546
   name: ch.swisstopo.hiks-siegfried-ta25_18711231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18711231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id545
+- dimensions: &id547
     Time:
       default: '18701231'
       values: ['18701231']
   name: ch.swisstopo.hiks-siegfried-ta25_18701231
   sources: [ch.swisstopo.hiks-siegfried-ta25_18701231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: *id545
+- dimensions: *id547
   name: ch.swisstopo.hiks-siegfried-ta25_18701231_source
   sources: [ch.swisstopo.hiks-siegfried-ta25_18701231_cache]
   title: ch.swisstopo.hiks-siegfried-ta25
-- dimensions: &id546
+- dimensions: &id548
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.hiks-siegfried-ta50_19491231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19491231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id546
+- dimensions: *id548
   name: ch.swisstopo.hiks-siegfried-ta50
   sources: [ch.swisstopo.hiks-siegfried-ta50_19491231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id546
+- dimensions: *id548
   name: ch.swisstopo.hiks-siegfried-ta50_19491231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19491231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id547
+- dimensions: &id549
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.hiks-siegfried-ta50_19481231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19481231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id547
+- dimensions: *id549
   name: ch.swisstopo.hiks-siegfried-ta50_19481231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19481231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id548
+- dimensions: &id550
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.hiks-siegfried-ta50_19471231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19471231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id548
+- dimensions: *id550
   name: ch.swisstopo.hiks-siegfried-ta50_19471231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19471231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id549
+- dimensions: &id551
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.hiks-siegfried-ta50_19461231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19461231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id549
+- dimensions: *id551
   name: ch.swisstopo.hiks-siegfried-ta50_19461231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19461231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id550
+- dimensions: &id552
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.hiks-siegfried-ta50_19451231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19451231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id550
+- dimensions: *id552
   name: ch.swisstopo.hiks-siegfried-ta50_19451231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19451231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id551
+- dimensions: &id553
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.hiks-siegfried-ta50_19441231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19441231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id551
+- dimensions: *id553
   name: ch.swisstopo.hiks-siegfried-ta50_19441231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19441231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id552
+- dimensions: &id554
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.hiks-siegfried-ta50_19431231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19431231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id552
+- dimensions: *id554
   name: ch.swisstopo.hiks-siegfried-ta50_19431231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19431231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id553
+- dimensions: &id555
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.hiks-siegfried-ta50_19421231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19421231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id553
+- dimensions: *id555
   name: ch.swisstopo.hiks-siegfried-ta50_19421231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19421231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id554
+- dimensions: &id556
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.hiks-siegfried-ta50_19411231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19411231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id554
+- dimensions: *id556
   name: ch.swisstopo.hiks-siegfried-ta50_19411231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19411231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id555
+- dimensions: &id557
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.hiks-siegfried-ta50_19401231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19401231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id555
+- dimensions: *id557
   name: ch.swisstopo.hiks-siegfried-ta50_19401231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19401231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id556
+- dimensions: &id558
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.hiks-siegfried-ta50_19391231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19391231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id556
+- dimensions: *id558
   name: ch.swisstopo.hiks-siegfried-ta50_19391231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19391231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id557
+- dimensions: &id559
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.hiks-siegfried-ta50_19381231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19381231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id557
+- dimensions: *id559
   name: ch.swisstopo.hiks-siegfried-ta50_19381231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19381231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id558
+- dimensions: &id560
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.hiks-siegfried-ta50_19371231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19371231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id558
+- dimensions: *id560
   name: ch.swisstopo.hiks-siegfried-ta50_19371231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19371231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id559
+- dimensions: &id561
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.hiks-siegfried-ta50_19361231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19361231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id559
+- dimensions: *id561
   name: ch.swisstopo.hiks-siegfried-ta50_19361231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19361231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id560
+- dimensions: &id562
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.hiks-siegfried-ta50_19351231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19351231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id560
+- dimensions: *id562
   name: ch.swisstopo.hiks-siegfried-ta50_19351231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19351231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id561
+- dimensions: &id563
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.hiks-siegfried-ta50_19341231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19341231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id561
+- dimensions: *id563
   name: ch.swisstopo.hiks-siegfried-ta50_19341231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19341231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id562
+- dimensions: &id564
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.hiks-siegfried-ta50_19331231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19331231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id562
+- dimensions: *id564
   name: ch.swisstopo.hiks-siegfried-ta50_19331231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19331231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id563
+- dimensions: &id565
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.hiks-siegfried-ta50_19321231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19321231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id563
+- dimensions: *id565
   name: ch.swisstopo.hiks-siegfried-ta50_19321231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19321231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id564
+- dimensions: &id566
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.hiks-siegfried-ta50_19311231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19311231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id564
+- dimensions: *id566
   name: ch.swisstopo.hiks-siegfried-ta50_19311231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19311231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id565
+- dimensions: &id567
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.hiks-siegfried-ta50_19301231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19301231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id565
+- dimensions: *id567
   name: ch.swisstopo.hiks-siegfried-ta50_19301231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19301231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id566
+- dimensions: &id568
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.hiks-siegfried-ta50_19291231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19291231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id566
+- dimensions: *id568
   name: ch.swisstopo.hiks-siegfried-ta50_19291231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19291231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id567
+- dimensions: &id569
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.hiks-siegfried-ta50_19281231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19281231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id567
+- dimensions: *id569
   name: ch.swisstopo.hiks-siegfried-ta50_19281231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19281231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id568
+- dimensions: &id570
     Time:
       default: '19271231'
       values: ['19271231']
   name: ch.swisstopo.hiks-siegfried-ta50_19271231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19271231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id568
+- dimensions: *id570
   name: ch.swisstopo.hiks-siegfried-ta50_19271231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19271231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id569
+- dimensions: &id571
     Time:
       default: '19261231'
       values: ['19261231']
   name: ch.swisstopo.hiks-siegfried-ta50_19261231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19261231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id569
+- dimensions: *id571
   name: ch.swisstopo.hiks-siegfried-ta50_19261231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19261231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id570
+- dimensions: &id572
     Time:
       default: '19251231'
       values: ['19251231']
   name: ch.swisstopo.hiks-siegfried-ta50_19251231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19251231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id570
+- dimensions: *id572
   name: ch.swisstopo.hiks-siegfried-ta50_19251231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19251231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id571
+- dimensions: &id573
     Time:
       default: '19241231'
       values: ['19241231']
   name: ch.swisstopo.hiks-siegfried-ta50_19241231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19241231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id571
+- dimensions: *id573
   name: ch.swisstopo.hiks-siegfried-ta50_19241231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19241231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id572
+- dimensions: &id574
     Time:
       default: '19231231'
       values: ['19231231']
   name: ch.swisstopo.hiks-siegfried-ta50_19231231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19231231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id572
+- dimensions: *id574
   name: ch.swisstopo.hiks-siegfried-ta50_19231231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19231231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id573
+- dimensions: &id575
     Time:
       default: '19221231'
       values: ['19221231']
   name: ch.swisstopo.hiks-siegfried-ta50_19221231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19221231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id573
+- dimensions: *id575
   name: ch.swisstopo.hiks-siegfried-ta50_19221231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19221231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id574
+- dimensions: &id576
     Time:
       default: '19211231'
       values: ['19211231']
   name: ch.swisstopo.hiks-siegfried-ta50_19211231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19211231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id574
+- dimensions: *id576
   name: ch.swisstopo.hiks-siegfried-ta50_19211231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19211231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id575
+- dimensions: &id577
     Time:
       default: '19201231'
       values: ['19201231']
   name: ch.swisstopo.hiks-siegfried-ta50_19201231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19201231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id575
+- dimensions: *id577
   name: ch.swisstopo.hiks-siegfried-ta50_19201231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19201231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id576
+- dimensions: &id578
     Time:
       default: '19191231'
       values: ['19191231']
   name: ch.swisstopo.hiks-siegfried-ta50_19191231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19191231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id576
+- dimensions: *id578
   name: ch.swisstopo.hiks-siegfried-ta50_19191231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19191231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id577
+- dimensions: &id579
     Time:
       default: '19181231'
       values: ['19181231']
   name: ch.swisstopo.hiks-siegfried-ta50_19181231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19181231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id577
+- dimensions: *id579
   name: ch.swisstopo.hiks-siegfried-ta50_19181231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19181231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id578
+- dimensions: &id580
     Time:
       default: '19171231'
       values: ['19171231']
   name: ch.swisstopo.hiks-siegfried-ta50_19171231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19171231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id578
+- dimensions: *id580
   name: ch.swisstopo.hiks-siegfried-ta50_19171231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19171231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id579
+- dimensions: &id581
     Time:
       default: '19161231'
       values: ['19161231']
   name: ch.swisstopo.hiks-siegfried-ta50_19161231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19161231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id579
+- dimensions: *id581
   name: ch.swisstopo.hiks-siegfried-ta50_19161231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19161231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id580
+- dimensions: &id582
     Time:
       default: '19151231'
       values: ['19151231']
   name: ch.swisstopo.hiks-siegfried-ta50_19151231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19151231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id580
+- dimensions: *id582
   name: ch.swisstopo.hiks-siegfried-ta50_19151231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19151231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id581
+- dimensions: &id583
     Time:
       default: '19141231'
       values: ['19141231']
   name: ch.swisstopo.hiks-siegfried-ta50_19141231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19141231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id581
+- dimensions: *id583
   name: ch.swisstopo.hiks-siegfried-ta50_19141231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19141231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id582
+- dimensions: &id584
     Time:
       default: '19131231'
       values: ['19131231']
   name: ch.swisstopo.hiks-siegfried-ta50_19131231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19131231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id582
+- dimensions: *id584
   name: ch.swisstopo.hiks-siegfried-ta50_19131231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19131231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id583
+- dimensions: &id585
     Time:
       default: '19121231'
       values: ['19121231']
   name: ch.swisstopo.hiks-siegfried-ta50_19121231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19121231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id583
+- dimensions: *id585
   name: ch.swisstopo.hiks-siegfried-ta50_19121231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19121231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id584
+- dimensions: &id586
     Time:
       default: '19111231'
       values: ['19111231']
   name: ch.swisstopo.hiks-siegfried-ta50_19111231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19111231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id584
+- dimensions: *id586
   name: ch.swisstopo.hiks-siegfried-ta50_19111231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19111231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id585
+- dimensions: &id587
     Time:
       default: '19101231'
       values: ['19101231']
   name: ch.swisstopo.hiks-siegfried-ta50_19101231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19101231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id585
+- dimensions: *id587
   name: ch.swisstopo.hiks-siegfried-ta50_19101231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19101231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id586
+- dimensions: &id588
     Time:
       default: '19091231'
       values: ['19091231']
   name: ch.swisstopo.hiks-siegfried-ta50_19091231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19091231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id586
+- dimensions: *id588
   name: ch.swisstopo.hiks-siegfried-ta50_19091231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19091231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id587
+- dimensions: &id589
     Time:
       default: '19081231'
       values: ['19081231']
   name: ch.swisstopo.hiks-siegfried-ta50_19081231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19081231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id587
+- dimensions: *id589
   name: ch.swisstopo.hiks-siegfried-ta50_19081231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19081231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id588
+- dimensions: &id590
     Time:
       default: '19071231'
       values: ['19071231']
   name: ch.swisstopo.hiks-siegfried-ta50_19071231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19071231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id588
+- dimensions: *id590
   name: ch.swisstopo.hiks-siegfried-ta50_19071231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19071231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id589
+- dimensions: &id591
     Time:
       default: '19061231'
       values: ['19061231']
   name: ch.swisstopo.hiks-siegfried-ta50_19061231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19061231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id589
+- dimensions: *id591
   name: ch.swisstopo.hiks-siegfried-ta50_19061231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19061231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id590
+- dimensions: &id592
     Time:
       default: '19051231'
       values: ['19051231']
   name: ch.swisstopo.hiks-siegfried-ta50_19051231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19051231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id590
+- dimensions: *id592
   name: ch.swisstopo.hiks-siegfried-ta50_19051231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19051231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id591
+- dimensions: &id593
     Time:
       default: '19041231'
       values: ['19041231']
   name: ch.swisstopo.hiks-siegfried-ta50_19041231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19041231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id591
+- dimensions: *id593
   name: ch.swisstopo.hiks-siegfried-ta50_19041231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19041231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id592
+- dimensions: &id594
     Time:
       default: '19031231'
       values: ['19031231']
   name: ch.swisstopo.hiks-siegfried-ta50_19031231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19031231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id592
+- dimensions: *id594
   name: ch.swisstopo.hiks-siegfried-ta50_19031231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19031231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id593
+- dimensions: &id595
     Time:
       default: '19021231'
       values: ['19021231']
   name: ch.swisstopo.hiks-siegfried-ta50_19021231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19021231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id593
+- dimensions: *id595
   name: ch.swisstopo.hiks-siegfried-ta50_19021231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19021231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id594
+- dimensions: &id596
     Time:
       default: '19011231'
       values: ['19011231']
   name: ch.swisstopo.hiks-siegfried-ta50_19011231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19011231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id594
+- dimensions: *id596
   name: ch.swisstopo.hiks-siegfried-ta50_19011231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19011231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id595
+- dimensions: &id597
     Time:
       default: '19001231'
       values: ['19001231']
   name: ch.swisstopo.hiks-siegfried-ta50_19001231
   sources: [ch.swisstopo.hiks-siegfried-ta50_19001231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id595
+- dimensions: *id597
   name: ch.swisstopo.hiks-siegfried-ta50_19001231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_19001231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id596
+- dimensions: &id598
     Time:
       default: '18991231'
       values: ['18991231']
   name: ch.swisstopo.hiks-siegfried-ta50_18991231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18991231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id596
+- dimensions: *id598
   name: ch.swisstopo.hiks-siegfried-ta50_18991231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18991231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id597
+- dimensions: &id599
     Time:
       default: '18981231'
       values: ['18981231']
   name: ch.swisstopo.hiks-siegfried-ta50_18981231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18981231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id597
+- dimensions: *id599
   name: ch.swisstopo.hiks-siegfried-ta50_18981231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18981231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id598
+- dimensions: &id600
     Time:
       default: '18971231'
       values: ['18971231']
   name: ch.swisstopo.hiks-siegfried-ta50_18971231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18971231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id598
+- dimensions: *id600
   name: ch.swisstopo.hiks-siegfried-ta50_18971231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18971231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id599
+- dimensions: &id601
     Time:
       default: '18961231'
       values: ['18961231']
   name: ch.swisstopo.hiks-siegfried-ta50_18961231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18961231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id599
+- dimensions: *id601
   name: ch.swisstopo.hiks-siegfried-ta50_18961231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18961231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id600
+- dimensions: &id602
     Time:
       default: '18951231'
       values: ['18951231']
   name: ch.swisstopo.hiks-siegfried-ta50_18951231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18951231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id600
+- dimensions: *id602
   name: ch.swisstopo.hiks-siegfried-ta50_18951231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18951231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id601
+- dimensions: &id603
     Time:
       default: '18941231'
       values: ['18941231']
   name: ch.swisstopo.hiks-siegfried-ta50_18941231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18941231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id601
+- dimensions: *id603
   name: ch.swisstopo.hiks-siegfried-ta50_18941231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18941231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id602
+- dimensions: &id604
     Time:
       default: '18931231'
       values: ['18931231']
   name: ch.swisstopo.hiks-siegfried-ta50_18931231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18931231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id602
+- dimensions: *id604
   name: ch.swisstopo.hiks-siegfried-ta50_18931231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18931231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id603
+- dimensions: &id605
     Time:
       default: '18921231'
       values: ['18921231']
   name: ch.swisstopo.hiks-siegfried-ta50_18921231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18921231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id603
+- dimensions: *id605
   name: ch.swisstopo.hiks-siegfried-ta50_18921231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18921231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id604
+- dimensions: &id606
     Time:
       default: '18911231'
       values: ['18911231']
   name: ch.swisstopo.hiks-siegfried-ta50_18911231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18911231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id604
+- dimensions: *id606
   name: ch.swisstopo.hiks-siegfried-ta50_18911231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18911231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id605
+- dimensions: &id607
     Time:
       default: '18901231'
       values: ['18901231']
   name: ch.swisstopo.hiks-siegfried-ta50_18901231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18901231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id605
+- dimensions: *id607
   name: ch.swisstopo.hiks-siegfried-ta50_18901231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18901231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id606
+- dimensions: &id608
     Time:
       default: '18891231'
       values: ['18891231']
   name: ch.swisstopo.hiks-siegfried-ta50_18891231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18891231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id606
+- dimensions: *id608
   name: ch.swisstopo.hiks-siegfried-ta50_18891231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18891231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id607
+- dimensions: &id609
     Time:
       default: '18881231'
       values: ['18881231']
   name: ch.swisstopo.hiks-siegfried-ta50_18881231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18881231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id607
+- dimensions: *id609
   name: ch.swisstopo.hiks-siegfried-ta50_18881231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18881231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id608
+- dimensions: &id610
     Time:
       default: '18871231'
       values: ['18871231']
   name: ch.swisstopo.hiks-siegfried-ta50_18871231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18871231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id608
+- dimensions: *id610
   name: ch.swisstopo.hiks-siegfried-ta50_18871231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18871231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id609
+- dimensions: &id611
     Time:
       default: '18861231'
       values: ['18861231']
   name: ch.swisstopo.hiks-siegfried-ta50_18861231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18861231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id609
+- dimensions: *id611
   name: ch.swisstopo.hiks-siegfried-ta50_18861231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18861231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id610
+- dimensions: &id612
     Time:
       default: '18851231'
       values: ['18851231']
   name: ch.swisstopo.hiks-siegfried-ta50_18851231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18851231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id610
+- dimensions: *id612
   name: ch.swisstopo.hiks-siegfried-ta50_18851231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18851231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id611
+- dimensions: &id613
     Time:
       default: '18841231'
       values: ['18841231']
   name: ch.swisstopo.hiks-siegfried-ta50_18841231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18841231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id611
+- dimensions: *id613
   name: ch.swisstopo.hiks-siegfried-ta50_18841231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18841231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id612
+- dimensions: &id614
     Time:
       default: '18831231'
       values: ['18831231']
   name: ch.swisstopo.hiks-siegfried-ta50_18831231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18831231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id612
+- dimensions: *id614
   name: ch.swisstopo.hiks-siegfried-ta50_18831231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18831231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id613
+- dimensions: &id615
     Time:
       default: '18821231'
       values: ['18821231']
   name: ch.swisstopo.hiks-siegfried-ta50_18821231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18821231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id613
+- dimensions: *id615
   name: ch.swisstopo.hiks-siegfried-ta50_18821231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18821231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id614
+- dimensions: &id616
     Time:
       default: '18811231'
       values: ['18811231']
   name: ch.swisstopo.hiks-siegfried-ta50_18811231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18811231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id614
+- dimensions: *id616
   name: ch.swisstopo.hiks-siegfried-ta50_18811231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18811231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id615
+- dimensions: &id617
     Time:
       default: '18801231'
       values: ['18801231']
   name: ch.swisstopo.hiks-siegfried-ta50_18801231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18801231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id615
+- dimensions: *id617
   name: ch.swisstopo.hiks-siegfried-ta50_18801231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18801231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id616
+- dimensions: &id618
     Time:
       default: '18791231'
       values: ['18791231']
   name: ch.swisstopo.hiks-siegfried-ta50_18791231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18791231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id616
+- dimensions: *id618
   name: ch.swisstopo.hiks-siegfried-ta50_18791231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18791231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id617
+- dimensions: &id619
     Time:
       default: '18781231'
       values: ['18781231']
   name: ch.swisstopo.hiks-siegfried-ta50_18781231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18781231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id617
+- dimensions: *id619
   name: ch.swisstopo.hiks-siegfried-ta50_18781231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18781231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id618
+- dimensions: &id620
     Time:
       default: '18771231'
       values: ['18771231']
   name: ch.swisstopo.hiks-siegfried-ta50_18771231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18771231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id618
+- dimensions: *id620
   name: ch.swisstopo.hiks-siegfried-ta50_18771231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18771231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id619
+- dimensions: &id621
     Time:
       default: '18761231'
       values: ['18761231']
   name: ch.swisstopo.hiks-siegfried-ta50_18761231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18761231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id619
+- dimensions: *id621
   name: ch.swisstopo.hiks-siegfried-ta50_18761231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18761231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id620
+- dimensions: &id622
     Time:
       default: '18751231'
       values: ['18751231']
   name: ch.swisstopo.hiks-siegfried-ta50_18751231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18751231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id620
+- dimensions: *id622
   name: ch.swisstopo.hiks-siegfried-ta50_18751231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18751231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id621
+- dimensions: &id623
     Time:
       default: '18741231'
       values: ['18741231']
   name: ch.swisstopo.hiks-siegfried-ta50_18741231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18741231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id621
+- dimensions: *id623
   name: ch.swisstopo.hiks-siegfried-ta50_18741231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18741231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id622
+- dimensions: &id624
     Time:
       default: '18731231'
       values: ['18731231']
   name: ch.swisstopo.hiks-siegfried-ta50_18731231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18731231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id622
+- dimensions: *id624
   name: ch.swisstopo.hiks-siegfried-ta50_18731231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18731231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id623
+- dimensions: &id625
     Time:
       default: '18721231'
       values: ['18721231']
   name: ch.swisstopo.hiks-siegfried-ta50_18721231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18721231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id623
+- dimensions: *id625
   name: ch.swisstopo.hiks-siegfried-ta50_18721231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18721231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id624
+- dimensions: &id626
     Time:
       default: '18711231'
       values: ['18711231']
   name: ch.swisstopo.hiks-siegfried-ta50_18711231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18711231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id624
+- dimensions: *id626
   name: ch.swisstopo.hiks-siegfried-ta50_18711231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18711231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id625
+- dimensions: &id627
     Time:
       default: '18701231'
       values: ['18701231']
   name: ch.swisstopo.hiks-siegfried-ta50_18701231
   sources: [ch.swisstopo.hiks-siegfried-ta50_18701231_cache_out]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: *id625
+- dimensions: *id627
   name: ch.swisstopo.hiks-siegfried-ta50_18701231_source
   sources: [ch.swisstopo.hiks-siegfried-ta50_18701231_cache]
   title: ch.swisstopo.hiks-siegfried-ta50
-- dimensions: &id626
+- dimensions: &id628
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.koordinatenaenderung_20061231
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache_out]
   title: "LV95 Koordinaten\xE4nderung"
-- dimensions: *id626
+- dimensions: *id628
   name: ch.swisstopo.koordinatenaenderung
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung"
-- dimensions: *id626
+- dimensions: *id628
   name: ch.swisstopo.koordinatenaenderung_20061231_source
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung"
-- dimensions: &id627
+- dimensions: &id629
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id627
+- dimensions: *id629
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater
-- dimensions: *id627
+- dimensions: *id629
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater
-- dimensions: &id628
+- dimensions: &id630
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id628
+- dimensions: *id630
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache]
   title: Luftbilder Privater
-- dimensions: &id629
+- dimensions: &id631
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id629
+- dimensions: *id631
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache]
   title: Luftbilder Privater
-- dimensions: &id630
+- dimensions: &id632
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id630
+- dimensions: *id632
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache]
   title: Luftbilder Privater
-- dimensions: &id631
+- dimensions: &id633
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id631
+- dimensions: *id633
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache]
   title: Luftbilder Privater
-- dimensions: &id632
+- dimensions: &id634
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id632
+- dimensions: *id634
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache]
   title: Luftbilder Privater
-- dimensions: &id633
+- dimensions: &id635
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id633
+- dimensions: *id635
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache]
   title: Luftbilder Privater
-- dimensions: &id634
+- dimensions: &id636
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id634
+- dimensions: *id636
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache]
   title: Luftbilder Privater
-- dimensions: &id635
+- dimensions: &id637
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id635
+- dimensions: *id637
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache]
   title: Luftbilder Privater
-- dimensions: &id636
+- dimensions: &id638
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id636
+- dimensions: *id638
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache]
   title: Luftbilder Privater
-- dimensions: &id637
+- dimensions: &id639
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id637
+- dimensions: *id639
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache]
   title: Luftbilder Privater
-- dimensions: &id638
+- dimensions: &id640
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id638
+- dimensions: *id640
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache]
   title: Luftbilder Privater
-- dimensions: &id639
+- dimensions: &id641
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id639
+- dimensions: *id641
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache]
   title: Luftbilder Privater
-- dimensions: &id640
+- dimensions: &id642
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id640
+- dimensions: *id642
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache]
   title: Luftbilder Privater
-- dimensions: &id641
+- dimensions: &id643
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id641
+- dimensions: *id643
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache]
   title: Luftbilder Privater
-- dimensions: &id642
+- dimensions: &id644
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id642
+- dimensions: *id644
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache]
   title: Luftbilder Privater
-- dimensions: &id643
+- dimensions: &id645
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id643
+- dimensions: *id645
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache]
   title: Luftbilder Privater
-- dimensions: &id644
+- dimensions: &id646
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id644
+- dimensions: *id646
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache]
   title: Luftbilder Privater
-- dimensions: &id645
+- dimensions: &id647
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id645
+- dimensions: *id647
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache]
   title: Luftbilder Privater
-- dimensions: &id646
+- dimensions: &id648
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id646
+- dimensions: *id648
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache]
   title: Luftbilder Privater
-- dimensions: &id647
+- dimensions: &id649
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id647
+- dimensions: *id649
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache]
   title: Luftbilder Privater
-- dimensions: &id648
+- dimensions: &id650
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache_out]
   title: Luftbilder Privater
-- dimensions: *id648
+- dimensions: *id650
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache]
   title: Luftbilder Privater
-- dimensions: &id649
+- dimensions: &id651
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id649
+- dimensions: *id651
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone
-- dimensions: *id649
+- dimensions: *id651
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone
-- dimensions: &id650
+- dimensions: &id652
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id650
+- dimensions: *id652
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache]
   title: Luftbilder Kantone
-- dimensions: &id651
+- dimensions: &id653
     Time:
       default: '20131231'
       values: ['20131231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id651
+- dimensions: *id653
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache]
   title: Luftbilder Kantone
-- dimensions: &id652
+- dimensions: &id654
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id652
+- dimensions: *id654
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache]
   title: Luftbilder Kantone
-- dimensions: &id653
+- dimensions: &id655
     Time:
       default: '20111231'
       values: ['20111231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id653
+- dimensions: *id655
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache]
   title: Luftbilder Kantone
-- dimensions: &id654
+- dimensions: &id656
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id654
+- dimensions: *id656
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache]
   title: Luftbilder Kantone
-- dimensions: &id655
+- dimensions: &id657
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id655
+- dimensions: *id657
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache]
   title: Luftbilder Kantone
-- dimensions: &id656
+- dimensions: &id658
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id656
+- dimensions: *id658
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache]
   title: Luftbilder Kantone
-- dimensions: &id657
+- dimensions: &id659
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id657
+- dimensions: *id659
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache]
   title: Luftbilder Kantone
-- dimensions: &id658
+- dimensions: &id660
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id658
+- dimensions: *id660
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache]
   title: Luftbilder Kantone
-- dimensions: &id659
+- dimensions: &id661
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id659
+- dimensions: *id661
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache]
   title: Luftbilder Kantone
-- dimensions: &id660
+- dimensions: &id662
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id660
+- dimensions: *id662
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache]
   title: Luftbilder Kantone
-- dimensions: &id661
+- dimensions: &id663
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache_out]
   title: Luftbilder Kantone
-- dimensions: *id661
+- dimensions: *id663
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache]
   title: Luftbilder Kantone
-- dimensions: &id662
+- dimensions: &id664
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id662
+- dimensions: *id664
   name: ch.swisstopo.lubis-luftbilder_farbe
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: *id662
+- dimensions: *id664
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id663
+- dimensions: &id665
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id663
+- dimensions: *id665
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id664
+- dimensions: &id666
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id664
+- dimensions: *id666
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id665
+- dimensions: &id667
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id665
+- dimensions: *id667
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id666
+- dimensions: &id668
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id666
+- dimensions: *id668
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id667
+- dimensions: &id669
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id667
+- dimensions: *id669
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id668
+- dimensions: &id670
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id668
+- dimensions: *id670
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id669
+- dimensions: &id671
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id669
+- dimensions: *id671
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id670
+- dimensions: &id672
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id670
+- dimensions: *id672
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id671
+- dimensions: &id673
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id671
+- dimensions: *id673
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id672
+- dimensions: &id674
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id672
+- dimensions: *id674
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id673
+- dimensions: &id675
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id673
+- dimensions: *id675
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id674
+- dimensions: &id676
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id674
+- dimensions: *id676
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id675
+- dimensions: &id677
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id675
+- dimensions: *id677
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id676
+- dimensions: &id678
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id676
+- dimensions: *id678
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id677
+- dimensions: &id679
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id677
+- dimensions: *id679
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id678
+- dimensions: &id680
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id678
+- dimensions: *id680
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id679
+- dimensions: &id681
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id679
+- dimensions: *id681
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id680
+- dimensions: &id682
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id680
+- dimensions: *id682
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id681
+- dimensions: &id683
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id681
+- dimensions: *id683
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id682
+- dimensions: &id684
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id682
+- dimensions: *id684
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id683
+- dimensions: &id685
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id683
+- dimensions: *id685
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id684
+- dimensions: &id686
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id684
+- dimensions: *id686
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id685
+- dimensions: &id687
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id685
+- dimensions: *id687
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id686
+- dimensions: &id688
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id686
+- dimensions: *id688
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id687
+- dimensions: &id689
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id687
+- dimensions: *id689
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id688
+- dimensions: &id690
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id688
+- dimensions: *id690
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id689
+- dimensions: &id691
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id689
+- dimensions: *id691
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id690
+- dimensions: &id692
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id690
+- dimensions: *id692
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id691
+- dimensions: &id693
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id691
+- dimensions: *id693
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id692
+- dimensions: &id694
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache_out]
   title: Luftbilder swisstopo farbig
-- dimensions: *id692
+- dimensions: *id694
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache]
   title: Luftbilder swisstopo farbig
-- dimensions: &id693
+- dimensions: &id695
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id693
+- dimensions: *id695
   name: ch.swisstopo.lubis-luftbilder_infrarot
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id693
+- dimensions: *id695
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id694
+- dimensions: &id696
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id694
+- dimensions: *id696
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id695
+- dimensions: &id697
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id695
+- dimensions: *id697
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id696
+- dimensions: &id698
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id696
+- dimensions: *id698
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id697
+- dimensions: &id699
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id697
+- dimensions: *id699
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id698
+- dimensions: &id700
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id698
+- dimensions: *id700
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id699
+- dimensions: &id701
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id699
+- dimensions: *id701
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id700
+- dimensions: &id702
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id700
+- dimensions: *id702
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id701
+- dimensions: &id703
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id701
+- dimensions: *id703
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id702
+- dimensions: &id704
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id702
+- dimensions: *id704
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id703
+- dimensions: &id705
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id703
+- dimensions: *id705
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id704
+- dimensions: &id706
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id704
+- dimensions: *id706
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id705
+- dimensions: &id707
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id705
+- dimensions: *id707
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id706
+- dimensions: &id708
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id706
+- dimensions: *id708
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id707
+- dimensions: &id709
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id707
+- dimensions: *id709
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id708
+- dimensions: &id710
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id708
+- dimensions: *id710
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id709
+- dimensions: &id711
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id709
+- dimensions: *id711
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id710
+- dimensions: &id712
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id710
+- dimensions: *id712
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id711
+- dimensions: &id713
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id711
+- dimensions: *id713
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id712
+- dimensions: &id714
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id712
+- dimensions: *id714
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id713
+- dimensions: &id715
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id713
+- dimensions: *id715
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id714
+- dimensions: &id716
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id714
+- dimensions: *id716
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id715
+- dimensions: &id717
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id715
+- dimensions: *id717
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id716
+- dimensions: &id718
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id716
+- dimensions: *id718
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id717
+- dimensions: &id719
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id717
+- dimensions: *id719
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id718
+- dimensions: &id720
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id718
+- dimensions: *id720
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id719
+- dimensions: &id721
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id719
+- dimensions: *id721
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id720
+- dimensions: &id722
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id720
+- dimensions: *id722
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id721
+- dimensions: &id723
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache_out]
   title: Luftbilder swisstopo infrarot
-- dimensions: *id721
+- dimensions: *id723
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache]
   title: Luftbilder swisstopo infrarot
-- dimensions: &id722
+- dimensions: &id724
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id722
+- dimensions: *id724
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: *id722
+- dimensions: *id724
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id723
+- dimensions: &id725
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id723
+- dimensions: *id725
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id724
+- dimensions: &id726
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id724
+- dimensions: *id726
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id725
+- dimensions: &id727
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id725
+- dimensions: *id727
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id726
+- dimensions: &id728
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id726
+- dimensions: *id728
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id727
+- dimensions: &id729
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id727
+- dimensions: *id729
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id728
+- dimensions: &id730
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id728
+- dimensions: *id730
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id729
+- dimensions: &id731
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id729
+- dimensions: *id731
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id730
+- dimensions: &id732
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id730
+- dimensions: *id732
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id731
+- dimensions: &id733
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id731
+- dimensions: *id733
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id732
+- dimensions: &id734
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id732
+- dimensions: *id734
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id733
+- dimensions: &id735
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id733
+- dimensions: *id735
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id734
+- dimensions: &id736
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id734
+- dimensions: *id736
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id735
+- dimensions: &id737
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id735
+- dimensions: *id737
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id736
+- dimensions: &id738
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id736
+- dimensions: *id738
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id737
+- dimensions: &id739
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id737
+- dimensions: *id739
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id738
+- dimensions: &id740
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id738
+- dimensions: *id740
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id739
+- dimensions: &id741
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id739
+- dimensions: *id741
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id740
+- dimensions: &id742
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id740
+- dimensions: *id742
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id741
+- dimensions: &id743
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id741
+- dimensions: *id743
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id742
+- dimensions: &id744
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id742
+- dimensions: *id744
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id743
+- dimensions: &id745
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id743
+- dimensions: *id745
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id744
+- dimensions: &id746
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id744
+- dimensions: *id746
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id745
+- dimensions: &id747
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id745
+- dimensions: *id747
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id746
+- dimensions: &id748
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id746
+- dimensions: *id748
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id747
+- dimensions: &id749
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id747
+- dimensions: *id749
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id748
+- dimensions: &id750
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id748
+- dimensions: *id750
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id749
+- dimensions: &id751
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id749
+- dimensions: *id751
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id750
+- dimensions: &id752
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id750
+- dimensions: *id752
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id751
+- dimensions: &id753
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id751
+- dimensions: *id753
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id752
+- dimensions: &id754
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id752
+- dimensions: *id754
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id753
+- dimensions: &id755
     Time:
       default: '19801231'
       values: ['19801231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id753
+- dimensions: *id755
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id754
+- dimensions: &id756
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id754
+- dimensions: *id756
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id755
+- dimensions: &id757
     Time:
       default: '19781231'
       values: ['19781231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id755
+- dimensions: *id757
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id756
+- dimensions: &id758
     Time:
       default: '19771231'
       values: ['19771231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id756
+- dimensions: *id758
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id757
+- dimensions: &id759
     Time:
       default: '19761231'
       values: ['19761231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id757
+- dimensions: *id759
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id758
+- dimensions: &id760
     Time:
       default: '19751231'
       values: ['19751231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id758
+- dimensions: *id760
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id759
+- dimensions: &id761
     Time:
       default: '19741231'
       values: ['19741231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id759
+- dimensions: *id761
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id760
+- dimensions: &id762
     Time:
       default: '19731231'
       values: ['19731231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id760
+- dimensions: *id762
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id761
+- dimensions: &id763
     Time:
       default: '19721231'
       values: ['19721231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id761
+- dimensions: *id763
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id762
+- dimensions: &id764
     Time:
       default: '19711231'
       values: ['19711231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id762
+- dimensions: *id764
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id763
+- dimensions: &id765
     Time:
       default: '19701231'
       values: ['19701231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id763
+- dimensions: *id765
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id764
+- dimensions: &id766
     Time:
       default: '19691231'
       values: ['19691231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id764
+- dimensions: *id766
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id765
+- dimensions: &id767
     Time:
       default: '19681231'
       values: ['19681231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id765
+- dimensions: *id767
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id766
+- dimensions: &id768
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id766
+- dimensions: *id768
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id767
+- dimensions: &id769
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id767
+- dimensions: *id769
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id768
+- dimensions: &id770
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id768
+- dimensions: *id770
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id769
+- dimensions: &id771
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id769
+- dimensions: *id771
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id770
+- dimensions: &id772
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id770
+- dimensions: *id772
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id771
+- dimensions: &id773
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id771
+- dimensions: *id773
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id772
+- dimensions: &id774
     Time:
       default: '19611231'
       values: ['19611231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id772
+- dimensions: *id774
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id773
+- dimensions: &id775
     Time:
       default: '19601231'
       values: ['19601231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id773
+- dimensions: *id775
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id774
+- dimensions: &id776
     Time:
       default: '19591231'
       values: ['19591231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id774
+- dimensions: *id776
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id775
+- dimensions: &id777
     Time:
       default: '19581231'
       values: ['19581231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id775
+- dimensions: *id777
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id776
+- dimensions: &id778
     Time:
       default: '19571231'
       values: ['19571231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id776
+- dimensions: *id778
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id777
+- dimensions: &id779
     Time:
       default: '19561231'
       values: ['19561231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id777
+- dimensions: *id779
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id778
+- dimensions: &id780
     Time:
       default: '19551231'
       values: ['19551231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id778
+- dimensions: *id780
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id779
+- dimensions: &id781
     Time:
       default: '19541231'
       values: ['19541231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id779
+- dimensions: *id781
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id780
+- dimensions: &id782
     Time:
       default: '19531231'
       values: ['19531231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id780
+- dimensions: *id782
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id781
+- dimensions: &id783
     Time:
       default: '19521231'
       values: ['19521231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id781
+- dimensions: *id783
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id782
+- dimensions: &id784
     Time:
       default: '19511231'
       values: ['19511231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id782
+- dimensions: *id784
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id783
+- dimensions: &id785
     Time:
       default: '19501231'
       values: ['19501231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id783
+- dimensions: *id785
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id784
+- dimensions: &id786
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id784
+- dimensions: *id786
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id785
+- dimensions: &id787
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id785
+- dimensions: *id787
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id786
+- dimensions: &id788
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id786
+- dimensions: *id788
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id787
+- dimensions: &id789
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id787
+- dimensions: *id789
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id788
+- dimensions: &id790
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id788
+- dimensions: *id790
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id789
+- dimensions: &id791
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id789
+- dimensions: *id791
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id790
+- dimensions: &id792
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id790
+- dimensions: *id792
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id791
+- dimensions: &id793
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id791
+- dimensions: *id793
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id792
+- dimensions: &id794
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id792
+- dimensions: *id794
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id793
+- dimensions: &id795
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id793
+- dimensions: *id795
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id794
+- dimensions: &id796
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id794
+- dimensions: *id796
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id795
+- dimensions: &id797
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id795
+- dimensions: *id797
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id796
+- dimensions: &id798
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id796
+- dimensions: *id798
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id797
+- dimensions: &id799
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id797
+- dimensions: *id799
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id798
+- dimensions: &id800
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id798
+- dimensions: *id800
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id799
+- dimensions: &id801
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id799
+- dimensions: *id801
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id800
+- dimensions: &id802
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id800
+- dimensions: *id802
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id801
+- dimensions: &id803
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id801
+- dimensions: *id803
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id802
+- dimensions: &id804
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id802
+- dimensions: *id804
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id803
+- dimensions: &id805
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id803
+- dimensions: *id805
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id804
+- dimensions: &id806
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id804
+- dimensions: *id806
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id805
+- dimensions: &id807
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache_out]
   title: Luftbilder swisstopo s/w
-- dimensions: *id805
+- dimensions: *id807
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache]
   title: Luftbilder swisstopo s/w
-- dimensions: &id806
+- dimensions: &id808
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe_20140520
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id806
+- dimensions: *id808
   name: ch.swisstopo.pixelkarte-farbe
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id806
+- dimensions: *id808
   name: ch.swisstopo.pixelkarte-farbe_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id807
+- dimensions: &id809
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe_20140106
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id807
+- dimensions: *id809
   name: ch.swisstopo.pixelkarte-farbe_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id808
+- dimensions: &id810
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe_20130903
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id808
+- dimensions: *id810
   name: ch.swisstopo.pixelkarte-farbe_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id809
+- dimensions: &id811
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe_20130213
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id809
+- dimensions: *id811
   name: ch.swisstopo.pixelkarte-farbe_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id810
+- dimensions: &id812
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe_20120809
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id810
+- dimensions: *id812
   name: ch.swisstopo.pixelkarte-farbe_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id811
+- dimensions: &id813
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-farbe_20111206
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id811
+- dimensions: *id813
   name: ch.swisstopo.pixelkarte-farbe_20111206_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id812
+- dimensions: &id814
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe_20111027
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id812
+- dimensions: *id814
   name: ch.swisstopo.pixelkarte-farbe_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id813
+- dimensions: &id815
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-farbe_20110401
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id813
+- dimensions: *id815
   name: ch.swisstopo.pixelkarte-farbe_20110401_source
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id814
+- dimensions: &id816
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache_out]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: *id814
+- dimensions: *id816
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: *id814
+- dimensions: *id816
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: &id815
+- dimensions: &id817
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache_out]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: *id815
+- dimensions: *id817
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: &id816
+- dimensions: &id818
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache_out]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: *id816
+- dimensions: *id818
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: &id817
+- dimensions: &id819
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache_out]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: *id817
+- dimensions: *id819
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: &id818
+- dimensions: &id820
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache_out]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: *id818
+- dimensions: *id820
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: &id819
+- dimensions: &id821
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache_out]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: *id819
+- dimensions: *id821
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache]
   title: Landeskarte 1:100'000 | LK100
-- dimensions: &id820
+- dimensions: &id822
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000
-- dimensions: *id820
+- dimensions: *id822
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Mio. | LK1000
-- dimensions: *id820
+- dimensions: *id822
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Mio. | LK1000
-- dimensions: &id821
+- dimensions: &id823
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000
-- dimensions: *id821
+- dimensions: *id823
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache]
   title: Landeskarte 1:1 Mio. | LK1000
-- dimensions: &id822
+- dimensions: &id824
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000
-- dimensions: *id822
+- dimensions: *id824
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache]
   title: Landeskarte 1:1 Mio. | LK1000
-- dimensions: &id823
+- dimensions: &id825
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache_out]
   title: Landeskarte 1:200'000 | LK200
-- dimensions: *id823
+- dimensions: *id825
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache]
   title: Landeskarte 1:200'000 | LK200
-- dimensions: *id823
+- dimensions: *id825
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache]
   title: Landeskarte 1:200'000 | LK200
-- dimensions: &id824
+- dimensions: &id826
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id824
+- dimensions: *id826
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id824
+- dimensions: *id826
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id825
+- dimensions: &id827
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id825
+- dimensions: *id827
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id826
+- dimensions: &id828
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id826
+- dimensions: *id828
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id827
+- dimensions: &id829
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id827
+- dimensions: *id829
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id828
+- dimensions: &id830
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id828
+- dimensions: *id830
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id829
+- dimensions: &id831
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id829
+- dimensions: *id831
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id830
+- dimensions: &id832
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache_out]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: *id830
+- dimensions: *id832
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: *id830
+- dimensions: *id832
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: &id831
+- dimensions: &id833
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache_out]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: *id831
+- dimensions: *id833
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: &id832
+- dimensions: &id834
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache_out]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: *id832
+- dimensions: *id834
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: &id833
+- dimensions: &id835
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache_out]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: *id833
+- dimensions: *id835
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: &id834
+- dimensions: &id836
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache_out]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: *id834
+- dimensions: *id836
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: &id835
+- dimensions: &id837
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache_out]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: *id835
+- dimensions: *id837
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache]
   title: Landeskarte 1:50'000 | LK50
-- dimensions: &id836
+- dimensions: &id838
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache_out]
   title: Landeskarte 1:500'000 | LK500
-- dimensions: *id836
+- dimensions: *id838
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache]
   title: Landeskarte 1:500'000 | LK500
-- dimensions: *id836
+- dimensions: *id838
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache]
   title: Landeskarte 1:500'000 | LK500
-- dimensions: &id837
+- dimensions: &id839
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-grau_20140520
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id837
+- dimensions: *id839
   name: ch.swisstopo.pixelkarte-grau
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id837
+- dimensions: *id839
   name: ch.swisstopo.pixelkarte-grau_20140520_source
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id838
+- dimensions: &id840
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-grau_20140106
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id838
+- dimensions: *id840
   name: ch.swisstopo.pixelkarte-grau_20140106_source
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id839
+- dimensions: &id841
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-grau_20130903
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id839
+- dimensions: *id841
   name: ch.swisstopo.pixelkarte-grau_20130903_source
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id840
+- dimensions: &id842
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-grau_20130213
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id840
+- dimensions: *id842
   name: ch.swisstopo.pixelkarte-grau_20130213_source
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id841
+- dimensions: &id843
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-grau_20120809
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id841
+- dimensions: *id843
   name: ch.swisstopo.pixelkarte-grau_20120809_source
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id842
+- dimensions: &id844
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-grau_20111206
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id842
+- dimensions: *id844
   name: ch.swisstopo.pixelkarte-grau_20111206_source
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id843
+- dimensions: &id845
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-grau_20111027
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id843
+- dimensions: *id845
   name: ch.swisstopo.pixelkarte-grau_20111027_source
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id844
+- dimensions: &id846
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-grau_20110401
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: *id844
+- dimensions: *id846
   name: ch.swisstopo.pixelkarte-grau_20110401_source
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache]
   title: Landeskarte 1:25'000 | LK25
-- dimensions: &id845
+- dimensions: &id847
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20140101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache_out]
   title: swissALTI3D Reliefschattierung
-- dimensions: *id845
+- dimensions: *id847
   name: ch.swisstopo.swissalti3d-reliefschattierung
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache]
   title: swissALTI3D Reliefschattierung
-- dimensions: *id845
+- dimensions: *id847
   name: ch.swisstopo.swissalti3d-reliefschattierung_20140101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache]
   title: swissALTI3D Reliefschattierung
-- dimensions: &id846
+- dimensions: &id848
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20130101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache_out]
   title: swissALTI3D Reliefschattierung
-- dimensions: *id846
+- dimensions: *id848
   name: ch.swisstopo.swissalti3d-reliefschattierung_20130101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache]
   title: swissALTI3D Reliefschattierung
-- dimensions: &id847
+- dimensions: &id849
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20110101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache_out]
   title: swissALTI3D Reliefschattierung
-- dimensions: *id847
+- dimensions: *id849
   name: ch.swisstopo.swissalti3d-reliefschattierung_20110101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache]
   title: swissALTI3D Reliefschattierung
-- dimensions: &id848
+- dimensions: &id850
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20000101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache_out]
   title: swissALTI3D Reliefschattierung
-- dimensions: *id848
+- dimensions: *id850
   name: ch.swisstopo.swissalti3d-reliefschattierung_20000101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache]
   title: swissALTI3D Reliefschattierung
-- dimensions: &id849
+- dimensions: &id851
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache_out]
   title: Bezirksgrenzen
-- dimensions: *id849
+- dimensions: *id851
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache]
   title: Bezirksgrenzen
-- dimensions: *id849
+- dimensions: *id851
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache]
   title: Bezirksgrenzen
-- dimensions: &id850
+- dimensions: &id852
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache_out]
   title: Bezirksgrenzen
-- dimensions: *id850
+- dimensions: *id852
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache]
   title: Bezirksgrenzen
-- dimensions: &id851
+- dimensions: &id853
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache_out]
   title: Bezirksgrenzen
-- dimensions: *id851
+- dimensions: *id853
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache]
   title: Bezirksgrenzen
-- dimensions: &id852
+- dimensions: &id854
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache_out]
   title: Gemeindegrenzen
-- dimensions: *id852
+- dimensions: *id854
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache]
   title: Gemeindegrenzen
-- dimensions: *id852
+- dimensions: *id854
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache]
   title: Gemeindegrenzen
-- dimensions: &id853
+- dimensions: &id855
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache_out]
   title: Gemeindegrenzen
-- dimensions: *id853
+- dimensions: *id855
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache]
   title: Gemeindegrenzen
-- dimensions: &id854
+- dimensions: &id856
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache_out]
   title: Gemeindegrenzen
-- dimensions: *id854
+- dimensions: *id856
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache]
   title: Gemeindegrenzen
-- dimensions: &id855
+- dimensions: &id857
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache_out]
   title: Kantonsgrenzen
-- dimensions: *id855
+- dimensions: *id857
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache]
   title: Kantonsgrenzen
-- dimensions: *id855
+- dimensions: *id857
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache]
   title: Kantonsgrenzen
-- dimensions: &id856
+- dimensions: &id858
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache_out]
   title: Kantonsgrenzen
-- dimensions: *id856
+- dimensions: *id858
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache]
   title: Kantonsgrenzen
-- dimensions: &id857
+- dimensions: &id859
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache_out]
   title: Kantonsgrenzen
-- dimensions: *id857
+- dimensions: *id859
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache]
   title: Kantonsgrenzen
-- dimensions: &id858
+- dimensions: &id860
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache_out]
   title: Landesgrenzen
-- dimensions: *id858
+- dimensions: *id860
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache]
   title: Landesgrenzen
-- dimensions: *id858
+- dimensions: *id860
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache]
   title: Landesgrenzen
-- dimensions: &id859
+- dimensions: &id861
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache_out]
   title: Landesgrenzen
-- dimensions: *id859
+- dimensions: *id861
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache]
   title: Landesgrenzen
-- dimensions: &id860
+- dimensions: &id862
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache_out]
   title: Landesgrenzen
-- dimensions: *id860
+- dimensions: *id862
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache]
   title: Landesgrenzen
-- dimensions: &id861
+- dimensions: &id863
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.swissbuildings3d_19980101
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache_out]
   title: "Vereinfachte 3D-Geb\xE4ude"
-- dimensions: *id861
+- dimensions: *id863
   name: ch.swisstopo.swissbuildings3d
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude"
-- dimensions: *id861
+- dimensions: *id863
   name: ch.swisstopo.swissbuildings3d_19980101_source
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude"
-- dimensions: &id862
+- dimensions: &id864
     Time:
       default: '20140620'
       values: ['20140620']
   name: ch.swisstopo.swissimage_20140620
   sources: [ch.swisstopo.swissimage_20140620_cache_out]
   title: SWISSIMAGE
-- dimensions: *id862
+- dimensions: *id864
   name: ch.swisstopo.swissimage
   sources: [ch.swisstopo.swissimage_20140620_cache]
   title: SWISSIMAGE
-- dimensions: *id862
+- dimensions: *id864
   name: ch.swisstopo.swissimage_20140620_source
   sources: [ch.swisstopo.swissimage_20140620_cache]
   title: SWISSIMAGE
-- dimensions: &id863
+- dimensions: &id865
     Time:
       default: '20131107'
       values: ['20131107']
   name: ch.swisstopo.swissimage_20131107
   sources: [ch.swisstopo.swissimage_20131107_cache_out]
   title: SWISSIMAGE
-- dimensions: *id863
+- dimensions: *id865
   name: ch.swisstopo.swissimage_20131107_source
   sources: [ch.swisstopo.swissimage_20131107_cache]
   title: SWISSIMAGE
-- dimensions: &id864
+- dimensions: &id866
     Time:
       default: '20130916'
       values: ['20130916']
   name: ch.swisstopo.swissimage_20130916
   sources: [ch.swisstopo.swissimage_20130916_cache_out]
   title: SWISSIMAGE
-- dimensions: *id864
+- dimensions: *id866
   name: ch.swisstopo.swissimage_20130916_source
   sources: [ch.swisstopo.swissimage_20130916_cache]
   title: SWISSIMAGE
-- dimensions: &id865
+- dimensions: &id867
     Time:
       default: '20130422'
       values: ['20130422']
   name: ch.swisstopo.swissimage_20130422
   sources: [ch.swisstopo.swissimage_20130422_cache_out]
   title: SWISSIMAGE
-- dimensions: *id865
+- dimensions: *id867
   name: ch.swisstopo.swissimage_20130422_source
   sources: [ch.swisstopo.swissimage_20130422_cache]
   title: SWISSIMAGE
-- dimensions: &id866
+- dimensions: &id868
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.swissimage_20120809
   sources: [ch.swisstopo.swissimage_20120809_cache_out]
   title: SWISSIMAGE
-- dimensions: *id866
+- dimensions: *id868
   name: ch.swisstopo.swissimage_20120809_source
   sources: [ch.swisstopo.swissimage_20120809_cache]
   title: SWISSIMAGE
-- dimensions: &id867
+- dimensions: &id869
     Time:
       default: '20120225'
       values: ['20120225']
   name: ch.swisstopo.swissimage_20120225
   sources: [ch.swisstopo.swissimage_20120225_cache_out]
   title: SWISSIMAGE
-- dimensions: *id867
+- dimensions: *id869
   name: ch.swisstopo.swissimage_20120225_source
   sources: [ch.swisstopo.swissimage_20120225_cache]
   title: SWISSIMAGE
-- dimensions: &id868
+- dimensions: &id870
     Time:
       default: '20110914'
       values: ['20110914']
   name: ch.swisstopo.swissimage_20110914
   sources: [ch.swisstopo.swissimage_20110914_cache_out]
   title: SWISSIMAGE
-- dimensions: *id868
+- dimensions: *id870
   name: ch.swisstopo.swissimage_20110914_source
   sources: [ch.swisstopo.swissimage_20110914_cache]
   title: SWISSIMAGE
-- dimensions: &id869
+- dimensions: &id871
     Time:
       default: '20110228'
       values: ['20110228']
   name: ch.swisstopo.swissimage_20110228
   sources: [ch.swisstopo.swissimage_20110228_cache_out]
   title: SWISSIMAGE
-- dimensions: *id869
+- dimensions: *id871
   name: ch.swisstopo.swissimage_20110228_source
   sources: [ch.swisstopo.swissimage_20110228_cache]
   title: SWISSIMAGE
-- dimensions: &id870
+- dimensions: &id872
     Time:
       default: '20140401'
       values: ['20140401']
   name: ch.swisstopo.swisstlm3d-karte-farbe_20140401
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20140401_cache_out]
   title: Karte swissTLM (farbig)
-- dimensions: *id870
+- dimensions: *id872
   name: ch.swisstopo.swisstlm3d-karte-farbe
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20140401_cache]
   title: Karte swissTLM (farbig)
-- dimensions: *id870
+- dimensions: *id872
   name: ch.swisstopo.swisstlm3d-karte-farbe_20140401_source
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20140401_cache]
   title: Karte swissTLM (farbig)
-- dimensions: &id871
+- dimensions: &id873
     Time:
       default: '20140401'
       values: ['20140401']
   name: ch.swisstopo.swisstlm3d-karte-grau_20140401
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20140401_cache_out]
   title: Karte swissTLM (grau)
-- dimensions: *id871
+- dimensions: *id873
   name: ch.swisstopo.swisstlm3d-karte-grau
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20140401_cache]
   title: Karte swissTLM (grau)
-- dimensions: *id871
+- dimensions: *id873
   name: ch.swisstopo.swisstlm3d-karte-grau_20140401_source
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20140401_cache]
   title: Karte swissTLM (grau)
-- dimensions: &id872
+- dimensions: &id874
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20140101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache_out]
   title: Wanderwege
-- dimensions: *id872
+- dimensions: *id874
   name: ch.swisstopo.swisstlm3d-wanderwege
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache]
   title: Wanderwege
-- dimensions: *id872
+- dimensions: *id874
   name: ch.swisstopo.swisstlm3d-wanderwege_20140101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache]
   title: Wanderwege
-- dimensions: &id873
+- dimensions: &id875
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20130101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20130101_cache_out]
   title: Wanderwege
-- dimensions: *id873
+- dimensions: *id875
   name: ch.swisstopo.swisstlm3d-wanderwege_20130101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20130101_cache]
   title: Wanderwege
-- dimensions: &id874
+- dimensions: &id876
     Time:
       default: '20131028'
       values: ['20131028']
   name: ch.swisstopo.transformationsgenauigkeit_20131028
   sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache_out]
   title: LV95 Transformationsgenauigkeit
-- dimensions: *id874
+- dimensions: *id876
   name: ch.swisstopo.transformationsgenauigkeit
   sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache]
   title: LV95 Transformationsgenauigkeit
-- dimensions: *id874
+- dimensions: *id876
   name: ch.swisstopo.transformationsgenauigkeit_20131028_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache]
   title: LV95 Transformationsgenauigkeit
-- dimensions: &id875
+- dimensions: &id877
     Time:
       default: '20100531'
       values: ['20100531']
   name: ch.swisstopo.transformationsgenauigkeit_20100531
   sources: [ch.swisstopo.transformationsgenauigkeit_20100531_cache_out]
   title: LV95 Transformationsgenauigkeit
-- dimensions: *id875
+- dimensions: *id877
   name: ch.swisstopo.transformationsgenauigkeit_20100531_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20100531_cache]
   title: LV95 Transformationsgenauigkeit
-- dimensions: &id876
+- dimensions: &id878
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20140101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache_out]
   title: Schutzgebiete VECTOR200
-- dimensions: *id876
+- dimensions: *id878
   name: ch.swisstopo.vec200-adminboundaries-protectedarea
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache]
   title: Schutzgebiete VECTOR200
-- dimensions: *id876
+- dimensions: *id878
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache]
   title: Schutzgebiete VECTOR200
-- dimensions: &id877
+- dimensions: &id879
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20130101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache_out]
   title: Schutzgebiete VECTOR200
-- dimensions: *id877
+- dimensions: *id879
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache]
   title: Schutzgebiete VECTOR200
-- dimensions: &id878
+- dimensions: &id880
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20100101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache_out]
   title: Schutzgebiete VECTOR200
-- dimensions: *id878
+- dimensions: *id880
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache]
   title: Schutzgebiete VECTOR200
-- dimensions: &id879
+- dimensions: &id881
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-building_20140101
   sources: [ch.swisstopo.vec200-building_20140101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200"
-- dimensions: *id879
+- dimensions: *id881
   name: ch.swisstopo.vec200-building
   sources: [ch.swisstopo.vec200-building_20140101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200"
-- dimensions: *id879
+- dimensions: *id881
   name: ch.swisstopo.vec200-building_20140101_source
   sources: [ch.swisstopo.vec200-building_20140101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200"
-- dimensions: &id880
+- dimensions: &id882
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-building_20130101
   sources: [ch.swisstopo.vec200-building_20130101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200"
-- dimensions: *id880
+- dimensions: *id882
   name: ch.swisstopo.vec200-building_20130101_source
   sources: [ch.swisstopo.vec200-building_20130101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200"
-- dimensions: &id881
+- dimensions: &id883
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-building_20100101
   sources: [ch.swisstopo.vec200-building_20100101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200"
-- dimensions: *id881
+- dimensions: *id883
   name: ch.swisstopo.vec200-building_20100101_source
   sources: [ch.swisstopo.vec200-building_20100101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200"
-- dimensions: &id882
+- dimensions: &id884
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-hydrography_20140101
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200"
-- dimensions: *id882
+- dimensions: *id884
   name: ch.swisstopo.vec200-hydrography
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache]
   title: "Gew\xE4ssernetz VECTOR200"
-- dimensions: *id882
+- dimensions: *id884
   name: ch.swisstopo.vec200-hydrography_20140101_source
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache]
   title: "Gew\xE4ssernetz VECTOR200"
-- dimensions: &id883
+- dimensions: &id885
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-hydrography_20130101
   sources: [ch.swisstopo.vec200-hydrography_20130101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200"
-- dimensions: *id883
+- dimensions: *id885
   name: ch.swisstopo.vec200-hydrography_20130101_source
   sources: [ch.swisstopo.vec200-hydrography_20130101_cache]
   title: "Gew\xE4ssernetz VECTOR200"
-- dimensions: &id884
+- dimensions: &id886
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-hydrography_20100101
   sources: [ch.swisstopo.vec200-hydrography_20100101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200"
-- dimensions: *id884
+- dimensions: *id886
   name: ch.swisstopo.vec200-hydrography_20100101_source
   sources: [ch.swisstopo.vec200-hydrography_20100101_cache]
   title: "Gew\xE4ssernetz VECTOR200"
-- dimensions: &id885
+- dimensions: &id887
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-landcover_20140101
   sources: [ch.swisstopo.vec200-landcover_20140101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200
-- dimensions: *id885
+- dimensions: *id887
   name: ch.swisstopo.vec200-landcover
   sources: [ch.swisstopo.vec200-landcover_20140101_cache]
   title: Prim. Bodenbedeckung VECTOR200
-- dimensions: *id885
+- dimensions: *id887
   name: ch.swisstopo.vec200-landcover_20140101_source
   sources: [ch.swisstopo.vec200-landcover_20140101_cache]
   title: Prim. Bodenbedeckung VECTOR200
-- dimensions: &id886
+- dimensions: &id888
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-landcover_20130101
   sources: [ch.swisstopo.vec200-landcover_20130101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200
-- dimensions: *id886
+- dimensions: *id888
   name: ch.swisstopo.vec200-landcover_20130101_source
   sources: [ch.swisstopo.vec200-landcover_20130101_cache]
   title: Prim. Bodenbedeckung VECTOR200
-- dimensions: &id887
+- dimensions: &id889
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-landcover_20100101
   sources: [ch.swisstopo.vec200-landcover_20100101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200
-- dimensions: *id887
+- dimensions: *id889
   name: ch.swisstopo.vec200-landcover_20100101_source
   sources: [ch.swisstopo.vec200-landcover_20100101_cache]
   title: Prim. Bodenbedeckung VECTOR200
-- dimensions: &id888
+- dimensions: &id890
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-landcover-wald_20140101
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache_out]
   title: "Waldfl\xE4chen"
-- dimensions: *id888
+- dimensions: *id890
   name: ch.swisstopo.vec200-landcover-wald
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache]
   title: "Waldfl\xE4chen"
-- dimensions: *id888
+- dimensions: *id890
   name: ch.swisstopo.vec200-landcover-wald_20140101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache]
   title: "Waldfl\xE4chen"
-- dimensions: &id889
+- dimensions: &id891
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-landcover-wald_20130101
   sources: [ch.swisstopo.vec200-landcover-wald_20130101_cache_out]
   title: "Waldfl\xE4chen"
-- dimensions: *id889
+- dimensions: *id891
   name: ch.swisstopo.vec200-landcover-wald_20130101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20130101_cache]
   title: "Waldfl\xE4chen"
-- dimensions: &id890
+- dimensions: &id892
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-miscellaneous_20140101
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache_out]
   title: Einzelobjekte VECTOR200
-- dimensions: *id890
+- dimensions: *id892
   name: ch.swisstopo.vec200-miscellaneous
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache]
   title: Einzelobjekte VECTOR200
-- dimensions: *id890
+- dimensions: *id892
   name: ch.swisstopo.vec200-miscellaneous_20140101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache]
   title: Einzelobjekte VECTOR200
-- dimensions: &id891
+- dimensions: &id893
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-miscellaneous_20130101
   sources: [ch.swisstopo.vec200-miscellaneous_20130101_cache_out]
   title: Einzelobjekte VECTOR200
-- dimensions: *id891
+- dimensions: *id893
   name: ch.swisstopo.vec200-miscellaneous_20130101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20130101_cache]
   title: Einzelobjekte VECTOR200
-- dimensions: &id892
+- dimensions: &id894
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-miscellaneous_20100101
   sources: [ch.swisstopo.vec200-miscellaneous_20100101_cache_out]
   title: Einzelobjekte VECTOR200
-- dimensions: *id892
+- dimensions: *id894
   name: ch.swisstopo.vec200-miscellaneous_20100101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20100101_cache]
   title: Einzelobjekte VECTOR200
-- dimensions: &id893
+- dimensions: &id895
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20140101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache_out]
   title: "H\xF6henkoten VECTOR200"
-- dimensions: *id893
+- dimensions: *id895
   name: ch.swisstopo.vec200-miscellaneous-geodpoint
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache]
   title: "H\xF6henkoten VECTOR200"
-- dimensions: *id893
+- dimensions: *id895
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache]
   title: "H\xF6henkoten VECTOR200"
-- dimensions: &id894
+- dimensions: &id896
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20130101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache_out]
   title: "H\xF6henkoten VECTOR200"
-- dimensions: *id894
+- dimensions: *id896
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache]
   title: "H\xF6henkoten VECTOR200"
-- dimensions: &id895
+- dimensions: &id897
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20100101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache_out]
   title: "H\xF6henkoten VECTOR200"
-- dimensions: *id895
+- dimensions: *id897
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache]
   title: "H\xF6henkoten VECTOR200"
-- dimensions: &id896
+- dimensions: &id898
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-names-namedlocation_20140101
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache_out]
   title: Namen VECTOR200
-- dimensions: *id896
+- dimensions: *id898
   name: ch.swisstopo.vec200-names-namedlocation
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache]
   title: Namen VECTOR200
-- dimensions: *id896
+- dimensions: *id898
   name: ch.swisstopo.vec200-names-namedlocation_20140101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache]
   title: Namen VECTOR200
-- dimensions: &id897
+- dimensions: &id899
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-names-namedlocation_20130101
   sources: [ch.swisstopo.vec200-names-namedlocation_20130101_cache_out]
   title: Namen VECTOR200
-- dimensions: *id897
+- dimensions: *id899
   name: ch.swisstopo.vec200-names-namedlocation_20130101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20130101_cache]
   title: Namen VECTOR200
-- dimensions: &id898
+- dimensions: &id900
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-names-namedlocation_20100101
   sources: [ch.swisstopo.vec200-names-namedlocation_20100101_cache_out]
   title: Namen VECTOR200
-- dimensions: *id898
+- dimensions: *id900
   name: ch.swisstopo.vec200-names-namedlocation_20100101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20100101_cache]
   title: Namen VECTOR200
-- dimensions: &id899
+- dimensions: &id901
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200"
-- dimensions: *id899
+- dimensions: *id901
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200"
-- dimensions: *id899
+- dimensions: *id901
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200"
-- dimensions: &id900
+- dimensions: &id902
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200"
-- dimensions: *id900
+- dimensions: *id902
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200"
-- dimensions: &id901
+- dimensions: &id903
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200"
-- dimensions: *id901
+- dimensions: *id903
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200"
-- dimensions: &id902
+- dimensions: &id904
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20140101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache_out]
   title: Strassennetz VECTOR200
-- dimensions: *id902
+- dimensions: *id904
   name: ch.swisstopo.vec200-transportation-strassennetz
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache]
   title: Strassennetz VECTOR200
-- dimensions: *id902
+- dimensions: *id904
   name: ch.swisstopo.vec200-transportation-strassennetz_20140101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache]
   title: Strassennetz VECTOR200
-- dimensions: &id903
+- dimensions: &id905
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20130101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20130101_cache_out]
   title: Strassennetz VECTOR200
-- dimensions: *id903
+- dimensions: *id905
   name: ch.swisstopo.vec200-transportation-strassennetz_20130101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20130101_cache]
   title: Strassennetz VECTOR200
-- dimensions: &id904
+- dimensions: &id906
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20100101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20100101_cache_out]
   title: Strassennetz VECTOR200
-- dimensions: *id904
+- dimensions: *id906
   name: ch.swisstopo.vec200-transportation-strassennetz_20100101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20100101_cache]
   title: Strassennetz VECTOR200
-- dimensions: &id905
+- dimensions: &id907
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-anlagen_20090401
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache_out]
   title: Anlagen VECTOR25
-- dimensions: *id905
+- dimensions: *id907
   name: ch.swisstopo.vec25-anlagen
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25
-- dimensions: *id905
+- dimensions: *id907
   name: ch.swisstopo.vec25-anlagen_20090401_source
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25
-- dimensions: &id906
+- dimensions: &id908
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-einzelobjekte_19980101
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache_out]
   title: Einzelobjekte VECTOR25
-- dimensions: *id906
+- dimensions: *id908
   name: ch.swisstopo.vec25-einzelobjekte
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25
-- dimensions: *id906
+- dimensions: *id908
   name: ch.swisstopo.vec25-einzelobjekte_19980101_source
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25
-- dimensions: &id907
+- dimensions: &id909
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache_out]
   title: Eisenbahnnetz VECTOR25
-- dimensions: *id907
+- dimensions: *id909
   name: ch.swisstopo.vec25-eisenbahnnetz
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25
-- dimensions: *id907
+- dimensions: *id909
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401_source
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25
-- dimensions: &id908
+- dimensions: &id910
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gebaeude_20090401
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache_out]
   title: "Geb\xE4ude VECTOR25"
-- dimensions: *id908
+- dimensions: *id910
   name: ch.swisstopo.vec25-gebaeude
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25"
-- dimensions: *id908
+- dimensions: *id910
   name: ch.swisstopo.vec25-gebaeude_20090401_source
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25"
-- dimensions: &id909
+- dimensions: &id911
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gewaessernetz_20090401
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache_out]
   title: "Gew\xE4ssernetz VECTOR25"
-- dimensions: *id909
+- dimensions: *id911
   name: ch.swisstopo.vec25-gewaessernetz
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25"
-- dimensions: *id909
+- dimensions: *id911
   name: ch.swisstopo.vec25-gewaessernetz_20090401_source
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25"
-- dimensions: &id910
+- dimensions: &id912
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-heckenbaeume_19980101
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache_out]
   title: "Hecken und B\xE4ume VECTOR25"
-- dimensions: *id910
+- dimensions: *id912
   name: ch.swisstopo.vec25-heckenbaeume
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25"
-- dimensions: *id910
+- dimensions: *id912
   name: ch.swisstopo.vec25-heckenbaeume_19980101_source
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25"
-- dimensions: &id911
+- dimensions: &id913
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-primaerflaechen_20090401
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache_out]
   title: "Prim\xE4rfl\xE4chen VECTOR25"
-- dimensions: *id911
+- dimensions: *id913
   name: ch.swisstopo.vec25-primaerflaechen
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25"
-- dimensions: *id911
+- dimensions: *id913
   name: ch.swisstopo.vec25-primaerflaechen_20090401_source
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25"
-- dimensions: &id912
+- dimensions: &id914
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-strassennetz_20090401
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache_out]
   title: Strassennetz VECTOR25
-- dimensions: *id912
+- dimensions: *id914
   name: ch.swisstopo.vec25-strassennetz
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25
-- dimensions: *id912
+- dimensions: *id914
   name: ch.swisstopo.vec25-strassennetz_20090401_source
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25
-- dimensions: &id913
+- dimensions: &id915
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache_out]
   title: "\xDCbriger Verkehr VECTOR25"
-- dimensions: *id913
+- dimensions: *id915
   name: ch.swisstopo.vec25-uebrigerverkehr
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25"
-- dimensions: *id913
+- dimensions: *id915
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401_source
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25"
-- dimensions: &id914
+- dimensions: &id916
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache_out]
   title: LV95 Verschiebungsvektoren TSP1
-- dimensions: *id914
+- dimensions: *id916
   name: ch.swisstopo.verschiebungsvektoren-tsp1
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1
-- dimensions: *id914
+- dimensions: *id916
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1
-- dimensions: &id915
+- dimensions: &id917
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache_out]
   title: LV95 Verschiebungsvektoren TSP2
-- dimensions: *id915
+- dimensions: *id917
   name: ch.swisstopo.verschiebungsvektoren-tsp2
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2
-- dimensions: *id915
+- dimensions: *id917
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2
-- dimensions: &id916
+- dimensions: &id918
     Time:
       default: '20110501'
       values: ['20110501']
   name: ch.vbs.territorialregionen_20110501
   sources: [ch.vbs.territorialregionen_20110501_cache_out]
   title: Territorialregionen
-- dimensions: *id916
+- dimensions: *id918
   name: ch.vbs.territorialregionen
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen
-- dimensions: *id916
+- dimensions: *id918
   name: ch.vbs.territorialregionen_20110501_source
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen
@@ -19792,6 +19859,9 @@ services:
     srs: ['EPSG:4326', 'EPSG:21781', 'EPSG:4258', 'EPSG:3857', 'EPSG:2056']
   wmts: {kvp: false, restful: true, restful_template: '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.{Format}'}
 sources:
+  boundaries_source:
+    req: {layers: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill, url: 'http://wms.geo.admin.ch'}
+    type: wms
   ch.are.agglomerationen_isolierte_staedte_20140101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -21136,6 +21206,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.wrz-wildruhezonen_portal/default/20140107/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.wrz-wildruhezonen_portal_20141105_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.wrz-wildruhezonen_portal/default/20141105/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bag.zecken-fsme-faelle_20121231_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -23440,6 +23522,9 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.kantone.cadastralwebmap-farbe/default/20121201/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.kantone.cadastralwebmap-farbe_wms_source:
+    req: {layers: cm_wms, url: 'http://wms.cadastralwebmap.ch/WMS'}
+    type: wms
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -23548,6 +23633,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo-vd.spannungsarme-gebiete/default/20131028/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo-vd.spannungsarme-gebiete_20141101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo-vd.spannungsarme-gebiete/default/20141101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.swisstopo.dreiecksvermaschung_20061231_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]

--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -65,7 +65,7 @@ def getLayersConfigs():
 
     models = get_wmts_models(LANG)
     layers_query = DBSession.query(models['GetCap'])
-    layers_query = layers_query.filter(models['GetCap'].maps.ilike('%%%s%%' % 'api'))  
+    layers_query = layers_query.filter(models['GetCap'].maps.ilike('%%%s%%' % 'api'))
     DBSession.close()
 
     return [q for q in layers_query.all()]
@@ -117,10 +117,9 @@ for layersConfig in getLayersConfigs():
                 cache_name = "%s_%s_cache_out" % (bod_layer_id, timestamp)
                 layer_name = "%s_%s" % (bod_layer_id, timestamp)
                 dimensions = {'Time': {'default': timestamp, 'values': [timestamp]}}
-    
+
                 # layer config: cache_out
                 layer = {'name': layer_name, 'title': title, 'dimensions': dimensions, 'sources': [cache_name]}
-
 
                 cache = {"sources": [wmts_cache_name], "format": "image/%s" % image_format, "grids": grid_names, "disable_storage": True, "meta_size": [1, 1], "meta_buffer": 0}
 
@@ -128,13 +127,13 @@ for layersConfig in getLayersConfigs():
                     cache["image"] = {"resampling_method": "bilinear"}
                 elif '.swisstlm3d-karte' in wmts_cache_name:
                     cache["image"] = {"resampling_method": "nearest"}
-    
+
                 mapproxy_config['layers'].append(layer)
                 mapproxy_config['caches'][cache_name] = cache
-    
+
                 # original source (one for all projection)
                 wmts_url = "http://wmts6.geo.admin.ch/1.0.0/" + server_layer_name + "/default/" + timestamp + "/21781/%(z)d/%(y)d/%(x)d.%(format)s"
-    
+
                 wmts_source = {"url": wmts_url,
                                "type": "tile",
                                "grid": "swisstopo-pixelkarte",
@@ -151,27 +150,27 @@ for layersConfig in getLayersConfigs():
                                    }
                                },
                                "coverage": {"bbox": [420000, 30000, 900000, 350000], "bbox_srs": "EPSG:21781"}}
-    
+
                 wmts_cache = {"sources": [wmts_source_name], "format": "image/%s" % image_format, "grids": ["swisstopo-pixelkarte"], "disable_storage": True}
 
                 if '.swissimage' in wmts_cache_name:
                     wmts_source["grid"] = "swisstopo-swissimage"
                     wmts_cache["grids"] = ["swisstopo-swissimage"]
-    
+
                 wmts_layer = {'name': wmts_source_name, 'title': title, 'dimensions': dimensions, 'sources': [wmts_cache_name]}
                 wmts_layer_current = {'name': wmts_source_name, 'title': title, 'dimensions': dimensions, 'sources': [wmts_cache_name]}
 
                 if timestamp == current_timestamp:
                     layer_current = {'name': bod_layer_id, 'title': title, 'dimensions': dimensions, 'sources': [wmts_cache_name]}
                     mapproxy_config['layers'].append(layer_current)
-    
+
                 if DEBUG:
                     print layer
-    
+
                 mapproxy_config['layers'].append(wmts_layer)
                 mapproxy_config['caches'][wmts_cache_name] = wmts_cache
                 mapproxy_config['sources'][wmts_source_name] = wmts_source
-    
+
 if DEBUG:
     print json.dumps(mapproxy_config, sort_keys=False, indent=4)
 
@@ -179,4 +178,3 @@ if DEBUG:
 with open('mapproxy/mapproxy.yaml', 'w') as o:
     o.write("# This is a generated file. Do not edit.\n\n")
     o.write(yaml.safe_dump(mapproxy_config, encoding=None))
-

--- a/mapproxy/templates/mapproxy.tpl
+++ b/mapproxy/templates/mapproxy.tpl
@@ -34,8 +34,40 @@ layers:
   - name: osm
     title: OpenStreetMap
     sources: [osm_cache]
+  - name: "ch.kantone.cadastralwebmap-farbe_wmts_current"
+    title: "CadastralWebMap"
+    sources: [ch.kantone.cadastralwebmap-farbe_wms_cache]
+    dimensions:
+       Time:
+          default: "current"
+          values: ["current"]
+
+sources:
+  osm_tms:
+    type: tile
+    grid: global_mercator_osm
+    url: http://c.tile.openstreetmap.org/%(tms_path)s.png
+    coverage:
+      bbox: [420000,30000,900000,350000]
+      bbox_srs: EPSG:21781
+  ch.kantone.cadastralwebmap-farbe_wms_source:
+    type: wms
+    req:
+      url: http://wms.cadastralwebmap.ch/WMS
+      layers: cm_wms
+  boundaries_source:
+    type: wms
+    req:
+      url: http://wms.geo.admin.ch
+      layers: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
 
 caches:
+  ch.kantone.cadastralwebmap-farbe_wms_cache:
+     disable_storage: true
+     format: image/png
+     meta_size: [1, 1]
+     grids: [epsg_21781, epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+     sources: [ch.kantone.cadastralwebmap-farbe_wms_source]
   osm_cache:
     grids: [global_mercator_osm]
     sources: [osm_tms]
@@ -47,16 +79,15 @@ caches:
       opacity: 100
       color: [0,0,0]
 
-sources:
-  osm_tms:
-    type: tile
-    grid: global_mercator_osm
-    url: http://c.tile.openstreetmap.org/%(tms_path)s.png
-    coverage:
-      bbox: [420000,30000,900000,350000]
-      bbox_srs: EPSG:21781
 
 grids:
+  epsg_21781:
+    res: [4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5,0.25,0.1]
+    bbox: [420000,30000,900000,350000]
+    bbox_srs: EPSG:21781
+    srs: EPSG:21781
+    origin: nw
+    stretch_factor: 1.0
   swisstopo-swissimage:
     res: [4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5,0.25]
     bbox: [420000,30000,900000,350000]


### PR DESCRIPTION
Goal ist to offect the layer 'ch.kantone.cadastralwebmap-farbe' also as a WMTS layer. Mapproxy is used to convert to WMTS from the original WMS.
- As the data and the source WMS is update on a regular basis, and we do not want/could update the mapproxy config at the same pace,  we could either use the WMTS keywords 'default' and 'current' or use a timesamp as '00000000' which has no signification
- Perfomance is very dependant from the original WMS server (extern)
- It replace the same layer now in production. (we could not define two backend for the same layer in one GetCapabiities). The timstamps used will be lost, unless we do some url rewriting.
- Access rules, same as native tiles.

See https://github.com/geoadmin/mf-chsdi3/issues/1054
