### PR TITLE
Remove cluttering print statement from tile tests

### DIFF
--- a/chsdi/tests/mapproxy/test_wmtsgettile.py
+++ b/chsdi/tests/mapproxy/test_wmtsgettile.py
@@ -26,7 +26,6 @@ def get_headers():
 
 
 def check_status_code(path):
-    print path
     if not path.startswith('http'):
         url = base_url + path
     else:


### PR DESCRIPTION
The print statement fills up the log with every tile request of the tests. It's probably more confusing that helping.

We can remove it as in case of failure, the URL will be visible.