### PR TITLE
Fix height test because of changed DTM

### DIFF
--- a/chsdi/tests/integration/test_height.py
+++ b/chsdi/tests/integration/test_height.py
@@ -30,7 +30,7 @@ class TestHeightView(TestsBase):
     def test_height_with_comb(self):
         resp = self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': '200000', 'layers': 'COMB'}, headers=self.headers, status=200)
         self.failUnless(resp.content_type == 'application/json')
-        self.failUnless(resp.json['height'] == '556.5')
+        self.failUnless(resp.json['height'] == '552.9')
 
     def test_height_wrong_layer(self):
         resp = self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': '200000', 'layers': 'TOTO'}, headers=self.headers, status=400)


### PR DESCRIPTION
Last build in Jenkins failed because of height test [1].

It seems like the COMB DTM Model changed on our infrastructure, but the difference in resulting height for Bern is 3.6 meters, which seems alot to me. @ltclm Do you know the reason for this big of a change?

(Note that the other models didn't change and before COMB and DTM2 were the same)

https://jenkins.dev.bgdi.ch/job/chsdi3/253/console