### PR TITLE
https mathjax issue (in api documentation)

### DIFF
--- a/chsdi/static/doc/source/api/terms_of_use.rst
+++ b/chsdi/static/doc/source/api/terms_of_use.rst
@@ -3,7 +3,7 @@
 .. raw:: html
 
   <head>
-    <link href="custom.css" rel="stylesheet" type="text/css" />
+    <link href="../_static/custom.css" rel="stylesheet" type="text/css" />
   </head>
         
 

--- a/chsdi/static/doc/source/conf.py
+++ b/chsdi/static/doc/source/conf.py
@@ -95,6 +95,9 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+# The path to the JavaScript file to include in the HTML files in order to 
+# load MathJax. By default insecure http protocol is used. 
+mathjax_path = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
 # -- Options for HTML output ---------------------------------------------------
 


### PR DESCRIPTION
Related to the issue with insecure (http) content from cdn mathjax plugin. Solved with a mathjay_path argument in the conf.py taking the  https protocol.

[Test https link](https://mf-chsdi3.dev.bgdi.ch/kan_https_safari_issue)
