### PR TITLE
Update from geo cadastral portals

### DIFF
--- a/chsdi/templates/htmlpopup/cadastralwebmap.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.mako
@@ -29,32 +29,31 @@
     % elif c['attributes']['ak'] == 'FR':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.fr.ch/index.php?reset_session&linkit=1&switch_id=switch_localisation&layer_select=Adresses,ParcVect,ParcVectnum,GrpMasque,GrpSituation,FondPlanContinu,copyright,Parcellaire,ParcScan&mapsize=0&recenter_bbox=${','.join(map(str,c['bbox']))}" target="_blank">FR</a></td></tr>
     % elif c['attributes']['ak'] == 'GE':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.ge.ch" target="_blank">GE</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://ge.ch/carte/pro/?mapresources=CADASTRE&extent=${2000000 + c['bbox'][0]},${1000000 + c['bbox'][1]},${2000000 + c['bbox'][2]},${1000000 + c['bbox'][3]}" target="_blank">GE</a></td></tr>
     % elif c['attributes']['ak'] == 'GL':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://map.geo.gl.ch/Public?visibleLayers=CH-Rahmen,BBFlaechen_sw,projektierte%20BBFlaechen,Flaechenelemente_sw,Linienelemente,Punktelemente,Grundstuecke%20(Parzellen),Liegenschaftsnummern,Grenzpunkte,BB%20Namen,EO%20Namen,Grundbuecher,Hoheitsgrenzpunkte,Fixpunkte%20Kat%201%202%203,Flur-%20und%20Ortsnamen,Lokalisationen,Gebaeudeadressen" target="_blank">GL</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://map.geo.gl.ch/Public?visibleLayers=CH-Rahmen,BBFlaechen_farbig,projektierte%20BBFlaechen,Flaechenelemente_farbig,Linienelemente,Punktelemente,Grundstuecke%20(Parzellen),Liegenschaftsnummern,Grenzpunkte,BB%20Namen,EO%20Namen,Grundbuecher,Hoheitsgrenzpunkte,Fixpunkte%20Kat%201%202%203,Flur-%20und%20Ortsnamen,Lokalisationen,Gebaeudeadressen&startExtent=${c['bbox'][0]},${c['bbox'][1]},${c['bbox'][2]},${c['bbox'][3]}" target="_blank">GL</a></td></tr>
     % elif c['attributes']['ak'] == 'JU':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://mapfish.jura.ch/main/wsgi/theme/Cadastre?&map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=11" target="_blank">JU</a></td></tr>
-    % elif c['attributes']['ak'] == 'SH':   
-       <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.gis.sh.ch/GIS_SH/?idp=1&uid=1&pwd=&map=10&lan=de&typ=3&bmurl=Nav@g@98@u@West@g@${c['bbox'][0]}@u@Nord@g@${c['bbox'][1]}@u@B@g@600" target="_blank">SH</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://mapfish.jura.ch/main/wsgi/theme/Cadastre?&map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=8" target="_blank">JU</a></td></tr>
+    % elif c['attributes']['ak'] == 'SH':
+       <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.gis.sh.ch/GIS_SH/?idp=1&uid=1&pwd=&map=10&lan=de&typ=3&bmurl=Nav@g@98@u@West@g@${(c['bbox'][0] + c['bbox'][2])/2}@u@Nord@g@${(c['bbox'][1] + c['bbox'][3])/2}@u@B@g@600" target="_blank">SH</a></td></tr>
     % elif c['attributes']['ak'] == 'SZ':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://webmap.sz.ch/BM31_WebMap/BM3.asp" target="_blank">SZ</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://webmap.sz.ch/BM31_WebMap/?idp=1&uid=3&pwd=&map=4&lan=de&typ=2&bmurl=Nav@g@22@u@West@g@${(c['bbox'][0] + c['bbox'][2])/2}@u@Nord@g@${(c['bbox'][1] + c['bbox'][3])/2}@u@B@g@${c['scale']}&dat=fs@g@0:4ae2e22b77b5091c,c967cd4c6822eee0,e99c56f567e5e97f,39483bcc77f422f5,4b048b83437bf7a9,b3b7203380d15873,bee3f1c60e1a845d,1728eb497f622a93,f78552014874d11f,136b202945b6b1b9,d9cf9214542c77c1,7eb16002e8c2dc47,ec974776a1ceeba0,f897f15fead4f6fd,37fd92a6ed58174e,e1887984e14002b7,f44d637c3584e8d0,e9e2a442eff50877,bc8022b4deccd819,6a214c64af1721ce,eaf8a22a527854e5,0945f4c1d24d86b7,98fa7375c309e508,e934449118c9c6dd,55a6326db48f4bea,e990f36363ef5fc3,4621149cf57bddac,ba256921c07443d2,c6d3efbdb9cc23d0,fe44ed10bed4a1b3,995c9ae4589a187f,a19e8b7259324d5b,2446246ca20351ce,7775ce4adaf02f1b,d23b3744bec5675b,2d9ca26cb61f96e1,1baecfb88f9662f3,be06a6503cc9e520!!" target="_blank">SZ</a></td></tr>
     % elif c['attributes']['ak'] == 'SO':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.sogis1.so.ch/sogis/internet/pmapper/somap.php?karte=ortsplan&extent=${','.join(map(str,c['bbox']))}" target="_blank">SO</a></td></tr>
     % elif c['attributes']['ak'] == 'TI':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.ti.ch" target="_blank">TI</a>
-</td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www4.ti.ch/tich/home/" target="_blank">TI</a></td></tr>
     % elif c['attributes']['ak'] == 'VD':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geoplanet.vd.ch/index.php?reset_session&linkit=1&switch_id=switch_cadastre&layer_select=complement_vd2,fond_continu_gris,canton_select,gc_mensuration_select,cad_parv_select,cad_parv_numero_select,ddp_select,ddp_npcs_select,cad_parv_plim_select,cad_bat_hs_cadastre_select,cad_bat_ss_select,npcs_bat_hs_select,npcs_bat_ss_select,couverture_sol,cad_cs_dur,cad_cs_vert,cad_cs_bois,cad_cs_eau,cad_cs_div&recenter_bbox=${','.join(map(str,c['bbox']))}&mapSize=4" target="_blank">VD</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.vd.ch/theme/cadastre_thm?map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=10" target="_blank">VD</a></td></tr>
     % elif c['attributes']['ak'] == 'TG':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geo.tg.ch/mapbender/frames/login.php?gui_id=Amtliche%20Vermessung&mb_myBBOX=${','.join(map(str,c['bbox']))}" target="_blank">TG</a></td></tr>
     % elif c['attributes']['ak'] == 'NE':
-        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://sitn.ne.ch/theme/cadastre?map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=12" target="_blank">NE</a></td></tr>
+        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://sitn.ne.ch/theme/cadastre?map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=10" target="_blank">NE</a></td></tr>
     % elif c['attributes']['ak'] == 'LU':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.lu.ch/map/grundbuchplan/" target="_blank">LU</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.lu.ch/map/grundbuchplan/?FOCUS=${(c['bbox'][0] + c['bbox'][2])/2}:${(c['bbox'][1] + c['bbox'][3])/2}:${c['scale']}" target="_blank">LU</a></td></tr>
     % elif c['attributes']['ak'] == 'OW':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.ow.ch" target="_blank">OW</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://map.gis-daten.ch/plan_fuer_grundbuch_bund_ow?xmin=${c['bbox'][0]}&ymin=${c['bbox'][1]}&xmax=${c['bbox'][2]}&ymax=${c['bbox'][3]}" target="_blank">OW</a></td></tr>
     % elif c['attributes']['ak'] == 'NW':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.nw.ch" target="_blank">NW</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://map.gis-daten.ch/plan_fuer_grundbuch_bund_nw?xmin=${c['bbox'][0]}&ymin=${c['bbox'][1]}&xmax=${c['bbox'][2]}&ymax=${c['bbox'][3]}" target="_blank">NW</a></td></tr>
     % elif c['attributes']['ak'] == 'UR':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geo.ur.ch/" target="_blank">UR</a></td></tr>
     % elif c['attributes']['ak'] == 'GR':
@@ -64,13 +63,17 @@
     % elif c['attributes']['ak'] == 'AR':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.ar.ch" target="_blank">AR</a></td></tr>
     % elif c['attributes']['ak'] == 'ZH':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.gis.zh.ch/gb/gb.asp?app=GB-AV&vn=4$11&rn=7$8$12&start=${c['bbox'][0]}$${c['bbox'][1]}&Massstab=500" target="_blank">ZH</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://maps.zh.ch/?topic=AVfarbigwwwZH&scale=${c['scale']}&x=${(c['bbox'][0] + c['bbox'][2])/2}&y=${(c['bbox'][1] + c['bbox'][3])/2}&offlayers=LCOBJPROJ%2Cbezirkslabels" target="_blank">ZH</a></td></tr>
     % elif c['attributes']['ak'] == 'BL':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geoview.bl.ch/?map_x=${2000000 + c['bbox'][0]}&map_y=${1000000 + c['bbox'][1]}&map_zoom=11" target="_blank">BL</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geoview.bl.ch/?map_x=${2000000 + (c['bbox'][0] + c['bbox'][2])/2}&map_y=${1000000 + (c['bbox'][1] + c['bbox'][3])/2}&map_zoom=9" target="_blank">BL</a></td></tr>
     % elif c['attributes']['ak'] == 'ZG':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.zugmap.ch" target="_blank">ZG</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.zugmap.ch/zugmap/?idp=1&uid=1&pwd=&map=1&lan=de&typ=3&bmurl=Nav@g@22@u@West@g@${(c['bbox'][0] + c['bbox'][2])/2}@u@Nord@g@${(c['bbox'][1] + c['bbox'][3])/2}@u@B@g@${c['scale']}&dat=fs@g@0:371167b2bf7dfc4b,c7bfc487a7a729d3,9d1d191f82fb57e3,1fb440cdc612de80,4119ae2a85acc4b5,b7b8c26dbec351a9!!" target="_blank">ZG</a></td></tr>
+    % elif c['attributes']['ak'] == 'SG':
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.sg.ch/" target="_blank">AG</a></td></tr>
+    % elif c['attributes']['ak'] == 'VS':
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.sit-valais.ch/fr/mo-c.html" target="_blnk">VS</a></td></br>
     % elif c['attributes']['ak'] == 'FL':
-        <tr><td class="cell-left">${_('link to geoportal')}</td><td><a href="http://geodaten.llv.li/geoshop/public.html" target="_blank">${_('FL')}</a></td></tr>
+        <tr><td class="cell-left">${_('link to geoportal')}</td><td><a href="http://geodaten.llv.li/geoshop/public.html?zoombox=${c['bbox'][0]},${c['bbox'][1]},${c['bbox'][2]},${c['bbox'][3]}" target="_blank">${_('FL')}</a></td></tr>
     % else:
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td>${_('Canton has provided no link to portal')}</td></tr>
     % endif


### PR DESCRIPTION
<a href="http://mf-geoadmin3.dev.bgdi.ch/ltpoa/?layers=ch.kantone.cadastralwebmap-farbe">Test link</a>

Update of existing and creation of new links to new geoportals

Correcting : issue from geoadmin 
<a href=https://github.com/geoadmin/mf-geoadmin3/issues/1809>1809</a>
- [x] AG 
- [x] BS 
- [x] BE 
- [x] FR 
- [x] GE
- [x] GL 
- [x] JU 
- [x] SH
- [x] SZ
- [x] SO 
- [x] TI **
- [x] VD 
- [x] TG 
- [x] NE 
- [x] LU 
- [x] OW 
- [x] NW 
- [x] UR ***
- [x] GR ***
- [x] AI ***
- [x] AR ***
- [x] ZH 
- [x] BL 
- [x] ZG
- [x] SG ***
- [x] VS 
- [x] FL 

" \* " for cantons with default map
" *\* " correction in next commit
" **\* " no geoportail stricto senso

New portals are in creation for SZ, VS, 
