### PR TITLE
Preserving the 'x-fowarded-proto' headers

### DIFF
--- a/apache/mapproxy.conf.in
+++ b/apache/mapproxy.conf.in
@@ -6,10 +6,10 @@ RewriteEngine On
 ExpiresActive On
 
 # MapProxy access control
-RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.EPSG.(\d+).xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,P]
-RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml [L,P]
+RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.EPSG.(\d+).xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,PT]
+RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml [L,PT]
 
-RewriteRule ^${apache_entry_path}/1.0.0/(.*)/default/(\d+)/(\d+)/(.*)   ${apache_entry_path}/mapproxy/wmts/1.0.0/$1_$2/default/$2/epsg_$3/$4 [L,P]
+RewriteRule ^${apache_entry_path}/1.0.0/(.*)/default/(\d+)/(\d+)/(.*)   ${apache_entry_path}/mapproxy/wmts/1.0.0/$1_$2/default/$2/epsg_$3/$4 [L,PT]
 
 WSGIDaemonProcess mf-chsdi3:${vars:apache_base_path}-mapproxy display-name=%{GROUP} user=${vars:modwsgi_user} ${vars:mapproxy_wsgi_options}
 


### PR DESCRIPTION
Compare:

**https** https://mf-chsdi3.dev.bgdi.ch/mom_https_getcap/1.0.0/WMTSCapabilities.xml

with

**http** http://mf-chsdi3.dev.bgdi.ch/mom_https_getcap/1.0.0/WMTSCapabilities.xml

See https://github.com/geoadmin/mf-chsdi3/issues/1078
