### PR TITLE
Support special characters for similarity queries

### DIFF
--- a/chsdi/lib/validation/mapservice.py
+++ b/chsdi/lib/validation/mapservice.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import re
+
 from shapely.geometry import asShape
 from pyramid.httpexceptions import HTTPBadRequest
 
@@ -93,7 +95,18 @@ class MapServiceValidation(MapNameValidation):
     def where(self, value):
         ## TODO regexp to test validity of sql clause
         if value is not None:
-            self._where = value
+            if 'ilike' in value:
+                match = re.search(r'(.*)(%.*%)(.*)', value)
+                where = ''.join((
+                    match.group(1).replace('\'', 'E\''),
+                    match.group(2).replace('\'', '\\\''),
+                    match.group(3)
+                ))
+                where = where.encode('ascii', 'replace')
+                where = where.replace('?', '%')
+                self._where = where
+            else:
+                self._where = value
 
     @geometry.setter
     def geometry(self, value):

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -1,4 +1,4 @@
-#-*- utf-8 -*-
+# -*- coding: utf-8 -*-
 
 import re
 
@@ -330,8 +330,9 @@ def _get_features_for_filters(params, models, maxFeatures=None, where=None):
             # Filter by sql query
             # Only one filter = one layer
             if where is not None:
-                query = query.filter(text(where))
-
+                query = query.filter(text(
+                    where
+                ))
             # Filter by bbox
             if params.geometry is not None:
                 geomFilter = model.geom_filter(


### PR DESCRIPTION
This PR is for: https://github.com/geoadmin/mf-geoadmin3/issues/2009

At some point the where `unicode` will be converted to byte `str` and will fail because for some reason we have non-ASCII unicode strings.

The famous `UnicodeError` ...

Here we 
1. Build a query to postrges can understand (Escaping the `\`  and telling postrgres to escape it with E)
2. We convert to byte `str` and replace unmapped characters with `?` that we finally replace with `%`

It's a workaround but it works fine.
If anybody has a better solution/understanding of what's going on please feel free.

[Current Link in prod]
(http://api3.geo.admin.ch/rest/services/all/MapServer/identify?geometryFormat=geojson&lang=fr&layers=all:ch.swisstopo.geologie-geotope&time=2013&where=nom+ilike+%27%25Bloc+erratique+rhodanien+de+la+L%C3%A9cherette+(Ch%C3%A2teau+d%27Oex,+VD)%25%27)

[Deployed Branch in test]
(http://mf-chsdi3.dev.bgdi.ch/gal_handle_accents/rest/services/all/MapServer/identify?geometryFormat=geojson&lang=fr&layers=all:ch.swisstopo.geologie-geotope&time=2013&where=nom+ilike+%27%25Bloc+erratique+rhodanien+de+la+L%C3%A9cherette+(Ch%C3%A2teau+d%27Oex,+VD)%25%27)
