### PR TITLE
Adapt sphinx index related tests on dev environment

### DIFF
--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -80,9 +80,13 @@ class TestSearchServiceView(TestsBase):
         self.failUnless('wil' in resp.json['results'][0]['attrs']['detail'])
 
     def test_search_location_max_address(self):
+        staging = self.testapp.app.registry.settings['geodata_staging']
+        maxresults = 62
+        if staging != 'test':
+            maxresults = 20
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': 'seftigenstrasse', 'type': 'locations'}, status=200)
         self.failUnless(resp.content_type == 'application/json')
-        self.failUnless(len(resp.json['results']) <= 20)
+        self.failUnless(len(resp.json['results']) <= maxresults)
 
     def test_search_locations_no_geometry(self):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': 'seftigenstrasse 264', 'type': 'locations', 'returnGeometry': 'false'}, status=200)


### PR DESCRIPTION
This fixes currently failing tests [1]. As discussed with @ltclm , this is caused because we are currently in the process of testing new swissnames indices on dev env. This fixes this for the dev env.

@loicgasser Can you review/merge today, please?

[1] https://jenkins.dev.bgdi.ch/job/chsdi3/281/console