### PR TITLE
[WIP] Get the total number of features of an identify request

### DIFF
--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -68,6 +68,7 @@ def _get_features_params(request):
     params.tolerance = request.params.get('tolerance')
     params.layers = request.params.get('layers', 'all')
     params.timeInstant = request.params.get('timeInstant')
+    params.maxFeatures = request.params.get('maxFeatures')
     return params
 
 
@@ -258,7 +259,10 @@ def _identify(request):
     if models is None:
         raise exc.HTTPBadRequest('No GeoTable was found for %s' % ' '.join(layerIds))
 
-    maxFeatures = 200
+    maxFeatures = params.maxFeatures
+    if maxFeatures is None:
+        maxFeatures = 200
+
     features = []
     for feature in _get_features_for_filters(params, models, maxFeatures=maxFeatures, where=params.where):
         f = _process_feature(feature, params)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -262,7 +262,8 @@ def _identify(request):
     maxFeatures = params.maxFeatures
     if maxFeatures is None:
         maxFeatures = 200
-
+    elif maxFeatures == 'all':
+        maxFeatures = 10000
     total = _get_nb_features_for_filters(params, models, maxFeatures=maxFeatures, where=params.where)
 
     features = []


### PR DESCRIPTION
For https://github.com/geoadmin/mf-geoadmin3/pull/2143

Add a maxFeatures paramater to the identify request and add the number of features available for this request in the response.

Still limited to 10000 features.