### PR TITLE
Removing the auth decorator for mapproxy

### DIFF
--- a/mapproxy/createWsgi.py
+++ b/mapproxy/createWsgi.py
@@ -22,23 +22,6 @@ for path in reversed(syspaths):
 from paste.deploy import loadapp
 
 
-class Auth():
-
-    def __init__(self, app):
-        self._app = app
-
-    def __call__(self, environ, start_response):
-        if environ.get('HTTP_X_SEARCHSERVER_AUTHORIZED') == 'true':
-            return self._app(environ, start_response)
-        else:
-            return self._forbidden(environ, start_response)
-
-    def _forbidden(self, environ, start_response):
-        start_response('403 Forbidden',
-            [('Content-Type', 'text/plain')])
-        return [b'You must have a registered referer to use this service.']
-
-
 # If you want to debug, uncomment the following lines
 #from paste.script.util.logging_config import fileConfig
 #fileConfig(r'%(log_config)s', {'here': os.path.dirname(__file__)})
@@ -46,7 +29,7 @@ class Auth():
 
 from mapproxy.wsgiapp import make_wsgi_app
 configfile="%(config)s"
-application = Auth(make_wsgi_app(configfile))
+application = make_wsgi_app(configfile)
 
 """
 


### PR DESCRIPTION
Using such a decorator for ressource whgich are cached is useless.

1/ Trying to get a tile, which is not in cache (OK, it is wrong)  --> forbidden

```
 curl -I --referer "http://www.arcgis.com" "http://wmts12.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/20130903/3857/13/4247/2880.jpeg"
HTTP/1.1 403 Forbidden
X-Cache: MISS
```

2/ This one is authorized (do it several time to fill the cache)

```
$ curl -I --referer "http://map.geo.admin.ch" "http://wmts12.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/20130903/3857/13/4247/2880.jpeg"
HTTP/1.1 200 OK
```

3/ First request again, the tile is in the cache

```
$ curl -I --referer "http://www.arcgis.com" "http://wmts12.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/20130903/3857/13/4247/2880.jpeg"
HTTP/1.1 200 OK
X-Cache: HIT 
X-Cache-Hits: 3
```
