### PR TITLE
Limit the number of words in the search

### DIFF
--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -5,6 +5,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from chsdi.lib.validation import MapNameValidation
 
 MAX_SPHINX_INDEX_LENGTH = 63
+MAX_SEARCH_TERMS = 10
 
 class SearchValidation(MapNameValidation):
 
@@ -83,6 +84,8 @@ class SearchValidation(MapNameValidation):
         searchTextList = value.split(' ')
         # Remove empty strings
         searchTextList = filter(None, searchTextList)
+        if len(searchTextList) > MAX_SEARCH_TERMS:
+            raise HTTPBadRequest("The searchText parameter can not contain more than 10 words")
         self._searchText = searchTextList
 
     @bbox.setter

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -508,7 +508,7 @@ Only RESTFul interface is available.
 +-------------------------------------+-------------------------------------------------------------------------------------------+
 | Parameters                          | Description                                                                               |
 +=====================================+===========================================================================================+
-| **searchText (required/optional)**  | Must be provided if the `bbox` is not. The text to search for.                            |
+| **searchText (required/optional)**  | Must be provided if the `bbox` is not. The text to search for. Maximum of 10 words.       |
 +-------------------------------------+-------------------------------------------------------------------------------------------+
 | **type (required)**                 | The type of performed search. Specify `locations` to perform a location search.           |
 +-------------------------------------+-------------------------------------------------------------------------------------------+
@@ -533,7 +533,7 @@ Only RESTFul interface is available.
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | Parameters                        | Description                                                                               |
 +===================================+===========================================================================================+
-| **searchText (required)**         | The text to search for.                                                                   |
+| **searchText (required)**         | The text to search for. Maximum of 10 words allowed.                                      |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **type (required)**               | The type of performed search. Specify `layers` to perform a layer search.                 |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
@@ -549,7 +549,7 @@ Only RESTFul interface is available.
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | Parameters                        | Description                                                                               |
 +===================================+===========================================================================================+
-| **searchText (required)**         | The text to search for (in features detail field).                                        |
+| **searchText (required)**         | The text to search for (in features detail field). Maximum of 10 words allowed.           |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **type (required)**               | The type of performed search. Specify `featuresearch` to perform a feature search.        |
 +-----------------------------------+-------------------------------------------------------------------------------------------+

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -254,3 +254,11 @@ class TestSearchServiceView(TestsBase):
     def test_locations_search_wrong_limit(self):
         params = {'searchText': 'chalais', 'type': 'locations', 'limit': '5.5'}
         self.testapp.get('/rest/services/ech/SearchServer', params=params, status=400)
+
+    def test_search_max_words(self):
+        self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 10 words, should work', 'type': 'locations', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=200)
+        self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 10 words, should work', 'type': 'layers', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=200)
+        self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 10 words, should work', 'type': 'featuresearch', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=200)
+        self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 11 words, should NOT work', 'type': 'locations', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=400)
+        self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 11 words, should NOT work', 'type': 'layers', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=400)
+        self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 11 words, should NOT work', 'type': 'featuresearch', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=400)


### PR DESCRIPTION
This renders the search a little more robust against long queries. It limits the number for **words** that the searchText can contain to 10.

I think this is reasonable.

@davidoesch @loicgasser @cedricmoullet Thoughts?