### PR TITLE
Fix height tests to be not on strange border case

### DIFF
--- a/chsdi/tests/integration/test_height.py
+++ b/chsdi/tests/integration/test_height.py
@@ -10,7 +10,7 @@ class TestHeightView(TestsBase):
         self.headers = {'X-SearchServer-Authorized': 'true'}
 
     def test_height_valid(self):
-        resp = self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': '200000'}, headers=self.headers, status=200)
+        resp = self.testapp.get('/rest/services/height', params={'easting': '600000.1', 'northing': '200000.1'}, headers=self.headers, status=200)
         self.failUnless(resp.content_type == 'application/json')
         self.failUnless(resp.json['height'] == '560.2')
 
@@ -18,17 +18,17 @@ class TestHeightView(TestsBase):
         resp = self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': '200000'}, status=403)
 
     def test_height_valid_with_lonlat(self):
-        resp = self.testapp.get('/rest/services/height', params={'lon': '600000', 'lat': '200000'}, headers=self.headers, status=200)
+        resp = self.testapp.get('/rest/services/height', params={'lon': '600000.1', 'lat': '200000.1'}, headers=self.headers, status=200)
         self.failUnless(resp.content_type == 'application/json')
         self.failUnless(resp.json['height'] == '560.2')
 
     def test_height_with_dtm2(self):
-        resp = self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': '200000', 'layers': 'DTM2'}, headers=self.headers, status=200)
+        resp = self.testapp.get('/rest/services/height', params={'easting': '600000.1', 'northing': '200000.1', 'layers': 'DTM2'}, headers=self.headers, status=200)
         self.failUnless(resp.content_type == 'application/json')
         self.failUnless(resp.json['height'] == '556.5')
 
     def test_height_with_comb(self):
-        resp = self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': '200000', 'layers': 'COMB'}, headers=self.headers, status=200)
+        resp = self.testapp.get('/rest/services/height', params={'easting': '600000.1', 'northing': '200000.1', 'layers': 'COMB'}, headers=self.headers, status=200)
         self.failUnless(resp.content_type == 'application/json')
         self.failUnless(resp.json['height'] == '556.5')
 


### PR DESCRIPTION
This replaces https://github.com/geoadmin/mf-chsdi3/pull/1240, which uses a bordercase that is not consistent. We don't know the reasons.