### PR TITLE
Queryable attributes translations

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -140,9 +140,6 @@ msgstr "Ecke unten links"
 msgid "Lower right corner"
 msgstr "Ecke unten rechts"
 
-msgid "MCPFE"
-msgstr "Schutzflächentyp"
-
 msgid "Man-made"
 msgstr "Künstlich"
 
@@ -202,9 +199,6 @@ msgstr "Rennbahn"
 
 msgid "Ruine"
 msgstr "Historische Ruine"
-
-msgid "SGNr"
-msgstr "Reservatsnummer"
 
 msgid "Schloss"
 msgstr "Schloss"
@@ -1360,6 +1354,27 @@ msgstr "http://www.bafu.admin.ch/index.html?lang=de"
 
 msgid "ch.bafu.waldreservate"
 msgstr "Waldreservate"
+
+msgid "ch.bafu.waldreservate.gisflaeche"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.waldreservate.mcpfe"
+msgstr "Schutzflächentyp"
+
+msgid "ch.bafu.waldreservate.name"
+msgstr "Name"
+
+msgid "ch.bafu.waldreservate.objnummer"
+msgstr "Reservatsnummer"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_1"
+msgstr "Keine aktiven Eingriffe"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_2"
+msgstr "Minimale Eingriffe"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_3"
+msgstr "Biodiversitätsförderung durch gezielte Eingriffe"
 
 msgid "ch.bafu.waldschadenflaechen-lothar"
 msgstr "Sturmschaden Lothar"
@@ -4731,15 +4746,6 @@ msgstr "Ort"
 
 msgid "tt_wald_natur"
 msgstr "Naturnahe Flächen, Wald"
-
-msgid "tt_waldreservate_1_1"
-msgstr "Keine aktiven Eingriffe"
-
-msgid "tt_waldreservate_1_2"
-msgstr "Minimale Eingriffe"
-
-msgid "tt_waldreservate_1_3"
-msgstr "Biodiversitätsförderung durch gezielte Eingriffe"
 
 msgid "tt_wasserflae"
 msgstr "Wasserflächen"

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -4789,19 +4789,25 @@ msgstr ""
 msgid "tt_pronatura_e3"
 msgstr ""
 
-msgid "MCPFE"
+msgid "ch.bafu.waldreservate.name"
 msgstr ""
 
-msgid "SGNr"
+msgid "ch.bafu.waldreservate.mcpfe"
 msgstr ""
 
-msgid "tt_waldreservate_1_1"
+msgid "ch.bafu.waldreservate.objnummer"
 msgstr ""
 
-msgid "tt_waldreservate_1_2"
+msgid "ch.bafu.waldreservate.gisflaeche"
 msgstr ""
 
-msgid "tt_waldreservate_1_3"
+msgid "ch.bafu.waldreservate.waldreservate_1_1"
+msgstr ""
+
+msgid "ch.bafu.waldreservate.waldreservate_1_2"
+msgstr ""
+
+msgid "ch.bafu.waldreservate.waldreservate_1_3"
 msgstr ""
 
 msgid "ch.bafu.waldreservate"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -140,9 +140,6 @@ msgstr "Lower left corner"
 msgid "Lower right corner"
 msgstr "Lower right corner"
 
-msgid "MCPFE"
-msgstr "Type of protected area"
-
 msgid "Man-made"
 msgstr "Künstlich"
 
@@ -202,9 +199,6 @@ msgstr "Rennbahn"
 
 msgid "Ruine"
 msgstr "Historische Ruine"
-
-msgid "SGNr"
-msgstr "Number oft he reserve"
 
 msgid "Schloss"
 msgstr "Schloss"
@@ -1360,6 +1354,27 @@ msgstr "http://www.bafu.admin.ch/index.html?lang=en"
 
 msgid "ch.bafu.waldreservate"
 msgstr "Forest Reserves"
+
+msgid "ch.bafu.waldreservate.gisflaeche"
+msgstr "Area [ha]"
+
+msgid "ch.bafu.waldreservate.mcpfe"
+msgstr "Type of protected area"
+
+msgid "ch.bafu.waldreservate.name"
+msgstr "Name"
+
+msgid "ch.bafu.waldreservate.objnummer"
+msgstr "Number oft he reserve"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_1"
+msgstr "No active intervention"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_2"
+msgstr "Minimum Intervention"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_3"
+msgstr "Conservation through active management"
 
 msgid "ch.bafu.waldschadenflaechen-lothar"
 msgstr "Lothar storm damage"
@@ -4732,15 +4747,6 @@ msgstr "Town"
 
 msgid "tt_wald_natur"
 msgstr "Forest and semi natural areas"
-
-msgid "tt_waldreservate_1_1"
-msgstr "No active intervention"
-
-msgid "tt_waldreservate_1_2"
-msgstr "Minimum Intervention"
-
-msgid "tt_waldreservate_1_3"
-msgstr "Conservation through active management"
 
 msgid "tt_wasserflae"
 msgstr "Waterbodies"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -140,9 +140,6 @@ msgstr "Ecke unten links"
 msgid "Lower right corner"
 msgstr "Ecke unten rechts"
 
-msgid "MCPFE"
-msgstr "Schutzflächentyp"
-
 msgid "Man-made"
 msgstr "Künstlich"
 
@@ -202,9 +199,6 @@ msgstr "Rennbahn"
 
 msgid "Ruine"
 msgstr "Historische Ruine"
-
-msgid "SGNr"
-msgstr "Reservatsnummer"
 
 msgid "Schloss"
 msgstr "Schloss"
@@ -1360,6 +1354,27 @@ msgstr "http://www.bafu.admin.ch/index.html?lang=de"
 
 msgid "ch.bafu.waldreservate"
 msgstr "Waldreservate"
+
+msgid "ch.bafu.waldreservate.gisflaeche"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.waldreservate.mcpfe"
+msgstr "Schutzflächentyp"
+
+msgid "ch.bafu.waldreservate.name"
+msgstr "Num"
+
+msgid "ch.bafu.waldreservate.objnummer"
+msgstr "Reservatsnummer"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_1"
+msgstr "Keine aktiven Eingriffe"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_2"
+msgstr "Minimale Eingriffe"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_3"
+msgstr "Biodiversitätsförderung durch gezielte Eingriffe"
 
 msgid "ch.bafu.waldschadenflaechen-lothar"
 msgstr "Sturmschaden Lothar"
@@ -4731,15 +4746,6 @@ msgstr "Ort"
 
 msgid "tt_wald_natur"
 msgstr "Naturnahe Flächen, Wald"
-
-msgid "tt_waldreservate_1_1"
-msgstr "Keine aktiven Eingriffe"
-
-msgid "tt_waldreservate_1_2"
-msgstr "Minimale Eingriffe"
-
-msgid "tt_waldreservate_1_3"
-msgstr "Biodiversitätsförderung durch gezielte Eingriffe"
 
 msgid "tt_wasserflae"
 msgstr "Wasserflächen"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -140,9 +140,6 @@ msgstr "Coin en bas à gauche"
 msgid "Lower right corner"
 msgstr "Coin en bas à droite"
 
-msgid "MCPFE"
-msgstr "Type de l’aire protégé"
-
 msgid "Man-made"
 msgstr "Artificielle"
 
@@ -202,9 +199,6 @@ msgstr "Circuit automobile"
 
 msgid "Ruine"
 msgstr "Ruine historique"
-
-msgid "SGNr"
-msgstr "Numéro de la réserve"
 
 msgid "Schloss"
 msgstr "Château"
@@ -1360,6 +1354,27 @@ msgstr "http://www.bafu.admin.ch/index.html?lang=fr"
 
 msgid "ch.bafu.waldreservate"
 msgstr "Réserves forestières"
+
+msgid "ch.bafu.waldreservate.gisflaeche"
+msgstr "Surface [ha]"
+
+msgid "ch.bafu.waldreservate.mcpfe"
+msgstr "Type de l’aire protégé"
+
+msgid "ch.bafu.waldreservate.name"
+msgstr "Nom"
+
+msgid "ch.bafu.waldreservate.objnummer"
+msgstr "Numéro de la réserve"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_1"
+msgstr "Pas d’interventions actives"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_2"
+msgstr "Interventions minimales"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_3"
+msgstr "Promotion de la biodiversité par des interventions ciblées"
 
 msgid "ch.bafu.waldschadenflaechen-lothar"
 msgstr "Dégâts de tempête Lothar"
@@ -4732,15 +4747,6 @@ msgstr "Lieu"
 
 msgid "tt_wald_natur"
 msgstr "Forêts et autres surfaces naturelles"
-
-msgid "tt_waldreservate_1_1"
-msgstr "Pas d’interventions actives"
-
-msgid "tt_waldreservate_1_2"
-msgstr "Interventions minimales"
-
-msgid "tt_waldreservate_1_3"
-msgstr "Promotion de la biodiversité par des interventions ciblées"
 
 msgid "tt_wasserflae"
 msgstr "Surfaces en eau"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -140,9 +140,6 @@ msgstr "Angolo in basso a sinistra"
 msgid "Lower right corner"
 msgstr "Angolo in basso a destra"
 
-msgid "MCPFE"
-msgstr "Tipo di superficie protetta"
-
 msgid "Man-made"
 msgstr "Artificielle"
 
@@ -202,9 +199,6 @@ msgstr "Circuit automobile"
 
 msgid "Ruine"
 msgstr "Ruine historique"
-
-msgid "SGNr"
-msgstr "Numero della riserva"
 
 msgid "Schloss"
 msgstr "Château"
@@ -1360,6 +1354,27 @@ msgstr "http://www.bafu.admin.ch/index.html?lang=it"
 
 msgid "ch.bafu.waldreservate"
 msgstr "Riserva forestali"
+
+msgid "ch.bafu.waldreservate.gisflaeche"
+msgstr "Superficie [ha]"
+
+msgid "ch.bafu.waldreservate.mcpfe"
+msgstr "Tipo di superficie protetta"
+
+msgid "ch.bafu.waldreservate.name"
+msgstr "Nome"
+
+msgid "ch.bafu.waldreservate.objnummer"
+msgstr "Numero della riserva"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_1"
+msgstr "Nessun intervento attivo"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_2"
+msgstr "Interventi minimi"
+
+msgid "ch.bafu.waldreservate.waldreservate_1_3"
+msgstr "Promozione delle biodiversità per mezzo di interventi specifici"
 
 msgid "ch.bafu.waldschadenflaechen-lothar"
 msgstr "Aree boschive danneggiate Lothar"
@@ -4732,15 +4747,6 @@ msgstr "Luogo"
 
 msgid "tt_wald_natur"
 msgstr "Foreste ed alter superfici naturali"
-
-msgid "tt_waldreservate_1_1"
-msgstr "Nessun intervento attivo"
-
-msgid "tt_waldreservate_1_2"
-msgstr "Interventi minimi"
-
-msgid "tt_waldreservate_1_3"
-msgstr "Promozione delle biodiversità per mezzo di interventi specifici"
 
 msgid "tt_wasserflae"
 msgstr "Superfici acquatiche"

--- a/chsdi/models/vector/bafu.py
+++ b/chsdi/models/vector/bafu.py
@@ -1254,6 +1254,7 @@ class waldreservate(Base, Vector):
     __template__ = 'templates/htmlpopup/bafu_waldreservate.mako'
     __bodId__ = 'ch.bafu.waldreservate'
     __label__ = 'name'
+    __queryable_attributes__ = ['objnummer', 'name', 'gisflaeche', 'mcpfe']
     id = Column('bgdi_id', Integer, primary_key=True)
     objnummer = Column('objnummer', Text)
     name = Column('name', Text)

--- a/chsdi/templates/htmlpopup/bafu_waldreservate.mako
+++ b/chsdi/templates/htmlpopup/bafu_waldreservate.mako
@@ -1,17 +1,17 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
-    <tr><td class="cell-left">${_('SGNr')}</td>                         <td>${c['attributes']['objnummer'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('name')}</td>                         <td>${c['attributes']['name'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('flaeche_ha')}</td>                   <td>${round(c['attributes']['gisflaeche'],2) or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.waldreservate.objnummer')}</td>                         <td>${c['attributes']['objnummer'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.waldreservate.name')}</td>                         <td>${c['attributes']['name'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.waldreservate.gisflaeche')}</td>                   <td>${round(c['attributes']['gisflaeche'],2) or '-'}</td></tr>
 % if c['attributes']['mcpfe'].strip()== 'MCPFE1.1':
-    <tr><td class="cell-left">${_('MCPFE')}</td>                        <td>${_('tt_waldreservate_1_1')}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.waldreservate.mcpfe')}</td>                        <td>${_('ch.bafu.waldreservate.waldreservate_1_1')}</td></tr>
 % elif c['attributes']['mcpfe'].strip()== 'MCPFE1.2':
-    <tr><td class="cell-left">${_('MCPFE')}</td>                        <td>${_('tt_waldreservate_1_2')}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.waldreservate.mcpfe')}</td>                        <td>${_('ch.bafu.waldreservate.waldreservate_1_2')}</td></tr>
 % elif c['attributes']['mcpfe'].strip()== 'MCPFE1.3':
-    <tr><td class="cell-left">${_('MCPFE')}</td>                        <td>${_('tt_waldreservate_1_3')}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.waldreservate.mcpfe')}</td>                        <td>${_('ch.bafu.waldreservate.waldreservate_1_3')}</td></tr>
 % else:
-    <tr><td class="cell-left">${_('MCPFE')}</td>                        <td>-</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.waldreservate.mcpfe')}</td>                        <td>-</td></tr>
 % endif
 </%def>
 


### PR DESCRIPTION
1. Add `__queryable_attributes__` to model
2. Add `msgid` to `empty.po` on the scheme `<layerid>.<atttributename>`
3. Modifiy the mako accordingly
4. Change, add or duplicate translations in BOD's `translations` table:

     ```insert into translations (msg_id,de,fr,it, rm, en)
     select 'ch.bafu.waldreservate.waldreservate_1_3',de,fr,it,rm,en
     from translation where msg_id='tt_waldreservate_1_3';```

5. Run `buildout install potranslate po2mo` and test the query tool and tooltip