### PR TITLE
Update Babel version to 1.3

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -37,7 +37,7 @@ bin-directory = buildout/bin
 # (to be copied from the dumppickedversions output)
 argparse = 1.2.1
 autopep8 = 0.9.3
-Babel = 0.9.6
+Babel = 1.3
 boto = 2.29.1
 c2c.recipe.msgfmt = 0.2.1
 collective.recipe.cmd = 0.8


### PR DESCRIPTION
Sphinx 1.3.1 requires 'babel>=1.3'

and http://pypi.camptocamp.net/pypi/Pygments/ is not down.

@loicgasser what do you think?