### PR TITLE
Adding download kml service

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -105,3 +105,6 @@ WSGIScriptAliasMatch ^${apache_entry_path}/ ${buildout:directory/buildout/parts/
    Order Deny,Allow
    Allow from all
 </LocationMatch>
+
+# kml file downloads
+AliasMatch ^${apache_entry_path}/kml/(map\.geo\.admin\.ch_KML_\d+\.kml)$ ${print_temp_dir}/kml/$1

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -85,6 +85,7 @@ def main(global_config, **settings):
     config.add_route('luftbilder', '/luftbilder/viewer.html')
     config.add_route('checker', '/checker')
     config.add_route('checker_dev', '/checker_dev')
+    config.add_route('downloadkml', '/downloadkml')
 
     # Some views for specific routes
     config.add_view(route_name='dev', renderer='chsdi:templates/index.pt')

--- a/chsdi/views/downloadkml.py
+++ b/chsdi/views/downloadkml.py
@@ -1,0 +1,79 @@
+#-*- coding: utf-8 -*-
+
+
+from chsdi.lib.decorators import requires_authorization
+
+import json
+import os
+import errno
+import sys
+import time
+import urllib2
+from pyramid.view import view_config
+from pyramid.response import Response
+from pyramid.httpexceptions import (HTTPBadRequest, HTTPInternalServerError)
+
+
+def make_sure_path_exists(path):
+    try:
+        os.makedirs(path)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise
+
+
+def delete_old_files(path):
+    now = time.time()
+    # older than 1 hour
+    cutoff = now - 3600
+    files = os.listdir(path)
+    for xfile in files:
+        fn = path + '/' + xfile
+        if os.path.isfile(fn):
+            t = os.stat(fn)
+            c = t.st_ctime
+            # delete file if older than a week
+            if c < cutoff:
+                os.remove(fn)
+
+
+class DownloadKML:
+
+    def __init__(self, request):
+        self.request = request
+        self.tmpdir = request.registry.settings['print_temp_dir'] + '/kml'
+        self.host = request.registry.settings['api_url'] + '/kml'
+
+    @requires_authorization()
+    @view_config(route_name='downloadkml', renderer='jsonp')
+    def downloadkml(self):
+
+        if self.request.method == 'OPTIONS':
+            return Response(status=200)
+
+        # IE is always URLEncoding the body
+        jsonstring = urllib2.unquote(self.request.body)
+
+        try:
+            spec = json.loads(jsonstring, encoding=self.request.charset)
+        except Exception as e:
+            raise HTTPBadRequest()
+
+        kml = spec.get('kml')
+        filename = spec.get('filename')
+        if kml is None or filename is None:
+            raise HTTPBadRequest()
+
+        make_sure_path_exists(self.tmpdir)
+        delete_old_files(self.tmpdir)
+
+        #create the file in the tmp dir
+        try:
+            with open(self.tmpdir + '/' + filename, 'w') as file_:
+                file_.write(kml.encode('utf8'))
+        except EnvironmentError:
+            raise HTTPInternalServerError()
+
+        return {
+            'url': self.host + '/' + filename
+        }


### PR DESCRIPTION
This PR adds a service that will take a filename and a kml string send to it and create a file on the system. The URL to get this file is send as a response. This can then be used to fetch the created file. This is needed for better kml export support in IE9 and Safari.

Note: the files created are deleted after 1 hour (check is done on each request).

A PR in geoadmin will follow that uses this service.
