### PR TITLE
Remove indentations and new line in jsonp renderer

### DIFF
--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -43,7 +43,7 @@ def main(global_config, **settings):
     # renderers
     config.add_renderer('.html', mako_renderer_factory)
     config.add_renderer('.js', mako_renderer_factory)
-    config.add_renderer('jsonp', JSONP(param_name='callback', indent=4))
+    config.add_renderer('jsonp', JSONP(param_name='callback', indent=None, separators=(',',':')))
     config.add_renderer('geojson', GeoJSON(jsonp_param_name='callback'))
     config.add_renderer('esrijson', EsriJSON(jsonp_param_name='callback'))
     config.add_renderer('csv', CSVRenderer)


### PR DESCRIPTION
Before:
http://api3.geo.admin.ch/1413455838/rest/services
http://api3.geo.admin.ch/rest/services/all/MapServer/layersConfig?lang=fr
http://api3.geo.admin.ch/1413455838/rest/services/ech/CatalogServer?lang=fr

After:
http://mf-chsdi3.dev.bgdi.ch/ltteo/rest/services
http://mf-chsdi3.dev.bgdi.ch/ltteo/rest/services/all/MapServer/layersConfig?lang=fr
http://mf-chsdi3.dev.bgdi.ch/ltteo/rest/services/ech/CatalogServer?lang=fr

500kb gained in appcache storage, and files are loaded a little bit faster (~100ms for the LayersConfig)

thx @procrastinatio for your python expertise
