### PR TITLE
Add releases service to get layer releases timestamps

### DIFF
--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -65,6 +65,7 @@ def main(global_config, **settings):
     config.add_route('identify', '/rest/services/{map}/MapServer/identify')
     config.add_route('find', '/rest/services/{map}/MapServer/find')
     config.add_route('legend', '/rest/services/{map}/MapServer/{layerId}/legend')
+    config.add_route('releases', '/rest/services/{map}/MapServer/{layerId}/releases')
     config.add_route('featureAttributes', '/rest/services/{map}/MapServer/{layerId}')
     config.add_route('feature', '/rest/services/{map}/MapServer/{layerId}/{featureId}')
     config.add_route('htmlPopup', '/rest/services/{map}/MapServer/{layerId}/{featureId}/htmlPopup')

--- a/chsdi/templates/index.pt
+++ b/chsdi/templates/index.pt
@@ -67,6 +67,10 @@
           <a href="rest/services/ech/MapServer/find?layer=ch.bafu.bundesinventare-bln&searchText=Lavaux&searchField=bln_name&returnGeometry=false">Find Lavaux in the field bln_name of the layer ch.bafu.bundesinventare-bln</a> <br>
           <a href="/rest/services/ech/MapServer/find?layer=ch.are.agglomerationen_isolierte_staedte&searchText=15&searchField=flaeche_ha">Find 15 in field flaeche_ha of layer ch.are.agglomerationen_isolierte_staedte (pre-infix match)</a> <br>
           <a href="/rest/services/ech/MapServer/find?layer=ch.bafu.bundesinventare-bln&searchText=1740.478&searchField=bln_fl&returnGeometry=false&contains=false">Find a exact match for 1740.478 in the field bln_fl</a>
+          <h3>Releases Service</h3>
+          <a href="rest/services/ech/MapServer/ch.swisstopo.zeitreihen/releases?mapExtent=611399.9999999999,158650,690299.9999999999,198150&imageDisplay=500,500,96">Zeitreihen Layer</a> <br>
+          <a href="rest/services/ech/MapServer/ch.swisstopo.images-swissimage.metadata/releases?mapExtent=611399.9999999999,158650,690299.9999999999,198150&imageDisplay=500,500,96">Layer without releases</a> <br>
+
           <h3>Varia</h3>
           <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362">Get Feature with id 362</a> <br>
           <a href="rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362/htmlPopup">Html Popup Ex 1</a> <br>

--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -388,3 +388,34 @@ class TestMapServiceView(TestsBase):
 
     def test_features_attributes_wrong_layer(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/dummy', status=400)
+
+zlayer = 'ch.swisstopo.zeitreihen'
+class TestReleasesService(TestsBase):
+
+    def test_service(self):
+        params = {'imageDisplay': '500,600,96', 'mapExtent': '611399.9999999999,158650,690299.9999999999,198150'}
+        resp = self.testapp.get('/rest/services/all/MapServer/' + zlayer + '/releases', params=params, status=200)
+        self.failUnless(resp.content_type == 'application/json')
+        self.failUnless(len(resp.json['results']) == 46, len(resp.json['results']))
+
+    def test_missing_params(self):
+        params = {'mapExtent': '611399.9999999999,158650,690299.9999999999,198150'}
+        resp = self.testapp.get('/rest/services/all/MapServer/' + zlayer + '/releases', params=params, status=400)
+        params = {'imageDisplay': '500,600,96'}
+        resp = self.testapp.get('/rest/services/all/MapServer/' + zlayer + '/releases', params=params, status=400)
+
+    def test_layer_without_releases(self):
+        params = {'imageDisplay': '500,600,96', 'mapExtent': '611399.9999999999,158650,690299.9999999999,198150'}
+        resp = self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.images-swissimage.metadata/releases', params=params, status=200)
+        self.failUnless(resp.content_type == 'application/json')
+        self.failUnless(len(resp.json['results']) == 0, len(resp.json['results']))
+
+
+
+    def test_unknown_layers(self):
+        params = {'imageDisplay': '500,600,96', 'mapExtent': '611399.9999999999,158650,690299.9999999999,198150'}
+        resp = self.testapp.get('/rest/services/all/MapServer/dummylayer/releases', params=params, status=400)
+
+
+    
+


### PR DESCRIPTION
In RE2, we had the zeitreihen service [1] to get 'release years' of the zeitreihen layer for a given zoom level and a given location. This PR adds a similar service in RE3. It's a little more generic than in RE2 and can be used on any layer (of course, AFAIK only zeitreihen has release years).

This is to be used in the new per-year prints currently under dev by @procrastinatio . As discussed, this new service will be used in front-end to get the desired timestamps for printing, which are then send to the print service.

@cedricmoullet As you are the author of the zeitreihen service of re2, can you please review by taking into account the following:
- This new service doesn't use meta models [2]. In my opinion, we have everything we need in the existing zeitreihen models. Or were there specifics in the meta models that I'm not aware of?
- Instead of a point and a tolerance, this new service here takes a mapextend (meters) and a imagedisplay (pixels) to calculate the resolution/scale for the correct model. The idea is to get all releases for the selected rectangle in the print service

[1] https://svn.prod.bgdi.ch/viewvc/mf-chsdi/trunk/chsdi/chsdi/controllers/zeitreihen.py?view=markup
[2] https://svn.prod.bgdi.ch/viewvc/mf-chsdi/trunk/chsdi/chsdi/model/vector/zeitreihen.py?view=markup
