### PR TITLE
Use fuzzy search when usual search fails

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -117,6 +117,15 @@ class Search(SearchValidation):
             except IOError:
                 raise exc.HTTPGatewayTimeout()
             temp = temp['matches'] if temp is not None else temp
+
+            # if standard index did not find anything, use soundex/metaphon indices
+            # which should be more fuzzy in its results
+            if temp is None or len(temp) <= 0:
+                try:
+                    temp = self.sphinx.Query(searchTextFinal, index='swisssearch_fuzzy')
+                except IOError:
+                    raise exc.HTTPGatewayTimeout()
+                temp = temp['matches'] if temp is not None else temp
         else:
             temp = []
         if temp is not None and len(temp) != 0:


### PR DESCRIPTION
This PR extends the existing search in that when the existing search does not find any results, it will use the newly created fuzzy indices (soundex and metaphon indices). This fixes most typo-driven errors.

@davidoesch @cedricmoullet @ltclm
[Test here](http://mf-geoadmin3.dev.bgdi.ch/gjn_soundex) and compare with current production.

Note: only the `locations` search is affected and only addresses have fuzzy indices right now (not plz, cantons, municipals and other elements of swisssearch)
