### PR TITLE
Include pkey in getAttributes when needed

### DIFF
--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -168,22 +168,27 @@ class Vector(GeoInterface):
             return cls.__mapper__.columns.get(columnName)
         return None
 
-    def getOrmColumnsNames(self):
+    def getOrmColumnsNames(self, excludePkey=True):
         primaryKeyColumn = self.__mapper__.get_property_by_column(self.primary_key_column()).key
         geomColumnKey = self.__mapper__.get_property_by_column(self.geometry_column()).key
         geomColumnToReturnKey = self.__mapper__.get_property_by_column(self.geometry_column_to_return()).key
+        if excludePkey:
+            keysToExclude = (primaryKeyColumn, geomColumnKey, geomColumnToReturnKey)
+        else:
+            keysToExclude = (geomColumnKey, geomColumnToReturnKey)
+
         for column in self.__mapper__.columns:
             ormColumnName = self.__mapper__.get_property_by_column(column).key
-            if ormColumnName not in (primaryKeyColumn, geomColumnKey, geomColumnToReturnKey):
+            if ormColumnName not in keysToExclude:
                 yield ormColumnName
 
     def getAttributesKeys(self):
-        attributes = [columnName for columnName in self.getOrmColumnsNames()]
+        attributes = [columnName for columnName in self.getOrmColumnsNames(excludePkey=False)]
         return attributes
 
-    def getAttributes(self):
+    def getAttributes(self, excludePkey=True):
         attributes = {}
-        for ormColumnName in self.getOrmColumnsNames():
+        for ormColumnName in self.getOrmColumnsNames(excludePkey=excludePkey):
             attribute = getattr(self, ormColumnName)
             attributes[ormColumnName] = formatAttribute(attribute)
         return self.insertLabel(attributes)

--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -145,7 +145,7 @@ class ZAEHLSTELLENREGLOC(Base, Vector):
     __table_args__ = ({'schema': 'astra', 'autoload': False})
     __template__ = 'templates/htmlpopup/verkehrszaehlstellen.mako'
     __bodId__ = 'ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal'
-    __queryable_attributes__ = ['nr', 'zaehlstellen_bezeichnung']
+    __queryable_attributes__ = ['id', 'zaehlstellen_bezeichnung']
     __extended_info__ = True
     __label__ = 'zaehlstellen_bezeichnung'
     id = Column('nr', Integer, primary_key=True)
@@ -178,7 +178,7 @@ class ZAEHLSTELLENUEBER(Base, Vector):
     __table_args__ = ({'schema': 'astra', 'autoload': False})
     __template__ = 'templates/htmlpopup/verkehrszaehlstellen.mako'
     __bodId__ = 'ch.astra.strassenverkehrszaehlung_messstellen-uebergeordnet'
-    __queryable_attributes__ = ['nr', 'zaehlstellen_bezeichnung']
+    __queryable_attributes__ = ['id', 'zaehlstellen_bezeichnung']
     __extended_info__ = True
     __label__ = 'zaehlstellen_bezeichnung'
     id = Column('nr', Integer, primary_key=True)

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -134,7 +134,7 @@ def feature_attributes(request):
     fields = []
     for row_nr, row in enumerate(results):
         for attr_nr, attr in enumerate(attributes):
-            attrs = row.getAttributes()
+            attrs = row.getAttributes(excludePkey=False)
             if row_nr == 0:
                 field_type = _find_type(models[0](), attr)
                 fields.append({'name': attr, 'type': str(field_type),


### PR DESCRIPTION
Would be nice to have it for tomorrow.

Some layers define pkeys as queryable attributes, this was not taken into account so far.