### PR TITLE
[WIP] Use resolution instead of scale for model distinction

### DIFF
--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -16,21 +16,18 @@ from chsdi.esrigeojsonencoder import loads
 from shapely.geometry import asShape
 
 
-def getScale(imageDisplay, mapExtent):
-    metersPerInch = 0.0254
-    imgPixelPerInch = imageDisplay[2]
-    imgPixelHeight = imageDisplay[1]
-    imgPixelWidth = imageDisplay[0]
+def getResolution(imageDisplay, mapExtent):
     bounds = mapExtent.bounds
-
     mapMeterWidth = abs(bounds[0] - bounds[2])
     mapMeterHeight = abs(bounds[1] - bounds[3])
-    imgMeterWidth = (imgPixelWidth / imgPixelPerInch) * metersPerInch
-    imgMeterHeight = (imgPixelHeight / imgPixelPerInch) * metersPerInch
+    xRes = mapMeterWidth / imageDisplay[0]
+    yRes = mapMeterHeight / imageDisplay[1]
+    return max(xRes, yRes)
 
-    resolution = max((imgMeterWidth / mapMeterWidth, imgMeterHeight / mapMeterHeight))
-    scale = 1.0 / resolution
-    return int(scale)
+
+def getScale(imageDisplay, mapExtent):
+    resolution = getResolution(imageDisplay, mapExtent)
+    return resolution * 39.37 * imageDisplay[2]
 
 
 def getToleranceMeters(imageDisplay, mapExtent, tolerance):
@@ -48,8 +45,8 @@ def getToleranceMeters(imageDisplay, mapExtent, tolerance):
 
 
 class Vector(GeoInterface):
-    __minscale__ = 0
-    __maxscale__ = maxsize
+    __minresolution__ = 0
+    __maxresolution__ = maxsize
     attributes = {}
 
     # Overrides GeoInterface
@@ -139,12 +136,12 @@ class Vector(GeoInterface):
     @classmethod
     def geom_filter(cls, geometry, geometryType, imageDisplay, mapExtent, tolerance):
         toleranceMeters = getToleranceMeters(imageDisplay, mapExtent, tolerance)
-        scale = None
-        minScale = cls.__minscale__ if hasattr(cls, '__minscale__') else None
-        maxScale = cls.__maxscale__ if hasattr(cls, '__maxscale__') else None
-        if minScale is not None and maxScale is not None and toleranceMeters != 0.0:
-            scale = getScale(imageDisplay, mapExtent)
-        if scale is None or (scale > cls.__minscale__ and scale <= cls.__maxscale__):
+        resolution = None
+        minRes = cls.__minresolution__ if hasattr(cls, '__minresolution__') else None
+        maxRes = cls.__maxresolution__ if hasattr(cls, '__maxresolution__') else None
+        if minRes is not None and maxRes is not None and toleranceMeters != 0.0:
+            resolution = getResolution(imageDisplay, mapExtent)
+        if resolution is None or (resolution > cls.__minresolution__ and resolution <= cls.__maxresolution__):
             geom = esriRest2Shapely(geometry, geometryType)
             wkbGeometry = WKBSpatialElement(buffer(geom.wkb), 21781)
             geomColumn = cls.geometry_column()

--- a/chsdi/models/vector/edi.py
+++ b/chsdi/models/vector/edi.py
@@ -14,8 +14,8 @@ class Arealstatistik2009(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_std.mako'
     __bodId__ = 'ch.bfs.arealstatistik'
-    # __minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -33,8 +33,8 @@ class Arealstatistik1985(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_std.mako'
     __bodId__ = 'ch.bfs.arealstatistik-1985'
-    # __minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -52,8 +52,8 @@ class Arealstatistik1997(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_std.mako'
     __bodId__ = 'ch.bfs.arealstatistik-1997'
-    #__minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -71,8 +71,8 @@ class ArealstatistikBodenbedeckung2009(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_nolc.mako'
     __bodId__ = 'ch.bfs.arealstatistik-bodenbedeckung'
-    #__minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -90,8 +90,8 @@ class ArealstatistikBodenbedeckung1997(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_nolc.mako'
     __bodId__ = 'ch.bfs.arealstatistik-bodenbedeckung-1997'
-    #__minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -109,8 +109,8 @@ class ArealstatistikBodenbedeckung1985(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_nolc.mako'
     __bodId__ = 'ch.bfs.arealstatistik-bodenbedeckung-1985'
-    #__minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -128,8 +128,8 @@ class ArealstatistikBodennutzung(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_nolu.mako'
     __bodId__ = 'ch.bfs.arealstatistik-bodennutzung'
-    #__minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -147,8 +147,8 @@ class ArealstatistikBodennutzung1997(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_nolu.mako'
     __bodId__ = 'ch.bfs.arealstatistik-bodennutzung-1997'
-    #__minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)
@@ -166,8 +166,8 @@ class ArealstatistikBodennutzung1985(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/arealstatistik_nolu.mako'
     __bodId__ = 'ch.bfs.arealstatistik-bodennutzung-1985'
-    #__minscale__ = 5001
-    __maxscale__ = 50000
+    # __minresolution__ = 0.505
+    __maxresolution__ = 5.05
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
     fj85 = Column('fj85', Integer)

--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -16,8 +16,6 @@ class Gebaeuderegister(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/gebaeuderegister.mako'
     __bodId__ = 'ch.bfs.gebaeude_wohnungs_register'
-    # __minscale__ = 5001
-    # due to https://redmine.bgdi.admin.ch/issues/3146 ltmoc  __maxscale__ = 25000
     id = Column('egid_edid', Text, primary_key=True)
     egid = Column('egid', Integer)
     strname1 = Column('strname1', Text)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -140,7 +140,7 @@ class treasurehunt(Base, Vector):
     __tablename__ = 'treasurehunt'
     __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/treasurehunt.mako'
-    __maxscale__ = 2505
+    __maxresolution__ = 0.255
     __bodId__ = 'ch.swisstopo.treasurehunt'
     id = Column('bgdi_id', Integer, primary_key=True)
     title_de = Column('title_de', Text)

--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -734,8 +734,8 @@ class sgt_facilities(Base, Vector):
     objname_text_fr = Column('objname_text_fr', Text)
     objname_text_it = Column('objname_text_it', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 80005
-    __maxscale__ = 100000005
+    __minresolution__ = 8.05
+    __maxresolution__ = 10000.0
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bfe.sachplan-geologie-tiefenlager', sgt_facilities)
@@ -768,8 +768,8 @@ class sgt_planning(Base, Vector):
     description = Column('description', Text)
     web = Column('web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 20005
-    __maxscale__ = 500005
+    __minresolution__ = 2.05
+    __maxresolution__ = 50.05
 
 register('ch.bfe.sachplan-geologie-tiefenlager', sgt_planning)
 
@@ -800,8 +800,7 @@ class sgt_planning_raster(Base, Vector):
     description = Column('description', Text)
     web = Column('web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __maxscale__ = 20005
-    __minscale__ = 1
+    __maxresolution__ = 2.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bfe.sachplan-geologie-tiefenlager', sgt_planning_raster)
@@ -829,8 +828,8 @@ class sgt_facilities_td(Base, Vector):
     objname_text_fr = Column('objname_text_fr', Text)
     objname_text_it = Column('objname_text_it', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 80005
-    __maxscale__ = 100000005
+    __minresolution__ = 8.05
+    __maxresolution__ = 10000.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung', sgt_facilities_td)
@@ -862,8 +861,8 @@ class sgt_planning_td(Base, Vector):
     description = Column('description', Text)
     web = Column('web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 20005
-    __maxscale__ = 500005
+    __minresolution__ = 2.05
+    __maxresolution__ = 50.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung', sgt_planning_td)
@@ -895,8 +894,7 @@ class sgt_planning_raster_td(Base, Vector):
     description = Column('description', Text)
     web = Column('web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __maxscale__ = 20005
-    __minscale__ = 1
+    __maxsresolution__ = 2.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung', sgt_planning_raster_td)
@@ -959,8 +957,8 @@ class sil_planning_a(Base, Vector):
     description_text_it = Column('description_text_it', Text)
     document_web = Column('document_web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 20005
-    __maxscale__ = 500005
+    __minresolution__ = 2.05
+    __maxresolution__ = 50.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bazl.sachplan-infrastruktur-luftfahrt_anhorung', sil_planning_a)
@@ -994,8 +992,7 @@ class sil_planning_raster_a(Base, Vector):
     description_text_it = Column('description_text_it', Text)
     document_web = Column('document_web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __maxscale__ = 20005
-    __minscale__ = 1
+    __minresolution__ = 2.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bazl.sachplan-infrastruktur-luftfahrt_anhorung', sil_planning_raster_a)
@@ -1058,8 +1055,8 @@ class sil_planning_k(Base, Vector):
     description_text_it = Column('description_text_it', Text)
     document_web = Column('document_web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 20005
-    __maxscale__ = 500005
+    __minresolution__ = 2.05
+    __maxresolution___ = 50.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bazl.sachplan-infrastruktur-luftfahrt_kraft', sil_planning_k)
@@ -1093,8 +1090,7 @@ class sil_planning_raster_k(Base, Vector):
     description_text_it = Column('description_text_it', Text)
     document_web = Column('document_web', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __maxscale__ = 20005
-    __minscale__ = 1
+    __maxresolution__ = 2.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bazl.sachplan-infrastruktur-luftfahrt_kraft', sil_planning_raster_k)
@@ -1222,8 +1218,8 @@ class sis_planning_a (Base, Vector):
     doc_web = Column('doc_web', Text)
     doc_title = Column('doc_title', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 20005
-    __maxscale__ = 500005
+    __minresolution__ = 2.05
+    __maxresolution___ = 50.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bav.sachplan-infrastruktur-schiene_anhorung', sis_planning_a)
@@ -1284,8 +1280,7 @@ class sis_planning_raster_a (Base, Vector):
     doc_web = Column('doc_web', Text)
     doc_title = Column('doc_title', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __maxscale__ = 20005
-    __minscale__ = 1
+    __maxresolution__ = 2.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bav.sachplan-infrastruktur-schiene_anhorung', sis_planning_raster_a)
@@ -1352,8 +1347,8 @@ class sis_planning_k (Base, Vector):
     doc_web = Column('doc_web', Text)
     doc_title = Column('doc_title', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __minscale__ = 20005
-    __maxscale__ = 500005
+    __minresolution__ = 2.05
+    __maxresolution___ = 50.05
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bav.sachplan-infrastruktur-schiene_kraft', sis_planning_k)
@@ -1389,8 +1384,7 @@ class sis_planning_raster_k (Base, Vector):
     doc_web = Column('doc_web', Text)
     doc_title = Column('doc_title', Text)
     bgdi_created = Column('bgdi_created', Text)
-    __maxscale__ = 20005
-    __minscale__ = 1
+    __maxresolution__ = 20005
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
 
 register('ch.bav.sachplan-infrastruktur-schiene_kraft', sis_planning_raster_k)

--- a/chsdi/models/vector/zeitreihen.py
+++ b/chsdi/models/vector/zeitreihen.py
@@ -15,8 +15,8 @@ class Zeitreihen_15(Base, Vector):
     __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/zeitreihen.mako'
     __bodId__ = 'ch.swisstopo.zeitreihen'
-    __minscale__ = 100005
-    __maxscale__ = 5000000005
+    __minresolution__ = 10.05
+    __maxresolution__ = 500005
     __timeInstant__ = 'years'
     id = Column('bgdi_id', Text, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
@@ -34,8 +34,8 @@ class Zeitreihen_20(Base, Vector):
     __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/zeitreihen.mako'
     __bodId__ = 'ch.swisstopo.zeitreihen'
-    __minscale__ = 50005
-    __maxscale__ = 100005
+    __minresolution__ = 5.05
+    __maxresolution__ = 10.05
     __timeInstant__ = 'years'
     id = Column('bgdi_id', Text, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
@@ -53,8 +53,8 @@ class Zeitreihen_21(Base, Vector):
     __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/zeitreihen.mako'
     __bodId__ = 'ch.swisstopo.zeitreihen'
-    __minscale__ = 25005
-    __maxscale__ = 50005
+    __minresolution__ = 2.55
+    __maxresolution__ = 5.05
     __timeInstant__ = 'years'
     id = Column('bgdi_id', Text, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))
@@ -72,8 +72,8 @@ class Zeitreihen_22(Base, Vector):
     __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/zeitreihen.mako'
     __bodId__ = 'ch.swisstopo.zeitreihen'
-    __minscale__ = 0
-    __maxscale__ = 25005
+    __minresolution__ = 0
+    __maxresolution__ = 2.55
     __timeInstant__ = 'years'
     id = Column('bgdi_id', Text, primary_key=True)
     the_geom = GeometryColumn(Geometry(dimension=2, srid=21781))


### PR DESCRIPTION
See discussion here https://github.com/geoadmin/mf-geoadmin3/issues/1788

@AFoletti @ltclm Could you verify the values for the non-zeitreihen models?

Zeitreihen works as expected when this PR is applied.
