### PR TITLE
Assure feedback encoding of text is utf-8 in email

### DIFF
--- a/chsdi/views/feedback.py
+++ b/chsdi/views/feedback.py
@@ -36,7 +36,8 @@ def feedback(self, request):
         msg.attach(
             MIMEText(unicodedata.normalize('NFKD',
                                            unicode(text)).encode('UTF-8',
-                                                                 'ignore')))
+                                                                 'ignore'),
+                     _charset='utf-8'))
         # Attach meta information
         part = MIMEBase('application', 'json')
         part.set_payload(json.dumps(jsonToAttach))


### PR DESCRIPTION
https://github.com/geoadmin/mf-geoadmin3/issues/2100

@loicgasser We need this for next week. Please review.