### PR TITLE
Add a limit parameter to SearchServer

### DIFF
--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -19,6 +19,7 @@ class SearchValidation(MapNameValidation):
         self._returnGeometry = None
         self._origins = None
         self._typeInfo = None
+        self._limit = None
 
     @property
     def searchText(self):
@@ -55,6 +56,10 @@ class SearchValidation(MapNameValidation):
     @property
     def typeInfo(self):
         return self._typeInfo
+
+    @property
+    def limit(self):
+        return self._limit
 
     @featureIndexes.setter
     def featureIndexes(self, value):
@@ -104,9 +109,9 @@ class SearchValidation(MapNameValidation):
         if value is not None:
             if len(value) != 4:
                 raise HTTPBadRequest('Only years are supported as timeInstant parameter')
-            try:
+            if value.isdigit():
                 self._timeInstant = int(value)
-            except ValueError:
+            else:
                 raise HTTPBadRequest('Please provide an integer for the parameter timeInstant')
         else:
             self._timeInstant = value
@@ -122,9 +127,9 @@ class SearchValidation(MapNameValidation):
                 if len(val) == 0:
                     result.append(None)
                 else:
-                    try:
+                    if val.isdigit():
                         result.append(int(val))
-                    except ValueError:
+                    else:
                         raise HTTPBadRequest('Please provide integers for timeStamps parameter')
             self._timeStamps = result
 
@@ -149,3 +154,11 @@ class SearchValidation(MapNameValidation):
         elif value not in acceptedTypes:
             raise HTTPBadRequest('The type parameter you provided is not valid. Possible values are %s' % (', '.join(acceptedTypes)))
         self._typeInfo = value
+
+    @limit.setter
+    def limit(self, value):
+        if value is not None:
+            if value.isdigit():
+                self._limit = int(value)
+            else:
+              raise HTTPBadRequest('The limit parameter should be an integer')

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -523,6 +523,8 @@ Only RESTFul interface is available.
 |                                     | zipcode,gg25,district,kantone,sn25,address,parcel                                         |
 |                                     | A description of the origins can be found hereunder. Per default all origins are used.    |
 +-------------------------------------+-------------------------------------------------------------------------------------------+
+| **limit (optional)**                | The maximum number of results to retrive per request (Max and default limit=50)           |
++-------------------------------------+-------------------------------------------------------------------------------------------+
 | **callback (optional)**             | The name of the callback function.                                                        |
 +-------------------------------------+-------------------------------------------------------------------------------------------+
 
@@ -536,6 +538,8 @@ Only RESTFul interface is available.
 | **type (required)**               | The type of performed search. Specify `layers` to perform a layer search.                 |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **lang (optional)**               | The language metadata. Possible values: de (default), fr, it, rm, en.                     |
++-----------------------------------+-------------------------------------------------------------------------------------------+
+| **limit (optional)**              | The maximum number of results to retrive per request (Max and default limit=30)           |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **callback (optional)**           | The name of the callback function.                                                        |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
@@ -554,6 +558,8 @@ Only RESTFul interface is available.
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **features (required)**           | A comma separated list of technical layer names.                                          |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
+| **limit (optional)**              | The maximum number of results to retrive per request (Max and default limit=20)           |
++-----------------------------------+-------------------------------------------------------------------------------------------+
 | **callback (optional)**           | The name of the callback function.                                                        |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 
@@ -568,6 +574,8 @@ Only RESTFul interface is available.
 |                                   | should be filtered (SRID: 21781).                                                         |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **features (optional)**           | A comma separated list of technical layer names.                                          |
++-----------------------------------+-------------------------------------------------------------------------------------------+
+| **limit (optional)**              | The maximum number of results to retrive per request (Max and default limit=200)          |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **callback (optional)**           | The name of the callback function.                                                        |
 +-----------------------------------+-------------------------------------------------------------------------------------------+

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -245,3 +245,12 @@ class TestSearchServiceView(TestsBase):
         self.failUnless(len(resp.json['results']) == 1)
         self.failUnless(resp.json['results'][0]['attrs']['origin'] == 'feature')
         self.failUnless(resp.json['results'][0]['attrs']['detail'] == 'general-suworow-denkmal')
+
+    def test_locations_search_limit(self):
+        params = {'searchText': 'chalais', 'type': 'locations', 'limit': '1'}
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.failUnless(len(resp.json['results']) == 1)
+
+    def test_locations_search_wrong_limit(self):
+        params = {'searchText': 'chalais', 'type': 'locations', 'limit': '5.5'}
+        self.testapp.get('/rest/services/ech/SearchServer', params=params, status=400)


### PR DESCRIPTION
https://github.com/geoadmin/mf-chsdi3/issues/1121

This PR allows the user to define a custom `limit` parameter for SearchServer requests.
Actual default value is kept, but it is now also a max value.