### PR TITLE
Fix tests cause by default authorisation to false PR

### DIFF
--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -134,7 +134,7 @@ class TestSearchServiceView(TestsBase):
         self.testapp.extra_environ = {}
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params={'searchText': 'Beaulieustrasse 2', 'type': 'locations'}, status=200)
         self.failUnless(resp.content_type == 'application/json')
-        self.failUnless('geom_st_box2d' in resp.json['results'][0]['attrs'].keys())
+        self.failUnless('geom_st_box2d' not in resp.json['results'][0]['attrs'].keys())
 
     def test_search_locations_authorized_no_geometry(self):
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params={'searchText': 'Beaulieustrasse 2', 'type': 'locations', 'returnGeometry': 'false'}, headers=dict(HTTP_X_SEARCHSERVER_AUTHORIZED='true'), status=200)


### PR DESCRIPTION
This fixes the tests that fails now because of https://github.com/geoadmin/mf-chsdi3/pull/1087.

Per default, we are _not_ authorized now.
