### PR TITLE
IE9 JSON trick

### DIFF
--- a/chsdi/views/printproxy.py
+++ b/chsdi/views/printproxy.py
@@ -219,8 +219,11 @@ class PrintProxy(object):
         if self.request.method == 'OPTIONS':
             return Response(status=200)
 
+        # IE is always URLEncoding the body
+        jsonstring = urllib2.unquote(self.request.body)
+
         try:
-            spec = json.loads(self.request.body)
+            spec = json.loads(jsonstring, encoding=self.request.charset)
 
         except:
             raise HTTPBadRequest()


### PR DESCRIPTION
JSOn sent via IE9 have to be decoded...

See https://github.com/geoadmin/mf-chsdi3/blob/master/chsdi/views/downloadkml.py#L55
