### PR TITLE
Reduce all sphinx search indices passed to a maximum of 64 characters

### DIFF
--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -4,6 +4,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 
 from chsdi.lib.validation import MapNameValidation
 
+MAX_SPHINX_INDEX_LENGTH = 64
 
 class SearchValidation(MapNameValidation):
 
@@ -58,19 +59,8 @@ class SearchValidation(MapNameValidation):
     @featureIndexes.setter
     def featureIndexes(self, value):
         if value is not None and value != '':
-            # SphinxSearch does not support indices longer than 64
-            # characters, that's why we have to hardcode here to
-            # something below 64 (indices are prepared with this name)
-            value = value.replace(
-                'ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet',
-                'ch_swisstopo_geologie-hydro_karte-grundwasservul'
-            )
-            value = value.replace(
-                'ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen',
-                'ch_swisstopo_geologie-hydro_karte-grundwasservor'
-            )
             value = value.replace('.', '_')
-            self._featureIndexes = value.split(',')
+            self._featureIndexes = [idx[:MAX_SPHINX_INDEX_LENGTH] for idx in value.split(',')]
 
     @timeEnabled.setter
     def timeEnabled(self, value):


### PR DESCRIPTION
SphinxSearch allows index names to be a maxium of 64 characters long. As we can have technical layernames that are longer than that, we create such indices with their names stripped to 64 characters.

This PR does the same thing in the search service.

Note @ltclm has a rule in the db which assured that the stripped names still remain unique.
