### PR TITLE
Remove SearchServer type=featureidentify service

### DIFF
--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -148,7 +148,7 @@ class SearchValidation(MapNameValidation):
 
     @typeInfo.setter
     def typeInfo(self, value):
-        acceptedTypes = ['locations', 'layers', 'features', 'featureidentify', 'featuresearch']
+        acceptedTypes = ['locations', 'layers', 'featuresearch']
         if value is None:
             raise HTTPBadRequest('Please provide a type parameter. Possible values are %s' % (', '.join(acceptedTypes)))
         elif value not in acceptedTypes:

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -484,7 +484,7 @@ URL
 Description
 ***********
 
-The search service is separated in 4 various categories or types:
+The search service is separated in 3 various categories or types:
 
 * The **location search** which is composed of the following geocoded locations:
 
@@ -496,7 +496,6 @@ The search service is separated in 4 various categories or types:
   * The cadastral parcels
 * The **layer search** wich enables the search of layers belonging to the GeoAdmin API.
 * The **feature search** which is used to search through features descriptions. Note: you can also specify a bounding box to filter the features. (`Searchable layers <../../../api/faq/index.html#which-layers-are-searchable>`_)
-* The **feature identify** which is designed to efficiently discover the features of a layer based on a geographic extent. (`Identifiable layers <../../../api/faq/index.html#which-layers-have-a-tooltip>`_)
 
 Input parameters
 ****************
@@ -563,23 +562,6 @@ Only RESTFul interface is available.
 | **callback (optional)**           | The name of the callback function.                                                        |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 
-**Feature Identify**
-
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| Parameters                        | Description                                                                               |
-+===================================+===========================================================================================+
-| **type (required)**               | The type of performed search. Specify `featureidentify` to perform a feature search.      |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **bbox (optional)**               | A comma separated list of 4 coordinates representing the bounding box on which features   |
-|                                   | should be filtered (SRID: 21781).                                                         |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **features (optional)**           | A comma separated list of technical layer names.                                          |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **limit (optional)**              | The maximum number of results to retrive per request (Max and default limit=200)          |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **callback (optional)**           | The name of the callback function.                                                        |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-
 Response syntax
 ***************
 
@@ -642,7 +624,6 @@ Examples
 - Search for locations within a given map extent (the `bbox`): `https://api3.geo.admin.ch/rest/services/api/SearchServer?bbox=551306.5625,167918.328125,551754.125,168514.625&type=locations  <../../../rest/services/api/SearchServer?bbox=551306.5625,167918.328125,551754.125,168514.625&type=locations>`_
 - Search for layers in French matching the word “géoïde” in their description: `https://api3.geo.admin.ch/rest/services/api/SearchServer?searchText=géoïde&type=layers&lang=fr <../../../rest/services/api/SearchServer?searchText=géoïde&type=layers&lang=fr>`_ 
 - Search for features matching word "433" in their description: `https://api3.geo.admin.ch/rest/services/api/SearchServer?features=ch.bafu.hydrologie-gewaesserzustandsmessstationen&type=featuresearch&searchText=433 <../../../rest/services/api/SearchServer?features=ch.bafu.hydrologie-gewaesserzustandsmessstationen&type=featuresearch&searchText=433>`_
-- Search only for features belonging to the layer “ch.astra.ivs-reg_loc” (only using a bbox, no search text): `https://api3.geo.admin.ch/rest/services/api/SearchServer?features=ch.astra.ivs-reg_loc&type=featureidentify&bbox=551306.5625,167918.328125,551754.125,168514.625 <../../../rest/services/api/SearchServer?features=ch.astra.ivs-reg_loc&type=featureidentify&bbox=551306.5625,167918.328125,551754.125,168514.625>`_
 
 Example of feature search usage with other services
 ***************************************************

--- a/chsdi/templates/index.mako
+++ b/chsdi/templates/index.mako
@@ -157,8 +157,6 @@
           in ch.swisstopo.lubis-luftbilder_farbe
           with time parameter (several  results)</a> <br>
           <a href="rest/services/inspire/SearchServer?features=ch.bafu.hydrologie-gewaesserzustandsmessstationen&type=featuresearch&searchText=4331">Search for features using that matches a given searchText in their search fields</a> <br>
-      <h3>Feature identify (type=featureidentify) only bbox search, no search text)</h3>
-          <a href="rest/services/inspire/SearchServer?features=ch.astra.ivs-reg_loc&type=featureidentify&bbox=551306.5625,167918.328125,551754.125,168514.625">Search for features in ch.astra.ivs-reg_loc (only features within the bbox)</a> <br>
       <h2>Attributes values</h2>
       <a href="rest/services/api/MapServer/ch.bazl.luftfahrthindernis/attributes/obstacletype">Possible values for attribute 'obstacletype' of layer 'ch.bazl.luftfahrthindernis'</a><br />
       <a href="rest/services/api/MapServer/ch.bazl.luftfahrthindernis/attributes/startofconstruction">Possible values for attribute 'startofconstruction' of layer 'ch.bazl.luftfahrthindernis'</a><br />

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -183,12 +183,6 @@ class TestSearchServiceView(TestsBase):
         params = {'type': 'locations'}
         self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=400)
 
-    def test_features_bbox(self):
-        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'features': 'ch.astra.ivs-reg_loc', 'type': 'featureidentify', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=200)
-        self.failUnless(resp.content_type == 'application/json')
-        self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
-        self.failUnless(resp.json['results'][0]['attrs']['feature_id'] == '43543')
-
     def test_features_timeinstant(self):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542199,206799,542201,206801', 'timeInstant': '1981'}, status=200)
         self.failUnless(resp.content_type == 'application/json')
@@ -238,13 +232,6 @@ class TestSearchServiceView(TestsBase):
     def test_features_wrong_timestamps_2(self):
         params = {'searchText': '19810590048970', 'features': 'ch.swisstopo.lubis-luftbilder_farbe', 'type': 'featuresearch', 'bbox': '542200,206800,542200,206800', 'timeStamps': '1952.00'}
         self.testapp.get('/rest/services/ech/SearchServer', params=params, status=400)
-
-    def test_featuressearch_geodist(self):
-        resp = self.testapp.get('/rest/services/all/SearchServer', params={'features': 'ch.babs.kulturgueter', 'type': 'featureidentify', 'bbox': '688290,166864,688309,166884'})
-        self.failUnless(resp.content_type == 'application/json')
-        self.failUnless(len(resp.json['results']) == 1)
-        self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
-        self.failUnless(resp.json['results'][0]['attrs']['detail'] == 'general-suworow-denkmal')
 
     def test_locations_search_limit(self):
         params = {'searchText': 'chalais', 'type': 'locations', 'limit': '1'}


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/geoadmin-api/u4a8jV6j0W4

Once this is deployed (not before 25th of March), we can update and merge https://github.com/geoadmin/service-sphinxsearch/pull/186 and remove all those queryable sphinx indices.