### PR TITLE
Use ci jenkins icon for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ mf-chsdi3
 
 next generation of api3.geo.admin.ch
 
-Jenkins Build Status: [![Jenkins Build Status](https://jenkins.dev.bgdi.ch/buildStatus/icon?job=chsdi3)](https://jenkins.dev.bgdi.ch/job/chsdi3/)
+Jenkins Build Status: [![Jenkins Build Status](https://jenkins.ci.bgdi.ch/buildStatus/icon?job=chsdi3)](https://jenkins.dev.bgdi.ch/job/chsdi3/)
 
 # Getting started
 


### PR DESCRIPTION
jenkins.dev will be deprecated. We will rely on jenkins.ci now.