### PR TITLE
Filtering out geometries for unauthorized access

### DIFF
--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -419,6 +419,57 @@ class TestMapServiceView(TestsBase):
 zlayer = 'ch.swisstopo.zeitreihen'
 
 
+class TestGebauedeGeometry(TestsBase):
+
+    def test_feature_not_authorized(self):
+        headers = {'X-SearchServer-Authorized': 'false'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register/490830_0', headers=headers, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertFalse('geometry' in resp.json['feature'])
+
+    def test_feature_authorized(self):
+        headers = {'X-SearchServer-Authorized': 'true'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register/490830_0', headers=headers, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertTrue('geometry' in resp.json['feature'])
+
+    def test_find_not_authorized(self):
+        headers = {'X-SearchServer-Authorized': 'false'}
+        params = {'layer': 'ch.bfs.gebaeude_wohnungs_register', 'searchText': 'berges', 'searchField': 'strname1'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/find', params=params, headers=headers, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertTrue(len(resp.json['results']) >= 1)
+        self.assertFalse('geometry' in resp.json['results'][0])
+
+    def test_find_authorized(self):
+        headers = {'X-SearchServer-Authorized': 'true'}
+        params = {'layer': 'ch.bfs.gebaeude_wohnungs_register', 'searchText': 'berges', 'searchField': 'strname1'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/find', params=params, headers=headers, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertTrue(len(resp.json['results']) >= 1)
+        self.assertTrue('geometry' in resp.json['results'][0])
+
+    def test_identify_not_authorized(self):
+        headers = {'X-SearchServer-Authorized': 'false'}
+        params = {'geometry': '653199.9999999999,137409.99999999997', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryPoint',
+                  'imageDisplay': '1920,623,96', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register', 'mapExtent': '633200,132729.99999999997,671600,145189.99999999997',
+                  'tolerance': '5'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=headers, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertTrue(len(resp.json['results']) >= 1)
+        self.assertFalse('geometry' in resp.json['results'][0])
+
+    def test_identify_authorized(self):
+        headers = {'X-SearchServer-Authorized': 'true'}
+        params = {'geometry': '653199.9999999999,137409.99999999997', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryPoint',
+                  'imageDisplay': '1920,623,96', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register', 'mapExtent': '633200,132729.99999999997,671600,145189.99999999997',
+                  'tolerance': '5'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=headers, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertTrue(len(resp.json['results']) >= 1)
+        self.assertTrue('geometry' in resp.json['results'][0])
+
+
 class TestReleasesService(TestsBase):
 
     def test_service(self):

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -20,6 +20,8 @@ from chsdi.models import models_from_name, oereb_models_from_bodid
 from chsdi.models.bod import OerebMetadata, get_bod_model
 from chsdi.views.layers import get_layer, get_layers_metadata_for_params
 
+PROTECTED_GEOMETRY_LAYERS = ['ch.bfs.gebaeude_wohnungs_register']
+
 
 # For several features
 class FeatureParams(MapServiceValidation):
@@ -476,11 +478,11 @@ def _process_feature(feature, params):
         # Filter out this layer individually, disregarding of the global returnGeometry
         # setting
         if not params.varnish_authorized:
-            if hasattr(params, 'layers') and feature.__bodId__ == 'ch.bfs.gebaeude_wohnungs_register':
+            if hasattr(params, 'layers') and feature.__bodId__ in PROTECTED_GEOMETRY_LAYERS:
                 f = feature.__interface__
-            if hasattr(params, 'layer') and params.layer == 'ch.bfs.gebaeude_wohnungs_register':
+            if hasattr(params, 'layer') and params.layer in PROTECTED_GEOMETRY_LAYERS:
                 f = feature.__interface__
-            if hasattr(params, 'layerId') and params.layerId == 'ch.bfs.gebaeude_wohnungs_register':
+            if hasattr(params, 'layerId') and params.layerId in PROTECTED_GEOMETRY_LAYERS:
                 f = feature.__interface__
     else:
         f = feature.__interface__


### PR DESCRIPTION
Carefully test, as I do'nt know exactly how the result, either a JSON or a GeoJSON is used in the makos. If it has to be a geometry, we should use a dummy one.