### PR TITLE
mapproxy config updated with new showme tilesets

### DIFF
--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -829,6 +829,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_hochwasser_20140101_cache]
+  ch.bafu.showme-gemeinden_hochwasser_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_source]
+  ch.bafu.showme-gemeinden_hochwasser_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id013
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
   ch.bafu.showme-gemeinden_lawinen_20100101_cache:
     disable_storage: true
     format: image/png
@@ -889,6 +901,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_lawinen_20140101_cache]
+  ch.bafu.showme-gemeinden_lawinen_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_lawinen_20150101_source]
+  ch.bafu.showme-gemeinden_lawinen_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id014
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
   ch.bafu.showme-gemeinden_rutschungen_20100101_cache:
     disable_storage: true
     format: image/png
@@ -949,6 +973,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_rutschungen_20140101_cache]
+  ch.bafu.showme-gemeinden_rutschungen_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_source]
+  ch.bafu.showme-gemeinden_rutschungen_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id015
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
   ch.bafu.showme-gemeinden_sturzprozesse_20100101_cache:
     disable_storage: true
     format: image/png
@@ -1009,6 +1045,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache]
+  ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_source]
+  ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id016
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
   ch.bafu.showme-kantone_hochwasser_20100101_cache:
     disable_storage: true
     format: image/png
@@ -1069,6 +1117,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_hochwasser_20140101_cache]
+  ch.bafu.showme-kantone_hochwasser_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_hochwasser_20150101_source]
+  ch.bafu.showme-kantone_hochwasser_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id017
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
   ch.bafu.showme-kantone_lawinen_20100101_cache:
     disable_storage: true
     format: image/png
@@ -1129,6 +1189,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_lawinen_20140101_cache]
+  ch.bafu.showme-kantone_lawinen_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_lawinen_20150101_source]
+  ch.bafu.showme-kantone_lawinen_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id018
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
   ch.bafu.showme-kantone_rutschungen_20100101_cache:
     disable_storage: true
     format: image/png
@@ -1189,6 +1261,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_rutschungen_20140101_cache]
+  ch.bafu.showme-kantone_rutschungen_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_rutschungen_20150101_source]
+  ch.bafu.showme-kantone_rutschungen_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id019
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
   ch.bafu.showme-kantone_sturzprozesse_20100101_cache:
     disable_storage: true
     format: image/png
@@ -1249,6 +1333,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_sturzprozesse_20140101_cache]
+  ch.bafu.showme-kantone_sturzprozesse_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_source]
+  ch.bafu.showme-kantone_sturzprozesse_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id020
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
   ch.bafu.sturm-boeenspitzen_100_20141107_cache:
     disable_storage: true
     format: image/png
@@ -3241,18 +3337,6 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
-  ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache:
-    disable_storage: true
-    format: image/png
-    grids: [swisstopo-pixelkarte]
-    sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_source]
-  ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache_out:
-    disable_storage: true
-    format: image/png
-    grids: [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
-    meta_buffer: 0
-    meta_size: [1, 1]
-    sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache]
   ch.bazl.luftfahrtkarten-icao_20110310_cache:
     disable_storage: true
     format: image/png
@@ -7974,6 +8058,18 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache]
+  ch.swisstopo.swisstlm3d-wanderwege_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_source]
+  ch.swisstopo.swisstlm3d-wanderwege_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id090
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
   ch.swisstopo.transformationsgenauigkeit_20100531_cache:
     disable_storage: true
     format: image/png
@@ -8815,48 +8911,48 @@ layers:
       values: ['20150101']
   name: ch.babs.kulturgueter_20150101
   sources: [ch.babs.kulturgueter_20150101_cache_out]
-  title: "Kulturg\xFCterschutzinventar (20150101)"
+  title: KGS Inventar (20150101)
 - dimensions: *id118
   name: ch.babs.kulturgueter
   sources: [ch.babs.kulturgueter_20150101_cache]
-  title: "Kulturg\xFCterschutzinventar ('current')"
+  title: KGS Inventar ('current')
 - dimensions: *id118
   name: ch.babs.kulturgueter_20150101_source
   sources: [ch.babs.kulturgueter_20150101_cache]
-  title: "Kulturg\xFCterschutzinventar (20150101, source)"
+  title: KGS Inventar (20150101, source)
 - dimensions: &id119
     Time:
       default: '20140120'
       values: ['20140120']
   name: ch.babs.kulturgueter_20140120
   sources: [ch.babs.kulturgueter_20140120_cache_out]
-  title: "Kulturg\xFCterschutzinventar (20140120)"
+  title: KGS Inventar (20140120)
 - dimensions: *id119
   name: ch.babs.kulturgueter_20140120_source
   sources: [ch.babs.kulturgueter_20140120_cache]
-  title: "Kulturg\xFCterschutzinventar (20140120, source)"
+  title: KGS Inventar (20140120, source)
 - dimensions: &id120
     Time:
       default: '20130220'
       values: ['20130220']
   name: ch.babs.kulturgueter_20130220
   sources: [ch.babs.kulturgueter_20130220_cache_out]
-  title: "Kulturg\xFCterschutzinventar (20130220)"
+  title: KGS Inventar (20130220)
 - dimensions: *id120
   name: ch.babs.kulturgueter_20130220_source
   sources: [ch.babs.kulturgueter_20130220_cache]
-  title: "Kulturg\xFCterschutzinventar (20130220, source)"
+  title: KGS Inventar (20130220, source)
 - dimensions: &id121
     Time:
       default: '20091127'
       values: ['20091127']
   name: ch.babs.kulturgueter_20091127
   sources: [ch.babs.kulturgueter_20091127_cache_out]
-  title: "Kulturg\xFCterschutzinventar (20091127)"
+  title: KGS Inventar (20091127)
 - dimensions: *id121
   name: ch.babs.kulturgueter_20091127_source
   sources: [ch.babs.kulturgueter_20091127_cache]
-  title: "Kulturg\xFCterschutzinventar (20091127, source)"
+  title: KGS Inventar (20091127, source)
 - dimensions: &id122
     Time:
       default: '20070702'
@@ -9475,7826 +9571,7910 @@ layers:
   title: Nationalpark (20010117, source)
 - dimensions: &id166
     Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-gemeinden_hochwasser_20150101
+  sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache_out]
+  title: 'ShowMe Gemeinden: Hochwasser (20150101)'
+- dimensions: *id166
+  name: ch.bafu.showme-gemeinden_hochwasser
+  sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
+  title: 'ShowMe Gemeinden: Hochwasser (''current'')'
+- dimensions: *id166
+  name: ch.bafu.showme-gemeinden_hochwasser_20150101_source
+  sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
+  title: 'ShowMe Gemeinden: Hochwasser (20150101, source)'
+- dimensions: &id167
+    Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_hochwasser_20140101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20140101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20140101)'
-- dimensions: *id166
-  name: ch.bafu.showme-gemeinden_hochwasser
-  sources: [ch.bafu.showme-gemeinden_hochwasser_20140101_cache]
-  title: 'ShowMe Gemeinden: Hochwasser (''current'')'
-- dimensions: *id166
+- dimensions: *id167
   name: ch.bafu.showme-gemeinden_hochwasser_20140101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20140101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20140101, source)'
-- dimensions: &id167
+- dimensions: &id168
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_hochwasser_20130101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20130101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20130101)'
-- dimensions: *id167
+- dimensions: *id168
   name: ch.bafu.showme-gemeinden_hochwasser_20130101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20130101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20130101, source)'
-- dimensions: &id168
+- dimensions: &id169
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_hochwasser_20120101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20120101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20120101)'
-- dimensions: *id168
+- dimensions: *id169
   name: ch.bafu.showme-gemeinden_hochwasser_20120101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20120101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20120101, source)'
-- dimensions: &id169
+- dimensions: &id170
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_hochwasser_20110101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20110101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20110101)'
-- dimensions: *id169
+- dimensions: *id170
   name: ch.bafu.showme-gemeinden_hochwasser_20110101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20110101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20110101, source)'
-- dimensions: &id170
+- dimensions: &id171
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_hochwasser_20100101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20100101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20100101)'
-- dimensions: *id170
+- dimensions: *id171
   name: ch.bafu.showme-gemeinden_hochwasser_20100101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20100101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20100101, source)'
-- dimensions: &id171
+- dimensions: &id172
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-gemeinden_lawinen_20150101
+  sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache_out]
+  title: 'ShowMe Gemeinden: Lawinen (20150101)'
+- dimensions: *id172
+  name: ch.bafu.showme-gemeinden_lawinen
+  sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
+  title: 'ShowMe Gemeinden: Lawinen (''current'')'
+- dimensions: *id172
+  name: ch.bafu.showme-gemeinden_lawinen_20150101_source
+  sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
+  title: 'ShowMe Gemeinden: Lawinen (20150101, source)'
+- dimensions: &id173
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_lawinen_20140101
   sources: [ch.bafu.showme-gemeinden_lawinen_20140101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20140101)'
-- dimensions: *id171
-  name: ch.bafu.showme-gemeinden_lawinen
-  sources: [ch.bafu.showme-gemeinden_lawinen_20140101_cache]
-  title: 'ShowMe Gemeinden: Lawinen (''current'')'
-- dimensions: *id171
+- dimensions: *id173
   name: ch.bafu.showme-gemeinden_lawinen_20140101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20140101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20140101, source)'
-- dimensions: &id172
+- dimensions: &id174
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_lawinen_20130101
   sources: [ch.bafu.showme-gemeinden_lawinen_20130101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20130101)'
-- dimensions: *id172
+- dimensions: *id174
   name: ch.bafu.showme-gemeinden_lawinen_20130101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20130101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20130101, source)'
-- dimensions: &id173
+- dimensions: &id175
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_lawinen_20120101
   sources: [ch.bafu.showme-gemeinden_lawinen_20120101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20120101)'
-- dimensions: *id173
+- dimensions: *id175
   name: ch.bafu.showme-gemeinden_lawinen_20120101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20120101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20120101, source)'
-- dimensions: &id174
+- dimensions: &id176
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_lawinen_20110101
   sources: [ch.bafu.showme-gemeinden_lawinen_20110101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20110101)'
-- dimensions: *id174
+- dimensions: *id176
   name: ch.bafu.showme-gemeinden_lawinen_20110101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20110101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20110101, source)'
-- dimensions: &id175
+- dimensions: &id177
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_lawinen_20100101
   sources: [ch.bafu.showme-gemeinden_lawinen_20100101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20100101)'
-- dimensions: *id175
+- dimensions: *id177
   name: ch.bafu.showme-gemeinden_lawinen_20100101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20100101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20100101, source)'
-- dimensions: &id176
+- dimensions: &id178
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-gemeinden_rutschungen_20150101
+  sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache_out]
+  title: 'ShowMe Gemeinden: Rutschungen (20150101)'
+- dimensions: *id178
+  name: ch.bafu.showme-gemeinden_rutschungen
+  sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
+  title: 'ShowMe Gemeinden: Rutschungen (''current'')'
+- dimensions: *id178
+  name: ch.bafu.showme-gemeinden_rutschungen_20150101_source
+  sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
+  title: 'ShowMe Gemeinden: Rutschungen (20150101, source)'
+- dimensions: &id179
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_rutschungen_20140101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20140101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20140101)'
-- dimensions: *id176
-  name: ch.bafu.showme-gemeinden_rutschungen
-  sources: [ch.bafu.showme-gemeinden_rutschungen_20140101_cache]
-  title: 'ShowMe Gemeinden: Rutschungen (''current'')'
-- dimensions: *id176
+- dimensions: *id179
   name: ch.bafu.showme-gemeinden_rutschungen_20140101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20140101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20140101, source)'
-- dimensions: &id177
+- dimensions: &id180
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_rutschungen_20130101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20130101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20130101)'
-- dimensions: *id177
+- dimensions: *id180
   name: ch.bafu.showme-gemeinden_rutschungen_20130101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20130101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20130101, source)'
-- dimensions: &id178
+- dimensions: &id181
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_rutschungen_20120101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20120101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20120101)'
-- dimensions: *id178
+- dimensions: *id181
   name: ch.bafu.showme-gemeinden_rutschungen_20120101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20120101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20120101, source)'
-- dimensions: &id179
+- dimensions: &id182
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_rutschungen_20110101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20110101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20110101)'
-- dimensions: *id179
+- dimensions: *id182
   name: ch.bafu.showme-gemeinden_rutschungen_20110101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20110101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20110101, source)'
-- dimensions: &id180
+- dimensions: &id183
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_rutschungen_20100101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20100101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20100101)'
-- dimensions: *id180
+- dimensions: *id183
   name: ch.bafu.showme-gemeinden_rutschungen_20100101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20100101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20100101, source)'
-- dimensions: &id181
+- dimensions: &id184
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-gemeinden_sturzprozesse_20150101
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache_out]
+  title: 'ShowMe Gemeinden: Sturzprozesse (20150101)'
+- dimensions: *id184
+  name: ch.bafu.showme-gemeinden_sturzprozesse
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
+  title: 'ShowMe Gemeinden: Sturzprozesse (''current'')'
+- dimensions: *id184
+  name: ch.bafu.showme-gemeinden_sturzprozesse_20150101_source
+  sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
+  title: 'ShowMe Gemeinden: Sturzprozesse (20150101, source)'
+- dimensions: &id185
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20140101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20140101)'
-- dimensions: *id181
-  name: ch.bafu.showme-gemeinden_sturzprozesse
-  sources: [ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache]
-  title: 'ShowMe Gemeinden: Sturzprozesse (''current'')'
-- dimensions: *id181
+- dimensions: *id185
   name: ch.bafu.showme-gemeinden_sturzprozesse_20140101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20140101, source)'
-- dimensions: &id182
+- dimensions: &id186
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20130101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20130101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20130101)'
-- dimensions: *id182
+- dimensions: *id186
   name: ch.bafu.showme-gemeinden_sturzprozesse_20130101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20130101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20130101, source)'
-- dimensions: &id183
+- dimensions: &id187
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20120101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20120101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20120101)'
-- dimensions: *id183
+- dimensions: *id187
   name: ch.bafu.showme-gemeinden_sturzprozesse_20120101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20120101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20120101, source)'
-- dimensions: &id184
+- dimensions: &id188
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20110101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20110101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20110101)'
-- dimensions: *id184
+- dimensions: *id188
   name: ch.bafu.showme-gemeinden_sturzprozesse_20110101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20110101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20110101, source)'
-- dimensions: &id185
+- dimensions: &id189
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20100101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20100101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20100101)'
-- dimensions: *id185
+- dimensions: *id189
   name: ch.bafu.showme-gemeinden_sturzprozesse_20100101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20100101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20100101, source)'
-- dimensions: &id186
+- dimensions: &id190
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-kantone_hochwasser_20150101
+  sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache_out]
+  title: 'ShowMe Kantone: Hochwasser (20150101)'
+- dimensions: *id190
+  name: ch.bafu.showme-kantone_hochwasser
+  sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
+  title: 'ShowMe Kantone: Hochwasser (''current'')'
+- dimensions: *id190
+  name: ch.bafu.showme-kantone_hochwasser_20150101_source
+  sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
+  title: 'ShowMe Kantone: Hochwasser (20150101, source)'
+- dimensions: &id191
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_hochwasser_20140101
   sources: [ch.bafu.showme-kantone_hochwasser_20140101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20140101)'
-- dimensions: *id186
-  name: ch.bafu.showme-kantone_hochwasser
-  sources: [ch.bafu.showme-kantone_hochwasser_20140101_cache]
-  title: 'ShowMe Kantone: Hochwasser (''current'')'
-- dimensions: *id186
+- dimensions: *id191
   name: ch.bafu.showme-kantone_hochwasser_20140101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20140101_cache]
   title: 'ShowMe Kantone: Hochwasser (20140101, source)'
-- dimensions: &id187
+- dimensions: &id192
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_hochwasser_20130101
   sources: [ch.bafu.showme-kantone_hochwasser_20130101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20130101)'
-- dimensions: *id187
+- dimensions: *id192
   name: ch.bafu.showme-kantone_hochwasser_20130101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20130101_cache]
   title: 'ShowMe Kantone: Hochwasser (20130101, source)'
-- dimensions: &id188
+- dimensions: &id193
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_hochwasser_20120101
   sources: [ch.bafu.showme-kantone_hochwasser_20120101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20120101)'
-- dimensions: *id188
+- dimensions: *id193
   name: ch.bafu.showme-kantone_hochwasser_20120101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20120101_cache]
   title: 'ShowMe Kantone: Hochwasser (20120101, source)'
-- dimensions: &id189
+- dimensions: &id194
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_hochwasser_20110101
   sources: [ch.bafu.showme-kantone_hochwasser_20110101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20110101)'
-- dimensions: *id189
+- dimensions: *id194
   name: ch.bafu.showme-kantone_hochwasser_20110101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20110101_cache]
   title: 'ShowMe Kantone: Hochwasser (20110101, source)'
-- dimensions: &id190
+- dimensions: &id195
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_hochwasser_20100101
   sources: [ch.bafu.showme-kantone_hochwasser_20100101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20100101)'
-- dimensions: *id190
+- dimensions: *id195
   name: ch.bafu.showme-kantone_hochwasser_20100101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20100101_cache]
   title: 'ShowMe Kantone: Hochwasser (20100101, source)'
-- dimensions: &id191
+- dimensions: &id196
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-kantone_lawinen_20150101
+  sources: [ch.bafu.showme-kantone_lawinen_20150101_cache_out]
+  title: 'ShowMe Kantone: Lawinen (20150101)'
+- dimensions: *id196
+  name: ch.bafu.showme-kantone_lawinen
+  sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
+  title: 'ShowMe Kantone: Lawinen (''current'')'
+- dimensions: *id196
+  name: ch.bafu.showme-kantone_lawinen_20150101_source
+  sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
+  title: 'ShowMe Kantone: Lawinen (20150101, source)'
+- dimensions: &id197
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_lawinen_20140101
   sources: [ch.bafu.showme-kantone_lawinen_20140101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20140101)'
-- dimensions: *id191
-  name: ch.bafu.showme-kantone_lawinen
-  sources: [ch.bafu.showme-kantone_lawinen_20140101_cache]
-  title: 'ShowMe Kantone: Lawinen (''current'')'
-- dimensions: *id191
+- dimensions: *id197
   name: ch.bafu.showme-kantone_lawinen_20140101_source
   sources: [ch.bafu.showme-kantone_lawinen_20140101_cache]
   title: 'ShowMe Kantone: Lawinen (20140101, source)'
-- dimensions: &id192
+- dimensions: &id198
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_lawinen_20130101
   sources: [ch.bafu.showme-kantone_lawinen_20130101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20130101)'
-- dimensions: *id192
+- dimensions: *id198
   name: ch.bafu.showme-kantone_lawinen_20130101_source
   sources: [ch.bafu.showme-kantone_lawinen_20130101_cache]
   title: 'ShowMe Kantone: Lawinen (20130101, source)'
-- dimensions: &id193
+- dimensions: &id199
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_lawinen_20120101
   sources: [ch.bafu.showme-kantone_lawinen_20120101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20120101)'
-- dimensions: *id193
+- dimensions: *id199
   name: ch.bafu.showme-kantone_lawinen_20120101_source
   sources: [ch.bafu.showme-kantone_lawinen_20120101_cache]
   title: 'ShowMe Kantone: Lawinen (20120101, source)'
-- dimensions: &id194
+- dimensions: &id200
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_lawinen_20110101
   sources: [ch.bafu.showme-kantone_lawinen_20110101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20110101)'
-- dimensions: *id194
+- dimensions: *id200
   name: ch.bafu.showme-kantone_lawinen_20110101_source
   sources: [ch.bafu.showme-kantone_lawinen_20110101_cache]
   title: 'ShowMe Kantone: Lawinen (20110101, source)'
-- dimensions: &id195
+- dimensions: &id201
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_lawinen_20100101
   sources: [ch.bafu.showme-kantone_lawinen_20100101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20100101)'
-- dimensions: *id195
+- dimensions: *id201
   name: ch.bafu.showme-kantone_lawinen_20100101_source
   sources: [ch.bafu.showme-kantone_lawinen_20100101_cache]
   title: 'ShowMe Kantone: Lawinen (20100101, source)'
-- dimensions: &id196
+- dimensions: &id202
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-kantone_rutschungen_20150101
+  sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache_out]
+  title: 'ShowMe Kantone: Rutschungen (20150101)'
+- dimensions: *id202
+  name: ch.bafu.showme-kantone_rutschungen
+  sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
+  title: 'ShowMe Kantone: Rutschungen (''current'')'
+- dimensions: *id202
+  name: ch.bafu.showme-kantone_rutschungen_20150101_source
+  sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
+  title: 'ShowMe Kantone: Rutschungen (20150101, source)'
+- dimensions: &id203
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_rutschungen_20140101
   sources: [ch.bafu.showme-kantone_rutschungen_20140101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20140101)'
-- dimensions: *id196
-  name: ch.bafu.showme-kantone_rutschungen
-  sources: [ch.bafu.showme-kantone_rutschungen_20140101_cache]
-  title: 'ShowMe Kantone: Rutschungen (''current'')'
-- dimensions: *id196
+- dimensions: *id203
   name: ch.bafu.showme-kantone_rutschungen_20140101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20140101_cache]
   title: 'ShowMe Kantone: Rutschungen (20140101, source)'
-- dimensions: &id197
+- dimensions: &id204
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_rutschungen_20130101
   sources: [ch.bafu.showme-kantone_rutschungen_20130101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20130101)'
-- dimensions: *id197
+- dimensions: *id204
   name: ch.bafu.showme-kantone_rutschungen_20130101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20130101_cache]
   title: 'ShowMe Kantone: Rutschungen (20130101, source)'
-- dimensions: &id198
+- dimensions: &id205
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_rutschungen_20120101
   sources: [ch.bafu.showme-kantone_rutschungen_20120101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20120101)'
-- dimensions: *id198
+- dimensions: *id205
   name: ch.bafu.showme-kantone_rutschungen_20120101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20120101_cache]
   title: 'ShowMe Kantone: Rutschungen (20120101, source)'
-- dimensions: &id199
+- dimensions: &id206
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_rutschungen_20110101
   sources: [ch.bafu.showme-kantone_rutschungen_20110101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20110101)'
-- dimensions: *id199
+- dimensions: *id206
   name: ch.bafu.showme-kantone_rutschungen_20110101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20110101_cache]
   title: 'ShowMe Kantone: Rutschungen (20110101, source)'
-- dimensions: &id200
+- dimensions: &id207
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_rutschungen_20100101
   sources: [ch.bafu.showme-kantone_rutschungen_20100101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20100101)'
-- dimensions: *id200
+- dimensions: *id207
   name: ch.bafu.showme-kantone_rutschungen_20100101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20100101_cache]
   title: 'ShowMe Kantone: Rutschungen (20100101, source)'
-- dimensions: &id201
+- dimensions: &id208
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.bafu.showme-kantone_sturzprozesse_20150101
+  sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache_out]
+  title: 'ShowMe Kantone: Sturzprozesse (20150101)'
+- dimensions: *id208
+  name: ch.bafu.showme-kantone_sturzprozesse
+  sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
+  title: 'ShowMe Kantone: Sturzprozesse (''current'')'
+- dimensions: *id208
+  name: ch.bafu.showme-kantone_sturzprozesse_20150101_source
+  sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
+  title: 'ShowMe Kantone: Sturzprozesse (20150101, source)'
+- dimensions: &id209
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_sturzprozesse_20140101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20140101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20140101)'
-- dimensions: *id201
-  name: ch.bafu.showme-kantone_sturzprozesse
-  sources: [ch.bafu.showme-kantone_sturzprozesse_20140101_cache]
-  title: 'ShowMe Kantone: Sturzprozesse (''current'')'
-- dimensions: *id201
+- dimensions: *id209
   name: ch.bafu.showme-kantone_sturzprozesse_20140101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20140101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20140101, source)'
-- dimensions: &id202
+- dimensions: &id210
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_sturzprozesse_20130101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20130101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20130101)'
-- dimensions: *id202
+- dimensions: *id210
   name: ch.bafu.showme-kantone_sturzprozesse_20130101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20130101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20130101, source)'
-- dimensions: &id203
+- dimensions: &id211
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_sturzprozesse_20120101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20120101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20120101)'
-- dimensions: *id203
+- dimensions: *id211
   name: ch.bafu.showme-kantone_sturzprozesse_20120101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20120101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20120101, source)'
-- dimensions: &id204
+- dimensions: &id212
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_sturzprozesse_20110101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20110101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20110101)'
-- dimensions: *id204
+- dimensions: *id212
   name: ch.bafu.showme-kantone_sturzprozesse_20110101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20110101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20110101, source)'
-- dimensions: &id205
+- dimensions: &id213
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_sturzprozesse_20100101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20100101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20100101)'
-- dimensions: *id205
+- dimensions: *id213
   name: ch.bafu.showme-kantone_sturzprozesse_20100101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20100101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20100101, source)'
-- dimensions: &id206
+- dimensions: &id214
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_100_20141107
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 (20141107)"
-- dimensions: *id206
+- dimensions: *id214
   name: ch.bafu.sturm-boeenspitzen_100
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 ('current')"
-- dimensions: *id206
+- dimensions: *id214
   name: ch.bafu.sturm-boeenspitzen_100_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 (20141107, source)"
-- dimensions: &id207
+- dimensions: &id215
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_30_20141107
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 (20141107)"
-- dimensions: *id207
+- dimensions: *id215
   name: ch.bafu.sturm-boeenspitzen_30
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 ('current')"
-- dimensions: *id207
+- dimensions: *id215
   name: ch.bafu.sturm-boeenspitzen_30_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 (20141107, source)"
-- dimensions: &id208
+- dimensions: &id216
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_300_20141107
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 (20141107)"
-- dimensions: *id208
+- dimensions: *id216
   name: ch.bafu.sturm-boeenspitzen_300
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 ('current')"
-- dimensions: *id208
+- dimensions: *id216
   name: ch.bafu.sturm-boeenspitzen_300_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 (20141107, source)"
-- dimensions: &id209
+- dimensions: &id217
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_50_20141107
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 (20141107)"
-- dimensions: *id209
+- dimensions: *id217
   name: ch.bafu.sturm-boeenspitzen_50
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 ('current')"
-- dimensions: *id209
+- dimensions: *id217
   name: ch.bafu.sturm-boeenspitzen_50_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 (20141107, source)"
-- dimensions: &id210
+- dimensions: &id218
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_100_20141107
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 100 (20141107)"
-- dimensions: *id210
+- dimensions: *id218
   name: ch.bafu.sturm-staudruck_100
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 100 ('current')"
-- dimensions: *id210
+- dimensions: *id218
   name: ch.bafu.sturm-staudruck_100_20141107_source
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 100 (20141107, source)"
-- dimensions: &id211
+- dimensions: &id219
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_30_20141107
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 30 (20141107)"
-- dimensions: *id211
+- dimensions: *id219
   name: ch.bafu.sturm-staudruck_30
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 30 ('current')"
-- dimensions: *id211
+- dimensions: *id219
   name: ch.bafu.sturm-staudruck_30_20141107_source
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 30 (20141107, source)"
-- dimensions: &id212
+- dimensions: &id220
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_300_20141107
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 300 (20141107)"
-- dimensions: *id212
+- dimensions: *id220
   name: ch.bafu.sturm-staudruck_300
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 300 ('current')"
-- dimensions: *id212
+- dimensions: *id220
   name: ch.bafu.sturm-staudruck_300_20141107_source
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 300 (20141107, source)"
-- dimensions: &id213
+- dimensions: &id221
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_50_20141107
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 50 (20141107)"
-- dimensions: *id213
+- dimensions: *id221
   name: ch.bafu.sturm-staudruck_50
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 50 ('current')"
-- dimensions: *id213
+- dimensions: *id221
   name: ch.bafu.sturm-staudruck_50_20141107_source
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 50 (20141107, source)"
-- dimensions: &id214
+- dimensions: &id222
     Time:
       default: '20150226'
       values: ['20150226']
   name: ch.bafu.swissprtr_20150226
   sources: [ch.bafu.swissprtr_20150226_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20150226)
-- dimensions: *id214
+- dimensions: *id222
   name: ch.bafu.swissprtr
   sources: [ch.bafu.swissprtr_20150226_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) ('current')
-- dimensions: *id214
+- dimensions: *id222
   name: ch.bafu.swissprtr_20150226_source
   sources: [ch.bafu.swissprtr_20150226_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20150226, source)
-- dimensions: &id215
+- dimensions: &id223
     Time:
       default: '20140213'
       values: ['20140213']
   name: ch.bafu.swissprtr_20140213
   sources: [ch.bafu.swissprtr_20140213_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20140213)
-- dimensions: *id215
+- dimensions: *id223
   name: ch.bafu.swissprtr_20140213_source
   sources: [ch.bafu.swissprtr_20140213_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20140213, source)
-- dimensions: &id216
+- dimensions: &id224
     Time:
       default: '20130207'
       values: ['20130207']
   name: ch.bafu.swissprtr_20130207
   sources: [ch.bafu.swissprtr_20130207_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20130207)
-- dimensions: *id216
+- dimensions: *id224
   name: ch.bafu.swissprtr_20130207_source
   sources: [ch.bafu.swissprtr_20130207_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20130207, source)
-- dimensions: &id217
+- dimensions: &id225
     Time:
       default: '20120404'
       values: ['20120404']
   name: ch.bafu.swissprtr_20120404
   sources: [ch.bafu.swissprtr_20120404_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20120404)
-- dimensions: *id217
+- dimensions: *id225
   name: ch.bafu.swissprtr_20120404_source
   sources: [ch.bafu.swissprtr_20120404_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20120404, source)
-- dimensions: &id218
+- dimensions: &id226
     Time:
       default: '20110222'
       values: ['20110222']
   name: ch.bafu.swissprtr_20110222
   sources: [ch.bafu.swissprtr_20110222_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20110222)
-- dimensions: *id218
+- dimensions: *id226
   name: ch.bafu.swissprtr_20110222_source
   sources: [ch.bafu.swissprtr_20110222_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20110222, source)
-- dimensions: &id219
+- dimensions: &id227
     Time:
       default: '20080724'
       values: ['20080724']
   name: ch.bafu.unesco-weltnaturerbe_20080724
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache_out]
   title: "UNESCO-Welterbe Naturst\xE4tten (20080724)"
-- dimensions: *id219
+- dimensions: *id227
   name: ch.bafu.unesco-weltnaturerbe
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache]
   title: "UNESCO-Welterbe Naturst\xE4tten ('current')"
-- dimensions: *id219
+- dimensions: *id227
   name: ch.bafu.unesco-weltnaturerbe_20080724_source
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache]
   title: "UNESCO-Welterbe Naturst\xE4tten (20080724, source)"
-- dimensions: &id220
+- dimensions: &id228
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-entnahme_20040101
   sources: [ch.bafu.wasser-entnahme_20040101_cache_out]
   title: Wasserentnahme (20040101)
-- dimensions: *id220
+- dimensions: *id228
   name: ch.bafu.wasser-entnahme
   sources: [ch.bafu.wasser-entnahme_20040101_cache]
   title: Wasserentnahme ('current')
-- dimensions: *id220
+- dimensions: *id228
   name: ch.bafu.wasser-entnahme_20040101_source
   sources: [ch.bafu.wasser-entnahme_20040101_cache]
   title: Wasserentnahme (20040101, source)
-- dimensions: &id221
+- dimensions: &id229
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-gebietsauslaesse_20120701
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache_out]
   title: "Gebietsausl\xE4sse (20120701)"
-- dimensions: *id221
+- dimensions: *id229
   name: ch.bafu.wasser-gebietsauslaesse
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache]
   title: "Gebietsausl\xE4sse ('current')"
-- dimensions: *id221
+- dimensions: *id229
   name: ch.bafu.wasser-gebietsauslaesse_20120701_source
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache]
   title: "Gebietsausl\xE4sse (20120701, source)"
-- dimensions: &id222
+- dimensions: &id230
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-leitungen_20040101
   sources: [ch.bafu.wasser-leitungen_20040101_cache_out]
   title: Zuleitung (20040101)
-- dimensions: *id222
+- dimensions: *id230
   name: ch.bafu.wasser-leitungen
   sources: [ch.bafu.wasser-leitungen_20040101_cache]
   title: Zuleitung ('current')
-- dimensions: *id222
+- dimensions: *id230
   name: ch.bafu.wasser-leitungen_20040101_source
   sources: [ch.bafu.wasser-leitungen_20040101_cache]
   title: Zuleitung (20040101, source)
-- dimensions: &id223
+- dimensions: &id231
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-rueckgabe_20040101
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache_out]
   title: "Wasserr\xFCckgabe (20040101)"
-- dimensions: *id223
+- dimensions: *id231
   name: ch.bafu.wasser-rueckgabe
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache]
   title: "Wasserr\xFCckgabe ('current')"
-- dimensions: *id223
+- dimensions: *id231
   name: ch.bafu.wasser-rueckgabe_20040101_source
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache]
   title: "Wasserr\xFCckgabe (20040101, source)"
-- dimensions: &id224
+- dimensions: &id232
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-teileinzugsgebiete_2_20120701
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache_out]
   title: Teileinzugsgebiete 2km2 (20120701)
-- dimensions: *id224
+- dimensions: *id232
   name: ch.bafu.wasser-teileinzugsgebiete_2
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache]
   title: Teileinzugsgebiete 2km2 ('current')
-- dimensions: *id224
+- dimensions: *id232
   name: ch.bafu.wasser-teileinzugsgebiete_2_20120701_source
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache]
   title: Teileinzugsgebiete 2km2 (20120701, source)
-- dimensions: &id225
+- dimensions: &id233
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-teileinzugsgebiete_40_20120701
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache_out]
   title: Teileinzugsgebiete 40km2 (20120701)
-- dimensions: *id225
+- dimensions: *id233
   name: ch.bafu.wasser-teileinzugsgebiete_40
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache]
   title: Teileinzugsgebiete 40km2 ('current')
-- dimensions: *id225
+- dimensions: *id233
   name: ch.bafu.wasser-teileinzugsgebiete_40_20120701_source
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache]
   title: Teileinzugsgebiete 40km2 (20120701, source)
-- dimensions: &id226
+- dimensions: &id234
     Time:
       default: '20150106'
       values: ['20150106']
   name: ch.bafu.wrz-wildruhezonen_portal_20150106
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache_out]
   title: Wildruhezonen (20150106)
-- dimensions: *id226
+- dimensions: *id234
   name: ch.bafu.wrz-wildruhezonen_portal
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache]
   title: Wildruhezonen ('current')
-- dimensions: *id226
+- dimensions: *id234
   name: ch.bafu.wrz-wildruhezonen_portal_20150106_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache]
   title: Wildruhezonen (20150106, source)
-- dimensions: &id227
+- dimensions: &id235
     Time:
       default: '20141105'
       values: ['20141105']
   name: ch.bafu.wrz-wildruhezonen_portal_20141105
   sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache_out]
   title: Wildruhezonen (20141105)
-- dimensions: *id227
+- dimensions: *id235
   name: ch.bafu.wrz-wildruhezonen_portal_20141105_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache]
   title: Wildruhezonen (20141105, source)
-- dimensions: &id228
+- dimensions: &id236
     Time:
       default: '20140107'
       values: ['20140107']
   name: ch.bafu.wrz-wildruhezonen_portal_20140107
   sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache_out]
   title: Wildruhezonen (20140107)
-- dimensions: *id228
+- dimensions: *id236
   name: ch.bafu.wrz-wildruhezonen_portal_20140107_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache]
   title: Wildruhezonen (20140107, source)
-- dimensions: &id229
+- dimensions: &id237
     Time:
       default: '20131118'
       values: ['20131118']
   name: ch.bafu.wrz-wildruhezonen_portal_20131118
   sources: [ch.bafu.wrz-wildruhezonen_portal_20131118_cache_out]
   title: Wildruhezonen (20131118)
-- dimensions: *id229
+- dimensions: *id237
   name: ch.bafu.wrz-wildruhezonen_portal_20131118_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20131118_cache]
   title: Wildruhezonen (20131118, source)
-- dimensions: &id230
+- dimensions: &id238
     Time:
       default: '20130111'
       values: ['20130111']
   name: ch.bafu.wrz-wildruhezonen_portal_20130111
   sources: [ch.bafu.wrz-wildruhezonen_portal_20130111_cache_out]
   title: Wildruhezonen (20130111)
-- dimensions: *id230
+- dimensions: *id238
   name: ch.bafu.wrz-wildruhezonen_portal_20130111_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20130111_cache]
   title: Wildruhezonen (20130111, source)
-- dimensions: &id231
+- dimensions: &id239
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.bag.zecken-fsme-faelle_20141231
   sources: [ch.bag.zecken-fsme-faelle_20141231_cache_out]
   title: "FSME - Lokale H\xE4ufungen (20141231)"
-- dimensions: *id231
+- dimensions: *id239
   name: ch.bag.zecken-fsme-faelle
   sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
   title: "FSME - Lokale H\xE4ufungen ('current')"
-- dimensions: *id231
+- dimensions: *id239
   name: ch.bag.zecken-fsme-faelle_20141231_source
   sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
   title: "FSME - Lokale H\xE4ufungen (20141231, source)"
-- dimensions: &id232
+- dimensions: &id240
     Time:
       default: '20140220'
       values: ['20140220']
   name: ch.bag.zecken-fsme-faelle_20140220
   sources: [ch.bag.zecken-fsme-faelle_20140220_cache_out]
   title: "FSME - Lokale H\xE4ufungen (20140220)"
-- dimensions: *id232
+- dimensions: *id240
   name: ch.bag.zecken-fsme-faelle_20140220_source
   sources: [ch.bag.zecken-fsme-faelle_20140220_cache]
   title: "FSME - Lokale H\xE4ufungen (20140220, source)"
-- dimensions: &id233
+- dimensions: &id241
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.bag.zecken-fsme-faelle_20121231
   sources: [ch.bag.zecken-fsme-faelle_20121231_cache_out]
   title: "FSME - Lokale H\xE4ufungen (20121231)"
-- dimensions: *id233
+- dimensions: *id241
   name: ch.bag.zecken-fsme-faelle_20121231_source
   sources: [ch.bag.zecken-fsme-faelle_20121231_cache]
   title: "FSME - Lokale H\xE4ufungen (20121231, source)"
-- dimensions: &id234
+- dimensions: &id242
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.bag.zecken-fsme-impfung_20141231
   sources: [ch.bag.zecken-fsme-impfung_20141231_cache_out]
   title: FSME - Impfempfehlung (20141231)
-- dimensions: *id234
+- dimensions: *id242
   name: ch.bag.zecken-fsme-impfung
   sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
   title: FSME - Impfempfehlung ('current')
-- dimensions: *id234
+- dimensions: *id242
   name: ch.bag.zecken-fsme-impfung_20141231_source
   sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
   title: FSME - Impfempfehlung (20141231, source)
-- dimensions: &id235
+- dimensions: &id243
     Time:
       default: '20140220'
       values: ['20140220']
   name: ch.bag.zecken-fsme-impfung_20140220
   sources: [ch.bag.zecken-fsme-impfung_20140220_cache_out]
   title: FSME - Impfempfehlung (20140220)
-- dimensions: *id235
+- dimensions: *id243
   name: ch.bag.zecken-fsme-impfung_20140220_source
   sources: [ch.bag.zecken-fsme-impfung_20140220_cache]
   title: FSME - Impfempfehlung (20140220, source)
-- dimensions: &id236
+- dimensions: &id244
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.bag.zecken-fsme-impfung_20121231
   sources: [ch.bag.zecken-fsme-impfung_20121231_cache_out]
   title: FSME - Impfempfehlung (20121231)
-- dimensions: *id236
+- dimensions: *id244
   name: ch.bag.zecken-fsme-impfung_20121231_source
   sources: [ch.bag.zecken-fsme-impfung_20121231_cache]
   title: FSME - Impfempfehlung (20121231, source)
-- dimensions: &id237
+- dimensions: &id245
     Time:
       default: '20110613'
       values: ['20110613']
   name: ch.bag.zecken-lyme_20110613
   sources: [ch.bag.zecken-lyme_20110613_cache_out]
   title: Borreliose Risikogebiete (20110613)
-- dimensions: *id237
+- dimensions: *id245
   name: ch.bag.zecken-lyme
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete ('current')
-- dimensions: *id237
+- dimensions: *id245
   name: ch.bag.zecken-lyme_20110613_source
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete (20110613, source)
-- dimensions: &id238
+- dimensions: &id246
     Time:
       default: '20140801'
       values: ['20140801']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache_out]
   title: Bundesinventar ISOS (20140801)
-- dimensions: *id238
+- dimensions: *id246
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache]
   title: Bundesinventar ISOS ('current')
-- dimensions: *id238
+- dimensions: *id246
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache]
   title: Bundesinventar ISOS (20140801, source)
-- dimensions: &id239
+- dimensions: &id247
     Time:
       default: '20131113'
       values: ['20131113']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache_out]
   title: Bundesinventar ISOS (20131113)
-- dimensions: *id239
+- dimensions: *id247
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache]
   title: Bundesinventar ISOS (20131113, source)
-- dimensions: &id240
+- dimensions: &id248
     Time:
       default: '20121218'
       values: ['20121218']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache_out]
   title: Bundesinventar ISOS (20121218)
-- dimensions: *id240
+- dimensions: *id248
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache]
   title: Bundesinventar ISOS (20121218, source)
-- dimensions: &id241
+- dimensions: &id249
     Time:
       default: '20120510'
       values: ['20120510']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache_out]
   title: Bundesinventar ISOS (20120510)
-- dimensions: *id241
+- dimensions: *id249
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache]
   title: Bundesinventar ISOS (20120510, source)
-- dimensions: &id242
+- dimensions: &id250
     Time:
       default: '20110915'
       values: ['20110915']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache_out]
   title: Bundesinventar ISOS (20110915)
-- dimensions: *id242
+- dimensions: *id250
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache]
   title: Bundesinventar ISOS (20110915, source)
-- dimensions: &id243
+- dimensions: &id251
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anbieter-eigenes_festnetz_20141120
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141120_cache_out]
   title: Anzahl Leitungsanbieter (20141120)
-- dimensions: *id243
+- dimensions: *id251
   name: ch.bakom.anbieter-eigenes_festnetz
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141120_cache]
   title: Anzahl Leitungsanbieter ('current')
-- dimensions: *id243
+- dimensions: *id251
   name: ch.bakom.anbieter-eigenes_festnetz_20141120_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141120_cache]
   title: Anzahl Leitungsanbieter (20141120, source)
-- dimensions: &id244
+- dimensions: &id252
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anbieter-eigenes_festnetz_20141021
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache_out]
   title: Anzahl Leitungsanbieter (20141021)
-- dimensions: *id244
+- dimensions: *id252
   name: ch.bakom.anbieter-eigenes_festnetz_20141021_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache]
   title: Anzahl Leitungsanbieter (20141021, source)
-- dimensions: &id245
+- dimensions: &id253
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anbieter-eigenes_festnetz_20140625
   sources: [ch.bakom.anbieter-eigenes_festnetz_20140625_cache_out]
   title: Anzahl Leitungsanbieter (20140625)
-- dimensions: *id245
+- dimensions: *id253
   name: ch.bakom.anbieter-eigenes_festnetz_20140625_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20140625_cache]
   title: Anzahl Leitungsanbieter (20140625, source)
-- dimensions: &id246
+- dimensions: &id254
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anbieter-eigenes_festnetz_20131212
   sources: [ch.bakom.anbieter-eigenes_festnetz_20131212_cache_out]
   title: Anzahl Leitungsanbieter (20131212)
-- dimensions: *id246
+- dimensions: *id254
   name: ch.bakom.anbieter-eigenes_festnetz_20131212_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20131212_cache]
   title: Anzahl Leitungsanbieter (20131212, source)
-- dimensions: &id247
+- dimensions: &id255
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anbieter-eigenes_festnetz_20130901
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130901_cache_out]
   title: Anzahl Leitungsanbieter (20130901)
-- dimensions: *id247
+- dimensions: *id255
   name: ch.bakom.anbieter-eigenes_festnetz_20130901_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130901_cache]
   title: Anzahl Leitungsanbieter (20130901, source)
-- dimensions: &id248
+- dimensions: &id256
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anbieter-eigenes_festnetz_20130601
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130601_cache_out]
   title: Anzahl Leitungsanbieter (20130601)
-- dimensions: *id248
+- dimensions: *id256
   name: ch.bakom.anbieter-eigenes_festnetz_20130601_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130601_cache]
   title: Anzahl Leitungsanbieter (20130601, source)
-- dimensions: &id249
+- dimensions: &id257
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anbieter-eigenes_festnetz_20121222
   sources: [ch.bakom.anbieter-eigenes_festnetz_20121222_cache_out]
   title: Anzahl Leitungsanbieter (20121222)
-- dimensions: *id249
+- dimensions: *id257
   name: ch.bakom.anbieter-eigenes_festnetz_20121222_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20121222_cache]
   title: Anzahl Leitungsanbieter (20121222, source)
-- dimensions: &id250
+- dimensions: &id258
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anschlussart-glasfaser_20141120
   sources: [ch.bakom.anschlussart-glasfaser_20141120_cache_out]
   title: Glasfaser (20141120)
-- dimensions: *id250
+- dimensions: *id258
   name: ch.bakom.anschlussart-glasfaser
   sources: [ch.bakom.anschlussart-glasfaser_20141120_cache]
   title: Glasfaser ('current')
-- dimensions: *id250
+- dimensions: *id258
   name: ch.bakom.anschlussart-glasfaser_20141120_source
   sources: [ch.bakom.anschlussart-glasfaser_20141120_cache]
   title: Glasfaser (20141120, source)
-- dimensions: &id251
+- dimensions: &id259
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-glasfaser_20141021
   sources: [ch.bakom.anschlussart-glasfaser_20141021_cache_out]
   title: Glasfaser (20141021)
-- dimensions: *id251
+- dimensions: *id259
   name: ch.bakom.anschlussart-glasfaser_20141021_source
   sources: [ch.bakom.anschlussart-glasfaser_20141021_cache]
   title: Glasfaser (20141021, source)
-- dimensions: &id252
+- dimensions: &id260
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-glasfaser_20140625
   sources: [ch.bakom.anschlussart-glasfaser_20140625_cache_out]
   title: Glasfaser (20140625)
-- dimensions: *id252
+- dimensions: *id260
   name: ch.bakom.anschlussart-glasfaser_20140625_source
   sources: [ch.bakom.anschlussart-glasfaser_20140625_cache]
   title: Glasfaser (20140625, source)
-- dimensions: &id253
+- dimensions: &id261
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-glasfaser_20131212
   sources: [ch.bakom.anschlussart-glasfaser_20131212_cache_out]
   title: Glasfaser (20131212)
-- dimensions: *id253
+- dimensions: *id261
   name: ch.bakom.anschlussart-glasfaser_20131212_source
   sources: [ch.bakom.anschlussart-glasfaser_20131212_cache]
   title: Glasfaser (20131212, source)
-- dimensions: &id254
+- dimensions: &id262
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-glasfaser_20130901
   sources: [ch.bakom.anschlussart-glasfaser_20130901_cache_out]
   title: Glasfaser (20130901)
-- dimensions: *id254
+- dimensions: *id262
   name: ch.bakom.anschlussart-glasfaser_20130901_source
   sources: [ch.bakom.anschlussart-glasfaser_20130901_cache]
   title: Glasfaser (20130901, source)
-- dimensions: &id255
+- dimensions: &id263
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-glasfaser_20130601
   sources: [ch.bakom.anschlussart-glasfaser_20130601_cache_out]
   title: Glasfaser (20130601)
-- dimensions: *id255
+- dimensions: *id263
   name: ch.bakom.anschlussart-glasfaser_20130601_source
   sources: [ch.bakom.anschlussart-glasfaser_20130601_cache]
   title: Glasfaser (20130601, source)
-- dimensions: &id256
+- dimensions: &id264
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-glasfaser_20121222
   sources: [ch.bakom.anschlussart-glasfaser_20121222_cache_out]
   title: Glasfaser (20121222)
-- dimensions: *id256
+- dimensions: *id264
   name: ch.bakom.anschlussart-glasfaser_20121222_source
   sources: [ch.bakom.anschlussart-glasfaser_20121222_cache]
   title: Glasfaser (20121222, source)
-- dimensions: &id257
+- dimensions: &id265
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anschlussart-koaxialkabel_20141120
   sources: [ch.bakom.anschlussart-koaxialkabel_20141120_cache_out]
   title: Koaxial-Kabel (20141120)
-- dimensions: *id257
+- dimensions: *id265
   name: ch.bakom.anschlussart-koaxialkabel
   sources: [ch.bakom.anschlussart-koaxialkabel_20141120_cache]
   title: Koaxial-Kabel ('current')
-- dimensions: *id257
+- dimensions: *id265
   name: ch.bakom.anschlussart-koaxialkabel_20141120_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20141120_cache]
   title: Koaxial-Kabel (20141120, source)
-- dimensions: &id258
+- dimensions: &id266
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-koaxialkabel_20141021
   sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache_out]
   title: Koaxial-Kabel (20141021)
-- dimensions: *id258
+- dimensions: *id266
   name: ch.bakom.anschlussart-koaxialkabel_20141021_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache]
   title: Koaxial-Kabel (20141021, source)
-- dimensions: &id259
+- dimensions: &id267
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-koaxialkabel_20140625
   sources: [ch.bakom.anschlussart-koaxialkabel_20140625_cache_out]
   title: Koaxial-Kabel (20140625)
-- dimensions: *id259
+- dimensions: *id267
   name: ch.bakom.anschlussart-koaxialkabel_20140625_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20140625_cache]
   title: Koaxial-Kabel (20140625, source)
-- dimensions: &id260
+- dimensions: &id268
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-koaxialkabel_20131212
   sources: [ch.bakom.anschlussart-koaxialkabel_20131212_cache_out]
   title: Koaxial-Kabel (20131212)
-- dimensions: *id260
+- dimensions: *id268
   name: ch.bakom.anschlussart-koaxialkabel_20131212_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20131212_cache]
   title: Koaxial-Kabel (20131212, source)
-- dimensions: &id261
+- dimensions: &id269
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-koaxialkabel_20130901
   sources: [ch.bakom.anschlussart-koaxialkabel_20130901_cache_out]
   title: Koaxial-Kabel (20130901)
-- dimensions: *id261
+- dimensions: *id269
   name: ch.bakom.anschlussart-koaxialkabel_20130901_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20130901_cache]
   title: Koaxial-Kabel (20130901, source)
-- dimensions: &id262
+- dimensions: &id270
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-koaxialkabel_20130601
   sources: [ch.bakom.anschlussart-koaxialkabel_20130601_cache_out]
   title: Koaxial-Kabel (20130601)
-- dimensions: *id262
+- dimensions: *id270
   name: ch.bakom.anschlussart-koaxialkabel_20130601_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20130601_cache]
   title: Koaxial-Kabel (20130601, source)
-- dimensions: &id263
+- dimensions: &id271
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-koaxialkabel_20121222
   sources: [ch.bakom.anschlussart-koaxialkabel_20121222_cache_out]
   title: Koaxial-Kabel (20121222)
-- dimensions: *id263
+- dimensions: *id271
   name: ch.bakom.anschlussart-koaxialkabel_20121222_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20121222_cache]
   title: Koaxial-Kabel (20121222, source)
-- dimensions: &id264
+- dimensions: &id272
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anschlussart-kupferdraht_20141120
   sources: [ch.bakom.anschlussart-kupferdraht_20141120_cache_out]
   title: Kupfer-Draht (20141120)
-- dimensions: *id264
+- dimensions: *id272
   name: ch.bakom.anschlussart-kupferdraht
   sources: [ch.bakom.anschlussart-kupferdraht_20141120_cache]
   title: Kupfer-Draht ('current')
-- dimensions: *id264
+- dimensions: *id272
   name: ch.bakom.anschlussart-kupferdraht_20141120_source
   sources: [ch.bakom.anschlussart-kupferdraht_20141120_cache]
   title: Kupfer-Draht (20141120, source)
-- dimensions: &id265
+- dimensions: &id273
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-kupferdraht_20141021
   sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache_out]
   title: Kupfer-Draht (20141021)
-- dimensions: *id265
+- dimensions: *id273
   name: ch.bakom.anschlussart-kupferdraht_20141021_source
   sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache]
   title: Kupfer-Draht (20141021, source)
-- dimensions: &id266
+- dimensions: &id274
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-kupferdraht_20140625
   sources: [ch.bakom.anschlussart-kupferdraht_20140625_cache_out]
   title: Kupfer-Draht (20140625)
-- dimensions: *id266
+- dimensions: *id274
   name: ch.bakom.anschlussart-kupferdraht_20140625_source
   sources: [ch.bakom.anschlussart-kupferdraht_20140625_cache]
   title: Kupfer-Draht (20140625, source)
-- dimensions: &id267
+- dimensions: &id275
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-kupferdraht_20131212
   sources: [ch.bakom.anschlussart-kupferdraht_20131212_cache_out]
   title: Kupfer-Draht (20131212)
-- dimensions: *id267
+- dimensions: *id275
   name: ch.bakom.anschlussart-kupferdraht_20131212_source
   sources: [ch.bakom.anschlussart-kupferdraht_20131212_cache]
   title: Kupfer-Draht (20131212, source)
-- dimensions: &id268
+- dimensions: &id276
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-kupferdraht_20130901
   sources: [ch.bakom.anschlussart-kupferdraht_20130901_cache_out]
   title: Kupfer-Draht (20130901)
-- dimensions: *id268
+- dimensions: *id276
   name: ch.bakom.anschlussart-kupferdraht_20130901_source
   sources: [ch.bakom.anschlussart-kupferdraht_20130901_cache]
   title: Kupfer-Draht (20130901, source)
-- dimensions: &id269
+- dimensions: &id277
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-kupferdraht_20130601
   sources: [ch.bakom.anschlussart-kupferdraht_20130601_cache_out]
   title: Kupfer-Draht (20130601)
-- dimensions: *id269
+- dimensions: *id277
   name: ch.bakom.anschlussart-kupferdraht_20130601_source
   sources: [ch.bakom.anschlussart-kupferdraht_20130601_cache]
   title: Kupfer-Draht (20130601, source)
-- dimensions: &id270
+- dimensions: &id278
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-kupferdraht_20121222
   sources: [ch.bakom.anschlussart-kupferdraht_20121222_cache_out]
   title: Kupfer-Draht (20121222)
-- dimensions: *id270
+- dimensions: *id278
   name: ch.bakom.anschlussart-kupferdraht_20121222_source
   sources: [ch.bakom.anschlussart-kupferdraht_20121222_cache]
   title: Kupfer-Draht (20121222, source)
-- dimensions: &id271
+- dimensions: &id279
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink1_20141120
   sources: [ch.bakom.downlink1_20141120_cache_out]
   title: "Download \u2265 1 Mbit/s (20141120)"
-- dimensions: *id271
+- dimensions: *id279
   name: ch.bakom.downlink1
   sources: [ch.bakom.downlink1_20141120_cache]
   title: "Download \u2265 1 Mbit/s ('current')"
-- dimensions: *id271
+- dimensions: *id279
   name: ch.bakom.downlink1_20141120_source
   sources: [ch.bakom.downlink1_20141120_cache]
   title: "Download \u2265 1 Mbit/s (20141120, source)"
-- dimensions: &id272
+- dimensions: &id280
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink1_20141021
   sources: [ch.bakom.downlink1_20141021_cache_out]
   title: "Download \u2265 1 Mbit/s (20141021)"
-- dimensions: *id272
+- dimensions: *id280
   name: ch.bakom.downlink1_20141021_source
   sources: [ch.bakom.downlink1_20141021_cache]
   title: "Download \u2265 1 Mbit/s (20141021, source)"
-- dimensions: &id273
+- dimensions: &id281
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink1_20140625
   sources: [ch.bakom.downlink1_20140625_cache_out]
   title: "Download \u2265 1 Mbit/s (20140625)"
-- dimensions: *id273
+- dimensions: *id281
   name: ch.bakom.downlink1_20140625_source
   sources: [ch.bakom.downlink1_20140625_cache]
   title: "Download \u2265 1 Mbit/s (20140625, source)"
-- dimensions: &id274
+- dimensions: &id282
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink1_20131212
   sources: [ch.bakom.downlink1_20131212_cache_out]
   title: "Download \u2265 1 Mbit/s (20131212)"
-- dimensions: *id274
+- dimensions: *id282
   name: ch.bakom.downlink1_20131212_source
   sources: [ch.bakom.downlink1_20131212_cache]
   title: "Download \u2265 1 Mbit/s (20131212, source)"
-- dimensions: &id275
+- dimensions: &id283
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink1_20130901
   sources: [ch.bakom.downlink1_20130901_cache_out]
   title: "Download \u2265 1 Mbit/s (20130901)"
-- dimensions: *id275
+- dimensions: *id283
   name: ch.bakom.downlink1_20130901_source
   sources: [ch.bakom.downlink1_20130901_cache]
   title: "Download \u2265 1 Mbit/s (20130901, source)"
-- dimensions: &id276
+- dimensions: &id284
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink1_20130601
   sources: [ch.bakom.downlink1_20130601_cache_out]
   title: "Download \u2265 1 Mbit/s (20130601)"
-- dimensions: *id276
+- dimensions: *id284
   name: ch.bakom.downlink1_20130601_source
   sources: [ch.bakom.downlink1_20130601_cache]
   title: "Download \u2265 1 Mbit/s (20130601, source)"
-- dimensions: &id277
+- dimensions: &id285
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink1_20121222
   sources: [ch.bakom.downlink1_20121222_cache_out]
   title: "Download \u2265 1 Mbit/s (20121222)"
-- dimensions: *id277
+- dimensions: *id285
   name: ch.bakom.downlink1_20121222_source
   sources: [ch.bakom.downlink1_20121222_cache]
   title: "Download \u2265 1 Mbit/s (20121222, source)"
-- dimensions: &id278
+- dimensions: &id286
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink10_20141120
   sources: [ch.bakom.downlink10_20141120_cache_out]
   title: "Download \u2265 10 Mbit/s (20141120)"
-- dimensions: *id278
+- dimensions: *id286
   name: ch.bakom.downlink10
   sources: [ch.bakom.downlink10_20141120_cache]
   title: "Download \u2265 10 Mbit/s ('current')"
-- dimensions: *id278
+- dimensions: *id286
   name: ch.bakom.downlink10_20141120_source
   sources: [ch.bakom.downlink10_20141120_cache]
   title: "Download \u2265 10 Mbit/s (20141120, source)"
-- dimensions: &id279
+- dimensions: &id287
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink10_20141021
   sources: [ch.bakom.downlink10_20141021_cache_out]
   title: "Download \u2265 10 Mbit/s (20141021)"
-- dimensions: *id279
+- dimensions: *id287
   name: ch.bakom.downlink10_20141021_source
   sources: [ch.bakom.downlink10_20141021_cache]
   title: "Download \u2265 10 Mbit/s (20141021, source)"
-- dimensions: &id280
+- dimensions: &id288
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink10_20140625
   sources: [ch.bakom.downlink10_20140625_cache_out]
   title: "Download \u2265 10 Mbit/s (20140625)"
-- dimensions: *id280
+- dimensions: *id288
   name: ch.bakom.downlink10_20140625_source
   sources: [ch.bakom.downlink10_20140625_cache]
   title: "Download \u2265 10 Mbit/s (20140625, source)"
-- dimensions: &id281
+- dimensions: &id289
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink10_20131212
   sources: [ch.bakom.downlink10_20131212_cache_out]
   title: "Download \u2265 10 Mbit/s (20131212)"
-- dimensions: *id281
+- dimensions: *id289
   name: ch.bakom.downlink10_20131212_source
   sources: [ch.bakom.downlink10_20131212_cache]
   title: "Download \u2265 10 Mbit/s (20131212, source)"
-- dimensions: &id282
+- dimensions: &id290
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink10_20130901
   sources: [ch.bakom.downlink10_20130901_cache_out]
   title: "Download \u2265 10 Mbit/s (20130901)"
-- dimensions: *id282
+- dimensions: *id290
   name: ch.bakom.downlink10_20130901_source
   sources: [ch.bakom.downlink10_20130901_cache]
   title: "Download \u2265 10 Mbit/s (20130901, source)"
-- dimensions: &id283
+- dimensions: &id291
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink10_20130601
   sources: [ch.bakom.downlink10_20130601_cache_out]
   title: "Download \u2265 10 Mbit/s (20130601)"
-- dimensions: *id283
+- dimensions: *id291
   name: ch.bakom.downlink10_20130601_source
   sources: [ch.bakom.downlink10_20130601_cache]
   title: "Download \u2265 10 Mbit/s (20130601, source)"
-- dimensions: &id284
+- dimensions: &id292
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink10_20121222
   sources: [ch.bakom.downlink10_20121222_cache_out]
   title: "Download \u2265 10 Mbit/s (20121222)"
-- dimensions: *id284
+- dimensions: *id292
   name: ch.bakom.downlink10_20121222_source
   sources: [ch.bakom.downlink10_20121222_cache]
   title: "Download \u2265 10 Mbit/s (20121222, source)"
-- dimensions: &id285
+- dimensions: &id293
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink100_20141120
   sources: [ch.bakom.downlink100_20141120_cache_out]
   title: "Download \u2265 100 Mbit/s (20141120)"
-- dimensions: *id285
+- dimensions: *id293
   name: ch.bakom.downlink100
   sources: [ch.bakom.downlink100_20141120_cache]
   title: "Download \u2265 100 Mbit/s ('current')"
-- dimensions: *id285
+- dimensions: *id293
   name: ch.bakom.downlink100_20141120_source
   sources: [ch.bakom.downlink100_20141120_cache]
   title: "Download \u2265 100 Mbit/s (20141120, source)"
-- dimensions: &id286
+- dimensions: &id294
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink100_20141021
   sources: [ch.bakom.downlink100_20141021_cache_out]
   title: "Download \u2265 100 Mbit/s (20141021)"
-- dimensions: *id286
+- dimensions: *id294
   name: ch.bakom.downlink100_20141021_source
   sources: [ch.bakom.downlink100_20141021_cache]
   title: "Download \u2265 100 Mbit/s (20141021, source)"
-- dimensions: &id287
+- dimensions: &id295
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink100_20140625
   sources: [ch.bakom.downlink100_20140625_cache_out]
   title: "Download \u2265 100 Mbit/s (20140625)"
-- dimensions: *id287
+- dimensions: *id295
   name: ch.bakom.downlink100_20140625_source
   sources: [ch.bakom.downlink100_20140625_cache]
   title: "Download \u2265 100 Mbit/s (20140625, source)"
-- dimensions: &id288
+- dimensions: &id296
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink100_20131212
   sources: [ch.bakom.downlink100_20131212_cache_out]
   title: "Download \u2265 100 Mbit/s (20131212)"
-- dimensions: *id288
+- dimensions: *id296
   name: ch.bakom.downlink100_20131212_source
   sources: [ch.bakom.downlink100_20131212_cache]
   title: "Download \u2265 100 Mbit/s (20131212, source)"
-- dimensions: &id289
+- dimensions: &id297
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink100_20130901
   sources: [ch.bakom.downlink100_20130901_cache_out]
   title: "Download \u2265 100 Mbit/s (20130901)"
-- dimensions: *id289
+- dimensions: *id297
   name: ch.bakom.downlink100_20130901_source
   sources: [ch.bakom.downlink100_20130901_cache]
   title: "Download \u2265 100 Mbit/s (20130901, source)"
-- dimensions: &id290
+- dimensions: &id298
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink100_20130601
   sources: [ch.bakom.downlink100_20130601_cache_out]
   title: "Download \u2265 100 Mbit/s (20130601)"
-- dimensions: *id290
+- dimensions: *id298
   name: ch.bakom.downlink100_20130601_source
   sources: [ch.bakom.downlink100_20130601_cache]
   title: "Download \u2265 100 Mbit/s (20130601, source)"
-- dimensions: &id291
+- dimensions: &id299
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink100_20121222
   sources: [ch.bakom.downlink100_20121222_cache_out]
   title: "Download \u2265 100 Mbit/s (20121222)"
-- dimensions: *id291
+- dimensions: *id299
   name: ch.bakom.downlink100_20121222_source
   sources: [ch.bakom.downlink100_20121222_cache]
   title: "Download \u2265 100 Mbit/s (20121222, source)"
-- dimensions: &id292
+- dimensions: &id300
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink2_20141120
   sources: [ch.bakom.downlink2_20141120_cache_out]
   title: "Download \u2265 2 Mbit/s (20141120)"
-- dimensions: *id292
+- dimensions: *id300
   name: ch.bakom.downlink2
   sources: [ch.bakom.downlink2_20141120_cache]
   title: "Download \u2265 2 Mbit/s ('current')"
-- dimensions: *id292
+- dimensions: *id300
   name: ch.bakom.downlink2_20141120_source
   sources: [ch.bakom.downlink2_20141120_cache]
   title: "Download \u2265 2 Mbit/s (20141120, source)"
-- dimensions: &id293
+- dimensions: &id301
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink2_20141021
   sources: [ch.bakom.downlink2_20141021_cache_out]
   title: "Download \u2265 2 Mbit/s (20141021)"
-- dimensions: *id293
+- dimensions: *id301
   name: ch.bakom.downlink2_20141021_source
   sources: [ch.bakom.downlink2_20141021_cache]
   title: "Download \u2265 2 Mbit/s (20141021, source)"
-- dimensions: &id294
+- dimensions: &id302
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink2_20140625
   sources: [ch.bakom.downlink2_20140625_cache_out]
   title: "Download \u2265 2 Mbit/s (20140625)"
-- dimensions: *id294
+- dimensions: *id302
   name: ch.bakom.downlink2_20140625_source
   sources: [ch.bakom.downlink2_20140625_cache]
   title: "Download \u2265 2 Mbit/s (20140625, source)"
-- dimensions: &id295
+- dimensions: &id303
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink2_20131212
   sources: [ch.bakom.downlink2_20131212_cache_out]
   title: "Download \u2265 2 Mbit/s (20131212)"
-- dimensions: *id295
+- dimensions: *id303
   name: ch.bakom.downlink2_20131212_source
   sources: [ch.bakom.downlink2_20131212_cache]
   title: "Download \u2265 2 Mbit/s (20131212, source)"
-- dimensions: &id296
+- dimensions: &id304
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink2_20130901
   sources: [ch.bakom.downlink2_20130901_cache_out]
   title: "Download \u2265 2 Mbit/s (20130901)"
-- dimensions: *id296
+- dimensions: *id304
   name: ch.bakom.downlink2_20130901_source
   sources: [ch.bakom.downlink2_20130901_cache]
   title: "Download \u2265 2 Mbit/s (20130901, source)"
-- dimensions: &id297
+- dimensions: &id305
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink2_20130601
   sources: [ch.bakom.downlink2_20130601_cache_out]
   title: "Download \u2265 2 Mbit/s (20130601)"
-- dimensions: *id297
+- dimensions: *id305
   name: ch.bakom.downlink2_20130601_source
   sources: [ch.bakom.downlink2_20130601_cache]
   title: "Download \u2265 2 Mbit/s (20130601, source)"
-- dimensions: &id298
+- dimensions: &id306
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink2_20121222
   sources: [ch.bakom.downlink2_20121222_cache_out]
   title: "Download \u2265 2 Mbit/s (20121222)"
-- dimensions: *id298
+- dimensions: *id306
   name: ch.bakom.downlink2_20121222_source
   sources: [ch.bakom.downlink2_20121222_cache]
   title: "Download \u2265 2 Mbit/s (20121222, source)"
-- dimensions: &id299
+- dimensions: &id307
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink20_20141120
   sources: [ch.bakom.downlink20_20141120_cache_out]
   title: "Download \u2265 20 Mbit/s (20141120)"
-- dimensions: *id299
+- dimensions: *id307
   name: ch.bakom.downlink20
   sources: [ch.bakom.downlink20_20141120_cache]
   title: "Download \u2265 20 Mbit/s ('current')"
-- dimensions: *id299
+- dimensions: *id307
   name: ch.bakom.downlink20_20141120_source
   sources: [ch.bakom.downlink20_20141120_cache]
   title: "Download \u2265 20 Mbit/s (20141120, source)"
-- dimensions: &id300
+- dimensions: &id308
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink20_20141021
   sources: [ch.bakom.downlink20_20141021_cache_out]
   title: "Download \u2265 20 Mbit/s (20141021)"
-- dimensions: *id300
+- dimensions: *id308
   name: ch.bakom.downlink20_20141021_source
   sources: [ch.bakom.downlink20_20141021_cache]
   title: "Download \u2265 20 Mbit/s (20141021, source)"
-- dimensions: &id301
+- dimensions: &id309
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink20_20140625
   sources: [ch.bakom.downlink20_20140625_cache_out]
   title: "Download \u2265 20 Mbit/s (20140625)"
-- dimensions: *id301
+- dimensions: *id309
   name: ch.bakom.downlink20_20140625_source
   sources: [ch.bakom.downlink20_20140625_cache]
   title: "Download \u2265 20 Mbit/s (20140625, source)"
-- dimensions: &id302
+- dimensions: &id310
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink20_20131212
   sources: [ch.bakom.downlink20_20131212_cache_out]
   title: "Download \u2265 20 Mbit/s (20131212)"
-- dimensions: *id302
+- dimensions: *id310
   name: ch.bakom.downlink20_20131212_source
   sources: [ch.bakom.downlink20_20131212_cache]
   title: "Download \u2265 20 Mbit/s (20131212, source)"
-- dimensions: &id303
+- dimensions: &id311
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink20_20130901
   sources: [ch.bakom.downlink20_20130901_cache_out]
   title: "Download \u2265 20 Mbit/s (20130901)"
-- dimensions: *id303
+- dimensions: *id311
   name: ch.bakom.downlink20_20130901_source
   sources: [ch.bakom.downlink20_20130901_cache]
   title: "Download \u2265 20 Mbit/s (20130901, source)"
-- dimensions: &id304
+- dimensions: &id312
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink20_20130601
   sources: [ch.bakom.downlink20_20130601_cache_out]
   title: "Download \u2265 20 Mbit/s (20130601)"
-- dimensions: *id304
+- dimensions: *id312
   name: ch.bakom.downlink20_20130601_source
   sources: [ch.bakom.downlink20_20130601_cache]
   title: "Download \u2265 20 Mbit/s (20130601, source)"
-- dimensions: &id305
+- dimensions: &id313
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink20_20121222
   sources: [ch.bakom.downlink20_20121222_cache_out]
   title: "Download \u2265 20 Mbit/s (20121222)"
-- dimensions: *id305
+- dimensions: *id313
   name: ch.bakom.downlink20_20121222_source
   sources: [ch.bakom.downlink20_20121222_cache]
   title: "Download \u2265 20 Mbit/s (20121222, source)"
-- dimensions: &id306
+- dimensions: &id314
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink50_20141120
   sources: [ch.bakom.downlink50_20141120_cache_out]
   title: "Download \u2265 50 Mbit/s (20141120)"
-- dimensions: *id306
+- dimensions: *id314
   name: ch.bakom.downlink50
   sources: [ch.bakom.downlink50_20141120_cache]
   title: "Download \u2265 50 Mbit/s ('current')"
-- dimensions: *id306
+- dimensions: *id314
   name: ch.bakom.downlink50_20141120_source
   sources: [ch.bakom.downlink50_20141120_cache]
   title: "Download \u2265 50 Mbit/s (20141120, source)"
-- dimensions: &id307
+- dimensions: &id315
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink50_20141021
   sources: [ch.bakom.downlink50_20141021_cache_out]
   title: "Download \u2265 50 Mbit/s (20141021)"
-- dimensions: *id307
+- dimensions: *id315
   name: ch.bakom.downlink50_20141021_source
   sources: [ch.bakom.downlink50_20141021_cache]
   title: "Download \u2265 50 Mbit/s (20141021, source)"
-- dimensions: &id308
+- dimensions: &id316
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink50_20140625
   sources: [ch.bakom.downlink50_20140625_cache_out]
   title: "Download \u2265 50 Mbit/s (20140625)"
-- dimensions: *id308
+- dimensions: *id316
   name: ch.bakom.downlink50_20140625_source
   sources: [ch.bakom.downlink50_20140625_cache]
   title: "Download \u2265 50 Mbit/s (20140625, source)"
-- dimensions: &id309
+- dimensions: &id317
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink50_20131212
   sources: [ch.bakom.downlink50_20131212_cache_out]
   title: "Download \u2265 50 Mbit/s (20131212)"
-- dimensions: *id309
+- dimensions: *id317
   name: ch.bakom.downlink50_20131212_source
   sources: [ch.bakom.downlink50_20131212_cache]
   title: "Download \u2265 50 Mbit/s (20131212, source)"
-- dimensions: &id310
+- dimensions: &id318
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink50_20130901
   sources: [ch.bakom.downlink50_20130901_cache_out]
   title: "Download \u2265 50 Mbit/s (20130901)"
-- dimensions: *id310
+- dimensions: *id318
   name: ch.bakom.downlink50_20130901_source
   sources: [ch.bakom.downlink50_20130901_cache]
   title: "Download \u2265 50 Mbit/s (20130901, source)"
-- dimensions: &id311
+- dimensions: &id319
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink50_20130601
   sources: [ch.bakom.downlink50_20130601_cache_out]
   title: "Download \u2265 50 Mbit/s (20130601)"
-- dimensions: *id311
+- dimensions: *id319
   name: ch.bakom.downlink50_20130601_source
   sources: [ch.bakom.downlink50_20130601_cache]
   title: "Download \u2265 50 Mbit/s (20130601, source)"
-- dimensions: &id312
+- dimensions: &id320
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink50_20121222
   sources: [ch.bakom.downlink50_20121222_cache_out]
   title: "Download \u2265 50 Mbit/s (20121222)"
-- dimensions: *id312
+- dimensions: *id320
   name: ch.bakom.downlink50_20121222_source
   sources: [ch.bakom.downlink50_20121222_cache]
   title: "Download \u2265 50 Mbit/s (20121222, source)"
-- dimensions: &id313
+- dimensions: &id321
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink1_20141120
   sources: [ch.bakom.uplink1_20141120_cache_out]
   title: "Upload \u2265 1 Mbit/s (20141120)"
-- dimensions: *id313
+- dimensions: *id321
   name: ch.bakom.uplink1
   sources: [ch.bakom.uplink1_20141120_cache]
   title: "Upload \u2265 1 Mbit/s ('current')"
-- dimensions: *id313
+- dimensions: *id321
   name: ch.bakom.uplink1_20141120_source
   sources: [ch.bakom.uplink1_20141120_cache]
   title: "Upload \u2265 1 Mbit/s (20141120, source)"
-- dimensions: &id314
+- dimensions: &id322
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink1_20141021
   sources: [ch.bakom.uplink1_20141021_cache_out]
   title: "Upload \u2265 1 Mbit/s (20141021)"
-- dimensions: *id314
+- dimensions: *id322
   name: ch.bakom.uplink1_20141021_source
   sources: [ch.bakom.uplink1_20141021_cache]
   title: "Upload \u2265 1 Mbit/s (20141021, source)"
-- dimensions: &id315
+- dimensions: &id323
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink1_20140625
   sources: [ch.bakom.uplink1_20140625_cache_out]
   title: "Upload \u2265 1 Mbit/s (20140625)"
-- dimensions: *id315
+- dimensions: *id323
   name: ch.bakom.uplink1_20140625_source
   sources: [ch.bakom.uplink1_20140625_cache]
   title: "Upload \u2265 1 Mbit/s (20140625, source)"
-- dimensions: &id316
+- dimensions: &id324
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink1_20131212
   sources: [ch.bakom.uplink1_20131212_cache_out]
   title: "Upload \u2265 1 Mbit/s (20131212)"
-- dimensions: *id316
+- dimensions: *id324
   name: ch.bakom.uplink1_20131212_source
   sources: [ch.bakom.uplink1_20131212_cache]
   title: "Upload \u2265 1 Mbit/s (20131212, source)"
-- dimensions: &id317
+- dimensions: &id325
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink1_20130901
   sources: [ch.bakom.uplink1_20130901_cache_out]
   title: "Upload \u2265 1 Mbit/s (20130901)"
-- dimensions: *id317
+- dimensions: *id325
   name: ch.bakom.uplink1_20130901_source
   sources: [ch.bakom.uplink1_20130901_cache]
   title: "Upload \u2265 1 Mbit/s (20130901, source)"
-- dimensions: &id318
+- dimensions: &id326
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink1_20130601
   sources: [ch.bakom.uplink1_20130601_cache_out]
   title: "Upload \u2265 1 Mbit/s (20130601)"
-- dimensions: *id318
+- dimensions: *id326
   name: ch.bakom.uplink1_20130601_source
   sources: [ch.bakom.uplink1_20130601_cache]
   title: "Upload \u2265 1 Mbit/s (20130601, source)"
-- dimensions: &id319
+- dimensions: &id327
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink1_20121222
   sources: [ch.bakom.uplink1_20121222_cache_out]
   title: "Upload \u2265 1 Mbit/s (20121222)"
-- dimensions: *id319
+- dimensions: *id327
   name: ch.bakom.uplink1_20121222_source
   sources: [ch.bakom.uplink1_20121222_cache]
   title: "Upload \u2265 1 Mbit/s (20121222, source)"
-- dimensions: &id320
+- dimensions: &id328
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink10_20141120
   sources: [ch.bakom.uplink10_20141120_cache_out]
   title: "Upload \u2265 10 Mbit/s (20141120)"
-- dimensions: *id320
+- dimensions: *id328
   name: ch.bakom.uplink10
   sources: [ch.bakom.uplink10_20141120_cache]
   title: "Upload \u2265 10 Mbit/s ('current')"
-- dimensions: *id320
+- dimensions: *id328
   name: ch.bakom.uplink10_20141120_source
   sources: [ch.bakom.uplink10_20141120_cache]
   title: "Upload \u2265 10 Mbit/s (20141120, source)"
-- dimensions: &id321
+- dimensions: &id329
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink10_20141021
   sources: [ch.bakom.uplink10_20141021_cache_out]
   title: "Upload \u2265 10 Mbit/s (20141021)"
-- dimensions: *id321
+- dimensions: *id329
   name: ch.bakom.uplink10_20141021_source
   sources: [ch.bakom.uplink10_20141021_cache]
   title: "Upload \u2265 10 Mbit/s (20141021, source)"
-- dimensions: &id322
+- dimensions: &id330
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink10_20140625
   sources: [ch.bakom.uplink10_20140625_cache_out]
   title: "Upload \u2265 10 Mbit/s (20140625)"
-- dimensions: *id322
+- dimensions: *id330
   name: ch.bakom.uplink10_20140625_source
   sources: [ch.bakom.uplink10_20140625_cache]
   title: "Upload \u2265 10 Mbit/s (20140625, source)"
-- dimensions: &id323
+- dimensions: &id331
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink10_20131212
   sources: [ch.bakom.uplink10_20131212_cache_out]
   title: "Upload \u2265 10 Mbit/s (20131212)"
-- dimensions: *id323
+- dimensions: *id331
   name: ch.bakom.uplink10_20131212_source
   sources: [ch.bakom.uplink10_20131212_cache]
   title: "Upload \u2265 10 Mbit/s (20131212, source)"
-- dimensions: &id324
+- dimensions: &id332
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink10_20130901
   sources: [ch.bakom.uplink10_20130901_cache_out]
   title: "Upload \u2265 10 Mbit/s (20130901)"
-- dimensions: *id324
+- dimensions: *id332
   name: ch.bakom.uplink10_20130901_source
   sources: [ch.bakom.uplink10_20130901_cache]
   title: "Upload \u2265 10 Mbit/s (20130901, source)"
-- dimensions: &id325
+- dimensions: &id333
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink10_20130601
   sources: [ch.bakom.uplink10_20130601_cache_out]
   title: "Upload \u2265 10 Mbit/s (20130601)"
-- dimensions: *id325
+- dimensions: *id333
   name: ch.bakom.uplink10_20130601_source
   sources: [ch.bakom.uplink10_20130601_cache]
   title: "Upload \u2265 10 Mbit/s (20130601, source)"
-- dimensions: &id326
+- dimensions: &id334
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink10_20121222
   sources: [ch.bakom.uplink10_20121222_cache_out]
   title: "Upload \u2265 10 Mbit/s (20121222)"
-- dimensions: *id326
+- dimensions: *id334
   name: ch.bakom.uplink10_20121222_source
   sources: [ch.bakom.uplink10_20121222_cache]
   title: "Upload \u2265 10 Mbit/s (20121222, source)"
-- dimensions: &id327
+- dimensions: &id335
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink100_20141120
   sources: [ch.bakom.uplink100_20141120_cache_out]
   title: ch.bakom.uplink100 (20141120)
-- dimensions: *id327
+- dimensions: *id335
   name: ch.bakom.uplink100
   sources: [ch.bakom.uplink100_20141120_cache]
   title: ch.bakom.uplink100 ('current')
-- dimensions: *id327
+- dimensions: *id335
   name: ch.bakom.uplink100_20141120_source
   sources: [ch.bakom.uplink100_20141120_cache]
   title: ch.bakom.uplink100 (20141120, source)
-- dimensions: &id328
+- dimensions: &id336
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink100_20141021
   sources: [ch.bakom.uplink100_20141021_cache_out]
   title: ch.bakom.uplink100 (20141021)
-- dimensions: *id328
+- dimensions: *id336
   name: ch.bakom.uplink100_20141021_source
   sources: [ch.bakom.uplink100_20141021_cache]
   title: ch.bakom.uplink100 (20141021, source)
-- dimensions: &id329
+- dimensions: &id337
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink100_20140625
   sources: [ch.bakom.uplink100_20140625_cache_out]
   title: ch.bakom.uplink100 (20140625)
-- dimensions: *id329
+- dimensions: *id337
   name: ch.bakom.uplink100_20140625_source
   sources: [ch.bakom.uplink100_20140625_cache]
   title: ch.bakom.uplink100 (20140625, source)
-- dimensions: &id330
+- dimensions: &id338
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink100_20131212
   sources: [ch.bakom.uplink100_20131212_cache_out]
   title: ch.bakom.uplink100 (20131212)
-- dimensions: *id330
+- dimensions: *id338
   name: ch.bakom.uplink100_20131212_source
   sources: [ch.bakom.uplink100_20131212_cache]
   title: ch.bakom.uplink100 (20131212, source)
-- dimensions: &id331
+- dimensions: &id339
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink100_20130901
   sources: [ch.bakom.uplink100_20130901_cache_out]
   title: ch.bakom.uplink100 (20130901)
-- dimensions: *id331
+- dimensions: *id339
   name: ch.bakom.uplink100_20130901_source
   sources: [ch.bakom.uplink100_20130901_cache]
   title: ch.bakom.uplink100 (20130901, source)
-- dimensions: &id332
+- dimensions: &id340
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink100_20130601
   sources: [ch.bakom.uplink100_20130601_cache_out]
   title: ch.bakom.uplink100 (20130601)
-- dimensions: *id332
+- dimensions: *id340
   name: ch.bakom.uplink100_20130601_source
   sources: [ch.bakom.uplink100_20130601_cache]
   title: ch.bakom.uplink100 (20130601, source)
-- dimensions: &id333
+- dimensions: &id341
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink100_20121222
   sources: [ch.bakom.uplink100_20121222_cache_out]
   title: ch.bakom.uplink100 (20121222)
-- dimensions: *id333
+- dimensions: *id341
   name: ch.bakom.uplink100_20121222_source
   sources: [ch.bakom.uplink100_20121222_cache]
   title: ch.bakom.uplink100 (20121222, source)
-- dimensions: &id334
+- dimensions: &id342
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink2_20141120
   sources: [ch.bakom.uplink2_20141120_cache_out]
   title: "Upload \u2265 2 Mbit/s (20141120)"
-- dimensions: *id334
+- dimensions: *id342
   name: ch.bakom.uplink2
   sources: [ch.bakom.uplink2_20141120_cache]
   title: "Upload \u2265 2 Mbit/s ('current')"
-- dimensions: *id334
+- dimensions: *id342
   name: ch.bakom.uplink2_20141120_source
   sources: [ch.bakom.uplink2_20141120_cache]
   title: "Upload \u2265 2 Mbit/s (20141120, source)"
-- dimensions: &id335
+- dimensions: &id343
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink2_20141021
   sources: [ch.bakom.uplink2_20141021_cache_out]
   title: "Upload \u2265 2 Mbit/s (20141021)"
-- dimensions: *id335
+- dimensions: *id343
   name: ch.bakom.uplink2_20141021_source
   sources: [ch.bakom.uplink2_20141021_cache]
   title: "Upload \u2265 2 Mbit/s (20141021, source)"
-- dimensions: &id336
+- dimensions: &id344
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink2_20140625
   sources: [ch.bakom.uplink2_20140625_cache_out]
   title: "Upload \u2265 2 Mbit/s (20140625)"
-- dimensions: *id336
+- dimensions: *id344
   name: ch.bakom.uplink2_20140625_source
   sources: [ch.bakom.uplink2_20140625_cache]
   title: "Upload \u2265 2 Mbit/s (20140625, source)"
-- dimensions: &id337
+- dimensions: &id345
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink2_20131212
   sources: [ch.bakom.uplink2_20131212_cache_out]
   title: "Upload \u2265 2 Mbit/s (20131212)"
-- dimensions: *id337
+- dimensions: *id345
   name: ch.bakom.uplink2_20131212_source
   sources: [ch.bakom.uplink2_20131212_cache]
   title: "Upload \u2265 2 Mbit/s (20131212, source)"
-- dimensions: &id338
+- dimensions: &id346
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink2_20130901
   sources: [ch.bakom.uplink2_20130901_cache_out]
   title: "Upload \u2265 2 Mbit/s (20130901)"
-- dimensions: *id338
+- dimensions: *id346
   name: ch.bakom.uplink2_20130901_source
   sources: [ch.bakom.uplink2_20130901_cache]
   title: "Upload \u2265 2 Mbit/s (20130901, source)"
-- dimensions: &id339
+- dimensions: &id347
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink2_20130601
   sources: [ch.bakom.uplink2_20130601_cache_out]
   title: "Upload \u2265 2 Mbit/s (20130601)"
-- dimensions: *id339
+- dimensions: *id347
   name: ch.bakom.uplink2_20130601_source
   sources: [ch.bakom.uplink2_20130601_cache]
   title: "Upload \u2265 2 Mbit/s (20130601, source)"
-- dimensions: &id340
+- dimensions: &id348
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink2_20121222
   sources: [ch.bakom.uplink2_20121222_cache_out]
   title: "Upload \u2265 2 Mbit/s (20121222)"
-- dimensions: *id340
+- dimensions: *id348
   name: ch.bakom.uplink2_20121222_source
   sources: [ch.bakom.uplink2_20121222_cache]
   title: "Upload \u2265 2 Mbit/s (20121222, source)"
-- dimensions: &id341
+- dimensions: &id349
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink20_20141120
   sources: [ch.bakom.uplink20_20141120_cache_out]
   title: "Upload \u2265 20 Mbit/s (20141120)"
-- dimensions: *id341
+- dimensions: *id349
   name: ch.bakom.uplink20
   sources: [ch.bakom.uplink20_20141120_cache]
   title: "Upload \u2265 20 Mbit/s ('current')"
-- dimensions: *id341
+- dimensions: *id349
   name: ch.bakom.uplink20_20141120_source
   sources: [ch.bakom.uplink20_20141120_cache]
   title: "Upload \u2265 20 Mbit/s (20141120, source)"
-- dimensions: &id342
+- dimensions: &id350
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink20_20141021
   sources: [ch.bakom.uplink20_20141021_cache_out]
   title: "Upload \u2265 20 Mbit/s (20141021)"
-- dimensions: *id342
+- dimensions: *id350
   name: ch.bakom.uplink20_20141021_source
   sources: [ch.bakom.uplink20_20141021_cache]
   title: "Upload \u2265 20 Mbit/s (20141021, source)"
-- dimensions: &id343
+- dimensions: &id351
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink20_20140625
   sources: [ch.bakom.uplink20_20140625_cache_out]
   title: "Upload \u2265 20 Mbit/s (20140625)"
-- dimensions: *id343
+- dimensions: *id351
   name: ch.bakom.uplink20_20140625_source
   sources: [ch.bakom.uplink20_20140625_cache]
   title: "Upload \u2265 20 Mbit/s (20140625, source)"
-- dimensions: &id344
+- dimensions: &id352
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink20_20131212
   sources: [ch.bakom.uplink20_20131212_cache_out]
   title: "Upload \u2265 20 Mbit/s (20131212)"
-- dimensions: *id344
+- dimensions: *id352
   name: ch.bakom.uplink20_20131212_source
   sources: [ch.bakom.uplink20_20131212_cache]
   title: "Upload \u2265 20 Mbit/s (20131212, source)"
-- dimensions: &id345
+- dimensions: &id353
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink20_20130901
   sources: [ch.bakom.uplink20_20130901_cache_out]
   title: "Upload \u2265 20 Mbit/s (20130901)"
-- dimensions: *id345
+- dimensions: *id353
   name: ch.bakom.uplink20_20130901_source
   sources: [ch.bakom.uplink20_20130901_cache]
   title: "Upload \u2265 20 Mbit/s (20130901, source)"
-- dimensions: &id346
+- dimensions: &id354
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink20_20130601
   sources: [ch.bakom.uplink20_20130601_cache_out]
   title: "Upload \u2265 20 Mbit/s (20130601)"
-- dimensions: *id346
+- dimensions: *id354
   name: ch.bakom.uplink20_20130601_source
   sources: [ch.bakom.uplink20_20130601_cache]
   title: "Upload \u2265 20 Mbit/s (20130601, source)"
-- dimensions: &id347
+- dimensions: &id355
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink20_20121222
   sources: [ch.bakom.uplink20_20121222_cache_out]
   title: "Upload \u2265 20 Mbit/s (20121222)"
-- dimensions: *id347
+- dimensions: *id355
   name: ch.bakom.uplink20_20121222_source
   sources: [ch.bakom.uplink20_20121222_cache]
   title: "Upload \u2265 20 Mbit/s (20121222, source)"
-- dimensions: &id348
+- dimensions: &id356
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink50_20141120
   sources: [ch.bakom.uplink50_20141120_cache_out]
   title: "Upload \u2265 50 Mbit/s (20141120)"
-- dimensions: *id348
+- dimensions: *id356
   name: ch.bakom.uplink50
   sources: [ch.bakom.uplink50_20141120_cache]
   title: "Upload \u2265 50 Mbit/s ('current')"
-- dimensions: *id348
+- dimensions: *id356
   name: ch.bakom.uplink50_20141120_source
   sources: [ch.bakom.uplink50_20141120_cache]
   title: "Upload \u2265 50 Mbit/s (20141120, source)"
-- dimensions: &id349
+- dimensions: &id357
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink50_20141021
   sources: [ch.bakom.uplink50_20141021_cache_out]
   title: "Upload \u2265 50 Mbit/s (20141021)"
-- dimensions: *id349
+- dimensions: *id357
   name: ch.bakom.uplink50_20141021_source
   sources: [ch.bakom.uplink50_20141021_cache]
   title: "Upload \u2265 50 Mbit/s (20141021, source)"
-- dimensions: &id350
+- dimensions: &id358
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink50_20140625
   sources: [ch.bakom.uplink50_20140625_cache_out]
   title: "Upload \u2265 50 Mbit/s (20140625)"
-- dimensions: *id350
+- dimensions: *id358
   name: ch.bakom.uplink50_20140625_source
   sources: [ch.bakom.uplink50_20140625_cache]
   title: "Upload \u2265 50 Mbit/s (20140625, source)"
-- dimensions: &id351
+- dimensions: &id359
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink50_20131212
   sources: [ch.bakom.uplink50_20131212_cache_out]
   title: "Upload \u2265 50 Mbit/s (20131212)"
-- dimensions: *id351
+- dimensions: *id359
   name: ch.bakom.uplink50_20131212_source
   sources: [ch.bakom.uplink50_20131212_cache]
   title: "Upload \u2265 50 Mbit/s (20131212, source)"
-- dimensions: &id352
+- dimensions: &id360
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink50_20130901
   sources: [ch.bakom.uplink50_20130901_cache_out]
   title: "Upload \u2265 50 Mbit/s (20130901)"
-- dimensions: *id352
+- dimensions: *id360
   name: ch.bakom.uplink50_20130901_source
   sources: [ch.bakom.uplink50_20130901_cache]
   title: "Upload \u2265 50 Mbit/s (20130901, source)"
-- dimensions: &id353
+- dimensions: &id361
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink50_20130601
   sources: [ch.bakom.uplink50_20130601_cache_out]
   title: "Upload \u2265 50 Mbit/s (20130601)"
-- dimensions: *id353
+- dimensions: *id361
   name: ch.bakom.uplink50_20130601_source
   sources: [ch.bakom.uplink50_20130601_cache]
   title: "Upload \u2265 50 Mbit/s (20130601, source)"
-- dimensions: &id354
+- dimensions: &id362
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink50_20121222
   sources: [ch.bakom.uplink50_20121222_cache_out]
   title: "Upload \u2265 50 Mbit/s (20121222)"
-- dimensions: *id354
+- dimensions: *id362
   name: ch.bakom.uplink50_20121222_source
   sources: [ch.bakom.uplink50_20121222_cache]
   title: "Upload \u2265 50 Mbit/s (20121222, source)"
-- dimensions: &id355
+- dimensions: &id363
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.verfuegbarkeit-hdtv_20141120
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141120_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141120)"
-- dimensions: *id355
+- dimensions: *id363
   name: ch.bakom.verfuegbarkeit-hdtv
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141120_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz ('current')"
-- dimensions: *id355
+- dimensions: *id363
   name: ch.bakom.verfuegbarkeit-hdtv_20141120_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141120_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141120, source)"
-- dimensions: &id356
+- dimensions: &id364
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.verfuegbarkeit-hdtv_20141021
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141021)"
-- dimensions: *id356
+- dimensions: *id364
   name: ch.bakom.verfuegbarkeit-hdtv_20141021_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141021, source)"
-- dimensions: &id357
+- dimensions: &id365
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.verfuegbarkeit-hdtv_20140625
   sources: [ch.bakom.verfuegbarkeit-hdtv_20140625_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20140625)"
-- dimensions: *id357
+- dimensions: *id365
   name: ch.bakom.verfuegbarkeit-hdtv_20140625_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20140625_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20140625, source)"
-- dimensions: &id358
+- dimensions: &id366
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.verfuegbarkeit-hdtv_20131212
   sources: [ch.bakom.verfuegbarkeit-hdtv_20131212_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20131212)"
-- dimensions: *id358
+- dimensions: *id366
   name: ch.bakom.verfuegbarkeit-hdtv_20131212_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20131212_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20131212, source)"
-- dimensions: &id359
+- dimensions: &id367
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.verfuegbarkeit-hdtv_20130901
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130901_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130901)"
-- dimensions: *id359
+- dimensions: *id367
   name: ch.bakom.verfuegbarkeit-hdtv_20130901_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130901_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130901, source)"
-- dimensions: &id360
+- dimensions: &id368
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.verfuegbarkeit-hdtv_20130601
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130601_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130601)"
-- dimensions: *id360
+- dimensions: *id368
   name: ch.bakom.verfuegbarkeit-hdtv_20130601_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130601_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130601, source)"
-- dimensions: &id361
+- dimensions: &id369
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.verfuegbarkeit-hdtv_20121222
   sources: [ch.bakom.verfuegbarkeit-hdtv_20121222_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20121222)"
-- dimensions: *id361
+- dimensions: *id369
   name: ch.bakom.verfuegbarkeit-hdtv_20121222_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20121222_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20121222, source)"
-- dimensions: &id362
+- dimensions: &id370
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.verfuegbarkeit-tv_20141120
   sources: [ch.bakom.verfuegbarkeit-tv_20141120_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141120)"
-- dimensions: *id362
+- dimensions: *id370
   name: ch.bakom.verfuegbarkeit-tv
   sources: [ch.bakom.verfuegbarkeit-tv_20141120_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz ('current')"
-- dimensions: *id362
+- dimensions: *id370
   name: ch.bakom.verfuegbarkeit-tv_20141120_source
   sources: [ch.bakom.verfuegbarkeit-tv_20141120_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141120, source)"
-- dimensions: &id363
+- dimensions: &id371
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.verfuegbarkeit-tv_20141021
   sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141021)"
-- dimensions: *id363
+- dimensions: *id371
   name: ch.bakom.verfuegbarkeit-tv_20141021_source
   sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141021, source)"
-- dimensions: &id364
+- dimensions: &id372
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.verfuegbarkeit-tv_20140625
   sources: [ch.bakom.verfuegbarkeit-tv_20140625_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20140625)"
-- dimensions: *id364
+- dimensions: *id372
   name: ch.bakom.verfuegbarkeit-tv_20140625_source
   sources: [ch.bakom.verfuegbarkeit-tv_20140625_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20140625, source)"
-- dimensions: &id365
+- dimensions: &id373
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.verfuegbarkeit-tv_20131212
   sources: [ch.bakom.verfuegbarkeit-tv_20131212_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20131212)"
-- dimensions: *id365
+- dimensions: *id373
   name: ch.bakom.verfuegbarkeit-tv_20131212_source
   sources: [ch.bakom.verfuegbarkeit-tv_20131212_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20131212, source)"
-- dimensions: &id366
+- dimensions: &id374
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.verfuegbarkeit-tv_20130901
   sources: [ch.bakom.verfuegbarkeit-tv_20130901_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130901)"
-- dimensions: *id366
+- dimensions: *id374
   name: ch.bakom.verfuegbarkeit-tv_20130901_source
   sources: [ch.bakom.verfuegbarkeit-tv_20130901_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130901, source)"
-- dimensions: &id367
+- dimensions: &id375
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.verfuegbarkeit-tv_20130601
   sources: [ch.bakom.verfuegbarkeit-tv_20130601_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130601)"
-- dimensions: *id367
+- dimensions: *id375
   name: ch.bakom.verfuegbarkeit-tv_20130601_source
   sources: [ch.bakom.verfuegbarkeit-tv_20130601_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130601, source)"
-- dimensions: &id368
+- dimensions: &id376
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.verfuegbarkeit-tv_20121222
   sources: [ch.bakom.verfuegbarkeit-tv_20121222_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20121222)"
-- dimensions: *id368
+- dimensions: *id376
   name: ch.bakom.verfuegbarkeit-tv_20121222_source
   sources: [ch.bakom.verfuegbarkeit-tv_20121222_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20121222, source)"
-- dimensions: &id369
+- dimensions: &id377
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-tv_20070704
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache_out]
   title: Versorgungsgebiete TV (20070704)
-- dimensions: *id369
+- dimensions: *id377
   name: ch.bakom.versorgungsgebiet-tv
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV ('current')
-- dimensions: *id369
+- dimensions: *id377
   name: ch.bakom.versorgungsgebiet-tv_20070704_source
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV (20070704, source)
-- dimensions: &id370
+- dimensions: &id378
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-ukw_20070704
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache_out]
   title: Versorgungsgebiete Radio (20070704)
-- dimensions: *id370
+- dimensions: *id378
   name: ch.bakom.versorgungsgebiet-ukw
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio ('current')
-- dimensions: *id370
+- dimensions: *id378
   name: ch.bakom.versorgungsgebiet-ukw_20070704_source
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio (20070704, source)
-- dimensions: &id371
+- dimensions: &id379
     Time:
       default: '20120203'
       values: ['20120203']
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache_out]
   title: "UNESCO-Welterbe Kulturst\xE4tten (20120203)"
-- dimensions: *id371
+- dimensions: *id379
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten ('current')"
-- dimensions: *id371
+- dimensions: *id379
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_source
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten (20120203, source)"
-- dimensions: &id372
-    Time:
-      default: '20101109'
-      values: ['20101109']
-  name: ch.bav.laerm-emissionplan_eisenbahn_2015_20101109
-  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache_out]
-  title: Emissionsplan Eisenbahn 2015 (20101109)
-- dimensions: *id372
-  name: ch.bav.laerm-emissionplan_eisenbahn_2015
-  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache]
-  title: Emissionsplan Eisenbahn 2015 ('current')
-- dimensions: *id372
-  name: ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_source
-  sources: [ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_cache]
-  title: Emissionsplan Eisenbahn 2015 (20101109, source)
-- dimensions: &id373
+- dimensions: &id380
     Time:
       default: '20150305'
       values: ['20150305']
   name: ch.bazl.luftfahrtkarten-icao_20150305
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache_out]
   title: Luftfahrtkarte ICAO (20150305)
-- dimensions: *id373
+- dimensions: *id380
   name: ch.bazl.luftfahrtkarten-icao
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache]
   title: Luftfahrtkarte ICAO ('current')
-- dimensions: *id373
+- dimensions: *id380
   name: ch.bazl.luftfahrtkarten-icao_20150305_source
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache]
   title: Luftfahrtkarte ICAO (20150305, source)
-- dimensions: &id374
+- dimensions: &id381
     Time:
       default: '20140306'
       values: ['20140306']
   name: ch.bazl.luftfahrtkarten-icao_20140306
   sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache_out]
   title: Luftfahrtkarte ICAO (20140306)
-- dimensions: *id374
+- dimensions: *id381
   name: ch.bazl.luftfahrtkarten-icao_20140306_source
   sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache]
   title: Luftfahrtkarte ICAO (20140306, source)
-- dimensions: &id375
+- dimensions: &id382
     Time:
       default: '20130307'
       values: ['20130307']
   name: ch.bazl.luftfahrtkarten-icao_20130307
   sources: [ch.bazl.luftfahrtkarten-icao_20130307_cache_out]
   title: Luftfahrtkarte ICAO (20130307)
-- dimensions: *id375
+- dimensions: *id382
   name: ch.bazl.luftfahrtkarten-icao_20130307_source
   sources: [ch.bazl.luftfahrtkarten-icao_20130307_cache]
   title: Luftfahrtkarte ICAO (20130307, source)
-- dimensions: &id376
+- dimensions: &id383
     Time:
       default: '20120308'
       values: ['20120308']
   name: ch.bazl.luftfahrtkarten-icao_20120308
   sources: [ch.bazl.luftfahrtkarten-icao_20120308_cache_out]
   title: Luftfahrtkarte ICAO (20120308)
-- dimensions: *id376
+- dimensions: *id383
   name: ch.bazl.luftfahrtkarten-icao_20120308_source
   sources: [ch.bazl.luftfahrtkarten-icao_20120308_cache]
   title: Luftfahrtkarte ICAO (20120308, source)
-- dimensions: &id377
+- dimensions: &id384
     Time:
       default: '20110310'
       values: ['20110310']
   name: ch.bazl.luftfahrtkarten-icao_20110310
   sources: [ch.bazl.luftfahrtkarten-icao_20110310_cache_out]
   title: Luftfahrtkarte ICAO (20110310)
-- dimensions: *id377
+- dimensions: *id384
   name: ch.bazl.luftfahrtkarten-icao_20110310_source
   sources: [ch.bazl.luftfahrtkarten-icao_20110310_cache]
   title: Luftfahrtkarte ICAO (20110310, source)
-- dimensions: &id378
+- dimensions: &id385
     Time:
       default: '20130822'
       values: ['20130822']
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache_out]
   title: "Projektierungszonen: Flugh\xE4fen (20130822)"
-- dimensions: *id378
+- dimensions: *id385
   name: ch.bazl.projektierungszonen-flughafenanlagen
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen ('current')"
-- dimensions: *id378
+- dimensions: *id385
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822_source
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen (20130822, source)"
-- dimensions: &id379
+- dimensions: &id386
     Time:
       default: '20150305'
       values: ['20150305']
   name: ch.bazl.segelflugkarte_20150305
   sources: [ch.bazl.segelflugkarte_20150305_cache_out]
   title: Segelflugkarte (20150305)
-- dimensions: *id379
+- dimensions: *id386
   name: ch.bazl.segelflugkarte
   sources: [ch.bazl.segelflugkarte_20150305_cache]
   title: Segelflugkarte ('current')
-- dimensions: *id379
+- dimensions: *id386
   name: ch.bazl.segelflugkarte_20150305_source
   sources: [ch.bazl.segelflugkarte_20150305_cache]
   title: Segelflugkarte (20150305, source)
-- dimensions: &id380
+- dimensions: &id387
     Time:
       default: '20140306'
       values: ['20140306']
   name: ch.bazl.segelflugkarte_20140306
   sources: [ch.bazl.segelflugkarte_20140306_cache_out]
   title: Segelflugkarte (20140306)
-- dimensions: *id380
+- dimensions: *id387
   name: ch.bazl.segelflugkarte_20140306_source
   sources: [ch.bazl.segelflugkarte_20140306_cache]
   title: Segelflugkarte (20140306, source)
-- dimensions: &id381
+- dimensions: &id388
     Time:
       default: '20130307'
       values: ['20130307']
   name: ch.bazl.segelflugkarte_20130307
   sources: [ch.bazl.segelflugkarte_20130307_cache_out]
   title: Segelflugkarte (20130307)
-- dimensions: *id381
+- dimensions: *id388
   name: ch.bazl.segelflugkarte_20130307_source
   sources: [ch.bazl.segelflugkarte_20130307_cache]
   title: Segelflugkarte (20130307, source)
-- dimensions: &id382
+- dimensions: &id389
     Time:
       default: '20120308'
       values: ['20120308']
   name: ch.bazl.segelflugkarte_20120308
   sources: [ch.bazl.segelflugkarte_20120308_cache_out]
   title: Segelflugkarte (20120308)
-- dimensions: *id382
+- dimensions: *id389
   name: ch.bazl.segelflugkarte_20120308_source
   sources: [ch.bazl.segelflugkarte_20120308_cache]
   title: Segelflugkarte (20120308, source)
-- dimensions: &id383
+- dimensions: &id390
     Time:
       default: '20120911'
       values: ['20120911']
   name: ch.bfe.kernkraftwerke_20120911
   sources: [ch.bfe.kernkraftwerke_20120911_cache_out]
   title: Kernkraftwerke (20120911)
-- dimensions: *id383
+- dimensions: *id390
   name: ch.bfe.kernkraftwerke
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke ('current')
-- dimensions: *id383
+- dimensions: *id390
   name: ch.bfe.kernkraftwerke_20120911_source
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke (20120911, source)
-- dimensions: &id384
+- dimensions: &id391
     Time:
       default: '20120531'
       values: ['20120531']
   name: ch.bfe.kleinwasserkraftpotentiale_20120531
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache_out]
   title: Kleinwasserkraftpotentiale (20120531)
-- dimensions: *id384
+- dimensions: *id391
   name: ch.bfe.kleinwasserkraftpotentiale
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale ('current')
-- dimensions: *id384
+- dimensions: *id391
   name: ch.bfe.kleinwasserkraftpotentiale_20120531_source
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale (20120531, source)
-- dimensions: &id385
+- dimensions: &id392
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik_20131121
   sources: [ch.bfs.arealstatistik_20131121_cache_out]
   title: Arealstatistik 2004/09 NOAS04 (20131121)
-- dimensions: *id385
+- dimensions: *id392
   name: ch.bfs.arealstatistik
   sources: [ch.bfs.arealstatistik_20131121_cache]
   title: Arealstatistik 2004/09 NOAS04 ('current')
-- dimensions: *id385
+- dimensions: *id392
   name: ch.bfs.arealstatistik_20131121_source
   sources: [ch.bfs.arealstatistik_20131121_cache]
   title: Arealstatistik 2004/09 NOAS04 (20131121, source)
-- dimensions: &id386
+- dimensions: &id393
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-1985_20131121
   sources: [ch.bfs.arealstatistik-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOAS04 (20131121)
-- dimensions: *id386
+- dimensions: *id393
   name: ch.bfs.arealstatistik-1985
   sources: [ch.bfs.arealstatistik-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOAS04 ('current')
-- dimensions: *id386
+- dimensions: *id393
   name: ch.bfs.arealstatistik-1985_20131121_source
   sources: [ch.bfs.arealstatistik-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOAS04 (20131121, source)
-- dimensions: &id387
+- dimensions: &id394
     Time:
       default: '19790101'
       values: ['19790101']
   name: ch.bfs.arealstatistik-1985_19790101
   sources: [ch.bfs.arealstatistik-1985_19790101_cache_out]
   title: Arealstatistik 1979/85 NOAS04 (19790101)
-- dimensions: *id387
+- dimensions: *id394
   name: ch.bfs.arealstatistik-1985_19790101_source
   sources: [ch.bfs.arealstatistik-1985_19790101_cache]
   title: Arealstatistik 1979/85 NOAS04 (19790101, source)
-- dimensions: &id388
+- dimensions: &id395
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-1997_20131121
   sources: [ch.bfs.arealstatistik-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOAS04 (20131121)
-- dimensions: *id388
+- dimensions: *id395
   name: ch.bfs.arealstatistik-1997
   sources: [ch.bfs.arealstatistik-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOAS04 ('current')
-- dimensions: *id388
+- dimensions: *id395
   name: ch.bfs.arealstatistik-1997_20131121_source
   sources: [ch.bfs.arealstatistik-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOAS04 (20131121, source)
-- dimensions: &id389
+- dimensions: &id396
     Time:
       default: '19920101'
       values: ['19920101']
   name: ch.bfs.arealstatistik-1997_19920101
   sources: [ch.bfs.arealstatistik-1997_19920101_cache_out]
   title: Arealstatistik 1992/97 NOAS04 (19920101)
-- dimensions: *id389
+- dimensions: *id396
   name: ch.bfs.arealstatistik-1997_19920101_source
   sources: [ch.bfs.arealstatistik-1997_19920101_cache]
   title: Arealstatistik 1992/97 NOAS04 (19920101, source)
-- dimensions: &id390
+- dimensions: &id397
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache_out]
   title: Arealstatistik 2004/09 NOLC04 (20131121)
-- dimensions: *id390
+- dimensions: *id397
   name: ch.bfs.arealstatistik-bodenbedeckung
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04 ('current')
-- dimensions: *id390
+- dimensions: *id397
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04 (20131121, source)
-- dimensions: &id391
+- dimensions: &id398
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLC04 (20131121)
-- dimensions: *id391
+- dimensions: *id398
   name: ch.bfs.arealstatistik-bodenbedeckung-1985
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04 ('current')
-- dimensions: *id391
+- dimensions: *id398
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04 (20131121, source)
-- dimensions: &id392
+- dimensions: &id399
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLC04 (20131121)
-- dimensions: *id392
+- dimensions: *id399
   name: ch.bfs.arealstatistik-bodenbedeckung-1997
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04 ('current')
-- dimensions: *id392
+- dimensions: *id399
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04 (20131121, source)
-- dimensions: &id393
+- dimensions: &id400
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache_out]
   title: Arealstatistik 2004/09 NOLU04  (20131121)
-- dimensions: *id393
+- dimensions: *id400
   name: ch.bfs.arealstatistik-bodennutzung
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: Arealstatistik 2004/09 NOLU04  ('current')
-- dimensions: *id393
+- dimensions: *id400
   name: ch.bfs.arealstatistik-bodennutzung_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: Arealstatistik 2004/09 NOLU04  (20131121, source)
-- dimensions: &id394
+- dimensions: &id401
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLU04 (20131121)
-- dimensions: *id394
+- dimensions: *id401
   name: ch.bfs.arealstatistik-bodennutzung-1985
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04 ('current')
-- dimensions: *id394
+- dimensions: *id401
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04 (20131121, source)
-- dimensions: &id395
+- dimensions: &id402
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLU04 (20131121)
-- dimensions: *id395
+- dimensions: *id402
   name: ch.bfs.arealstatistik-bodennutzung-1997
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04 ('current')
-- dimensions: *id395
+- dimensions: *id402
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04 (20131121, source)
-- dimensions: &id396
+- dimensions: &id403
     Time:
       default: '20070116'
       values: ['20070116']
   name: ch.bfs.arealstatistik-hintergrund_20070116
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache_out]
   title: Vereinfachte Bodennutzung (20070116)
-- dimensions: *id396
+- dimensions: *id403
   name: ch.bfs.arealstatistik-hintergrund
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
   title: Vereinfachte Bodennutzung ('current')
-- dimensions: *id396
+- dimensions: *id403
   name: ch.bfs.arealstatistik-hintergrund_20070116_source
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
   title: Vereinfachte Bodennutzung (20070116, source)
-- dimensions: &id397
+- dimensions: &id404
     Time:
       default: '19970901'
       values: ['19970901']
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache_out]
   title: Waldmischungsgrad 1990/1992 (19970901)
-- dimensions: *id397
+- dimensions: *id404
   name: ch.bfs.arealstatistik-waldmischungsgrad
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992 ('current')
-- dimensions: *id397
+- dimensions: *id404
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901_source
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992 (19970901, source)
-- dimensions: &id398
+- dimensions: &id405
     Time:
       default: '20130212'
       values: ['20130212']
   name: ch.bfs.gebaeude_wohnungs_register_20130212
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache_out]
   title: "Geb\xE4ude- und Wohnungsregister (20130212)"
-- dimensions: *id398
+- dimensions: *id405
   name: ch.bfs.gebaeude_wohnungs_register
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
   title: "Geb\xE4ude- und Wohnungsregister ('current')"
-- dimensions: *id398
+- dimensions: *id405
   name: ch.bfs.gebaeude_wohnungs_register_20130212_source
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
   title: "Geb\xE4ude- und Wohnungsregister (20130212, source)"
-- dimensions: &id399
+- dimensions: &id406
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.alpprodukte_20130531
   sources: [ch.blw.alpprodukte_20130531_cache_out]
   title: Alpprodukte (20130531)
-- dimensions: *id399
+- dimensions: *id406
   name: ch.blw.alpprodukte
   sources: [ch.blw.alpprodukte_20130531_cache]
   title: Alpprodukte ('current')
-- dimensions: *id399
+- dimensions: *id406
   name: ch.blw.alpprodukte_20130531_source
   sources: [ch.blw.alpprodukte_20130531_cache]
   title: Alpprodukte (20130531, source)
-- dimensions: &id400
+- dimensions: &id407
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.alpprodukte_20081024
   sources: [ch.blw.alpprodukte_20081024_cache_out]
   title: Alpprodukte (20081024)
-- dimensions: *id400
+- dimensions: *id407
   name: ch.blw.alpprodukte_20081024_source
   sources: [ch.blw.alpprodukte_20081024_cache]
   title: Alpprodukte (20081024, source)
-- dimensions: &id401
+- dimensions: &id408
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.bergprodukte_20130531
   sources: [ch.blw.bergprodukte_20130531_cache_out]
   title: Bergprodukte (20130531)
-- dimensions: *id401
+- dimensions: *id408
   name: ch.blw.bergprodukte
   sources: [ch.blw.bergprodukte_20130531_cache]
   title: Bergprodukte ('current')
-- dimensions: *id401
+- dimensions: *id408
   name: ch.blw.bergprodukte_20130531_source
   sources: [ch.blw.bergprodukte_20130531_cache]
   title: Bergprodukte (20130531, source)
-- dimensions: &id402
+- dimensions: &id409
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bergprodukte_20081024
   sources: [ch.blw.bergprodukte_20081024_cache_out]
   title: Bergprodukte (20081024)
-- dimensions: *id402
+- dimensions: *id409
   name: ch.blw.bergprodukte_20081024_source
   sources: [ch.blw.bergprodukte_20081024_cache]
   title: Bergprodukte (20081024, source)
-- dimensions: &id403
+- dimensions: &id410
     Time:
       default: '20091110'
       values: ['20091110']
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache_out]
   title: "Bew\xE4sserungsbed\xFCrftigkeit (20091110)"
-- dimensions: *id403
+- dimensions: *id410
   name: ch.blw.bewaesserungsbeduerftigkeit
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit ('current')"
-- dimensions: *id403
+- dimensions: *id410
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110_source
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit (20091110, source)"
-- dimensions: &id404
+- dimensions: &id411
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-gruendigkeit_20120601
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache_out]
   title: "Gr\xFCndigkeit (20120601)"
-- dimensions: *id404
+- dimensions: *id411
   name: ch.blw.bodeneignung-gruendigkeit
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit ('current')"
-- dimensions: *id404
+- dimensions: *id411
   name: ch.blw.bodeneignung-gruendigkeit_20120601_source
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit (20120601, source)"
-- dimensions: &id405
+- dimensions: &id412
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturland_20081024
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache_out]
   title: "Bodeneignung f\xFCr Kulturland (20081024)"
-- dimensions: *id405
+- dimensions: *id412
   name: ch.blw.bodeneignung-kulturland
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland ('current')"
-- dimensions: *id405
+- dimensions: *id412
   name: ch.blw.bodeneignung-kulturland_20081024_source
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland (20081024, source)"
-- dimensions: &id406
+- dimensions: &id413
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturtyp_20081024
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache_out]
   title: 'Bodeneignung: Kulturtyp (20081024)'
-- dimensions: *id406
+- dimensions: *id413
   name: ch.blw.bodeneignung-kulturtyp
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp (''current'')'
-- dimensions: *id406
+- dimensions: *id413
   name: ch.blw.bodeneignung-kulturtyp_20081024_source
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp (20081024, source)'
-- dimensions: &id407
+- dimensions: &id414
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache_out]
   title: "N\xE4hrstoffspeicherverm\xF6gen (20120601)"
-- dimensions: *id407
+- dimensions: *id414
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen ('current')"
-- dimensions: *id407
+- dimensions: *id414
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen (20120601, source)"
-- dimensions: &id408
+- dimensions: &id415
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-skelettgehalt_20120601
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache_out]
   title: Skelettgehalt (20120601)
-- dimensions: *id408
+- dimensions: *id415
   name: ch.blw.bodeneignung-skelettgehalt
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt ('current')
-- dimensions: *id408
+- dimensions: *id415
   name: ch.blw.bodeneignung-skelettgehalt_20120601_source
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt (20120601, source)
-- dimensions: &id409
+- dimensions: &id416
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-vernaessung_20120601
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache_out]
   title: "Vern\xE4ssung (20120601)"
-- dimensions: *id409
+- dimensions: *id416
   name: ch.blw.bodeneignung-vernaessung
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung ('current')"
-- dimensions: *id409
+- dimensions: *id416
   name: ch.blw.bodeneignung-vernaessung_20120601_source
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung (20120601, source)"
-- dimensions: &id410
+- dimensions: &id417
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache_out]
   title: "Wasserdurchl\xE4ssigkeit (20120601)"
-- dimensions: *id410
+- dimensions: *id417
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit ('current')"
-- dimensions: *id410
+- dimensions: *id417
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_source
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit (20120601, source)"
-- dimensions: &id411
+- dimensions: &id418
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache_out]
   title: "Wasserspeicherverm\xF6gen (20120601)"
-- dimensions: *id411
+- dimensions: *id418
   name: ch.blw.bodeneignung-wasserspeichervermoegen
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen ('current')"
-- dimensions: *id411
+- dimensions: *id418
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen (20120601, source)"
-- dimensions: &id412
+- dimensions: &id419
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion_20100103
   sources: [ch.blw.erosion_20100103_cache_out]
   title: Erosionsrisiko qualitativ 1 (20100103)
-- dimensions: *id412
+- dimensions: *id419
   name: ch.blw.erosion
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1 ('current')
-- dimensions: *id412
+- dimensions: *id419
   name: ch.blw.erosion_20100103_source
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1 (20100103, source)
-- dimensions: &id413
+- dimensions: &id420
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion-mit_bergzonen_20100103
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache_out]
   title: Erosionsrisiko qualitativ 2 (20100103)
-- dimensions: *id413
+- dimensions: *id420
   name: ch.blw.erosion-mit_bergzonen
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2 ('current')
-- dimensions: *id413
+- dimensions: *id420
   name: ch.blw.erosion-mit_bergzonen_20100103_source
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2 (20100103, source)
-- dimensions: &id414
+- dimensions: &id421
     Time:
       default: '20100601'
       values: ['20100601']
   name: ch.blw.erosion-quantitativ_20100601
   sources: [ch.blw.erosion-quantitativ_20100601_cache_out]
   title: Erosionsrisiko quantitativ (20100601)
-- dimensions: *id414
+- dimensions: *id421
   name: ch.blw.erosion-quantitativ
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ ('current')
-- dimensions: *id414
+- dimensions: *id421
   name: ch.blw.erosion-quantitativ_20100601_source
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ (20100601, source)
-- dimensions: &id415
+- dimensions: &id422
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.feldblockkarte_20120601
   sources: [ch.blw.feldblockkarte_20120601_cache_out]
   title: Feldblockkarte (20120601)
-- dimensions: *id415
+- dimensions: *id422
   name: ch.blw.feldblockkarte
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte ('current')
-- dimensions: *id415
+- dimensions: *id422
   name: ch.blw.feldblockkarte_20120601_source
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte (20120601, source)
-- dimensions: &id416
+- dimensions: &id423
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte_20121201
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache_out]
   title: "Gew\xE4sseranschluss (20121201)"
-- dimensions: *id416
+- dimensions: *id423
   name: ch.blw.gewaesseranschlusskarte
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss ('current')"
-- dimensions: *id416
+- dimensions: *id423
   name: ch.blw.gewaesseranschlusskarte_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss (20121201, source)"
-- dimensions: &id417
+- dimensions: &id424
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache_out]
   title: "Gew\xE4sseranschluss erweitert (20121201)"
-- dimensions: *id417
+- dimensions: *id424
   name: ch.blw.gewaesseranschlusskarte-direkt
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert ('current')"
-- dimensions: *id417
+- dimensions: *id424
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert (20121201, source)"
-- dimensions: &id418
+- dimensions: &id425
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.hang_steillagen_20121231
   sources: [ch.blw.hang_steillagen_20121231_cache_out]
   title: Hanglagen (20121231)
-- dimensions: *id418
+- dimensions: *id425
   name: ch.blw.hang_steillagen
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen ('current')
-- dimensions: *id418
+- dimensions: *id425
   name: ch.blw.hang_steillagen_20121231_source
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen (20121231, source)
-- dimensions: &id419
+- dimensions: &id426
     Time:
       default: '20100501'
       values: ['20100501']
   name: ch.blw.hang_steillagen_20100501
   sources: [ch.blw.hang_steillagen_20100501_cache_out]
   title: Hanglagen (20100501)
-- dimensions: *id419
+- dimensions: *id426
   name: ch.blw.hang_steillagen_20100501_source
   sources: [ch.blw.hang_steillagen_20100501_cache]
   title: Hanglagen (20100501, source)
-- dimensions: &id420
+- dimensions: &id427
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-futterbau_20081024
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache_out]
   title: Klimaeignung Futterbau (20081024)
-- dimensions: *id420
+- dimensions: *id427
   name: ch.blw.klimaeignung-futterbau
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau ('current')
-- dimensions: *id420
+- dimensions: *id427
   name: ch.blw.klimaeignung-futterbau_20081024_source
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau (20081024, source)
-- dimensions: &id421
+- dimensions: &id428
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-getreidebau_20081024
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache_out]
   title: Klimaeignung Getreidebau (20081024)
-- dimensions: *id421
+- dimensions: *id428
   name: ch.blw.klimaeignung-getreidebau
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau ('current')
-- dimensions: *id421
+- dimensions: *id428
   name: ch.blw.klimaeignung-getreidebau_20081024_source
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau (20081024, source)
-- dimensions: &id422
+- dimensions: &id429
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kartoffeln_20081024
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache_out]
   title: Klimaeignung Kartoffeln (20081024)
-- dimensions: *id422
+- dimensions: *id429
   name: ch.blw.klimaeignung-kartoffeln
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln ('current')
-- dimensions: *id422
+- dimensions: *id429
   name: ch.blw.klimaeignung-kartoffeln_20081024_source
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln (20081024, source)
-- dimensions: &id423
+- dimensions: &id430
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-koernermais_20081024
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache_out]
   title: "Klimaeignung K\xF6rnermais (20081024)"
-- dimensions: *id423
+- dimensions: *id430
   name: ch.blw.klimaeignung-koernermais
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais ('current')"
-- dimensions: *id423
+- dimensions: *id430
   name: ch.blw.klimaeignung-koernermais_20081024_source
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais (20081024, source)"
-- dimensions: &id424
+- dimensions: &id431
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kulturland_20081024
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache_out]
   title: Klimaeignung Kulturland (20081024)
-- dimensions: *id424
+- dimensions: *id431
   name: ch.blw.klimaeignung-kulturland
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland ('current')
-- dimensions: *id424
+- dimensions: *id431
   name: ch.blw.klimaeignung-kulturland_20081024_source
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland (20081024, source)
-- dimensions: &id425
+- dimensions: &id432
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-spezialkulturen_20081024
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache_out]
   title: Klimaeignung Spezialkulturen (20081024)
-- dimensions: *id425
+- dimensions: *id432
   name: ch.blw.klimaeignung-spezialkulturen
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen ('current')
-- dimensions: *id425
+- dimensions: *id432
   name: ch.blw.klimaeignung-spezialkulturen_20081024_source
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen (20081024, source)
-- dimensions: &id426
+- dimensions: &id433
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-typ_20081024
   sources: [ch.blw.klimaeignung-typ_20081024_cache_out]
   title: "Klimaeignung \xDCbersicht (20081024)"
-- dimensions: *id426
+- dimensions: *id433
   name: ch.blw.klimaeignung-typ
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht ('current')"
-- dimensions: *id426
+- dimensions: *id433
   name: ch.blw.klimaeignung-typ_20081024_source
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht (20081024, source)"
-- dimensions: &id427
+- dimensions: &id434
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache_out]
   title: Klimaeignung Zwischenfruchtbau (20081024)
-- dimensions: *id427
+- dimensions: *id434
   name: ch.blw.klimaeignung-zwischenfruchtbau
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau ('current')
-- dimensions: *id427
+- dimensions: *id434
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024_source
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau (20081024, source)
-- dimensions: &id428
+- dimensions: &id435
     Time:
       default: '20140418'
       values: ['20140418']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140418
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20140418)
-- dimensions: *id428
+- dimensions: *id435
   name: ch.blw.landwirtschaftliche-zonengrenzen
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache]
   title: Landwirtschaftliche Zonengrenzen ('current')
-- dimensions: *id428
+- dimensions: *id435
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140418_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache]
   title: Landwirtschaftliche Zonengrenzen (20140418, source)
-- dimensions: &id429
+- dimensions: &id436
     Time:
       default: '20140417'
       values: ['20140417']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140417
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20140417)
-- dimensions: *id429
+- dimensions: *id436
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140417_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache]
   title: Landwirtschaftliche Zonengrenzen (20140417, source)
-- dimensions: &id430
+- dimensions: &id437
     Time:
       default: '20140108'
       values: ['20140108']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140108
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20140108)
-- dimensions: *id430
+- dimensions: *id437
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140108_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache]
   title: Landwirtschaftliche Zonengrenzen (20140108, source)
-- dimensions: &id431
+- dimensions: &id438
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20130531
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20130531)
-- dimensions: *id431
+- dimensions: *id438
   name: ch.blw.landwirtschaftliche-zonengrenzen_20130531_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache]
   title: Landwirtschaftliche Zonengrenzen (20130531, source)
-- dimensions: &id432
+- dimensions: &id439
     Time:
       default: '20111214'
       values: ['20111214']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111214
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20111214)
-- dimensions: *id432
+- dimensions: *id439
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111214_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache]
   title: Landwirtschaftliche Zonengrenzen (20111214, source)
-- dimensions: &id433
+- dimensions: &id440
     Time:
       default: '20111010'
       values: ['20111010']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111010
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20111010)
-- dimensions: *id433
+- dimensions: *id440
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111010_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache]
   title: Landwirtschaftliche Zonengrenzen (20111010, source)
-- dimensions: &id434
+- dimensions: &id441
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.niederschlagshaushalt_20081024
   sources: [ch.blw.niederschlagshaushalt_20081024_cache_out]
   title: Niederschlagshaushalt (20081024)
-- dimensions: *id434
+- dimensions: *id441
   name: ch.blw.niederschlagshaushalt
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt ('current')
-- dimensions: *id434
+- dimensions: *id441
   name: ch.blw.niederschlagshaushalt_20081024_source
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt (20081024, source)
-- dimensions: &id435
+- dimensions: &id442
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.steil_terrassenlagen_rebbau_20121231
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache_out]
   title: "Rebfl\xE4chen in Hanglagen (20121231)"
-- dimensions: *id435
+- dimensions: *id442
   name: ch.blw.steil_terrassenlagen_rebbau
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen ('current')"
-- dimensions: *id435
+- dimensions: *id442
   name: ch.blw.steil_terrassenlagen_rebbau_20121231_source
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen (20121231, source)"
-- dimensions: &id436
+- dimensions: &id443
     Time:
       default: '20100501'
       values: ['20100501']
   name: ch.blw.steil_terrassenlagen_rebbau_20100501
   sources: [ch.blw.steil_terrassenlagen_rebbau_20100501_cache_out]
   title: "Rebfl\xE4chen in Hanglagen (20100501)"
-- dimensions: *id436
+- dimensions: *id443
   name: ch.blw.steil_terrassenlagen_rebbau_20100501_source
   sources: [ch.blw.steil_terrassenlagen_rebbau_20100501_cache]
   title: "Rebfl\xE4chen in Hanglagen (20100501, source)"
-- dimensions: &id437
+- dimensions: &id444
     Time:
       default: '20110805'
       values: ['20110805']
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache_out]
   title: GGA Fleischware (20110805)
-- dimensions: *id437
+- dimensions: *id444
   name: ch.blw.ursprungsbezeichnungen-fleisch
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware ('current')
-- dimensions: *id437
+- dimensions: *id444
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805_source
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware (20110805, source)
-- dimensions: &id438
+- dimensions: &id445
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-fleisch_20081024
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache_out]
   title: GGA Fleischware (20081024)
-- dimensions: *id438
+- dimensions: *id445
   name: ch.blw.ursprungsbezeichnungen-fleisch_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache]
   title: GGA Fleischware (20081024, source)
-- dimensions: &id439
+- dimensions: &id446
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache_out]
   title: "GUB K\xE4se (20081024)"
-- dimensions: *id439
+- dimensions: *id446
   name: ch.blw.ursprungsbezeichnungen-kaese
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se ('current')"
-- dimensions: *id439
+- dimensions: *id446
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se (20081024, source)"
-- dimensions: &id440
+- dimensions: &id447
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache_out]
   title: GUB Pflanzliche Produkte (20081024)
-- dimensions: *id440
+- dimensions: *id447
   name: ch.blw.ursprungsbezeichnungen-pflanzen
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte ('current')
-- dimensions: *id440
+- dimensions: *id447
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte (20081024, source)
-- dimensions: &id441
+- dimensions: &id448
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache_out]
   title: GUB Spirituosen (20081024)
-- dimensions: *id441
+- dimensions: *id448
   name: ch.blw.ursprungsbezeichnungen-spirituosen
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen ('current')
-- dimensions: *id441
+- dimensions: *id448
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen (20081024, source)
-- dimensions: &id442
+- dimensions: &id449
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache_out]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20120101)"
-- dimensions: *id442
+- dimensions: *id449
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz ('current')"
-- dimensions: *id442
+- dimensions: *id449
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_source
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20120101, source)"
-- dimensions: &id443
+- dimensions: &id450
     Time:
       default: '20110412'
       values: ['20110412']
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache_out]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20110412)"
-- dimensions: *id443
+- dimensions: *id450
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_source
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20110412, source)"
-- dimensions: &id444
+- dimensions: &id451
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.kantone.cadastralwebmap-farbe_20121201
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache_out]
   title: CadastralWebMap (20121201)
-- dimensions: *id444
+- dimensions: *id451
   name: ch.kantone.cadastralwebmap-farbe
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
   title: CadastralWebMap ('current')
-- dimensions: *id444
+- dimensions: *id451
   name: ch.kantone.cadastralwebmap-farbe_20121201_source
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
   title: CadastralWebMap (20121201, source)
-- dimensions: &id445
+- dimensions: &id452
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.dreiecksvermaschung_20061231
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache_out]
   title: LV95 Dreiecksvermaschung (20061231)
-- dimensions: *id445
+- dimensions: *id452
   name: ch.swisstopo.dreiecksvermaschung
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung ('current')
-- dimensions: *id445
+- dimensions: *id452
   name: ch.swisstopo.dreiecksvermaschung_20061231_source
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung (20061231, source)
-- dimensions: &id446
+- dimensions: &id453
     Time:
       default: '20140924'
       values: ['20140924']
   name: ch.swisstopo.fixpunkte-agnes_20140924
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache_out]
   title: AGNES (20140924)
-- dimensions: *id446
+- dimensions: *id453
   name: ch.swisstopo.fixpunkte-agnes
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES ('current')
-- dimensions: *id446
+- dimensions: *id453
   name: ch.swisstopo.fixpunkte-agnes_20140924_source
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES (20140924, source)
-- dimensions: &id447
+- dimensions: &id454
     Time:
       default: '20120622'
       values: ['20120622']
   name: ch.swisstopo.fixpunkte-agnes_20120622
   sources: [ch.swisstopo.fixpunkte-agnes_20120622_cache_out]
   title: AGNES (20120622)
-- dimensions: *id447
+- dimensions: *id454
   name: ch.swisstopo.fixpunkte-agnes_20120622_source
   sources: [ch.swisstopo.fixpunkte-agnes_20120622_cache]
   title: AGNES (20120622, source)
-- dimensions: &id448
+- dimensions: &id455
     Time:
       default: '20110509'
       values: ['20110509']
   name: ch.swisstopo.fixpunkte-agnes_20110509
   sources: [ch.swisstopo.fixpunkte-agnes_20110509_cache_out]
   title: AGNES (20110509)
-- dimensions: *id448
+- dimensions: *id455
   name: ch.swisstopo.fixpunkte-agnes_20110509_source
   sources: [ch.swisstopo.fixpunkte-agnes_20110509_cache]
   title: AGNES (20110509, source)
-- dimensions: &id449
+- dimensions: &id456
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp1_20121212
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP1 (20121212)"
-- dimensions: *id449
+- dimensions: *id456
   name: ch.swisstopo.fixpunkte-hfp1
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1 ('current')"
-- dimensions: *id449
+- dimensions: *id456
   name: ch.swisstopo.fixpunkte-hfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1 (20121212, source)"
-- dimensions: &id450
+- dimensions: &id457
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp2_20121212
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP2 (20121212)"
-- dimensions: *id450
+- dimensions: *id457
   name: ch.swisstopo.fixpunkte-hfp2
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2 ('current')"
-- dimensions: *id450
+- dimensions: *id457
   name: ch.swisstopo.fixpunkte-hfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2 (20121212, source)"
-- dimensions: &id451
+- dimensions: &id458
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp1_20121212
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache_out]
   title: Lagefixpunkte LFP1 (20121212)
-- dimensions: *id451
+- dimensions: *id458
   name: ch.swisstopo.fixpunkte-lfp1
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1 ('current')
-- dimensions: *id451
+- dimensions: *id458
   name: ch.swisstopo.fixpunkte-lfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1 (20121212, source)
-- dimensions: &id452
+- dimensions: &id459
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp2_20121212
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache_out]
   title: Lagefixpunkte LFP2 (20121212)
-- dimensions: *id452
+- dimensions: *id459
   name: ch.swisstopo.fixpunkte-lfp2
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2 ('current')
-- dimensions: *id452
+- dimensions: *id459
   name: ch.swisstopo.fixpunkte-lfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2 (20121212, source)
-- dimensions: &id453
+- dimensions: &id460
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-ch1903_20041231
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache_out]
   title: Geoidmodell in CH1903 (20041231)
-- dimensions: *id453
+- dimensions: *id460
   name: ch.swisstopo.geoidmodell-ch1903
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903 ('current')
-- dimensions: *id453
+- dimensions: *id460
   name: ch.swisstopo.geoidmodell-ch1903_20041231_source
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903 (20041231, source)
-- dimensions: &id454
+- dimensions: &id461
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-etrs89_20041231
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache_out]
   title: Geoidmodell in ETRS89 (20041231)
-- dimensions: *id454
+- dimensions: *id461
   name: ch.swisstopo.geoidmodell-etrs89
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89 ('current')
-- dimensions: *id454
+- dimensions: *id461
   name: ch.swisstopo.geoidmodell-etrs89_20041231_source
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89 (20041231, source)
-- dimensions: &id455
+- dimensions: &id462
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache_out]
-  title: Eiszeitliches Maximum 500 (20081231)
-- dimensions: *id455
+  title: Letzteiszeitl. Max. (Karte) 500 (20081231)
+- dimensions: *id462
   name: ch.swisstopo.geologie-eiszeit-lgm-raster
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
-  title: Eiszeitliches Maximum 500 ('current')
-- dimensions: *id455
+  title: Letzteiszeitl. Max. (Karte) 500 ('current')
+- dimensions: *id462
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_source
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
-  title: Eiszeitliches Maximum 500 (20081231, source)
-- dimensions: &id456
+  title: Letzteiszeitl. Max. (Karte) 500 (20081231, source)
+- dimensions: &id463
     Time:
       default: '20140601'
       values: ['20140601']
   name: ch.swisstopo.geologie-geocover_20140601
   sources: [ch.swisstopo.geologie-geocover_20140601_cache_out]
-  title: "GeoCover - Geol. Vektordatens\xE4tze (20140601)"
-- dimensions: *id456
+  title: GeoCover - Vektordaten (20140601)
+- dimensions: *id463
   name: ch.swisstopo.geologie-geocover
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
-  title: "GeoCover - Geol. Vektordatens\xE4tze ('current')"
-- dimensions: *id456
+  title: GeoCover - Vektordaten ('current')
+- dimensions: *id463
   name: ch.swisstopo.geologie-geocover_20140601_source
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
-  title: "GeoCover - Geol. Vektordatens\xE4tze (20140601, source)"
-- dimensions: &id457
+  title: GeoCover - Vektordaten (20140601, source)
+- dimensions: &id464
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache_out]
   title: Bouguer-Anomalien 500 (19791231)
-- dimensions: *id457
+- dimensions: *id464
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache]
   title: Bouguer-Anomalien 500 ('current')
-- dimensions: *id457
+- dimensions: *id464
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache]
   title: Bouguer-Anomalien 500 (19791231, source)
-- dimensions: &id458
+- dimensions: &id465
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache_out]
-  title: Isostatische Anomalien (19791231)
-- dimensions: *id458
+  title: Isostatische Anomalien 500 (19791231)
+- dimensions: *id465
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
-  title: Isostatische Anomalien ('current')
-- dimensions: *id458
+  title: Isostatische Anomalien 500 ('current')
+- dimensions: *id465
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
-  title: Isostatische Anomalien (19791231, source)
-- dimensions: &id459
+  title: Isostatische Anomalien 500 (19791231, source)
+- dimensions: &id466
     Time:
       default: '20070425'
       values: ['20070425']
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache_out]
   title: Blatteinteilung GeoKarten 500 (20070425)
-- dimensions: *id459
+- dimensions: *id466
   name: ch.swisstopo.geologie-geolkarten500.metadata
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 ('current')
-- dimensions: *id459
+- dimensions: *id466
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425_source
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 (20070425, source)
-- dimensions: &id460
+- dimensions: &id467
     Time:
       default: '20080630'
       values: ['20080630']
   name: ch.swisstopo.geologie-geologische_karte_20080630
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache_out]
-  title: Geologische Karte 500 (20080630)
-- dimensions: *id460
+  title: Geologie 500 (20080630)
+- dimensions: *id467
   name: ch.swisstopo.geologie-geologische_karte
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
-  title: Geologische Karte 500 ('current')
-- dimensions: *id460
+  title: Geologie 500 ('current')
+- dimensions: *id467
   name: ch.swisstopo.geologie-geologische_karte_20080630_source
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
-  title: Geologische Karte 500 (20080630, source)
-- dimensions: &id461
+  title: Geologie 500 (20080630, source)
+- dimensions: &id468
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.geologie-geologische_karte_20051231
   sources: [ch.swisstopo.geologie-geologische_karte_20051231_cache_out]
-  title: Geologische Karte 500 (20051231)
-- dimensions: *id461
+  title: Geologie 500 (20051231)
+- dimensions: *id468
   name: ch.swisstopo.geologie-geologische_karte_20051231_source
   sources: [ch.swisstopo.geologie-geologische_karte_20051231_cache]
-  title: Geologische Karte 500 (20051231, source)
-- dimensions: &id462
+  title: Geologie 500 (20051231, source)
+- dimensions: &id469
     Time:
       default: '20131120'
       values: ['20131120']
   name: ch.swisstopo.geologie-geologischer_atlas_20131120
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache_out]
-  title: Geol. Atlas der Schweiz 1:25000 (20131120)
-- dimensions: *id462
+  title: Geologischer Atlas GA25 (20131120)
+- dimensions: *id469
   name: ch.swisstopo.geologie-geologischer_atlas
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
-  title: Geol. Atlas der Schweiz 1:25000 ('current')
-- dimensions: *id462
+  title: Geologischer Atlas GA25 ('current')
+- dimensions: *id469
   name: ch.swisstopo.geologie-geologischer_atlas_20131120_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
-  title: Geol. Atlas der Schweiz 1:25000 (20131120, source)
-- dimensions: &id463
+  title: Geologischer Atlas GA25 (20131120, source)
+- dimensions: &id470
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.swisstopo.geologie-geologischer_atlas_20120601
   sources: [ch.swisstopo.geologie-geologischer_atlas_20120601_cache_out]
-  title: Geol. Atlas der Schweiz 1:25000 (20120601)
-- dimensions: *id463
+  title: Geologischer Atlas GA25 (20120601)
+- dimensions: *id470
   name: ch.swisstopo.geologie-geologischer_atlas_20120601_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20120601_cache]
-  title: Geol. Atlas der Schweiz 1:25000 (20120601, source)
-- dimensions: &id464
+  title: Geologischer Atlas GA25 (20120601, source)
+- dimensions: &id471
     Time:
       default: '20101221'
       values: ['20101221']
   name: ch.swisstopo.geologie-geologischer_atlas_20101221
   sources: [ch.swisstopo.geologie-geologischer_atlas_20101221_cache_out]
-  title: Geol. Atlas der Schweiz 1:25000 (20101221)
-- dimensions: *id464
+  title: Geologischer Atlas GA25 (20101221)
+- dimensions: *id471
   name: ch.swisstopo.geologie-geologischer_atlas_20101221_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20101221_cache]
-  title: Geol. Atlas der Schweiz 1:25000 (20101221, source)
-- dimensions: &id465
+  title: Geologischer Atlas GA25 (20101221, source)
+- dimensions: &id472
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache_out]
-  title: Aeromagnetik Voralpen/Jura (19831231)
-- dimensions: *id465
+  title: Aeromagnetik Mittelland/Jura 500 (19831231)
+- dimensions: *id472
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
-  title: Aeromagnetik Voralpen/Jura ('current')
-- dimensions: *id465
+  title: Aeromagnetik Mittelland/Jura 500 ('current')
+- dimensions: *id472
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
-  title: Aeromagnetik Voralpen/Jura (19831231, source)
-- dimensions: &id466
+  title: Aeromagnetik Mittelland/Jura 500 (19831231, source)
+- dimensions: &id473
     Time:
       default: '20120628'
       values: ['20120628']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache_out]
-  title: Aeromagnetik (20120628)
-- dimensions: *id466
+  title: Aeromagnetik 500 (20120628)
+- dimensions: *id473
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
-  title: Aeromagnetik ('current')
-- dimensions: *id466
+  title: Aeromagnetik 500 ('current')
+- dimensions: *id473
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
-  title: Aeromagnetik (20120628, source)
-- dimensions: &id467
+  title: Aeromagnetik 500 (20120628, source)
+- dimensions: &id474
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache_out]
-  title: Aeromagnetik (19821231)
-- dimensions: *id467
+  title: Aeromagnetik 500 (19821231)
+- dimensions: *id474
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache]
-  title: Aeromagnetik (19821231, source)
-- dimensions: &id468
+  title: Aeromagnetik 500 (19821231, source)
+- dimensions: &id475
     Time:
       default: '20011203'
       values: ['20011203']
   name: ch.swisstopo.geologie-geophysik-deklination_20011203
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache_out]
-  title: Deklination (20011203)
-- dimensions: *id468
+  title: Deklination 500 (20011203)
+- dimensions: *id475
   name: ch.swisstopo.geologie-geophysik-deklination
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
-  title: Deklination ('current')
-- dimensions: *id468
+  title: Deklination 500 ('current')
+- dimensions: *id475
   name: ch.swisstopo.geologie-geophysik-deklination_20011203_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
-  title: Deklination (20011203, source)
-- dimensions: &id469
+  title: Deklination 500 (20011203, source)
+- dimensions: &id476
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-deklination_19791231
   sources: [ch.swisstopo.geologie-geophysik-deklination_19791231_cache_out]
-  title: Deklination (19791231)
-- dimensions: *id469
+  title: Deklination 500 (19791231)
+- dimensions: *id476
   name: ch.swisstopo.geologie-geophysik-deklination_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_19791231_cache]
-  title: Deklination (19791231, source)
-- dimensions: &id470
+  title: Deklination 500 (19791231, source)
+- dimensions: &id477
     Time:
       default: '20111121'
       values: ['20111121']
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache_out]
-  title: Geothermie (20111121)
-- dimensions: *id470
+  title: "W\xE4rmestromdichte 500 (20111121)"
+- dimensions: *id477
   name: ch.swisstopo.geologie-geophysik-geothermie
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
-  title: Geothermie ('current')
-- dimensions: *id470
+  title: "W\xE4rmestromdichte 500 ('current')"
+- dimensions: *id477
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
-  title: Geothermie (20111121, source)
-- dimensions: &id471
+  title: "W\xE4rmestromdichte 500 (20111121, source)"
+- dimensions: &id478
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.geologie-geophysik-geothermie_19821231
   sources: [ch.swisstopo.geologie-geophysik-geothermie_19821231_cache_out]
-  title: Geothermie (19821231)
-- dimensions: *id471
+  title: "W\xE4rmestromdichte 500 (19821231)"
+- dimensions: *id478
   name: ch.swisstopo.geologie-geophysik-geothermie_19821231_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_19821231_cache]
-  title: Geothermie (19821231, source)
-- dimensions: &id472
+  title: "W\xE4rmestromdichte 500 (19821231, source)"
+- dimensions: &id479
     Time:
       default: '20111128'
       values: ['20111128']
   name: ch.swisstopo.geologie-geophysik-inklination_20111128
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache_out]
-  title: Inklination (20111128)
-- dimensions: *id472
+  title: Inklination 500 (20111128)
+- dimensions: *id479
   name: ch.swisstopo.geologie-geophysik-inklination
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
-  title: Inklination ('current')
-- dimensions: *id472
+  title: Inklination 500 ('current')
+- dimensions: *id479
   name: ch.swisstopo.geologie-geophysik-inklination_20111128_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
-  title: Inklination (20111128, source)
-- dimensions: &id473
+  title: Inklination 500 (20111128, source)
+- dimensions: &id480
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-inklination_19791231
   sources: [ch.swisstopo.geologie-geophysik-inklination_19791231_cache_out]
-  title: Inklination (19791231)
-- dimensions: *id473
+  title: Inklination 500 (19791231)
+- dimensions: *id480
   name: ch.swisstopo.geologie-geophysik-inklination_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_19791231_cache]
-  title: Inklination (19791231, source)
-- dimensions: &id474
+  title: Inklination 500 (19791231, source)
+- dimensions: &id481
     Time:
       default: '19800101'
       values: ['19800101']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache_out]
-  title: "Magnetfeldst\xE4rke (19800101)"
-- dimensions: *id474
+  title: "Magnetfeldst\xE4rke 500 (19800101)"
+- dimensions: *id481
   name: ch.swisstopo.geologie-geophysik-totalintensitaet
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
-  title: "Magnetfeldst\xE4rke ('current')"
-- dimensions: *id474
+  title: "Magnetfeldst\xE4rke 500 ('current')"
+- dimensions: *id481
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
-  title: "Magnetfeldst\xE4rke (19800101, source)"
-- dimensions: &id475
+  title: "Magnetfeldst\xE4rke 500 (19800101, source)"
+- dimensions: &id482
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19791231
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache_out]
-  title: "Magnetfeldst\xE4rke (19791231)"
-- dimensions: *id475
+  title: "Magnetfeldst\xE4rke 500 (19791231)"
+- dimensions: *id482
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache]
-  title: "Magnetfeldst\xE4rke (19791231, source)"
-- dimensions: &id476
+  title: "Magnetfeldst\xE4rke 500 (19791231, source)"
+- dimensions: &id483
     Time:
       default: '19670101'
       values: ['19670101']
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache_out]
-  title: Geotechnik und Gesteine (19670101)
-- dimensions: *id476
+  title: Geotechnische Karte 200 (19670101)
+- dimensions: *id483
   name: ch.swisstopo.geologie-geotechnik-gk200
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
-  title: Geotechnik und Gesteine ('current')
-- dimensions: *id476
+  title: Geotechnische Karte 200 ('current')
+- dimensions: *id483
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
-  title: Geotechnik und Gesteine (19670101, source)
-- dimensions: &id477
+  title: Geotechnische Karte 200 (19670101, source)
+- dimensions: &id484
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache_out]
-  title: Entstehung der Gesteine (20060304)
-- dimensions: *id477
+  title: Entstehung der Gesteine 500 (20060304)
+- dimensions: *id484
   name: ch.swisstopo.geologie-geotechnik-gk500-genese
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
-  title: Entstehung der Gesteine ('current')
-- dimensions: *id477
+  title: Entstehung der Gesteine 500 ('current')
+- dimensions: *id484
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
-  title: Entstehung der Gesteine (20060304, source)
-- dimensions: &id478
+  title: Entstehung der Gesteine 500 (20060304, source)
+- dimensions: &id485
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache_out]
-  title: Entstehung der Gesteine (20000101)
-- dimensions: *id478
+  title: Entstehung der Gesteine 500 (20000101)
+- dimensions: *id485
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache]
-  title: Entstehung der Gesteine (20000101, source)
-- dimensions: &id479
+  title: Entstehung der Gesteine 500 (20000101, source)
+- dimensions: &id486
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache_out]
-  title: Gesteinklassierung (20060304)
-- dimensions: *id479
+  title: Gesteinsklassen 500 (20060304)
+- dimensions: *id486
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
-  title: Gesteinklassierung ('current')
-- dimensions: *id479
+  title: Gesteinsklassen 500 ('current')
+- dimensions: *id486
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
-  title: Gesteinklassierung (20060304, source)
-- dimensions: &id480
+  title: Gesteinsklassen 500 (20060304, source)
+- dimensions: &id487
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache_out]
-  title: Gesteinklassierung (20000101)
-- dimensions: *id480
+  title: Gesteinsklassen 500 (20000101)
+- dimensions: *id487
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache]
-  title: Gesteinklassierung (20000101, source)
-- dimensions: &id481
+  title: Gesteinsklassen 500 (20000101, source)
+- dimensions: &id488
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache_out]
-  title: Lithologie-Hauptgruppen (20060304)
-- dimensions: *id481
+  title: Lithologie (Hauptgruppen) 500 (20060304)
+- dimensions: *id488
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
-  title: Lithologie-Hauptgruppen ('current')
-- dimensions: *id481
+  title: Lithologie (Hauptgruppen) 500 ('current')
+- dimensions: *id488
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
-  title: Lithologie-Hauptgruppen (20060304, source)
-- dimensions: &id482
+  title: Lithologie (Hauptgruppen) 500 (20060304, source)
+- dimensions: &id489
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache_out]
-  title: Lithologie-Hauptgruppen (20000101)
-- dimensions: *id482
+  title: Lithologie (Hauptgruppen) 500 (20000101)
+- dimensions: *id489
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache]
-  title: Lithologie-Hauptgruppen (20000101, source)
-- dimensions: &id483
+  title: Lithologie (Hauptgruppen) 500 (20000101, source)
+- dimensions: &id490
     Time:
       default: '19900101'
       values: ['19900101']
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache_out]
-  title: Mineralische Rohstoffe (19900101)
-- dimensions: *id483
+  title: Mineralische Rohstoffe 200 (19900101)
+- dimensions: *id490
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
-  title: Mineralische Rohstoffe ('current')
-- dimensions: *id483
+  title: Mineralische Rohstoffe 200 ('current')
+- dimensions: *id490
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_source
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
-  title: Mineralische Rohstoffe (19900101, source)
-- dimensions: &id484
+  title: Mineralische Rohstoffe 200 (19900101, source)
+- dimensions: &id491
     Time:
       default: '20130620'
       values: ['20130620']
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache_out]
-  title: Steine an historischen Bauwerken (20130620)
-- dimensions: *id484
+  title: Steine an hist. Bauwerken (20130620)
+- dimensions: *id491
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
-  title: Steine an historischen Bauwerken ('current')
-- dimensions: *id484
+  title: Steine an hist. Bauwerken ('current')
+- dimensions: *id491
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_source
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
-  title: Steine an historischen Bauwerken (20130620, source)
-- dimensions: &id485
+  title: Steine an hist. Bauwerken (20130620, source)
+- dimensions: &id492
     Time:
       default: '20130107'
       values: ['20130107']
   name: ch.swisstopo.geologie-geotope_20130107
   sources: [ch.swisstopo.geologie-geotope_20130107_cache_out]
   title: Schweizerische Geotope (20130107)
-- dimensions: *id485
+- dimensions: *id492
   name: ch.swisstopo.geologie-geotope
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Schweizerische Geotope ('current')
-- dimensions: *id485
+- dimensions: *id492
   name: ch.swisstopo.geologie-geotope_20130107_source
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Schweizerische Geotope (20130107, source)
-- dimensions: &id486
+- dimensions: &id493
     Time:
       default: '20110201'
       values: ['20110201']
   name: ch.swisstopo.geologie-geotope_20110201
   sources: [ch.swisstopo.geologie-geotope_20110201_cache_out]
   title: Schweizerische Geotope (20110201)
-- dimensions: *id486
+- dimensions: *id493
   name: ch.swisstopo.geologie-geotope_20110201_source
   sources: [ch.swisstopo.geologie-geotope_20110201_cache]
   title: Schweizerische Geotope (20110201, source)
-- dimensions: &id487
+- dimensions: &id494
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache_out]
-  title: Gravimetrischer Atlas 1:100000 (20021231)
-- dimensions: *id487
+  title: Gravimetrischer Atlas 100 (20021231)
+- dimensions: *id494
   name: ch.swisstopo.geologie-gravimetrischer_atlas
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
-  title: Gravimetrischer Atlas 1:100000 ('current')
-- dimensions: *id487
+  title: Gravimetrischer Atlas 100 ('current')
+- dimensions: *id494
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
-  title: Gravimetrischer Atlas 1:100000 (20021231, source)
-- dimensions: &id488
+  title: Gravimetrischer Atlas 100 (20021231, source)
+- dimensions: &id495
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache_out]
-  title: Einteilung gravimetrischer Atlas (20021231)
-- dimensions: *id488
+  title: Einteilung gravim. Atlas 100 (20021231)
+- dimensions: *id495
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
-  title: Einteilung gravimetrischer Atlas ('current')
-- dimensions: *id488
+  title: Einteilung gravim. Atlas 100 ('current')
+- dimensions: *id495
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
-  title: Einteilung gravimetrischer Atlas (20021231, source)
-- dimensions: &id489
+  title: Einteilung gravim. Atlas 100 (20021231, source)
+- dimensions: &id496
     Time:
       default: '20081103'
       values: ['20081103']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache_out]
   title: Grundwasservorkommen 500 (20081103)
-- dimensions: *id489
+- dimensions: *id496
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 ('current')
-- dimensions: *id489
+- dimensions: *id496
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 (20081103, source)
-- dimensions: &id490
+- dimensions: &id497
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache_out]
   title: Grundwasservorkommen 500 (20070101)
-- dimensions: *id490
+- dimensions: *id497
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache]
   title: Grundwasservorkommen 500 (20070101, source)
-- dimensions: &id491
+- dimensions: &id498
     Time:
       default: '20081016'
       values: ['20081016']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache_out]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016)"
-- dimensions: *id491
+- dimensions: *id498
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 ('current')"
-- dimensions: *id491
+- dimensions: *id498
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016, source)"
-- dimensions: &id492
+- dimensions: &id499
     Time:
       default: '20070914'
       values: ['20070914']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache_out]
   title: "Grundwasservulnerabilit\xE4t 500 (20070914)"
-- dimensions: *id492
+- dimensions: *id499
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache]
   title: "Grundwasservulnerabilit\xE4t 500 (20070914, source)"
-- dimensions: &id493
+- dimensions: &id500
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache_out]
   title: Einteilung geol. Spezialkarten (20110101)
-- dimensions: *id493
+- dimensions: *id500
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten ('current')
-- dimensions: *id493
+- dimensions: *id500
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_source
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten (20110101, source)
-- dimensions: &id494
+- dimensions: &id501
     Time:
       default: '20080522'
       values: ['20080522']
   name: ch.swisstopo.geologie-tektonische_karte_20080522
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache_out]
-  title: Tektonische Karte 500 (20080522)
-- dimensions: *id494
+  title: Tektonik 500 (20080522)
+- dimensions: *id501
   name: ch.swisstopo.geologie-tektonische_karte
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
-  title: Tektonische Karte 500 ('current')
-- dimensions: *id494
+  title: Tektonik 500 ('current')
+- dimensions: *id501
   name: ch.swisstopo.geologie-tektonische_karte_20080522_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
-  title: Tektonische Karte 500 (20080522, source)
-- dimensions: &id495
+  title: Tektonik 500 (20080522, source)
+- dimensions: &id502
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.geologie-tektonische_karte_20051231
   sources: [ch.swisstopo.geologie-tektonische_karte_20051231_cache_out]
-  title: Tektonische Karte 500 (20051231)
-- dimensions: *id495
+  title: Tektonik 500 (20051231)
+- dimensions: *id502
   name: ch.swisstopo.geologie-tektonische_karte_20051231_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20051231_cache]
-  title: Tektonische Karte 500 (20051231, source)
-- dimensions: &id496
+  title: Tektonik 500 (20051231, source)
+- dimensions: &id503
     Time:
       default: '18650101'
       values: ['18650101']
   name: ch.swisstopo.hiks-dufour_18650101
   sources: [ch.swisstopo.hiks-dufour_18650101_cache_out]
   title: Dufourkarte Erstausgabe (18650101)
-- dimensions: *id496
+- dimensions: *id503
   name: ch.swisstopo.hiks-dufour
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe ('current')
-- dimensions: *id496
+- dimensions: *id503
   name: ch.swisstopo.hiks-dufour_18650101_source
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe (18650101, source)
-- dimensions: &id497
+- dimensions: &id504
     Time:
       default: '19260101'
       values: ['19260101']
   name: ch.swisstopo.hiks-siegfried_19260101
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache_out]
   title: Siegfriedkarte Erstausgabe (19260101)
-- dimensions: *id497
+- dimensions: *id504
   name: ch.swisstopo.hiks-siegfried
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe ('current')
-- dimensions: *id497
+- dimensions: *id504
   name: ch.swisstopo.hiks-siegfried_19260101_source
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe (19260101, source)
-- dimensions: &id498
+- dimensions: &id505
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.koordinatenaenderung_20061231
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache_out]
   title: "LV95 Koordinaten\xE4nderung (20061231)"
-- dimensions: *id498
+- dimensions: *id505
   name: ch.swisstopo.koordinatenaenderung
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung ('current')"
-- dimensions: *id498
+- dimensions: *id505
   name: ch.swisstopo.koordinatenaenderung_20061231_source
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung (20061231, source)"
-- dimensions: &id499
+- dimensions: &id506
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache_out]
   title: Luftbilder Privater (99991231)
-- dimensions: *id499
+- dimensions: *id506
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater ('current')
-- dimensions: *id499
+- dimensions: *id506
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater (99991231, source)
-- dimensions: &id500
+- dimensions: &id507
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache_out]
   title: Luftbilder Privater (20091231)
-- dimensions: *id500
+- dimensions: *id507
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache]
   title: Luftbilder Privater (20091231, source)
-- dimensions: &id501
+- dimensions: &id508
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache_out]
   title: Luftbilder Privater (20081231)
-- dimensions: *id501
+- dimensions: *id508
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache]
   title: Luftbilder Privater (20081231, source)
-- dimensions: &id502
+- dimensions: &id509
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache_out]
   title: Luftbilder Privater (20071231)
-- dimensions: *id502
+- dimensions: *id509
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache]
   title: Luftbilder Privater (20071231, source)
-- dimensions: &id503
+- dimensions: &id510
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache_out]
   title: Luftbilder Privater (20061231)
-- dimensions: *id503
+- dimensions: *id510
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache]
   title: Luftbilder Privater (20061231, source)
-- dimensions: &id504
+- dimensions: &id511
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache_out]
   title: Luftbilder Privater (20051231)
-- dimensions: *id504
+- dimensions: *id511
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache]
   title: Luftbilder Privater (20051231, source)
-- dimensions: &id505
+- dimensions: &id512
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache_out]
   title: Luftbilder Privater (20041231)
-- dimensions: *id505
+- dimensions: *id512
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache]
   title: Luftbilder Privater (20041231, source)
-- dimensions: &id506
+- dimensions: &id513
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache_out]
   title: Luftbilder Privater (20031231)
-- dimensions: *id506
+- dimensions: *id513
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache]
   title: Luftbilder Privater (20031231, source)
-- dimensions: &id507
+- dimensions: &id514
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache_out]
   title: Luftbilder Privater (20021231)
-- dimensions: *id507
+- dimensions: *id514
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache]
   title: Luftbilder Privater (20021231, source)
-- dimensions: &id508
+- dimensions: &id515
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache_out]
   title: Luftbilder Privater (20011231)
-- dimensions: *id508
+- dimensions: *id515
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache]
   title: Luftbilder Privater (20011231, source)
-- dimensions: &id509
+- dimensions: &id516
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache_out]
   title: Luftbilder Privater (20001231)
-- dimensions: *id509
+- dimensions: *id516
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache]
   title: Luftbilder Privater (20001231, source)
-- dimensions: &id510
+- dimensions: &id517
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache_out]
   title: Luftbilder Privater (19991231)
-- dimensions: *id510
+- dimensions: *id517
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache]
   title: Luftbilder Privater (19991231, source)
-- dimensions: &id511
+- dimensions: &id518
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache_out]
   title: Luftbilder Privater (19981231)
-- dimensions: *id511
+- dimensions: *id518
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache]
   title: Luftbilder Privater (19981231, source)
-- dimensions: &id512
+- dimensions: &id519
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache_out]
   title: Luftbilder Privater (19971231)
-- dimensions: *id512
+- dimensions: *id519
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache]
   title: Luftbilder Privater (19971231, source)
-- dimensions: &id513
+- dimensions: &id520
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache_out]
   title: Luftbilder Privater (19961231)
-- dimensions: *id513
+- dimensions: *id520
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache]
   title: Luftbilder Privater (19961231, source)
-- dimensions: &id514
+- dimensions: &id521
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache_out]
   title: Luftbilder Privater (19951231)
-- dimensions: *id514
+- dimensions: *id521
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache]
   title: Luftbilder Privater (19951231, source)
-- dimensions: &id515
+- dimensions: &id522
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache_out]
   title: Luftbilder Privater (19941231)
-- dimensions: *id515
+- dimensions: *id522
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache]
   title: Luftbilder Privater (19941231, source)
-- dimensions: &id516
+- dimensions: &id523
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache_out]
   title: Luftbilder Privater (19931231)
-- dimensions: *id516
+- dimensions: *id523
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache]
   title: Luftbilder Privater (19931231, source)
-- dimensions: &id517
+- dimensions: &id524
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache_out]
   title: Luftbilder Privater (19921231)
-- dimensions: *id517
+- dimensions: *id524
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache]
   title: Luftbilder Privater (19921231, source)
-- dimensions: &id518
+- dimensions: &id525
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache_out]
   title: Luftbilder Privater (19911231)
-- dimensions: *id518
+- dimensions: *id525
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache]
   title: Luftbilder Privater (19911231, source)
-- dimensions: &id519
+- dimensions: &id526
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache_out]
   title: Luftbilder Privater (19901231)
-- dimensions: *id519
+- dimensions: *id526
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache]
   title: Luftbilder Privater (19901231, source)
-- dimensions: &id520
+- dimensions: &id527
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache_out]
   title: Luftbilder Privater (19891231)
-- dimensions: *id520
+- dimensions: *id527
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache]
   title: Luftbilder Privater (19891231, source)
-- dimensions: &id521
+- dimensions: &id528
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache_out]
   title: Luftbilder Kantone (99991231)
-- dimensions: *id521
+- dimensions: *id528
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone ('current')
-- dimensions: *id521
+- dimensions: *id528
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone (99991231, source)
-- dimensions: &id522
+- dimensions: &id529
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache_out]
   title: Luftbilder Kantone (20141231)
-- dimensions: *id522
+- dimensions: *id529
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache]
   title: Luftbilder Kantone (20141231, source)
-- dimensions: &id523
+- dimensions: &id530
     Time:
       default: '20131231'
       values: ['20131231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache_out]
   title: Luftbilder Kantone (20131231)
-- dimensions: *id523
+- dimensions: *id530
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache]
   title: Luftbilder Kantone (20131231, source)
-- dimensions: &id524
+- dimensions: &id531
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache_out]
   title: Luftbilder Kantone (20121231)
-- dimensions: *id524
+- dimensions: *id531
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache]
   title: Luftbilder Kantone (20121231, source)
-- dimensions: &id525
+- dimensions: &id532
     Time:
       default: '20111231'
       values: ['20111231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache_out]
   title: Luftbilder Kantone (20111231)
-- dimensions: *id525
+- dimensions: *id532
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache]
   title: Luftbilder Kantone (20111231, source)
-- dimensions: &id526
+- dimensions: &id533
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache_out]
   title: Luftbilder Kantone (20091231)
-- dimensions: *id526
+- dimensions: *id533
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache]
   title: Luftbilder Kantone (20091231, source)
-- dimensions: &id527
+- dimensions: &id534
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache_out]
   title: Luftbilder Kantone (19841231)
-- dimensions: *id527
+- dimensions: *id534
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache]
   title: Luftbilder Kantone (19841231, source)
-- dimensions: &id528
+- dimensions: &id535
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache_out]
   title: Luftbilder Kantone (19671231)
-- dimensions: *id528
+- dimensions: *id535
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache]
   title: Luftbilder Kantone (19671231, source)
-- dimensions: &id529
+- dimensions: &id536
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache_out]
   title: Luftbilder Kantone (19661231)
-- dimensions: *id529
+- dimensions: *id536
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache]
   title: Luftbilder Kantone (19661231, source)
-- dimensions: &id530
+- dimensions: &id537
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache_out]
   title: Luftbilder Kantone (19651231)
-- dimensions: *id530
+- dimensions: *id537
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache]
   title: Luftbilder Kantone (19651231, source)
-- dimensions: &id531
+- dimensions: &id538
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache_out]
   title: Luftbilder Kantone (19641231)
-- dimensions: *id531
+- dimensions: *id538
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache]
   title: Luftbilder Kantone (19641231, source)
-- dimensions: &id532
+- dimensions: &id539
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache_out]
   title: Luftbilder Kantone (19631231)
-- dimensions: *id532
+- dimensions: *id539
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache]
   title: Luftbilder Kantone (19631231, source)
-- dimensions: &id533
+- dimensions: &id540
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache_out]
   title: Luftbilder Kantone (19621231)
-- dimensions: *id533
+- dimensions: *id540
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache]
   title: Luftbilder Kantone (19621231, source)
-- dimensions: &id534
+- dimensions: &id541
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache_out]
   title: Luftbilder swisstopo farbig (99991231)
-- dimensions: *id534
+- dimensions: *id541
   name: ch.swisstopo.lubis-luftbilder_farbe
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig ('current')
-- dimensions: *id534
+- dimensions: *id541
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig (99991231, source)
-- dimensions: &id535
+- dimensions: &id542
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache_out]
   title: Luftbilder swisstopo farbig (20101231)
-- dimensions: *id535
+- dimensions: *id542
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache]
   title: Luftbilder swisstopo farbig (20101231, source)
-- dimensions: &id536
+- dimensions: &id543
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache_out]
   title: Luftbilder swisstopo farbig (20091231)
-- dimensions: *id536
+- dimensions: *id543
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache]
   title: Luftbilder swisstopo farbig (20091231, source)
-- dimensions: &id537
+- dimensions: &id544
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache_out]
   title: Luftbilder swisstopo farbig (20081231)
-- dimensions: *id537
+- dimensions: *id544
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache]
   title: Luftbilder swisstopo farbig (20081231, source)
-- dimensions: &id538
+- dimensions: &id545
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache_out]
   title: Luftbilder swisstopo farbig (20071231)
-- dimensions: *id538
+- dimensions: *id545
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache]
   title: Luftbilder swisstopo farbig (20071231, source)
-- dimensions: &id539
+- dimensions: &id546
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache_out]
   title: Luftbilder swisstopo farbig (20061231)
-- dimensions: *id539
+- dimensions: *id546
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache]
   title: Luftbilder swisstopo farbig (20061231, source)
-- dimensions: &id540
+- dimensions: &id547
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache_out]
   title: Luftbilder swisstopo farbig (20051231)
-- dimensions: *id540
+- dimensions: *id547
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache]
   title: Luftbilder swisstopo farbig (20051231, source)
-- dimensions: &id541
+- dimensions: &id548
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache_out]
   title: Luftbilder swisstopo farbig (20041231)
-- dimensions: *id541
+- dimensions: *id548
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache]
   title: Luftbilder swisstopo farbig (20041231, source)
-- dimensions: &id542
+- dimensions: &id549
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache_out]
   title: Luftbilder swisstopo farbig (20031231)
-- dimensions: *id542
+- dimensions: *id549
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache]
   title: Luftbilder swisstopo farbig (20031231, source)
-- dimensions: &id543
+- dimensions: &id550
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache_out]
   title: Luftbilder swisstopo farbig (20021231)
-- dimensions: *id543
+- dimensions: *id550
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache]
   title: Luftbilder swisstopo farbig (20021231, source)
-- dimensions: &id544
+- dimensions: &id551
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache_out]
   title: Luftbilder swisstopo farbig (20011231)
-- dimensions: *id544
+- dimensions: *id551
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache]
   title: Luftbilder swisstopo farbig (20011231, source)
-- dimensions: &id545
+- dimensions: &id552
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache_out]
   title: Luftbilder swisstopo farbig (20001231)
-- dimensions: *id545
+- dimensions: *id552
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache]
   title: Luftbilder swisstopo farbig (20001231, source)
-- dimensions: &id546
+- dimensions: &id553
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache_out]
   title: Luftbilder swisstopo farbig (19991231)
-- dimensions: *id546
+- dimensions: *id553
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache]
   title: Luftbilder swisstopo farbig (19991231, source)
-- dimensions: &id547
+- dimensions: &id554
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache_out]
   title: Luftbilder swisstopo farbig (19981231)
-- dimensions: *id547
+- dimensions: *id554
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache]
   title: Luftbilder swisstopo farbig (19981231, source)
-- dimensions: &id548
+- dimensions: &id555
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache_out]
   title: Luftbilder swisstopo farbig (19971231)
-- dimensions: *id548
+- dimensions: *id555
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache]
   title: Luftbilder swisstopo farbig (19971231, source)
-- dimensions: &id549
+- dimensions: &id556
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache_out]
   title: Luftbilder swisstopo farbig (19961231)
-- dimensions: *id549
+- dimensions: *id556
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache]
   title: Luftbilder swisstopo farbig (19961231, source)
-- dimensions: &id550
+- dimensions: &id557
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache_out]
   title: Luftbilder swisstopo farbig (19951231)
-- dimensions: *id550
+- dimensions: *id557
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache]
   title: Luftbilder swisstopo farbig (19951231, source)
-- dimensions: &id551
+- dimensions: &id558
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache_out]
   title: Luftbilder swisstopo farbig (19941231)
-- dimensions: *id551
+- dimensions: *id558
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache]
   title: Luftbilder swisstopo farbig (19941231, source)
-- dimensions: &id552
+- dimensions: &id559
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache_out]
   title: Luftbilder swisstopo farbig (19931231)
-- dimensions: *id552
+- dimensions: *id559
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache]
   title: Luftbilder swisstopo farbig (19931231, source)
-- dimensions: &id553
+- dimensions: &id560
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache_out]
   title: Luftbilder swisstopo farbig (19921231)
-- dimensions: *id553
+- dimensions: *id560
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache]
   title: Luftbilder swisstopo farbig (19921231, source)
-- dimensions: &id554
+- dimensions: &id561
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache_out]
   title: Luftbilder swisstopo farbig (19911231)
-- dimensions: *id554
+- dimensions: *id561
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache]
   title: Luftbilder swisstopo farbig (19911231, source)
-- dimensions: &id555
+- dimensions: &id562
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache_out]
   title: Luftbilder swisstopo farbig (19901231)
-- dimensions: *id555
+- dimensions: *id562
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache]
   title: Luftbilder swisstopo farbig (19901231, source)
-- dimensions: &id556
+- dimensions: &id563
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache_out]
   title: Luftbilder swisstopo farbig (19891231)
-- dimensions: *id556
+- dimensions: *id563
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache]
   title: Luftbilder swisstopo farbig (19891231, source)
-- dimensions: &id557
+- dimensions: &id564
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache_out]
   title: Luftbilder swisstopo farbig (19881231)
-- dimensions: *id557
+- dimensions: *id564
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache]
   title: Luftbilder swisstopo farbig (19881231, source)
-- dimensions: &id558
+- dimensions: &id565
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache_out]
   title: Luftbilder swisstopo farbig (19871231)
-- dimensions: *id558
+- dimensions: *id565
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache]
   title: Luftbilder swisstopo farbig (19871231, source)
-- dimensions: &id559
+- dimensions: &id566
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache_out]
   title: Luftbilder swisstopo farbig (19861231)
-- dimensions: *id559
+- dimensions: *id566
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache]
   title: Luftbilder swisstopo farbig (19861231, source)
-- dimensions: &id560
+- dimensions: &id567
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache_out]
   title: Luftbilder swisstopo farbig (19851231)
-- dimensions: *id560
+- dimensions: *id567
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache]
   title: Luftbilder swisstopo farbig (19851231, source)
-- dimensions: &id561
+- dimensions: &id568
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache_out]
   title: Luftbilder swisstopo farbig (19841231)
-- dimensions: *id561
+- dimensions: *id568
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache]
   title: Luftbilder swisstopo farbig (19841231, source)
-- dimensions: &id562
+- dimensions: &id569
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache_out]
   title: Luftbilder swisstopo farbig (19831231)
-- dimensions: *id562
+- dimensions: *id569
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache]
   title: Luftbilder swisstopo farbig (19831231, source)
-- dimensions: &id563
+- dimensions: &id570
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache_out]
   title: Luftbilder swisstopo farbig (19821231)
-- dimensions: *id563
+- dimensions: *id570
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache]
   title: Luftbilder swisstopo farbig (19821231, source)
-- dimensions: &id564
+- dimensions: &id571
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache_out]
   title: Luftbilder swisstopo farbig (19811231)
-- dimensions: *id564
+- dimensions: *id571
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache]
   title: Luftbilder swisstopo farbig (19811231, source)
-- dimensions: &id565
+- dimensions: &id572
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache_out]
   title: Luftbilder swisstopo infrarot (99991231)
-- dimensions: *id565
+- dimensions: *id572
   name: ch.swisstopo.lubis-luftbilder_infrarot
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot ('current')
-- dimensions: *id565
+- dimensions: *id572
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot (99991231, source)
-- dimensions: &id566
+- dimensions: &id573
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache_out]
   title: Luftbilder swisstopo infrarot (20091231)
-- dimensions: *id566
+- dimensions: *id573
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache]
   title: Luftbilder swisstopo infrarot (20091231, source)
-- dimensions: &id567
+- dimensions: &id574
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache_out]
   title: Luftbilder swisstopo infrarot (20081231)
-- dimensions: *id567
+- dimensions: *id574
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache]
   title: Luftbilder swisstopo infrarot (20081231, source)
-- dimensions: &id568
+- dimensions: &id575
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache_out]
   title: Luftbilder swisstopo infrarot (20071231)
-- dimensions: *id568
+- dimensions: *id575
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache]
   title: Luftbilder swisstopo infrarot (20071231, source)
-- dimensions: &id569
+- dimensions: &id576
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache_out]
   title: Luftbilder swisstopo infrarot (20061231)
-- dimensions: *id569
+- dimensions: *id576
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache]
   title: Luftbilder swisstopo infrarot (20061231, source)
-- dimensions: &id570
+- dimensions: &id577
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache_out]
   title: Luftbilder swisstopo infrarot (20051231)
-- dimensions: *id570
+- dimensions: *id577
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache]
   title: Luftbilder swisstopo infrarot (20051231, source)
-- dimensions: &id571
+- dimensions: &id578
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache_out]
   title: Luftbilder swisstopo infrarot (20041231)
-- dimensions: *id571
+- dimensions: *id578
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache]
   title: Luftbilder swisstopo infrarot (20041231, source)
-- dimensions: &id572
+- dimensions: &id579
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache_out]
   title: Luftbilder swisstopo infrarot (20031231)
-- dimensions: *id572
+- dimensions: *id579
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache]
   title: Luftbilder swisstopo infrarot (20031231, source)
-- dimensions: &id573
+- dimensions: &id580
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache_out]
   title: Luftbilder swisstopo infrarot (20021231)
-- dimensions: *id573
+- dimensions: *id580
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache]
   title: Luftbilder swisstopo infrarot (20021231, source)
-- dimensions: &id574
+- dimensions: &id581
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache_out]
   title: Luftbilder swisstopo infrarot (20011231)
-- dimensions: *id574
+- dimensions: *id581
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache]
   title: Luftbilder swisstopo infrarot (20011231, source)
-- dimensions: &id575
+- dimensions: &id582
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache_out]
   title: Luftbilder swisstopo infrarot (20001231)
-- dimensions: *id575
+- dimensions: *id582
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache]
   title: Luftbilder swisstopo infrarot (20001231, source)
-- dimensions: &id576
+- dimensions: &id583
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache_out]
   title: Luftbilder swisstopo infrarot (19991231)
-- dimensions: *id576
+- dimensions: *id583
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache]
   title: Luftbilder swisstopo infrarot (19991231, source)
-- dimensions: &id577
+- dimensions: &id584
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache_out]
   title: Luftbilder swisstopo infrarot (19981231)
-- dimensions: *id577
+- dimensions: *id584
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache]
   title: Luftbilder swisstopo infrarot (19981231, source)
-- dimensions: &id578
+- dimensions: &id585
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache_out]
   title: Luftbilder swisstopo infrarot (19971231)
-- dimensions: *id578
+- dimensions: *id585
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache]
   title: Luftbilder swisstopo infrarot (19971231, source)
-- dimensions: &id579
+- dimensions: &id586
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache_out]
   title: Luftbilder swisstopo infrarot (19961231)
-- dimensions: *id579
+- dimensions: *id586
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache]
   title: Luftbilder swisstopo infrarot (19961231, source)
-- dimensions: &id580
+- dimensions: &id587
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache_out]
   title: Luftbilder swisstopo infrarot (19951231)
-- dimensions: *id580
+- dimensions: *id587
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache]
   title: Luftbilder swisstopo infrarot (19951231, source)
-- dimensions: &id581
+- dimensions: &id588
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache_out]
   title: Luftbilder swisstopo infrarot (19941231)
-- dimensions: *id581
+- dimensions: *id588
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache]
   title: Luftbilder swisstopo infrarot (19941231, source)
-- dimensions: &id582
+- dimensions: &id589
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache_out]
   title: Luftbilder swisstopo infrarot (19931231)
-- dimensions: *id582
+- dimensions: *id589
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache]
   title: Luftbilder swisstopo infrarot (19931231, source)
-- dimensions: &id583
+- dimensions: &id590
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache_out]
   title: Luftbilder swisstopo infrarot (19921231)
-- dimensions: *id583
+- dimensions: *id590
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache]
   title: Luftbilder swisstopo infrarot (19921231, source)
-- dimensions: &id584
+- dimensions: &id591
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache_out]
   title: Luftbilder swisstopo infrarot (19911231)
-- dimensions: *id584
+- dimensions: *id591
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache]
   title: Luftbilder swisstopo infrarot (19911231, source)
-- dimensions: &id585
+- dimensions: &id592
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache_out]
   title: Luftbilder swisstopo infrarot (19901231)
-- dimensions: *id585
+- dimensions: *id592
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache]
   title: Luftbilder swisstopo infrarot (19901231, source)
-- dimensions: &id586
+- dimensions: &id593
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache_out]
   title: Luftbilder swisstopo infrarot (19891231)
-- dimensions: *id586
+- dimensions: *id593
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache]
   title: Luftbilder swisstopo infrarot (19891231, source)
-- dimensions: &id587
+- dimensions: &id594
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache_out]
   title: Luftbilder swisstopo infrarot (19881231)
-- dimensions: *id587
+- dimensions: *id594
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache]
   title: Luftbilder swisstopo infrarot (19881231, source)
-- dimensions: &id588
+- dimensions: &id595
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache_out]
   title: Luftbilder swisstopo infrarot (19871231)
-- dimensions: *id588
+- dimensions: *id595
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache]
   title: Luftbilder swisstopo infrarot (19871231, source)
-- dimensions: &id589
+- dimensions: &id596
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache_out]
   title: Luftbilder swisstopo infrarot (19861231)
-- dimensions: *id589
+- dimensions: *id596
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache]
   title: Luftbilder swisstopo infrarot (19861231, source)
-- dimensions: &id590
+- dimensions: &id597
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache_out]
   title: Luftbilder swisstopo infrarot (19851231)
-- dimensions: *id590
+- dimensions: *id597
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache]
   title: Luftbilder swisstopo infrarot (19851231, source)
-- dimensions: &id591
+- dimensions: &id598
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache_out]
   title: Luftbilder swisstopo infrarot (19841231)
-- dimensions: *id591
+- dimensions: *id598
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache]
   title: Luftbilder swisstopo infrarot (19841231, source)
-- dimensions: &id592
+- dimensions: &id599
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache_out]
   title: Luftbilder swisstopo infrarot (19831231)
-- dimensions: *id592
+- dimensions: *id599
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache]
   title: Luftbilder swisstopo infrarot (19831231, source)
-- dimensions: &id593
+- dimensions: &id600
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache_out]
   title: Luftbilder swisstopo infrarot (19811231)
-- dimensions: *id593
+- dimensions: *id600
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache]
   title: Luftbilder swisstopo infrarot (19811231, source)
-- dimensions: &id594
+- dimensions: &id601
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache_out]
   title: Luftbilder swisstopo s/w (99991231)
-- dimensions: *id594
+- dimensions: *id601
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w ('current')
-- dimensions: *id594
+- dimensions: *id601
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w (99991231, source)
-- dimensions: &id595
+- dimensions: &id602
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache_out]
   title: Luftbilder swisstopo s/w (20101231)
-- dimensions: *id595
+- dimensions: *id602
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache]
   title: Luftbilder swisstopo s/w (20101231, source)
-- dimensions: &id596
+- dimensions: &id603
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache_out]
   title: Luftbilder swisstopo s/w (20091231)
-- dimensions: *id596
+- dimensions: *id603
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache]
   title: Luftbilder swisstopo s/w (20091231, source)
-- dimensions: &id597
+- dimensions: &id604
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache_out]
   title: Luftbilder swisstopo s/w (20081231)
-- dimensions: *id597
+- dimensions: *id604
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache]
   title: Luftbilder swisstopo s/w (20081231, source)
-- dimensions: &id598
+- dimensions: &id605
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache_out]
   title: Luftbilder swisstopo s/w (20071231)
-- dimensions: *id598
+- dimensions: *id605
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache]
   title: Luftbilder swisstopo s/w (20071231, source)
-- dimensions: &id599
+- dimensions: &id606
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache_out]
   title: Luftbilder swisstopo s/w (20061231)
-- dimensions: *id599
+- dimensions: *id606
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache]
   title: Luftbilder swisstopo s/w (20061231, source)
-- dimensions: &id600
+- dimensions: &id607
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache_out]
   title: Luftbilder swisstopo s/w (20051231)
-- dimensions: *id600
+- dimensions: *id607
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache]
   title: Luftbilder swisstopo s/w (20051231, source)
-- dimensions: &id601
+- dimensions: &id608
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache_out]
   title: Luftbilder swisstopo s/w (20041231)
-- dimensions: *id601
+- dimensions: *id608
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache]
   title: Luftbilder swisstopo s/w (20041231, source)
-- dimensions: &id602
+- dimensions: &id609
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache_out]
   title: Luftbilder swisstopo s/w (20031231)
-- dimensions: *id602
+- dimensions: *id609
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache]
   title: Luftbilder swisstopo s/w (20031231, source)
-- dimensions: &id603
+- dimensions: &id610
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache_out]
   title: Luftbilder swisstopo s/w (20021231)
-- dimensions: *id603
+- dimensions: *id610
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache]
   title: Luftbilder swisstopo s/w (20021231, source)
-- dimensions: &id604
+- dimensions: &id611
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache_out]
   title: Luftbilder swisstopo s/w (20011231)
-- dimensions: *id604
+- dimensions: *id611
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache]
   title: Luftbilder swisstopo s/w (20011231, source)
-- dimensions: &id605
+- dimensions: &id612
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache_out]
   title: Luftbilder swisstopo s/w (20001231)
-- dimensions: *id605
+- dimensions: *id612
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache]
   title: Luftbilder swisstopo s/w (20001231, source)
-- dimensions: &id606
+- dimensions: &id613
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache_out]
   title: Luftbilder swisstopo s/w (19991231)
-- dimensions: *id606
+- dimensions: *id613
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache]
   title: Luftbilder swisstopo s/w (19991231, source)
-- dimensions: &id607
+- dimensions: &id614
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache_out]
   title: Luftbilder swisstopo s/w (19981231)
-- dimensions: *id607
+- dimensions: *id614
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache]
   title: Luftbilder swisstopo s/w (19981231, source)
-- dimensions: &id608
+- dimensions: &id615
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache_out]
   title: Luftbilder swisstopo s/w (19971231)
-- dimensions: *id608
+- dimensions: *id615
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache]
   title: Luftbilder swisstopo s/w (19971231, source)
-- dimensions: &id609
+- dimensions: &id616
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache_out]
   title: Luftbilder swisstopo s/w (19961231)
-- dimensions: *id609
+- dimensions: *id616
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache]
   title: Luftbilder swisstopo s/w (19961231, source)
-- dimensions: &id610
+- dimensions: &id617
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache_out]
   title: Luftbilder swisstopo s/w (19951231)
-- dimensions: *id610
+- dimensions: *id617
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache]
   title: Luftbilder swisstopo s/w (19951231, source)
-- dimensions: &id611
+- dimensions: &id618
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache_out]
   title: Luftbilder swisstopo s/w (19941231)
-- dimensions: *id611
+- dimensions: *id618
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache]
   title: Luftbilder swisstopo s/w (19941231, source)
-- dimensions: &id612
+- dimensions: &id619
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache_out]
   title: Luftbilder swisstopo s/w (19931231)
-- dimensions: *id612
+- dimensions: *id619
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache]
   title: Luftbilder swisstopo s/w (19931231, source)
-- dimensions: &id613
+- dimensions: &id620
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache_out]
   title: Luftbilder swisstopo s/w (19921231)
-- dimensions: *id613
+- dimensions: *id620
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache]
   title: Luftbilder swisstopo s/w (19921231, source)
-- dimensions: &id614
+- dimensions: &id621
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache_out]
   title: Luftbilder swisstopo s/w (19911231)
-- dimensions: *id614
+- dimensions: *id621
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache]
   title: Luftbilder swisstopo s/w (19911231, source)
-- dimensions: &id615
+- dimensions: &id622
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache_out]
   title: Luftbilder swisstopo s/w (19901231)
-- dimensions: *id615
+- dimensions: *id622
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache]
   title: Luftbilder swisstopo s/w (19901231, source)
-- dimensions: &id616
+- dimensions: &id623
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache_out]
   title: Luftbilder swisstopo s/w (19891231)
-- dimensions: *id616
+- dimensions: *id623
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache]
   title: Luftbilder swisstopo s/w (19891231, source)
-- dimensions: &id617
+- dimensions: &id624
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache_out]
   title: Luftbilder swisstopo s/w (19881231)
-- dimensions: *id617
+- dimensions: *id624
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache]
   title: Luftbilder swisstopo s/w (19881231, source)
-- dimensions: &id618
+- dimensions: &id625
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache_out]
   title: Luftbilder swisstopo s/w (19871231)
-- dimensions: *id618
+- dimensions: *id625
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache]
   title: Luftbilder swisstopo s/w (19871231, source)
-- dimensions: &id619
+- dimensions: &id626
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache_out]
   title: Luftbilder swisstopo s/w (19861231)
-- dimensions: *id619
+- dimensions: *id626
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache]
   title: Luftbilder swisstopo s/w (19861231, source)
-- dimensions: &id620
+- dimensions: &id627
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache_out]
   title: Luftbilder swisstopo s/w (19851231)
-- dimensions: *id620
+- dimensions: *id627
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache]
   title: Luftbilder swisstopo s/w (19851231, source)
-- dimensions: &id621
+- dimensions: &id628
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache_out]
   title: Luftbilder swisstopo s/w (19841231)
-- dimensions: *id621
+- dimensions: *id628
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache]
   title: Luftbilder swisstopo s/w (19841231, source)
-- dimensions: &id622
+- dimensions: &id629
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache_out]
   title: Luftbilder swisstopo s/w (19831231)
-- dimensions: *id622
+- dimensions: *id629
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache]
   title: Luftbilder swisstopo s/w (19831231, source)
-- dimensions: &id623
+- dimensions: &id630
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache_out]
   title: Luftbilder swisstopo s/w (19821231)
-- dimensions: *id623
+- dimensions: *id630
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache]
   title: Luftbilder swisstopo s/w (19821231, source)
-- dimensions: &id624
+- dimensions: &id631
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache_out]
   title: Luftbilder swisstopo s/w (19811231)
-- dimensions: *id624
+- dimensions: *id631
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache]
   title: Luftbilder swisstopo s/w (19811231, source)
-- dimensions: &id625
+- dimensions: &id632
     Time:
       default: '19801231'
       values: ['19801231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache_out]
   title: Luftbilder swisstopo s/w (19801231)
-- dimensions: *id625
+- dimensions: *id632
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache]
   title: Luftbilder swisstopo s/w (19801231, source)
-- dimensions: &id626
+- dimensions: &id633
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache_out]
   title: Luftbilder swisstopo s/w (19791231)
-- dimensions: *id626
+- dimensions: *id633
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache]
   title: Luftbilder swisstopo s/w (19791231, source)
-- dimensions: &id627
+- dimensions: &id634
     Time:
       default: '19781231'
       values: ['19781231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache_out]
   title: Luftbilder swisstopo s/w (19781231)
-- dimensions: *id627
+- dimensions: *id634
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache]
   title: Luftbilder swisstopo s/w (19781231, source)
-- dimensions: &id628
+- dimensions: &id635
     Time:
       default: '19771231'
       values: ['19771231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache_out]
   title: Luftbilder swisstopo s/w (19771231)
-- dimensions: *id628
+- dimensions: *id635
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache]
   title: Luftbilder swisstopo s/w (19771231, source)
-- dimensions: &id629
+- dimensions: &id636
     Time:
       default: '19761231'
       values: ['19761231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache_out]
   title: Luftbilder swisstopo s/w (19761231)
-- dimensions: *id629
+- dimensions: *id636
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache]
   title: Luftbilder swisstopo s/w (19761231, source)
-- dimensions: &id630
+- dimensions: &id637
     Time:
       default: '19751231'
       values: ['19751231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache_out]
   title: Luftbilder swisstopo s/w (19751231)
-- dimensions: *id630
+- dimensions: *id637
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache]
   title: Luftbilder swisstopo s/w (19751231, source)
-- dimensions: &id631
+- dimensions: &id638
     Time:
       default: '19741231'
       values: ['19741231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache_out]
   title: Luftbilder swisstopo s/w (19741231)
-- dimensions: *id631
+- dimensions: *id638
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache]
   title: Luftbilder swisstopo s/w (19741231, source)
-- dimensions: &id632
+- dimensions: &id639
     Time:
       default: '19731231'
       values: ['19731231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache_out]
   title: Luftbilder swisstopo s/w (19731231)
-- dimensions: *id632
+- dimensions: *id639
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache]
   title: Luftbilder swisstopo s/w (19731231, source)
-- dimensions: &id633
+- dimensions: &id640
     Time:
       default: '19721231'
       values: ['19721231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache_out]
   title: Luftbilder swisstopo s/w (19721231)
-- dimensions: *id633
+- dimensions: *id640
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache]
   title: Luftbilder swisstopo s/w (19721231, source)
-- dimensions: &id634
+- dimensions: &id641
     Time:
       default: '19711231'
       values: ['19711231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache_out]
   title: Luftbilder swisstopo s/w (19711231)
-- dimensions: *id634
+- dimensions: *id641
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache]
   title: Luftbilder swisstopo s/w (19711231, source)
-- dimensions: &id635
+- dimensions: &id642
     Time:
       default: '19701231'
       values: ['19701231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache_out]
   title: Luftbilder swisstopo s/w (19701231)
-- dimensions: *id635
+- dimensions: *id642
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache]
   title: Luftbilder swisstopo s/w (19701231, source)
-- dimensions: &id636
+- dimensions: &id643
     Time:
       default: '19691231'
       values: ['19691231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache_out]
   title: Luftbilder swisstopo s/w (19691231)
-- dimensions: *id636
+- dimensions: *id643
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache]
   title: Luftbilder swisstopo s/w (19691231, source)
-- dimensions: &id637
+- dimensions: &id644
     Time:
       default: '19681231'
       values: ['19681231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache_out]
   title: Luftbilder swisstopo s/w (19681231)
-- dimensions: *id637
+- dimensions: *id644
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache]
   title: Luftbilder swisstopo s/w (19681231, source)
-- dimensions: &id638
+- dimensions: &id645
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache_out]
   title: Luftbilder swisstopo s/w (19671231)
-- dimensions: *id638
+- dimensions: *id645
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache]
   title: Luftbilder swisstopo s/w (19671231, source)
-- dimensions: &id639
+- dimensions: &id646
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache_out]
   title: Luftbilder swisstopo s/w (19661231)
-- dimensions: *id639
+- dimensions: *id646
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache]
   title: Luftbilder swisstopo s/w (19661231, source)
-- dimensions: &id640
+- dimensions: &id647
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache_out]
   title: Luftbilder swisstopo s/w (19651231)
-- dimensions: *id640
+- dimensions: *id647
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache]
   title: Luftbilder swisstopo s/w (19651231, source)
-- dimensions: &id641
+- dimensions: &id648
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache_out]
   title: Luftbilder swisstopo s/w (19641231)
-- dimensions: *id641
+- dimensions: *id648
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache]
   title: Luftbilder swisstopo s/w (19641231, source)
-- dimensions: &id642
+- dimensions: &id649
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache_out]
   title: Luftbilder swisstopo s/w (19631231)
-- dimensions: *id642
+- dimensions: *id649
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache]
   title: Luftbilder swisstopo s/w (19631231, source)
-- dimensions: &id643
+- dimensions: &id650
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache_out]
   title: Luftbilder swisstopo s/w (19621231)
-- dimensions: *id643
+- dimensions: *id650
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache]
   title: Luftbilder swisstopo s/w (19621231, source)
-- dimensions: &id644
+- dimensions: &id651
     Time:
       default: '19611231'
       values: ['19611231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache_out]
   title: Luftbilder swisstopo s/w (19611231)
-- dimensions: *id644
+- dimensions: *id651
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache]
   title: Luftbilder swisstopo s/w (19611231, source)
-- dimensions: &id645
+- dimensions: &id652
     Time:
       default: '19601231'
       values: ['19601231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache_out]
   title: Luftbilder swisstopo s/w (19601231)
-- dimensions: *id645
+- dimensions: *id652
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache]
   title: Luftbilder swisstopo s/w (19601231, source)
-- dimensions: &id646
+- dimensions: &id653
     Time:
       default: '19591231'
       values: ['19591231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache_out]
   title: Luftbilder swisstopo s/w (19591231)
-- dimensions: *id646
+- dimensions: *id653
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache]
   title: Luftbilder swisstopo s/w (19591231, source)
-- dimensions: &id647
+- dimensions: &id654
     Time:
       default: '19581231'
       values: ['19581231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache_out]
   title: Luftbilder swisstopo s/w (19581231)
-- dimensions: *id647
+- dimensions: *id654
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache]
   title: Luftbilder swisstopo s/w (19581231, source)
-- dimensions: &id648
+- dimensions: &id655
     Time:
       default: '19571231'
       values: ['19571231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache_out]
   title: Luftbilder swisstopo s/w (19571231)
-- dimensions: *id648
+- dimensions: *id655
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache]
   title: Luftbilder swisstopo s/w (19571231, source)
-- dimensions: &id649
+- dimensions: &id656
     Time:
       default: '19561231'
       values: ['19561231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache_out]
   title: Luftbilder swisstopo s/w (19561231)
-- dimensions: *id649
+- dimensions: *id656
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache]
   title: Luftbilder swisstopo s/w (19561231, source)
-- dimensions: &id650
+- dimensions: &id657
     Time:
       default: '19551231'
       values: ['19551231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache_out]
   title: Luftbilder swisstopo s/w (19551231)
-- dimensions: *id650
+- dimensions: *id657
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache]
   title: Luftbilder swisstopo s/w (19551231, source)
-- dimensions: &id651
+- dimensions: &id658
     Time:
       default: '19541231'
       values: ['19541231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache_out]
   title: Luftbilder swisstopo s/w (19541231)
-- dimensions: *id651
+- dimensions: *id658
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache]
   title: Luftbilder swisstopo s/w (19541231, source)
-- dimensions: &id652
+- dimensions: &id659
     Time:
       default: '19531231'
       values: ['19531231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache_out]
   title: Luftbilder swisstopo s/w (19531231)
-- dimensions: *id652
+- dimensions: *id659
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache]
   title: Luftbilder swisstopo s/w (19531231, source)
-- dimensions: &id653
+- dimensions: &id660
     Time:
       default: '19521231'
       values: ['19521231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache_out]
   title: Luftbilder swisstopo s/w (19521231)
-- dimensions: *id653
+- dimensions: *id660
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache]
   title: Luftbilder swisstopo s/w (19521231, source)
-- dimensions: &id654
+- dimensions: &id661
     Time:
       default: '19511231'
       values: ['19511231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache_out]
   title: Luftbilder swisstopo s/w (19511231)
-- dimensions: *id654
+- dimensions: *id661
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache]
   title: Luftbilder swisstopo s/w (19511231, source)
-- dimensions: &id655
+- dimensions: &id662
     Time:
       default: '19501231'
       values: ['19501231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache_out]
   title: Luftbilder swisstopo s/w (19501231)
-- dimensions: *id655
+- dimensions: *id662
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache]
   title: Luftbilder swisstopo s/w (19501231, source)
-- dimensions: &id656
+- dimensions: &id663
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache_out]
   title: Luftbilder swisstopo s/w (19491231)
-- dimensions: *id656
+- dimensions: *id663
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache]
   title: Luftbilder swisstopo s/w (19491231, source)
-- dimensions: &id657
+- dimensions: &id664
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache_out]
   title: Luftbilder swisstopo s/w (19481231)
-- dimensions: *id657
+- dimensions: *id664
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache]
   title: Luftbilder swisstopo s/w (19481231, source)
-- dimensions: &id658
+- dimensions: &id665
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache_out]
   title: Luftbilder swisstopo s/w (19471231)
-- dimensions: *id658
+- dimensions: *id665
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache]
   title: Luftbilder swisstopo s/w (19471231, source)
-- dimensions: &id659
+- dimensions: &id666
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache_out]
   title: Luftbilder swisstopo s/w (19461231)
-- dimensions: *id659
+- dimensions: *id666
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache]
   title: Luftbilder swisstopo s/w (19461231, source)
-- dimensions: &id660
+- dimensions: &id667
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache_out]
   title: Luftbilder swisstopo s/w (19451231)
-- dimensions: *id660
+- dimensions: *id667
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache]
   title: Luftbilder swisstopo s/w (19451231, source)
-- dimensions: &id661
+- dimensions: &id668
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache_out]
   title: Luftbilder swisstopo s/w (19441231)
-- dimensions: *id661
+- dimensions: *id668
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache]
   title: Luftbilder swisstopo s/w (19441231, source)
-- dimensions: &id662
+- dimensions: &id669
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache_out]
   title: Luftbilder swisstopo s/w (19431231)
-- dimensions: *id662
+- dimensions: *id669
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache]
   title: Luftbilder swisstopo s/w (19431231, source)
-- dimensions: &id663
+- dimensions: &id670
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache_out]
   title: Luftbilder swisstopo s/w (19421231)
-- dimensions: *id663
+- dimensions: *id670
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache]
   title: Luftbilder swisstopo s/w (19421231, source)
-- dimensions: &id664
+- dimensions: &id671
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache_out]
   title: Luftbilder swisstopo s/w (19411231)
-- dimensions: *id664
+- dimensions: *id671
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache]
   title: Luftbilder swisstopo s/w (19411231, source)
-- dimensions: &id665
+- dimensions: &id672
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache_out]
   title: Luftbilder swisstopo s/w (19401231)
-- dimensions: *id665
+- dimensions: *id672
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache]
   title: Luftbilder swisstopo s/w (19401231, source)
-- dimensions: &id666
+- dimensions: &id673
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache_out]
   title: Luftbilder swisstopo s/w (19391231)
-- dimensions: *id666
+- dimensions: *id673
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache]
   title: Luftbilder swisstopo s/w (19391231, source)
-- dimensions: &id667
+- dimensions: &id674
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache_out]
   title: Luftbilder swisstopo s/w (19381231)
-- dimensions: *id667
+- dimensions: *id674
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache]
   title: Luftbilder swisstopo s/w (19381231, source)
-- dimensions: &id668
+- dimensions: &id675
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache_out]
   title: Luftbilder swisstopo s/w (19371231)
-- dimensions: *id668
+- dimensions: *id675
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache]
   title: Luftbilder swisstopo s/w (19371231, source)
-- dimensions: &id669
+- dimensions: &id676
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache_out]
   title: Luftbilder swisstopo s/w (19361231)
-- dimensions: *id669
+- dimensions: *id676
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache]
   title: Luftbilder swisstopo s/w (19361231, source)
-- dimensions: &id670
+- dimensions: &id677
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache_out]
   title: Luftbilder swisstopo s/w (19351231)
-- dimensions: *id670
+- dimensions: *id677
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache]
   title: Luftbilder swisstopo s/w (19351231, source)
-- dimensions: &id671
+- dimensions: &id678
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache_out]
   title: Luftbilder swisstopo s/w (19341231)
-- dimensions: *id671
+- dimensions: *id678
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache]
   title: Luftbilder swisstopo s/w (19341231, source)
-- dimensions: &id672
+- dimensions: &id679
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache_out]
   title: Luftbilder swisstopo s/w (19331231)
-- dimensions: *id672
+- dimensions: *id679
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache]
   title: Luftbilder swisstopo s/w (19331231, source)
-- dimensions: &id673
+- dimensions: &id680
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache_out]
   title: Luftbilder swisstopo s/w (19321231)
-- dimensions: *id673
+- dimensions: *id680
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache]
   title: Luftbilder swisstopo s/w (19321231, source)
-- dimensions: &id674
+- dimensions: &id681
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache_out]
   title: Luftbilder swisstopo s/w (19311231)
-- dimensions: *id674
+- dimensions: *id681
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache]
   title: Luftbilder swisstopo s/w (19311231, source)
-- dimensions: &id675
+- dimensions: &id682
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache_out]
   title: Luftbilder swisstopo s/w (19301231)
-- dimensions: *id675
+- dimensions: *id682
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache]
   title: Luftbilder swisstopo s/w (19301231, source)
-- dimensions: &id676
+- dimensions: &id683
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache_out]
   title: Luftbilder swisstopo s/w (19291231)
-- dimensions: *id676
+- dimensions: *id683
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache]
   title: Luftbilder swisstopo s/w (19291231, source)
-- dimensions: &id677
+- dimensions: &id684
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache_out]
   title: Luftbilder swisstopo s/w (19281231)
-- dimensions: *id677
+- dimensions: *id684
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache]
   title: Luftbilder swisstopo s/w (19281231, source)
-- dimensions: &id678
+- dimensions: &id685
     Time:
       default: '19271231'
       values: ['19271231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache_out]
   title: Luftbilder swisstopo s/w (19271231)
-- dimensions: *id678
+- dimensions: *id685
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache]
   title: Luftbilder swisstopo s/w (19271231, source)
-- dimensions: &id679
+- dimensions: &id686
     Time:
       default: '19261231'
       values: ['19261231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache_out]
   title: Luftbilder swisstopo s/w (19261231)
-- dimensions: *id679
+- dimensions: *id686
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache]
   title: Luftbilder swisstopo s/w (19261231, source)
-- dimensions: &id680
+- dimensions: &id687
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe_20151231
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id680
+- dimensions: *id687
   name: ch.swisstopo.pixelkarte-farbe
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id680
+- dimensions: *id687
   name: ch.swisstopo.pixelkarte-farbe_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id681
+- dimensions: &id688
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe_20140520
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140520)
-- dimensions: *id681
+- dimensions: *id688
   name: ch.swisstopo.pixelkarte-farbe_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache]
   title: Landeskarte 1:25'000 | LK25 (20140520, source)
-- dimensions: &id682
+- dimensions: &id689
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe_20140106
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140106)
-- dimensions: *id682
+- dimensions: *id689
   name: ch.swisstopo.pixelkarte-farbe_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache]
   title: Landeskarte 1:25'000 | LK25 (20140106, source)
-- dimensions: &id683
+- dimensions: &id690
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe_20130903
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130903)
-- dimensions: *id683
+- dimensions: *id690
   name: ch.swisstopo.pixelkarte-farbe_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache]
   title: Landeskarte 1:25'000 | LK25 (20130903, source)
-- dimensions: &id684
+- dimensions: &id691
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe_20130213
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130213)
-- dimensions: *id684
+- dimensions: *id691
   name: ch.swisstopo.pixelkarte-farbe_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache]
   title: Landeskarte 1:25'000 | LK25 (20130213, source)
-- dimensions: &id685
+- dimensions: &id692
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe_20120809
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20120809)
-- dimensions: *id685
+- dimensions: *id692
   name: ch.swisstopo.pixelkarte-farbe_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache]
   title: Landeskarte 1:25'000 | LK25 (20120809, source)
-- dimensions: &id686
+- dimensions: &id693
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-farbe_20111206
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111206)
-- dimensions: *id686
+- dimensions: *id693
   name: ch.swisstopo.pixelkarte-farbe_20111206_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache]
   title: Landeskarte 1:25'000 | LK25 (20111206, source)
-- dimensions: &id687
+- dimensions: &id694
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe_20111027
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111027)
-- dimensions: *id687
+- dimensions: *id694
   name: ch.swisstopo.pixelkarte-farbe_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache]
   title: Landeskarte 1:25'000 | LK25 (20111027, source)
-- dimensions: &id688
+- dimensions: &id695
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-farbe_20110401
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20110401)
-- dimensions: *id688
+- dimensions: *id695
   name: ch.swisstopo.pixelkarte-farbe_20110401_source
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache]
   title: Landeskarte 1:25'000 | LK25 (20110401, source)
-- dimensions: &id689
+- dimensions: &id696
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000 (20140106)
-- dimensions: *id689
+- dimensions: *id696
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Mio. | LK1000 ('current')
-- dimensions: *id689
+- dimensions: *id696
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Mio. | LK1000 (20140106, source)
-- dimensions: &id690
+- dimensions: &id697
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000 (20120809)
-- dimensions: *id690
+- dimensions: *id697
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache]
   title: Landeskarte 1:1 Mio. | LK1000 (20120809, source)
-- dimensions: &id691
+- dimensions: &id698
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000 (20111027)
-- dimensions: *id691
+- dimensions: *id698
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache]
   title: Landeskarte 1:1 Mio. | LK1000 (20111027, source)
-- dimensions: &id692
+- dimensions: &id699
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20151231)
-- dimensions: *id692
+- dimensions: *id699
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
   title: Landeskarte 1:100'000 | LK100 ('current')
-- dimensions: *id692
+- dimensions: *id699
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
   title: Landeskarte 1:100'000 | LK100 (20151231, source)
-- dimensions: &id693
+- dimensions: &id700
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20140106)
-- dimensions: *id693
+- dimensions: *id700
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache]
   title: Landeskarte 1:100'000 | LK100 (20140106, source)
-- dimensions: &id694
+- dimensions: &id701
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20130903)
-- dimensions: *id694
+- dimensions: *id701
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache]
   title: Landeskarte 1:100'000 | LK100 (20130903, source)
-- dimensions: &id695
+- dimensions: &id702
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20130213)
-- dimensions: *id695
+- dimensions: *id702
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache]
   title: Landeskarte 1:100'000 | LK100 (20130213, source)
-- dimensions: &id696
+- dimensions: &id703
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20120809)
-- dimensions: *id696
+- dimensions: *id703
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache]
   title: Landeskarte 1:100'000 | LK100 (20120809, source)
-- dimensions: &id697
+- dimensions: &id704
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20111206)
-- dimensions: *id697
+- dimensions: *id704
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache]
   title: Landeskarte 1:100'000 | LK100 (20111206, source)
-- dimensions: &id698
+- dimensions: &id705
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20111027)
-- dimensions: *id698
+- dimensions: *id705
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache]
   title: Landeskarte 1:100'000 | LK100 (20111027, source)
-- dimensions: &id699
+- dimensions: &id706
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache_out]
   title: Landeskarte 1:200'000 | LK200 (20151231)
-- dimensions: *id699
+- dimensions: *id706
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
   title: Landeskarte 1:200'000 | LK200 ('current')
-- dimensions: *id699
+- dimensions: *id706
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
   title: Landeskarte 1:200'000 | LK200 (20151231, source)
-- dimensions: &id700
+- dimensions: &id707
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache_out]
   title: Landeskarte 1:200'000 | LK200 (20111027)
-- dimensions: *id700
+- dimensions: *id707
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache]
   title: Landeskarte 1:200'000 | LK200 (20111027, source)
-- dimensions: &id701
+- dimensions: &id708
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id701
+- dimensions: *id708
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id701
+- dimensions: *id708
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id702
+- dimensions: &id709
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache_out]
   title: Landeskarte 1:500'000 | LK500 (20151231)
-- dimensions: *id702
+- dimensions: *id709
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
   title: Landeskarte 1:500'000 | LK500 ('current')
-- dimensions: *id702
+- dimensions: *id709
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
   title: Landeskarte 1:500'000 | LK500 (20151231, source)
-- dimensions: &id703
+- dimensions: &id710
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache_out]
   title: Landeskarte 1:500'000 | LK500 (20111027)
-- dimensions: *id703
+- dimensions: *id710
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache]
   title: Landeskarte 1:500'000 | LK500 (20111027, source)
-- dimensions: &id704
+- dimensions: &id711
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20151231)
-- dimensions: *id704
+- dimensions: *id711
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
   title: Landeskarte 1:50'000 | LK50 ('current')
-- dimensions: *id704
+- dimensions: *id711
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
   title: Landeskarte 1:50'000 | LK50 (20151231, source)
-- dimensions: &id705
+- dimensions: &id712
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20140520)
-- dimensions: *id705
+- dimensions: *id712
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache]
   title: Landeskarte 1:50'000 | LK50 (20140520, source)
-- dimensions: &id706
+- dimensions: &id713
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20140106)
-- dimensions: *id706
+- dimensions: *id713
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache]
   title: Landeskarte 1:50'000 | LK50 (20140106, source)
-- dimensions: &id707
+- dimensions: &id714
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20130903)
-- dimensions: *id707
+- dimensions: *id714
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache]
   title: Landeskarte 1:50'000 | LK50 (20130903, source)
-- dimensions: &id708
+- dimensions: &id715
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20130213)
-- dimensions: *id708
+- dimensions: *id715
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache]
   title: Landeskarte 1:50'000 | LK50 (20130213, source)
-- dimensions: &id709
+- dimensions: &id716
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20120809)
-- dimensions: *id709
+- dimensions: *id716
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache]
   title: Landeskarte 1:50'000 | LK50 (20120809, source)
-- dimensions: &id710
+- dimensions: &id717
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20111027)
-- dimensions: *id710
+- dimensions: *id717
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache]
   title: Landeskarte 1:50'000 | LK50 (20111027, source)
-- dimensions: &id711
+- dimensions: &id718
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-grau_20151231
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id711
+- dimensions: *id718
   name: ch.swisstopo.pixelkarte-grau
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id711
+- dimensions: *id718
   name: ch.swisstopo.pixelkarte-grau_20151231_source
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id712
+- dimensions: &id719
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-grau_20140520
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140520)
-- dimensions: *id712
+- dimensions: *id719
   name: ch.swisstopo.pixelkarte-grau_20140520_source
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache]
   title: Landeskarte 1:25'000 | LK25 (20140520, source)
-- dimensions: &id713
+- dimensions: &id720
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-grau_20140106
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140106)
-- dimensions: *id713
+- dimensions: *id720
   name: ch.swisstopo.pixelkarte-grau_20140106_source
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache]
   title: Landeskarte 1:25'000 | LK25 (20140106, source)
-- dimensions: &id714
+- dimensions: &id721
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-grau_20130903
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130903)
-- dimensions: *id714
+- dimensions: *id721
   name: ch.swisstopo.pixelkarte-grau_20130903_source
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache]
   title: Landeskarte 1:25'000 | LK25 (20130903, source)
-- dimensions: &id715
+- dimensions: &id722
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-grau_20130213
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130213)
-- dimensions: *id715
+- dimensions: *id722
   name: ch.swisstopo.pixelkarte-grau_20130213_source
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache]
   title: Landeskarte 1:25'000 | LK25 (20130213, source)
-- dimensions: &id716
+- dimensions: &id723
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-grau_20120809
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20120809)
-- dimensions: *id716
+- dimensions: *id723
   name: ch.swisstopo.pixelkarte-grau_20120809_source
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache]
   title: Landeskarte 1:25'000 | LK25 (20120809, source)
-- dimensions: &id717
+- dimensions: &id724
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-grau_20111206
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111206)
-- dimensions: *id717
+- dimensions: *id724
   name: ch.swisstopo.pixelkarte-grau_20111206_source
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache]
   title: Landeskarte 1:25'000 | LK25 (20111206, source)
-- dimensions: &id718
+- dimensions: &id725
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-grau_20111027
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111027)
-- dimensions: *id718
+- dimensions: *id725
   name: ch.swisstopo.pixelkarte-grau_20111027_source
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache]
   title: Landeskarte 1:25'000 | LK25 (20111027, source)
-- dimensions: &id719
+- dimensions: &id726
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-grau_20110401
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20110401)
-- dimensions: *id719
+- dimensions: *id726
   name: ch.swisstopo.pixelkarte-grau_20110401_source
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache]
   title: Landeskarte 1:25'000 | LK25 (20110401, source)
-- dimensions: &id720
+- dimensions: &id727
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache_out]
   title: swissALTI3D Reliefschattierung (20150101)
-- dimensions: *id720
+- dimensions: *id727
   name: ch.swisstopo.swissalti3d-reliefschattierung
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung ('current')
-- dimensions: *id720
+- dimensions: *id727
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung (20150101, source)
-- dimensions: &id721
+- dimensions: &id728
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20140101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache_out]
   title: swissALTI3D Reliefschattierung (20140101)
-- dimensions: *id721
+- dimensions: *id728
   name: ch.swisstopo.swissalti3d-reliefschattierung_20140101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache]
   title: swissALTI3D Reliefschattierung (20140101, source)
-- dimensions: &id722
+- dimensions: &id729
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20130101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache_out]
   title: swissALTI3D Reliefschattierung (20130101)
-- dimensions: *id722
+- dimensions: *id729
   name: ch.swisstopo.swissalti3d-reliefschattierung_20130101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache]
   title: swissALTI3D Reliefschattierung (20130101, source)
-- dimensions: &id723
+- dimensions: &id730
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20110101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache_out]
   title: swissALTI3D Reliefschattierung (20110101)
-- dimensions: *id723
+- dimensions: *id730
   name: ch.swisstopo.swissalti3d-reliefschattierung_20110101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache]
   title: swissALTI3D Reliefschattierung (20110101, source)
-- dimensions: &id724
+- dimensions: &id731
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20000101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache_out]
   title: swissALTI3D Reliefschattierung (20000101)
-- dimensions: *id724
+- dimensions: *id731
   name: ch.swisstopo.swissalti3d-reliefschattierung_20000101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache]
   title: swissALTI3D Reliefschattierung (20000101, source)
-- dimensions: &id725
+- dimensions: &id732
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache_out]
   title: Bezirksgrenzen (20150101)
-- dimensions: *id725
+- dimensions: *id732
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen ('current')
-- dimensions: *id725
+- dimensions: *id732
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen (20150101, source)
-- dimensions: &id726
+- dimensions: &id733
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache_out]
   title: Bezirksgrenzen (20140101)
-- dimensions: *id726
+- dimensions: *id733
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache]
   title: Bezirksgrenzen (20140101, source)
-- dimensions: &id727
+- dimensions: &id734
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache_out]
   title: Bezirksgrenzen (20130101)
-- dimensions: *id727
+- dimensions: *id734
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache]
   title: Bezirksgrenzen (20130101, source)
-- dimensions: &id728
+- dimensions: &id735
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache_out]
   title: Bezirksgrenzen (20120101)
-- dimensions: *id728
+- dimensions: *id735
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache]
   title: Bezirksgrenzen (20120101, source)
-- dimensions: &id729
+- dimensions: &id736
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache_out]
   title: Gemeindegrenzen (20150101)
-- dimensions: *id729
+- dimensions: *id736
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen ('current')
-- dimensions: *id729
+- dimensions: *id736
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen (20150101, source)
-- dimensions: &id730
+- dimensions: &id737
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache_out]
   title: Gemeindegrenzen (20140101)
-- dimensions: *id730
+- dimensions: *id737
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache]
   title: Gemeindegrenzen (20140101, source)
-- dimensions: &id731
+- dimensions: &id738
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache_out]
   title: Gemeindegrenzen (20130101)
-- dimensions: *id731
+- dimensions: *id738
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache]
   title: Gemeindegrenzen (20130101, source)
-- dimensions: &id732
+- dimensions: &id739
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache_out]
   title: Gemeindegrenzen (20120101)
-- dimensions: *id732
+- dimensions: *id739
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache]
   title: Gemeindegrenzen (20120101, source)
-- dimensions: &id733
+- dimensions: &id740
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache_out]
   title: Kantonsgrenzen (20150101)
-- dimensions: *id733
+- dimensions: *id740
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen ('current')
-- dimensions: *id733
+- dimensions: *id740
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen (20150101, source)
-- dimensions: &id734
+- dimensions: &id741
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache_out]
   title: Kantonsgrenzen (20140101)
-- dimensions: *id734
+- dimensions: *id741
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache]
   title: Kantonsgrenzen (20140101, source)
-- dimensions: &id735
+- dimensions: &id742
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache_out]
   title: Kantonsgrenzen (20130101)
-- dimensions: *id735
+- dimensions: *id742
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache]
   title: Kantonsgrenzen (20130101, source)
-- dimensions: &id736
+- dimensions: &id743
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache_out]
   title: Kantonsgrenzen (20120101)
-- dimensions: *id736
+- dimensions: *id743
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache]
   title: Kantonsgrenzen (20120101, source)
-- dimensions: &id737
+- dimensions: &id744
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache_out]
   title: Landesgrenzen (20150101)
-- dimensions: *id737
+- dimensions: *id744
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen ('current')
-- dimensions: *id737
+- dimensions: *id744
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen (20150101, source)
-- dimensions: &id738
+- dimensions: &id745
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache_out]
   title: Landesgrenzen (20140101)
-- dimensions: *id738
+- dimensions: *id745
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache]
   title: Landesgrenzen (20140101, source)
-- dimensions: &id739
+- dimensions: &id746
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache_out]
   title: Landesgrenzen (20130101)
-- dimensions: *id739
+- dimensions: *id746
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache]
   title: Landesgrenzen (20130101, source)
-- dimensions: &id740
+- dimensions: &id747
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache_out]
   title: Landesgrenzen (20120101)
-- dimensions: *id740
+- dimensions: *id747
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache]
   title: Landesgrenzen (20120101, source)
-- dimensions: &id741
+- dimensions: &id748
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.swissbuildings3d_19980101
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache_out]
   title: "Vereinfachte 3D-Geb\xE4ude (19980101)"
-- dimensions: *id741
+- dimensions: *id748
   name: ch.swisstopo.swissbuildings3d
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude ('current')"
-- dimensions: *id741
+- dimensions: *id748
   name: ch.swisstopo.swissbuildings3d_19980101_source
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude (19980101, source)"
-- dimensions: &id742
+- dimensions: &id749
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.swissimage_20151231
   sources: [ch.swisstopo.swissimage_20151231_cache_out]
   title: SWISSIMAGE (20151231)
-- dimensions: *id742
+- dimensions: *id749
   name: ch.swisstopo.swissimage
   sources: [ch.swisstopo.swissimage_20151231_cache]
   title: SWISSIMAGE ('current')
-- dimensions: *id742
+- dimensions: *id749
   name: ch.swisstopo.swissimage_20151231_source
   sources: [ch.swisstopo.swissimage_20151231_cache]
   title: SWISSIMAGE (20151231, source)
-- dimensions: &id743
+- dimensions: &id750
     Time:
       default: '20140620'
       values: ['20140620']
   name: ch.swisstopo.swissimage_20140620
   sources: [ch.swisstopo.swissimage_20140620_cache_out]
   title: SWISSIMAGE (20140620)
-- dimensions: *id743
+- dimensions: *id750
   name: ch.swisstopo.swissimage_20140620_source
   sources: [ch.swisstopo.swissimage_20140620_cache]
   title: SWISSIMAGE (20140620, source)
-- dimensions: &id744
+- dimensions: &id751
     Time:
       default: '20131107'
       values: ['20131107']
   name: ch.swisstopo.swissimage_20131107
   sources: [ch.swisstopo.swissimage_20131107_cache_out]
   title: SWISSIMAGE (20131107)
-- dimensions: *id744
+- dimensions: *id751
   name: ch.swisstopo.swissimage_20131107_source
   sources: [ch.swisstopo.swissimage_20131107_cache]
   title: SWISSIMAGE (20131107, source)
-- dimensions: &id745
+- dimensions: &id752
     Time:
       default: '20130916'
       values: ['20130916']
   name: ch.swisstopo.swissimage_20130916
   sources: [ch.swisstopo.swissimage_20130916_cache_out]
   title: SWISSIMAGE (20130916)
-- dimensions: *id745
+- dimensions: *id752
   name: ch.swisstopo.swissimage_20130916_source
   sources: [ch.swisstopo.swissimage_20130916_cache]
   title: SWISSIMAGE (20130916, source)
-- dimensions: &id746
+- dimensions: &id753
     Time:
       default: '20130422'
       values: ['20130422']
   name: ch.swisstopo.swissimage_20130422
   sources: [ch.swisstopo.swissimage_20130422_cache_out]
   title: SWISSIMAGE (20130422)
-- dimensions: *id746
+- dimensions: *id753
   name: ch.swisstopo.swissimage_20130422_source
   sources: [ch.swisstopo.swissimage_20130422_cache]
   title: SWISSIMAGE (20130422, source)
-- dimensions: &id747
+- dimensions: &id754
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.swissimage_20120809
   sources: [ch.swisstopo.swissimage_20120809_cache_out]
   title: SWISSIMAGE (20120809)
-- dimensions: *id747
+- dimensions: *id754
   name: ch.swisstopo.swissimage_20120809_source
   sources: [ch.swisstopo.swissimage_20120809_cache]
   title: SWISSIMAGE (20120809, source)
-- dimensions: &id748
+- dimensions: &id755
     Time:
       default: '20120225'
       values: ['20120225']
   name: ch.swisstopo.swissimage_20120225
   sources: [ch.swisstopo.swissimage_20120225_cache_out]
   title: SWISSIMAGE (20120225)
-- dimensions: *id748
+- dimensions: *id755
   name: ch.swisstopo.swissimage_20120225_source
   sources: [ch.swisstopo.swissimage_20120225_cache]
   title: SWISSIMAGE (20120225, source)
-- dimensions: &id749
+- dimensions: &id756
     Time:
       default: '20110914'
       values: ['20110914']
   name: ch.swisstopo.swissimage_20110914
   sources: [ch.swisstopo.swissimage_20110914_cache_out]
   title: SWISSIMAGE (20110914)
-- dimensions: *id749
+- dimensions: *id756
   name: ch.swisstopo.swissimage_20110914_source
   sources: [ch.swisstopo.swissimage_20110914_cache]
   title: SWISSIMAGE (20110914, source)
-- dimensions: &id750
+- dimensions: &id757
     Time:
       default: '20110228'
       values: ['20110228']
   name: ch.swisstopo.swissimage_20110228
   sources: [ch.swisstopo.swissimage_20110228_cache_out]
   title: SWISSIMAGE (20110228)
-- dimensions: *id750
+- dimensions: *id757
   name: ch.swisstopo.swissimage_20110228_source
   sources: [ch.swisstopo.swissimage_20110228_cache]
   title: SWISSIMAGE (20110228, source)
-- dimensions: &id751
+- dimensions: &id758
     Time:
       default: '20140401'
       values: ['20140401']
   name: ch.swisstopo.swisstlm3d-karte-farbe_20140401
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20140401_cache_out]
   title: Karte swissTLM (farbig) (20140401)
-- dimensions: *id751
+- dimensions: *id758
   name: ch.swisstopo.swisstlm3d-karte-farbe
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20140401_cache]
   title: Karte swissTLM (farbig) ('current')
-- dimensions: *id751
+- dimensions: *id758
   name: ch.swisstopo.swisstlm3d-karte-farbe_20140401_source
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20140401_cache]
   title: Karte swissTLM (farbig) (20140401, source)
-- dimensions: &id752
+- dimensions: &id759
     Time:
       default: '20140401'
       values: ['20140401']
   name: ch.swisstopo.swisstlm3d-karte-grau_20140401
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20140401_cache_out]
   title: Karte swissTLM (grau) (20140401)
-- dimensions: *id752
+- dimensions: *id759
   name: ch.swisstopo.swisstlm3d-karte-grau
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20140401_cache]
   title: Karte swissTLM (grau) ('current')
-- dimensions: *id752
+- dimensions: *id759
   name: ch.swisstopo.swisstlm3d-karte-grau_20140401_source
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20140401_cache]
   title: Karte swissTLM (grau) (20140401, source)
-- dimensions: &id753
+- dimensions: &id760
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.swisstopo.swisstlm3d-wanderwege_20150101
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache_out]
+  title: Wanderwege (20150101)
+- dimensions: *id760
+  name: ch.swisstopo.swisstlm3d-wanderwege
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
+  title: Wanderwege ('current')
+- dimensions: *id760
+  name: ch.swisstopo.swisstlm3d-wanderwege_20150101_source
+  sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
+  title: Wanderwege (20150101, source)
+- dimensions: &id761
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20140101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache_out]
   title: Wanderwege (20140101)
-- dimensions: *id753
-  name: ch.swisstopo.swisstlm3d-wanderwege
-  sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache]
-  title: Wanderwege ('current')
-- dimensions: *id753
+- dimensions: *id761
   name: ch.swisstopo.swisstlm3d-wanderwege_20140101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache]
   title: Wanderwege (20140101, source)
-- dimensions: &id754
+- dimensions: &id762
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20130101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20130101_cache_out]
   title: Wanderwege (20130101)
-- dimensions: *id754
+- dimensions: *id762
   name: ch.swisstopo.swisstlm3d-wanderwege_20130101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20130101_cache]
   title: Wanderwege (20130101, source)
-- dimensions: &id755
+- dimensions: &id763
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo.transformationsgenauigkeit_20141101
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache_out]
   title: LV95 Transformationsgenauigkeit (20141101)
-- dimensions: *id755
+- dimensions: *id763
   name: ch.swisstopo.transformationsgenauigkeit
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit ('current')
-- dimensions: *id755
+- dimensions: *id763
   name: ch.swisstopo.transformationsgenauigkeit_20141101_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit (20141101, source)
-- dimensions: &id756
+- dimensions: &id764
     Time:
       default: '20131028'
       values: ['20131028']
   name: ch.swisstopo.transformationsgenauigkeit_20131028
   sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache_out]
   title: LV95 Transformationsgenauigkeit (20131028)
-- dimensions: *id756
+- dimensions: *id764
   name: ch.swisstopo.transformationsgenauigkeit_20131028_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache]
   title: LV95 Transformationsgenauigkeit (20131028, source)
-- dimensions: &id757
+- dimensions: &id765
     Time:
       default: '20100531'
       values: ['20100531']
   name: ch.swisstopo.transformationsgenauigkeit_20100531
   sources: [ch.swisstopo.transformationsgenauigkeit_20100531_cache_out]
   title: LV95 Transformationsgenauigkeit (20100531)
-- dimensions: *id757
+- dimensions: *id765
   name: ch.swisstopo.transformationsgenauigkeit_20100531_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20100531_cache]
   title: LV95 Transformationsgenauigkeit (20100531, source)
-- dimensions: &id758
+- dimensions: &id766
     Time:
       default: '20131101'
       values: ['20131101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache_out]
   title: PLZ und Ortschaften (20131101)
-- dimensions: *id758
+- dimensions: *id766
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften ('current')
-- dimensions: *id758
+- dimensions: *id766
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften (20131101, source)
-- dimensions: &id759
+- dimensions: &id767
     Time:
       default: '20130501'
       values: ['20130501']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache_out]
   title: PLZ und Ortschaften (20130501)
-- dimensions: *id759
+- dimensions: *id767
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache]
   title: PLZ und Ortschaften (20130501, source)
-- dimensions: &id760
+- dimensions: &id768
     Time:
       default: '20121102'
       values: ['20121102']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache_out]
   title: PLZ und Ortschaften (20121102)
-- dimensions: *id760
+- dimensions: *id768
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache]
   title: PLZ und Ortschaften (20121102, source)
-- dimensions: &id761
+- dimensions: &id769
     Time:
       default: '20120501'
       values: ['20120501']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache_out]
   title: PLZ und Ortschaften (20120501)
-- dimensions: *id761
+- dimensions: *id769
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache]
   title: PLZ und Ortschaften (20120501, source)
-- dimensions: &id762
+- dimensions: &id770
     Time:
       default: '20111101'
       values: ['20111101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache_out]
   title: PLZ und Ortschaften (20111101)
-- dimensions: *id762
+- dimensions: *id770
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache]
   title: PLZ und Ortschaften (20111101, source)
-- dimensions: &id763
+- dimensions: &id771
     Time:
       default: '20110502'
       values: ['20110502']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache_out]
   title: PLZ und Ortschaften (20110502)
-- dimensions: *id763
+- dimensions: *id771
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache]
   title: PLZ und Ortschaften (20110502, source)
-- dimensions: &id764
+- dimensions: &id772
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache_out]
   title: Spannungsarme Gebiete (20141101)
-- dimensions: *id764
+- dimensions: *id772
   name: ch.swisstopo-vd.spannungsarme-gebiete
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete ('current')
-- dimensions: *id764
+- dimensions: *id772
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete (20141101, source)
-- dimensions: &id765
+- dimensions: &id773
     Time:
       default: '20131028'
       values: ['20131028']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20131028
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache_out]
   title: Spannungsarme Gebiete (20131028)
-- dimensions: *id765
+- dimensions: *id773
   name: ch.swisstopo-vd.spannungsarme-gebiete_20131028_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache]
   title: Spannungsarme Gebiete (20131028, source)
-- dimensions: &id766
+- dimensions: &id774
     Time:
       default: '20121102'
       values: ['20121102']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20121102
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache_out]
   title: Spannungsarme Gebiete (20121102)
-- dimensions: *id766
+- dimensions: *id774
   name: ch.swisstopo-vd.spannungsarme-gebiete_20121102_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache]
   title: Spannungsarme Gebiete (20121102, source)
-- dimensions: &id767
+- dimensions: &id775
     Time:
       default: '20111216'
       values: ['20111216']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20111216
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache_out]
   title: Spannungsarme Gebiete (20111216)
-- dimensions: *id767
+- dimensions: *id775
   name: ch.swisstopo-vd.spannungsarme-gebiete_20111216_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache]
   title: Spannungsarme Gebiete (20111216, source)
-- dimensions: &id768
+- dimensions: &id776
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20140101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache_out]
   title: Schutzgebiete VECTOR200 (20140101)
-- dimensions: *id768
+- dimensions: *id776
   name: ch.swisstopo.vec200-adminboundaries-protectedarea
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache]
   title: Schutzgebiete VECTOR200 ('current')
-- dimensions: *id768
+- dimensions: *id776
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache]
   title: Schutzgebiete VECTOR200 (20140101, source)
-- dimensions: &id769
+- dimensions: &id777
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20130101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache_out]
   title: Schutzgebiete VECTOR200 (20130101)
-- dimensions: *id769
+- dimensions: *id777
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache]
   title: Schutzgebiete VECTOR200 (20130101, source)
-- dimensions: &id770
+- dimensions: &id778
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20100101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache_out]
   title: Schutzgebiete VECTOR200 (20100101)
-- dimensions: *id770
+- dimensions: *id778
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache]
   title: Schutzgebiete VECTOR200 (20100101, source)
-- dimensions: &id771
+- dimensions: &id779
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-building_20140101
   sources: [ch.swisstopo.vec200-building_20140101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20140101)"
-- dimensions: *id771
+- dimensions: *id779
   name: ch.swisstopo.vec200-building
   sources: [ch.swisstopo.vec200-building_20140101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 ('current')"
-- dimensions: *id771
+- dimensions: *id779
   name: ch.swisstopo.vec200-building_20140101_source
   sources: [ch.swisstopo.vec200-building_20140101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20140101, source)"
-- dimensions: &id772
+- dimensions: &id780
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-building_20130101
   sources: [ch.swisstopo.vec200-building_20130101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20130101)"
-- dimensions: *id772
+- dimensions: *id780
   name: ch.swisstopo.vec200-building_20130101_source
   sources: [ch.swisstopo.vec200-building_20130101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20130101, source)"
-- dimensions: &id773
+- dimensions: &id781
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-building_20100101
   sources: [ch.swisstopo.vec200-building_20100101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20100101)"
-- dimensions: *id773
+- dimensions: *id781
   name: ch.swisstopo.vec200-building_20100101_source
   sources: [ch.swisstopo.vec200-building_20100101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20100101, source)"
-- dimensions: &id774
+- dimensions: &id782
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-hydrography_20140101
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20140101)"
-- dimensions: *id774
+- dimensions: *id782
   name: ch.swisstopo.vec200-hydrography
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache]
   title: "Gew\xE4ssernetz VECTOR200 ('current')"
-- dimensions: *id774
+- dimensions: *id782
   name: ch.swisstopo.vec200-hydrography_20140101_source
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20140101, source)"
-- dimensions: &id775
+- dimensions: &id783
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-hydrography_20130101
   sources: [ch.swisstopo.vec200-hydrography_20130101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20130101)"
-- dimensions: *id775
+- dimensions: *id783
   name: ch.swisstopo.vec200-hydrography_20130101_source
   sources: [ch.swisstopo.vec200-hydrography_20130101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20130101, source)"
-- dimensions: &id776
+- dimensions: &id784
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-hydrography_20100101
   sources: [ch.swisstopo.vec200-hydrography_20100101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20100101)"
-- dimensions: *id776
+- dimensions: *id784
   name: ch.swisstopo.vec200-hydrography_20100101_source
   sources: [ch.swisstopo.vec200-hydrography_20100101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20100101, source)"
-- dimensions: &id777
+- dimensions: &id785
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-landcover_20140101
   sources: [ch.swisstopo.vec200-landcover_20140101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20140101)
-- dimensions: *id777
+- dimensions: *id785
   name: ch.swisstopo.vec200-landcover
   sources: [ch.swisstopo.vec200-landcover_20140101_cache]
   title: Prim. Bodenbedeckung VECTOR200 ('current')
-- dimensions: *id777
+- dimensions: *id785
   name: ch.swisstopo.vec200-landcover_20140101_source
   sources: [ch.swisstopo.vec200-landcover_20140101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20140101, source)
-- dimensions: &id778
+- dimensions: &id786
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-landcover_20130101
   sources: [ch.swisstopo.vec200-landcover_20130101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20130101)
-- dimensions: *id778
+- dimensions: *id786
   name: ch.swisstopo.vec200-landcover_20130101_source
   sources: [ch.swisstopo.vec200-landcover_20130101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20130101, source)
-- dimensions: &id779
+- dimensions: &id787
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-landcover_20100101
   sources: [ch.swisstopo.vec200-landcover_20100101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20100101)
-- dimensions: *id779
+- dimensions: *id787
   name: ch.swisstopo.vec200-landcover_20100101_source
   sources: [ch.swisstopo.vec200-landcover_20100101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20100101, source)
-- dimensions: &id780
+- dimensions: &id788
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-landcover-wald_20140101
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache_out]
   title: "Waldfl\xE4chen (20140101)"
-- dimensions: *id780
+- dimensions: *id788
   name: ch.swisstopo.vec200-landcover-wald
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache]
   title: "Waldfl\xE4chen ('current')"
-- dimensions: *id780
+- dimensions: *id788
   name: ch.swisstopo.vec200-landcover-wald_20140101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache]
   title: "Waldfl\xE4chen (20140101, source)"
-- dimensions: &id781
+- dimensions: &id789
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-landcover-wald_20130101
   sources: [ch.swisstopo.vec200-landcover-wald_20130101_cache_out]
   title: "Waldfl\xE4chen (20130101)"
-- dimensions: *id781
+- dimensions: *id789
   name: ch.swisstopo.vec200-landcover-wald_20130101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20130101_cache]
   title: "Waldfl\xE4chen (20130101, source)"
-- dimensions: &id782
+- dimensions: &id790
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-miscellaneous_20140101
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache_out]
   title: Einzelobjekte VECTOR200 (20140101)
-- dimensions: *id782
+- dimensions: *id790
   name: ch.swisstopo.vec200-miscellaneous
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache]
   title: Einzelobjekte VECTOR200 ('current')
-- dimensions: *id782
+- dimensions: *id790
   name: ch.swisstopo.vec200-miscellaneous_20140101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache]
   title: Einzelobjekte VECTOR200 (20140101, source)
-- dimensions: &id783
+- dimensions: &id791
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-miscellaneous_20130101
   sources: [ch.swisstopo.vec200-miscellaneous_20130101_cache_out]
   title: Einzelobjekte VECTOR200 (20130101)
-- dimensions: *id783
+- dimensions: *id791
   name: ch.swisstopo.vec200-miscellaneous_20130101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20130101_cache]
   title: Einzelobjekte VECTOR200 (20130101, source)
-- dimensions: &id784
+- dimensions: &id792
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-miscellaneous_20100101
   sources: [ch.swisstopo.vec200-miscellaneous_20100101_cache_out]
   title: Einzelobjekte VECTOR200 (20100101)
-- dimensions: *id784
+- dimensions: *id792
   name: ch.swisstopo.vec200-miscellaneous_20100101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20100101_cache]
   title: Einzelobjekte VECTOR200 (20100101, source)
-- dimensions: &id785
+- dimensions: &id793
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20140101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20140101)"
-- dimensions: *id785
+- dimensions: *id793
   name: ch.swisstopo.vec200-miscellaneous-geodpoint
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache]
   title: "H\xF6henkoten VECTOR200 ('current')"
-- dimensions: *id785
+- dimensions: *id793
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache]
   title: "H\xF6henkoten VECTOR200 (20140101, source)"
-- dimensions: &id786
+- dimensions: &id794
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20130101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20130101)"
-- dimensions: *id786
+- dimensions: *id794
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache]
   title: "H\xF6henkoten VECTOR200 (20130101, source)"
-- dimensions: &id787
+- dimensions: &id795
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20100101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20100101)"
-- dimensions: *id787
+- dimensions: *id795
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache]
   title: "H\xF6henkoten VECTOR200 (20100101, source)"
-- dimensions: &id788
+- dimensions: &id796
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-names-namedlocation_20140101
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache_out]
   title: Namen VECTOR200 (20140101)
-- dimensions: *id788
+- dimensions: *id796
   name: ch.swisstopo.vec200-names-namedlocation
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache]
   title: Namen VECTOR200 ('current')
-- dimensions: *id788
+- dimensions: *id796
   name: ch.swisstopo.vec200-names-namedlocation_20140101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache]
   title: Namen VECTOR200 (20140101, source)
-- dimensions: &id789
+- dimensions: &id797
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-names-namedlocation_20130101
   sources: [ch.swisstopo.vec200-names-namedlocation_20130101_cache_out]
   title: Namen VECTOR200 (20130101)
-- dimensions: *id789
+- dimensions: *id797
   name: ch.swisstopo.vec200-names-namedlocation_20130101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20130101_cache]
   title: Namen VECTOR200 (20130101, source)
-- dimensions: &id790
+- dimensions: &id798
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-names-namedlocation_20100101
   sources: [ch.swisstopo.vec200-names-namedlocation_20100101_cache_out]
   title: Namen VECTOR200 (20100101)
-- dimensions: *id790
+- dimensions: *id798
   name: ch.swisstopo.vec200-names-namedlocation_20100101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20100101_cache]
   title: Namen VECTOR200 (20100101, source)
-- dimensions: &id791
+- dimensions: &id799
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20140101)"
-- dimensions: *id791
+- dimensions: *id799
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 ('current')"
-- dimensions: *id791
+- dimensions: *id799
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20140101, source)"
-- dimensions: &id792
+- dimensions: &id800
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20130101)"
-- dimensions: *id792
+- dimensions: *id800
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20130101, source)"
-- dimensions: &id793
+- dimensions: &id801
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20100101)"
-- dimensions: *id793
+- dimensions: *id801
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20100101, source)"
-- dimensions: &id794
+- dimensions: &id802
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20140101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache_out]
   title: Strassennetz VECTOR200 (20140101)
-- dimensions: *id794
+- dimensions: *id802
   name: ch.swisstopo.vec200-transportation-strassennetz
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache]
   title: Strassennetz VECTOR200 ('current')
-- dimensions: *id794
+- dimensions: *id802
   name: ch.swisstopo.vec200-transportation-strassennetz_20140101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache]
   title: Strassennetz VECTOR200 (20140101, source)
-- dimensions: &id795
+- dimensions: &id803
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20130101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20130101_cache_out]
   title: Strassennetz VECTOR200 (20130101)
-- dimensions: *id795
+- dimensions: *id803
   name: ch.swisstopo.vec200-transportation-strassennetz_20130101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20130101_cache]
   title: Strassennetz VECTOR200 (20130101, source)
-- dimensions: &id796
+- dimensions: &id804
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20100101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20100101_cache_out]
   title: Strassennetz VECTOR200 (20100101)
-- dimensions: *id796
+- dimensions: *id804
   name: ch.swisstopo.vec200-transportation-strassennetz_20100101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20100101_cache]
   title: Strassennetz VECTOR200 (20100101, source)
-- dimensions: &id797
+- dimensions: &id805
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-anlagen_20090401
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache_out]
   title: Anlagen VECTOR25 (20090401)
-- dimensions: *id797
+- dimensions: *id805
   name: ch.swisstopo.vec25-anlagen
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25 ('current')
-- dimensions: *id797
+- dimensions: *id805
   name: ch.swisstopo.vec25-anlagen_20090401_source
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25 (20090401, source)
-- dimensions: &id798
+- dimensions: &id806
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-einzelobjekte_19980101
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache_out]
   title: Einzelobjekte VECTOR25 (19980101)
-- dimensions: *id798
+- dimensions: *id806
   name: ch.swisstopo.vec25-einzelobjekte
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25 ('current')
-- dimensions: *id798
+- dimensions: *id806
   name: ch.swisstopo.vec25-einzelobjekte_19980101_source
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25 (19980101, source)
-- dimensions: &id799
+- dimensions: &id807
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache_out]
   title: Eisenbahnnetz VECTOR25 (20090401)
-- dimensions: *id799
+- dimensions: *id807
   name: ch.swisstopo.vec25-eisenbahnnetz
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25 ('current')
-- dimensions: *id799
+- dimensions: *id807
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401_source
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25 (20090401, source)
-- dimensions: &id800
+- dimensions: &id808
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gebaeude_20090401
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache_out]
   title: "Geb\xE4ude VECTOR25 (20090401)"
-- dimensions: *id800
+- dimensions: *id808
   name: ch.swisstopo.vec25-gebaeude
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25 ('current')"
-- dimensions: *id800
+- dimensions: *id808
   name: ch.swisstopo.vec25-gebaeude_20090401_source
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25 (20090401, source)"
-- dimensions: &id801
+- dimensions: &id809
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gewaessernetz_20090401
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache_out]
   title: "Gew\xE4ssernetz VECTOR25 (20090401)"
-- dimensions: *id801
+- dimensions: *id809
   name: ch.swisstopo.vec25-gewaessernetz
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25 ('current')"
-- dimensions: *id801
+- dimensions: *id809
   name: ch.swisstopo.vec25-gewaessernetz_20090401_source
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25 (20090401, source)"
-- dimensions: &id802
+- dimensions: &id810
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-heckenbaeume_19980101
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache_out]
   title: "Hecken und B\xE4ume VECTOR25 (19980101)"
-- dimensions: *id802
+- dimensions: *id810
   name: ch.swisstopo.vec25-heckenbaeume
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25 ('current')"
-- dimensions: *id802
+- dimensions: *id810
   name: ch.swisstopo.vec25-heckenbaeume_19980101_source
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25 (19980101, source)"
-- dimensions: &id803
+- dimensions: &id811
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-primaerflaechen_20090401
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache_out]
   title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401)"
-- dimensions: *id803
+- dimensions: *id811
   name: ch.swisstopo.vec25-primaerflaechen
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25 ('current')"
-- dimensions: *id803
+- dimensions: *id811
   name: ch.swisstopo.vec25-primaerflaechen_20090401_source
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401, source)"
-- dimensions: &id804
+- dimensions: &id812
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-strassennetz_20090401
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache_out]
   title: Strassennetz VECTOR25 (20090401)
-- dimensions: *id804
+- dimensions: *id812
   name: ch.swisstopo.vec25-strassennetz
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25 ('current')
-- dimensions: *id804
+- dimensions: *id812
   name: ch.swisstopo.vec25-strassennetz_20090401_source
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25 (20090401, source)
-- dimensions: &id805
+- dimensions: &id813
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache_out]
   title: "\xDCbriger Verkehr VECTOR25 (20090401)"
-- dimensions: *id805
+- dimensions: *id813
   name: ch.swisstopo.vec25-uebrigerverkehr
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25 ('current')"
-- dimensions: *id805
+- dimensions: *id813
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401_source
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25 (20090401, source)"
-- dimensions: &id806
+- dimensions: &id814
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache_out]
   title: LV95 Verschiebungsvektoren TSP1 (20061231)
-- dimensions: *id806
+- dimensions: *id814
   name: ch.swisstopo.verschiebungsvektoren-tsp1
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 ('current')
-- dimensions: *id806
+- dimensions: *id814
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 (20061231, source)
-- dimensions: &id807
+- dimensions: &id815
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache_out]
   title: LV95 Verschiebungsvektoren TSP2 (20070101)
-- dimensions: *id807
+- dimensions: *id815
   name: ch.swisstopo.verschiebungsvektoren-tsp2
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 ('current')
-- dimensions: *id807
+- dimensions: *id815
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 (20070101, source)
-- dimensions: &id808
+- dimensions: &id816
     Time:
       default: '20110501'
       values: ['20110501']
   name: ch.vbs.territorialregionen_20110501
   sources: [ch.vbs.territorialregionen_20110501_cache_out]
   title: Territorialregionen (20110501)
-- dimensions: *id808
+- dimensions: *id816
   name: ch.vbs.territorialregionen
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen ('current')
-- dimensions: *id808
+- dimensions: *id816
   name: ch.vbs.territorialregionen_20110501_source
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen (20110501, source)
@@ -18147,6 +18327,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_hochwasser/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_hochwasser_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_hochwasser/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.showme-gemeinden_lawinen_20100101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -18207,6 +18399,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_lawinen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_lawinen_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_lawinen/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.showme-gemeinden_rutschungen_20100101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -18267,6 +18471,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_rutschungen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_rutschungen_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_rutschungen/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.showme-gemeinden_sturzprozesse_20100101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -18327,6 +18543,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_sturzprozesse/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-gemeinden_sturzprozesse_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-gemeinden_sturzprozesse/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.showme-kantone_hochwasser_20100101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -18387,6 +18615,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_hochwasser/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_hochwasser_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_hochwasser/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.showme-kantone_lawinen_20100101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -18447,6 +18687,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_lawinen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_lawinen_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_lawinen/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.showme-kantone_rutschungen_20100101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -18507,6 +18759,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_rutschungen/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_rutschungen_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_rutschungen/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.showme-kantone_sturzprozesse_20100101_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -18567,6 +18831,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_sturzprozesse/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.showme-kantone_sturzprozesse_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.showme-kantone_sturzprozesse/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.sturm-boeenspitzen_100_20141107_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20559,18 +20835,6 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.versorgungsgebiet-ukw/default/20070704/21781/%(z)d/%(y)d/%(x)d.%(format)s
-  ch.bav.laerm-emissionplan_eisenbahn_2015_20101109_source:
-    coverage:
-      bbox: [420000, 30000, 900000, 350000]
-      bbox_srs: EPSG:21781
-    grid: swisstopo-pixelkarte
-    http:
-      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
-    on_error:
-      204: {cache: true, response: transparent}
-    transparent: true
-    type: tile
-    url: http://wmts6.geo.admin.ch/1.0.0/ch.bav.laerm-emissionplan_eisenbahn_2015/default/20101109/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bazl.luftfahrtkarten-icao_20110310_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -25280,6 +25544,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swisstlm3d-wanderwege/default/20140101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swisstlm3d-wanderwege_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swisstlm3d-wanderwege/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.swisstopo.transformationsgenauigkeit_20100531_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]


### PR DESCRIPTION
- added a new timestamp for the 8 showme layers
- the old showme timestamps were switched from "zoomlevel_max = 26" to "zoomlevel_max = 23" (no need to compute further down due to dataset resolution

I see many other changes not directly involved with my modifications... @procrastinatio , could you maybe check that? Thanks!