### PR TITLE
Add tests for helpers and zadara helpers

### DIFF
--- a/buildout_int.cfg
+++ b/buildout_int.cfg
@@ -2,8 +2,6 @@
 extends = buildout.cfg
 
 [vars]
-# apache
-apache_base_path = main
 # urls
 api_url = //mf-chsdi3.int.bgdi.ch
 host = mf-chsdi3.int.bgdi.ch

--- a/buildout_prod.cfg
+++ b/buildout_prod.cfg
@@ -2,8 +2,6 @@
 extends = buildout.cfg
 
 [vars]
-# apache
-apache_base_path = main
 # urls
 api_url = //api3.geo.admin.ch
 host = api3.geo.admin.ch

--- a/chsdi/lib/zadara_helpers.py
+++ b/chsdi/lib/zadara_helpers.py
@@ -2,7 +2,6 @@
 
 import os
 import glob
-from pyramid.threadlocal import get_current_registry
 
 from chsdi.lib.helpers import make_api_url
 
@@ -16,7 +15,7 @@ def hbytes(num):
 
 
 def find_files(request, layerBodId, prefixFileName):
-    settings = get_current_registry().settings
+    settings = request.registry.settings
     downloadFolder = ''.join((settings['zadara_dir'], layerBodId))
     prefixWildCard = '%s*' % prefixFileName
     for filePath in glob.glob('/'.join((downloadFolder, prefixWildCard))):

--- a/chsdi/lib/zadara_helpers.py
+++ b/chsdi/lib/zadara_helpers.py
@@ -14,11 +14,10 @@ def hbytes(num):
     return "%3.1f %s" % (num, 'TB')
 
 
-def find_files(request, layerBodId, prefixFileName):
+def find_files(request, layerBodId, FilePattern):
     settings = request.registry.settings
     downloadFolder = ''.join((settings['zadara_dir'], layerBodId))
-    prefixWildCard = '%s*' % prefixFileName
-    for filePath in glob.glob('/'.join((downloadFolder, prefixWildCard))):
+    for filePath in glob.glob('/'.join((downloadFolder, FilePattern))):
         fileName = os.path.basename(filePath)
         fileSize = os.path.getsize(filePath)
         fileApiUrl = ''.join((make_api_url(request, True), '/downloads/', layerBodId, '/', fileName))

--- a/chsdi/templates/htmlpopup/gisgeol.mako
+++ b/chsdi/templates/htmlpopup/gisgeol.mako
@@ -7,7 +7,7 @@
 
     c['stable_id'] = False
     sgd_nr = c['layerBodId'] + '.' + 'sgd_nr'
-    files = [fileObject for fileObject in find_files(request, 'ch.swisstopo.geologie-gisgeol', c['attributes']['sgd_nr'])]
+    files = [fileObject for fileObject in find_files(request, 'ch.swisstopo.geologie-gisgeol', str(c['attributes']['sgd_nr'])+'.pdf')]
 
     def br(text):
         return text.replace('\n', markupsafe.Markup('<br />'))

--- a/chsdi/tests/functional/test_helpers.py
+++ b/chsdi/tests/functional/test_helpers.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from pyramid import testing
+
+from chsdi.lib.helpers import *
+
+
+class Test_Helpers(unittest.TestCase):
+
+    def test_make_agnostic(self):
+        url = 'http://foo.com'
+        agnostic_link = make_agnostic(url)
+        self.failUnless(not agnostic_link.startswith('http://'))
+        self.failUnless(agnostic_link.startswith('//'))
+
+        url_2 = 'https://foo.com'
+        agnostic_link_2 = make_agnostic(url)
+        self.failUnless(not agnostic_link_2.startswith('https://'))
+        self.failUnless(agnostic_link_2.startswith('//'))
+
+        url_3 = '//foo.com'
+        agnostic_link_3 = make_agnostic(url)
+        self.assertEqual(url_3, agnostic_link_3)
+
+    def test_make_api_url(self):
+        request = testing.DummyRequest()
+        request.host = 'api3.geo.admin.ch'
+        request.scheme = 'http'
+        request.registry.settings = {}
+        request.registry.settings['apache_base_path'] = 'main'
+        api_url = make_api_url(request, agnostic=True)
+        self.failUnless(not api_url.startswith('http://'))
+        self.failUnless(api_url.startswith('//'))
+        self.assertEqual(api_url, '//api3.geo.admin.ch')
+
+        request.scheme = 'https'
+        api_url = make_api_url(request)
+        self.assertEqual(api_url, 'https://api3.geo.admin.ch')
+
+        request.host = 'localhost:9000'
+        request.scheme = 'http'
+        api_url = make_api_url(request)
+        self.assertEqual(api_url, api_url)
+
+    def test_check_url(self):
+        from pyramid.httpexceptions import HTTPBadRequest
+        url = None
+        try:
+            check_url(url)
+        except Exception as e:
+            self.failUnless(isinstance(e, HTTPBadRequest))
+
+        url = 'dummy'
+        try:
+            check_url(url)
+        except Exception as e:
+            self.failUnless(isinstance(e, HTTPBadRequest))
+
+        url = 'http://dummy.com'
+        try:
+            check_url(url)
+        except Exception as e:
+            self.failUnless(isinstance(e, HTTPBadRequest))
+
+        url = 'http://admin.ch'
+        self.assertEqual(url, check_url(url))
+
+    def test_transformCoordinate(self):
+        from osgeo.ogr import Geometry
+        wkt = 'POINT (7.37840 45.91616)'
+        srid_from = 4326
+        srid_to = 21781
+        wkt_21781 = transformCoordinate(wkt, srid_from, srid_to)
+        self.failUnless(isinstance(wkt_21781, Geometry))
+        self.assertEqual(int(wkt_21781.GetX()), 595324)
+        self.assertEqual(int(wkt_21781.GetY()), 84952)

--- a/chsdi/tests/functional/test_vector.py
+++ b/chsdi/tests/functional/test_vector.py
@@ -2,8 +2,6 @@
 
 import unittest
 
-from pyramid import testing
-
 from chsdi.models.vector import getFallbackLangMatch
 
 

--- a/chsdi/tests/functional/test_zadara_helpers.py
+++ b/chsdi/tests/functional/test_zadara_helpers.py
@@ -19,8 +19,7 @@ class Test_ZadaraHelpers(unittest.TestCase):
         request.registry.settings['zadara_dir'] = '/var/local/cartoweb/downloads/'
         layerBodId = 'ch.swisstopo.geologie-gisgeol'
         fileName = os.listdir(request.registry.settings['zadara_dir'] + layerBodId)[0]
-        prefixFileName = fileName.split('.pdf')[0]
-        for f in find_files(request, layerBodId, prefixFileName):
+        for f in find_files(request, layerBodId, fileName):
             self.failUnless('name' in f)
             self.failUnless('size' in f)
             self.failUnless('url' in f)

--- a/chsdi/tests/functional/test_zadara_helpers.py
+++ b/chsdi/tests/functional/test_zadara_helpers.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from pyramid import testing
+
+from chsdi.lib.zadara_helpers import find_files
+
+
+class Test_ZadaraHelpers(unittest.TestCase):
+
+    def test_find_files(self):
+        import os
+        request = testing.DummyRequest()
+        request.host = 'api3.geo.admin.ch'
+        request.scheme = 'http'
+        request.registry.settings = {}
+        request.registry.settings['apache_base_path'] = 'main'
+        request.registry.settings['zadara_dir'] = '/var/local/cartoweb/downloads/'
+        layerBodId = 'ch.swisstopo.geologie-gisgeol'
+        fileName = os.listdir(request.registry.settings['zadara_dir'] + layerBodId)[0]
+        prefixFileName = fileName.split('.pdf')[0]
+        for f in find_files(request, layerBodId, prefixFileName):
+            self.failUnless('name' in f)
+            self.failUnless('size' in f)
+            self.failUnless('url' in f)
+            self.assertEqual(f['url'], ''.join(
+                ('//', request.host, '/downloads/', layerBodId, '/', fileName)
+            ))
+            self.failUnless(isinstance(f['size'], int))
+            self.assertEqual(f['name'], fileName)


### PR DESCRIPTION
This PR introduce some unit tests for our helpers. I'll try to add more and more of those kind of tests since they are fast to excecute and will help us organize the code.

Side note:
`apache_base_path` is the same for all envs is already present in `buildout.cfg`. As a result we can remove it.