### PR TITLE
Remove duplicate column definition

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -156,7 +156,6 @@ class GetCap(object):
     timestamp = Column('timestamp', Text)
     sswmts = Column('sswmts', Integer)
     bod_layer_id = Column('bod_layer_id', Text)
-    topics = Column('topics', Text)
     staging = Column('staging', Text)
     bezeichnung = Column('bezeichnung', Text)
     kurzbezeichnung = Column('kurzbezeichnung', Text)


### PR DESCRIPTION
Colum('topics') is used twice in the GetCap model, resulting in warnings during the build. This removes one definition to get rid of the warning.

Looks like `topics` of this model is never used, but would be glad if someone could verify also.