### PR TITLE
Geodata Staging on integration: switch to prod

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -190,6 +190,7 @@ exclude-directories = buildout
 interpreted-options = app_version = __import__('time').strftime('%s')
                       apache_entry_path = '' if options.get('apache_base_path') == 'main' else ('/' + options.get('apache_base_path'))
                       git_branch = __import__('subprocess').check_output(['git', 'rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']).rstrip()
+                      branch_staging = 'test' if options.get('deploy_target') == 'dev' else 'integration'
 
 extends = vars
 

--- a/buildout_branch.cfg.in
+++ b/buildout_branch.cfg.in
@@ -8,7 +8,7 @@ api_url = //mf-chsdi3.${vars:deploy_target}.bgdi.ch/${git_branch}
 host = mf-chsdi3.${vars:deploy_target}.bgdi.ch
 # On the branch, adapt this to point to the correct mf-geoadmin instance
 geoadminhost = mf-geoadmin3.${vars:deploy_target}.bgdi.ch
-# dbhost is taken from parent
+geodata_staging = ${branch_staging}
 
 [modwsgi]
 config-file = ${buildout:directory}/production.ini

--- a/buildout_int.cfg
+++ b/buildout_int.cfg
@@ -16,7 +16,7 @@ wmshost = wms-bgdi.int.bgdi.ch
 # mapproxy
 mapproxyhost = mf-chsdi3.int.bgdi.ch
 # Geodata staging
-geodata_staging= integration
+geodata_staging= prod
 # deploy target
 deploy_target = int
 # http proxy


### PR DESCRIPTION
During deploy, we deploy on integration and do automated and manual tests on the integration environment. When passing from integration to prod, we change a) the back-ends (db and sphinx) and b) the staging for the bod. Both a) and b) lead to troubles in the past during deploys.

This PR adresses troubles/problems introduced by b). We are setting the staging to prod when deploying to integration. We can now test the prod staging _before_ having to deploy to prod.

Note: this only affects the root (mf-chsdi3.int.bgdi.ch)
Note: branches on integration are still using the staging 'integration'. So we are still able to handle the use case for external tests
Note: a) still remains

@procrastinatio @AFoletti @alcapat @daguer @ltclm @cedricmoullet 
I would like your inputs for this.