### PR TITLE
WMTS axis-order mismatch

### DIFF
--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -162,7 +162,7 @@ Here is a description of the data one can find in the above response.
   - **bundCollectionName**: the collection name
   - **inspireUpperName**: the name of the `INSPIRE <http://www.geo.admin.ch/internet/geoportal/en/home/geoadmin/mission/inspire.html>`_ category (first level)
   - **urlApplication**: the application where this layer is published
-- **tileInfo**: WMTS general information in json format. Note that this section is always identical and is not tied to a particular "map" like in ESRI specifications.
+  - **tileInfo**: WMTS general information in json format. Note that this section is always identical and is not tied to a particular "map" like in ESRI specifications.
 
 
 Examples
@@ -833,8 +833,14 @@ Resolution [m]   Zoomlevel Map zoom  Tile width m Tiles X  Tiles Y    Tiles     
 **Notes**
 
 #. The zoom level 24 (resolution 1.5m) has been generated, but is not currently used in the API.
-#. The zoom levels 27 and 28 (resolution 0.25m and 0.1m) are only available for a few layers, e.g. swissimage or cadastral web map. For the others layers it is only a client zoom (tiles are stretched).
+#. The zoom levels 27 and 28 (resolution 0.25m and 0.1m) are only available for a few layers, 
+   e.g. swissimage or cadastral web map. For the others layers it is only a client zoom (tiles are stretched).
 #. You **have** to use the `<ResourceURL>` to construct the `GetTile` request. 
+#. **Axis order**: EPSG:21781 native WMTS tiles (*pregenerated* and stored in S3) use the
+   non-standard **row/col** order, while the Mapproxy reprojected ones (all other projections)
+   use the usual **col/row** order. The exception being *ch.kantone.cadastralwebmap-farbe* which always use
+   the **col/row** order.
+   However, most desktop GIS allow you to use the advertized order or to override it.
 
 Result
 ******

--- a/chsdi/templates/TileMatrixSet_4258.mako
+++ b/chsdi/templates/TileMatrixSet_4258.mako
@@ -200,4 +200,3 @@
 <MatrixHeight>17151</MatrixHeight>
 </TileMatrix>
 </TileMatrixSet>
-<TileMatrixSet>

--- a/chsdi/templates/index.mako
+++ b/chsdi/templates/index.mako
@@ -104,6 +104,9 @@
       <h2>MapProxy</h2>
           <a href="mapproxy/demo">MapProxy demo</a><br>
           <a href="rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=4326">GetCapabilities for EPSG:4326 (raw service)</a><br />
+          <a href="rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=4258">GetCapabilities for EPSG:4258 (raw service)</a><br />
+          <a href="rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=2056">GetCapabilities for EPSG:2056 (raw service)</a><br />
+          <a href="rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=3857">GetCapabilities for EPSG:3857 (raw service)</a><br />
           <div style="display: block">
           <img src="../mapproxy/wmts/1.0.0/ch.swisstopo.pixelkarte-farbe_20120809/default/20120809/epsg_4258/9/3/2.jpeg" width="256" height="256">
           </div>

--- a/chsdi/templates/wmtscapabilities.mako
+++ b/chsdi/templates/wmtscapabilities.mako
@@ -98,9 +98,10 @@ else:
                 % endif
             </TileMatrixSetLink>
             ## ACHTUNG: s3 tiles have a row/col order, mapproxy ones the standard col/row
-            % if epsg in ['21781', '2056'] and layer.id != 'ch.kantone.cadastralwebmap-farbe':
+            % if epsg in ['21781'] and layer.id != 'ch.kantone.cadastralwebmap-farbe':
                 <ResourceURL format="image/${str(layer.arr_all_formats).split(',')[0]}" resourceType="tile" template="${onlineressource}1.0.0/${layer.id|x,trim}/default/{Time}/${epsg}/{TileMatrix}/{TileRow}/{TileCol}.${str(layer.arr_all_formats).split(',')[0]}"/>
             % else:
+            ## Maproxy order
                 <ResourceURL format="image/${str(layer.arr_all_formats).split(',')[0]}" resourceType="tile" template="${onlineressource}1.0.0/${layer.id|x,trim}/default/{Time}/${epsg}/{TileMatrix}/{TileCol}/{TileRow}.${str(layer.arr_all_formats).split(',')[0]}"/>
             % endif
         </Layer>

--- a/chsdi/tests/integration/test_wmtscapabilities.py
+++ b/chsdi/tests/integration/test_wmtscapabilities.py
@@ -39,16 +39,17 @@ class TestWmtsCapabilitiesView(TestsBase):
         schema_url = os.path.join(os.path.dirname(__file__), "wmts/1.0/wmtsGetCapabilities_response.xsd")
         os.environ['XML_CATALOG_FILES'] = os.path.join(os.path.dirname(__file__), "xml/catalog")
 
-        for lang in ['de', 'fr']:
-            f = tempfile.NamedTemporaryFile(mode='w+t', prefix='WMTSCapabilities-', suffix='-' + lang)
-            resp = self.testapp.get('/rest/services/api/1.0.0/WMTSCapabilities.xml', params={'lang': lang, 'epsg': 4326}, status=200)
-            f.write(resp.body)
-            f.seek(0)
-            retcode = subprocess.call(["xmllint", "--noout", "--nocatalogs", "--schema", schema_url, f.name])
-            f.close()
-            self.failUnless(retcode == 0)
+        for lang in ['de', 'fr', 'it', 'en']:
+            for epsg in [4326, 4258, 2056, 3857]:
+                f = tempfile.NamedTemporaryFile(mode='w+t', prefix='WMTSCapabilities-', suffix='-%s-%s' % (lang, epsg))
+                resp = self.testapp.get('/rest/services/api/1.0.0/WMTSCapabilities.xml', params={'lang': lang, 'epsg': epsg}, status=200)
+                f.write(resp.body)
+                f.seek(0)
+                retcode = subprocess.call(["xmllint", "--noout", "--nocatalogs", "--schema", schema_url, f.name])
+                f.close()
+                self.failUnless(retcode == 0)
 
-    def test_gettile_wmtscapavilities(self):
+    def test_gettile_wmtscapabilities(self):
         import xml
         resp = self.testapp.get('/rest/services/inspire/1.0.0/WMTSCapabilities.xml', status=200)
         dom = xml.dom.minidom.parseString(resp.body)

--- a/chsdi/views/wmtscapabilities.py
+++ b/chsdi/views/wmtscapabilities.py
@@ -19,7 +19,7 @@ class WMTSCapabilites(MapNameValidation):
         self.models = get_wmts_models(self.lang)
         self.request = request
         epsg = request.params.get('epsg', '21781')
-        available_epsg_codes = ['21781', '4326', '2056', '4852', '3857']
+        available_epsg_codes = ['21781', '4326', '2056', '4258', '3857']
         if epsg in available_epsg_codes:
             if self.mapName != 'api' and epsg != '21781':
                 raise HTTPNotFound("EPSG:%s only available for topic 'api'" % epsg)


### PR DESCRIPTION
Please test thoroughly with all client you may have.

Test links:
* (EPSG:2056)[http://mf-chsdi3.dev.bgdi.ch/mom_axis_order/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=2056]
* (EPSG:4326)[http://mf-chsdi3.dev.bgdi.ch/mom_axis_order/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=4326]
* (EPSG:4258)[http://mf-chsdi3.dev.bgdi.ch/mom_axis_order/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=4258]
* (EPSG:3857)[http://mf-chsdi3.dev.bgdi.ch/mom_axis_order/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=3857]
