### PR TITLE
Support multi models in attributes listing and preview services

### DIFF
--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -409,12 +409,21 @@ class TestMapServiceView(TestsBase):
     def test_layersconfig_wrong_map(self):
         resp = self.testapp.get('/rest/services/foo/MapServer/layersConfig', status=400)
 
-    def test_features_attributes(self):
+    def test_layer_attributes(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln', status=200)
         self.failUnless(resp.content_type == 'application/json')
 
-    def test_features_attributes_wrong_layer(self):
+    def test_layer_attributes_wrong_layer(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/dummy', status=400)
+
+    def test_layer_attributes_multi_models(self):
+        resp = self.testapp.get('/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft', status=200)
+        self.failUnless(resp.content_type == 'application/json')
+        self.failUnless(len(resp.json['fields']) > 4)
+
+    def test_features_attributes_multi_models(self):
+        resp = self.testapp.get('/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft/attributes/plname_de', status=200)
+        self.failUnless(resp.content_type == 'application/json')
 
 zlayer = 'ch.swisstopo.zeitreihen'
 


### PR DESCRIPTION
This provides a fix for https://github.com/geoadmin/mf-chsdi3/issues/1220

We now support mulit models layers with different attributes

Now in attributes listing values are sorted.

*Attribute Listing*
Prod at the moment:
http://api3.geo.admin.ch/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft

not all searchable fields are displayed (or queryable attributes)

*VS*

Deployed branch
http://mf-chsdi3.dev.bgdi.ch/gal_attrs_mulit_models/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft

which actually displays all the available searchable fields.

*Attribute values preview (use plname_de)*
Prod at the moment:
http://api3.geo.admin.ch/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft/attributes/plname_de

ends up in a bad request (this field does not exist while it exists on the models)

*VS*

Deployed branch
http://mf-chsdi3.dev.bgdi.ch/gal_attrs_mulit_models/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft/attributes/plname_de

Returns a set of preview values for plname_de


Additionnaly I updated six which is compatibility module to smooth differences between Python 2 and 3.