### PR TITLE
remove unregistered attribute from htmlpopup mako

### DIFF
--- a/chsdi/templates/htmlpopup/ga25_point_info.mako
+++ b/chsdi/templates/htmlpopup/ga25_point_info.mako
@@ -1,6 +1,6 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c,lang)">
-    <tr><td class="cell-left">${_('geocover_id_geol')}</td><td>${c['attributes']['id_geol'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('geocover_basisdatensatz')}</td><td>${c['attributes']['basisdatensatz'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('geocover_description')}</td><td>${c['attributes']['description'] or '-'}</td></tr>
 </%def>


### PR DESCRIPTION
fixing 500 error described in https://github.com/geoadmin/mf-geoadmin3/issues/2057