### PR TITLE
CD Bund compliant fonts

### DIFF
--- a/chsdi/static/less/extended.less
+++ b/chsdi/static/less/extended.less
@@ -11,7 +11,7 @@ body {
 }
 .chsdi-htmlpopup-container {
   width: 580px; /* size for A4 print */ 
-  font-family: arial,helvetia,verdana;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   height: 100%;
   margin: auto;
   color: #333333;

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -54,6 +54,9 @@
     <style>
       body {
         margin: 10px;
+        color: #333;
+        font-size: 12px;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
       }
       .pull-right {
         float: right;
@@ -63,13 +66,14 @@
       }
       .header {
         height: 30px;
+        line-height: 30px;
         margin: 10px 0px;
         font-size: 14px;
         font-weight: bold;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        background-color:#EFEFEF;
+        background-color:#e9e9e9;
       }
       .wrapper {
         position: absolute;
@@ -93,7 +97,6 @@
       }
       #messagectrl {
         display: inline-block;
-        color: #5c5c5c;
       }
       .link-red {
         color: red;
@@ -101,6 +104,7 @@
       #lubismap {
         width: 100%;
         height: 100%;
+        font-size: 16px;
       }
       @media print { /* Used by Chrome */
         #lubismap, .wrapper {


### PR DESCRIPTION
Fix #1211

Some tests:

[Extended tooltip Luftbilder](http://mf-chsdi3.dev.bgdi.ch/ltkan/luftbilder/viewer.html?lang=fr&width=16862&layer=ch.swisstopo.lubis-luftbilder_schwarzweiss&bildnummer=19751840024369&title=No+de+l%27image&rotation=0&datenherr=swisstopo&height=17764&x=7300.86&y=11874.44&zoom=1)

[Extended tooltip ch.babs.kulturgueter](http://mf-chsdi3.dev.bgdi.ch/ltkan/rest/services/ech/MapServer/ch.babs.kulturgueter/9775/extendedHtmlPopup?lang=fr)