### PR TITLE
Support multiple timestamps in featuresearch/featureidentify search

### DIFF
--- a/chsdi/lib/sphinxapi/sphinxapi.py
+++ b/chsdi/lib/sphinxapi/sphinxapi.py
@@ -491,6 +491,14 @@ class SphinxClient:
         self._overrides = {}
 
 
+    # jeg: added function
+    def ResetFiltersOnly (self):
+        """
+        Clear filers only, not anchor as well
+        """
+        self._filters = []
+
+
     def ResetFilters (self):
         """
         Clear all filters (for multi-queries).

--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -13,6 +13,7 @@ class SearchValidation(MapNameValidation):
         self._featureIndexes = None
         self._timeInstant = None
         self._timeEnabled = None
+        self._timeStamps = None
         self._bbox = None
         self._returnGeometry = None
         self._origins = None
@@ -37,6 +38,10 @@ class SearchValidation(MapNameValidation):
     @property
     def timeInstant(self):
         return self._timeInstant
+
+    @property
+    def timeStamps(self):
+        return self._timeStamps
 
     @property
     def returnGeometry(self):
@@ -66,15 +71,6 @@ class SearchValidation(MapNameValidation):
             )
             value = value.replace('.', '_')
             self._featureIndexes = value.split(',')
-
-    @timeEnabled.setter
-    def timeEnabled(self, value):
-        if value is not None and value != '':
-            values = value.split(',')
-            result = []
-            for val in values:
-                result.append(True if val.lower() in ['true', 't', '1'] else False)
-            self._timeEnabled = result
 
     @timeEnabled.setter
     def timeEnabled(self, value):
@@ -125,6 +121,24 @@ class SearchValidation(MapNameValidation):
         else:
             self._timeInstant = value
 
+    @timeStamps.setter
+    def timeStamps(self, value):
+        if value is not None and value != '':
+            values = value.split(',')
+            result = []
+            for val in values:
+                if len(val) != 4 and len(val) != 0:
+                    raise HTTPBadRequest('Only years (4 digits) or empty strings are supported in timeStamps parameter')
+                if len(val) == 0:
+                    result.append(None)
+                else:
+                    try:
+                        result.append(int(val))
+                    except ValueError:
+                        raise HTTPBadRequest('Please provide integers for timeStamps parameter')
+            self._timeStamps = result
+
+ 
     @returnGeometry.setter
     def returnGeometry(self, value):
         if value is False or value == 'false':

--- a/chsdi/templates/index.pt
+++ b/chsdi/templates/index.pt
@@ -120,9 +120,12 @@
       <h4>Features and time </h4>
           <a
           href="rest/services/inspire/SearchServer?searchText=19810590048970&features=ch.swisstopo.lubis-luftbilder_farbe&type=featuresearch&bbox=542199.5,206799.5,542200.5,206800.5&timeInstant=1981&timeEnabled=true">Search for features
-          in ch.swisstopo.lubis-luftbilder_farbe with time parameter (1 result)</a> <br>
+          in ch.swisstopo.lubis-luftbilder_farbe with timeInstant parameter (1 result)</a> <br>
           <a
-          href="rest/services/inspire/SearchServer?searchText=19810590048970&features=ch.swisstopo.lubis-luftbilder_farbe&type=featuresearch&bbox=542199.5,206799.5,542200.5,206800.5&timeInstant=1953&timeEnabled=true">Search for features
+          href="rest/services/inspire/SearchServer?searchText=19810590048970&features=ch.swisstopo.lubis-luftbilder_farbe&type=featuresearch&bbox=542199.5,206799.5,542200.5,206800.5&timeInstant=1981&timeEnabled=true">Search for features
+          in ch.swisstopo.lubis-luftbilder_farbe with timeStamps parameter (1 result)</a> <br>
+          <a
+          href="rest/services/inspire/SearchServer?searchText=19810590048970&features=ch.swisstopo.lubis-luftbilder_farbe&type=featuresearch&bbox=542199.5,206799.5,542200.5,206800.5&timeStamps=1953&timeEnabled=true">Search for features
           in ch.swisstopo.lubis-luftbilder_farbe with time parameter (no  results)</a> <br>
           <a
           href="rest/services/inspire/SearchServer?searchText=19&features=ch.swisstopo.lubis-luftbilder_farbe&type=featuresearch&bbox=568465,187823,606865,201423&timeInstant=1998&timeEnabled=true">Search for features

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -187,8 +187,23 @@ class TestSearchServiceView(TestsBase):
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
         self.failUnless(resp.json['results'][0]['attrs']['feature_id'] == '43543')
 
-    def test_features_time(self):
+    def test_features_timeinstant(self):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542199,206799,542201,206801', 'timeInstant': '1981'}, status=200)
+        self.failUnless(resp.content_type == 'application/json')
+        self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
+
+    def test_features_timestamp(self):
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542199,206799,542201,206801', 'timeStamps': '1981'}, status=200)
+        self.failUnless(resp.content_type == 'application/json')
+        self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
+
+    def test_features_empty_timestamp(self):
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542199,206799,542201,206801', 'timeStamps': ''}, status=200)
+        self.failUnless(resp.content_type == 'application/json')
+        self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
+
+    def test_features_multiple_timestamps(self):
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '198', 'features': 'ch.swisstopo.lubis-luftbilder_farbe,ch.swisstopo.lubis-luftbilder_schwarzweiss', 'type': 'featuresearch', 'bbox': '542199,206799,542201,206801', 'timeStamps': '1986,1989', 'timeEnabled': 'true,true'}, status=200)
         self.failUnless(resp.content_type == 'application/json')
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
 
@@ -207,6 +222,16 @@ class TestSearchServiceView(TestsBase):
 
     def test_features_wrong_time_2(self):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeInstant': '1952.00'}, status=400)
+
+    def test_features_mix_timeinstant_timestamps(self):
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features':
+        'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeInstant': '1952', 'timeStamps': '1946'}, status=400)
+
+    def test_features_wrong_timestamps(self):
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeStamps': '19522'}, status=400)
+
+    def test_features_wrong_timestamps_2(self):
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeStamps': '1952.00'}, status=400)
 
     def test_featuressearch_geodist(self):
         resp = self.testapp.get('/rest/services/all/SearchServer', params={'features': 'ch.babs.kulturgueter', 'type': 'featureidentify', 'bbox': '688290,166864,688309,166884'})


### PR DESCRIPTION
To fully support the new time compare (layers_timestamp) feature of the map application, we need to extend the existing featuresearch and featureidentify search to support per-layer time settings. Right now, only one timeInstant can be specified.

This PR adds an additional timeStamps parameter, which allows to support the requirement. This PR is backwards compatible (it behaves exactly the same as before for existing parameters).

See also discusion here: https://github.com/geoadmin/mf-geoadmin3/pull/1784
