### PR TITLE
More robust post-create-code hook

### DIFF
--- a/deploy/hooks/pre-create-code.in
+++ b/deploy/hooks/pre-create-code.in
@@ -6,7 +6,7 @@ CODE_DIR=$2
 
 export PGUSER='${vars:modwsgi_user}'
 
-if [ $TARGET != 'demo' ];
+if [ -z $TARGET ] || [ $TARGET != 'demo' ];
 then
 
    cd $CODE_DIR


### PR DESCRIPTION
If Target was not defined (when using `deploydev.sh -s`), then the post-create-code script won't launch the nose tests. This PR changes that.