### PR TITLE
[WIP] Adapt to SSD based dtm path for profile/height service

### DIFF
--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -33,7 +33,7 @@ def main(global_config, **settings):
     config.include('pyramid_mako')
 
     # init raster files for height/profile and preload COMB file
-    init_rasterfiles(settings.get('data_path'), ['COMB'])
+    init_rasterfiles(settings.get('dtm_base_path'), ['COMB'])
 
     # configure 'locale' dir as the translation dir for chsdi app
     config.add_translation_dirs('chsdi:locale/')

--- a/chsdi/lib/raster/georaster.py
+++ b/chsdi/lib/raster/georaster.py
@@ -17,12 +17,11 @@ def get_raster(name):
     return result
 
 def init_rasterfiles(datapath, preloadtypes):
-    base_path = 'bund/swisstopo/'
     global _rasterfiles
     _rasterfiles = {
-        'DTM25': datapath + base_path + 'dhm25_25_matrix/mm0001.shp',
-        'DTM2': datapath + base_path + 'swissalti3d/2m/index.shp',
-        'COMB': datapath + base_path + 'swissalti3d/kombo_2m_dhm25/index.shp'
+        'DTM25': datapath + 'dhm25_25_matrix/mm0001.shp',
+        'DTM2': datapath + 'swissalti3d/2m/index.shp',
+        'COMB': datapath + 'swissalti3d/kombo_2m_dhm25/index.shp'
     }
     for pt in preloadtypes:
         get_raster(pt)

--- a/production.ini.in
+++ b/production.ini.in
@@ -37,7 +37,7 @@ sqlalchemy.lubis.url = postgresql://${vars:dbhost}:${vars:dbport}/lubis
 # Mako specific
 mako.directories = chsdi:templates
 
-data_path = /var/local/cartoweb/
+dtm_base_path = /var/local/profile/
 zadara_dir = ${vars:zadara_dir}
 geodata_staging = ${geodata_staging}
 sphinxhost = ${sphinxhost}


### PR DESCRIPTION
**To be applied after DTM data is copied to new SSD backed directory.**

@ltclm Merging this PR should be enough to switch the profile backend to the SSD based directory. Please make sure that the DTM's contain relative paths or the correct absolute paths.