### PR TITLE
Print A3: go to full resolution

### DIFF
--- a/print/config.yaml
+++ b/print/config.yaml
@@ -1,5 +1,5 @@
 # allowed DPIs
-dpis: [150, 100]
+dpis: [150]
 
 #
 # the list of allowed hosts


### PR DESCRIPTION
150 dpis for both A4 and A3. The geoadmin part is not reverted as it can handle only one dpi value, see [#1899](https://github.com/geoadmin/mf-geoadmin3/pull/1899/files).