### PR TITLE
More robust rotation handling for lubis tooltips/viewer

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -119,11 +119,15 @@ preview_url = determinePreviewUrl(c['featureId'])
 
 image_width = c['attributes']['image_width'] if 'image_width' in  c['attributes'] else None
 image_height = c['attributes']['image_height'] if 'image_height' in c['attributes'] else None
+image_rotation = c['attributes']['rotation'] if 'rotation' in c['attributes'] else None
 
-if image_width == None or image_height == None:
+if image_width is None or image_height is None:
   wh = imagesize_from_metafile(c['featureId'])
   image_width = wh[0]
   image_height = wh[1]
+
+if image_rotation is None:
+  image_rotation = 0
 
 datum = date_to_str(c['attributes']['flugdatum'])
 params = (
@@ -134,7 +138,7 @@ params = (
     c['attributes']['firma'],
     c['layerBodId'],
     lang,
-    c['attributes']['rotation'] if 'rotation' in  c['attributes'] else 0)
+    image_rotation)
 viewer_url = get_viewer_url(request, params)
 %>
 <tr>
@@ -223,12 +227,15 @@ endif
 datum = date_to_str(c['attributes']['flugdatum'])
 image_width =  c['attributes']['image_width'] if 'image_width' in  c['attributes'] else None
 image_height = c['attributes']['image_height'] if 'image_height' in c['attributes'] else None
-image_rotation = c['attributes']['rotation'] if 'rotation' in c['attributes'] else 0
+image_rotation = c['attributes']['rotation'] if 'rotation' in c['attributes'] else None
 
-if image_width == None or image_height == None:
+if image_width is None or image_height is None:
   wh = imagesize_from_metafile(c['featureId'])
   image_width = wh[0]
   image_height = wh[1]
+
+if image_rotation is None:
+  image_rotation = 0
 
 params = (
     image_width, 

--- a/chsdi/templates/lubis_map.mako
+++ b/chsdi/templates/lubis_map.mako
@@ -4,7 +4,7 @@
         var curInstance = MAX_INSTANCES;
         var width = parseInt(${width});
         var height = parseInt(${height});
-        var rotation= parseInt(${rotation if rotation is not None else 0}) * Math.PI / 180;
+        var rotation= parseInt(${rotation if rotation != 'None' and rotation is not None else 0}) * Math.PI / 180;
 
         var url = '//aerialimages{curInstance}.geo.admin.ch/tiles/${ebkey}/';
         var resolutions = [1]; // 1 is the min resolution of the pyramid (for all images)


### PR DESCRIPTION
This is to fix https://github.com/geoadmin/mf-chsdi3/issues/1280 where urls to Lubis images contain the text 'None'. The rotation handling is much more robust now in the tooltips and in the viewer.