### PR TITLE
Adapt wmts tests

### DIFF
--- a/chsdi/tests/mapproxy/__init__.py
+++ b/chsdi/tests/mapproxy/__init__.py
@@ -1,0 +1,29 @@
+#-*- coding: utf-8 -*-
+
+import os
+from chsdi.tests.integration import TestsBase
+
+
+class MapProxyTestsBase(TestsBase):
+
+    def setUp(self):
+        super(MapProxyTestsBase, self).setUp()
+        registry = self.testapp.app.registry
+        try:
+            os.environ["http_proxy"] = registry.settings['http_proxy']
+            apache_entry_path = registry.settings['apache_entry_path']
+            self.mapproxy_url = "http://" + registry.settings['mapproxyhost'] + apache_entry_path
+        except KeyError as e:
+            raise e
+        self.BAD_REFERER = 'http://foo.ch'
+        self.GOOD_REFERER = 'http://unittest.geo.admin.ch'
+        self.EPSGS = [21781, 4326, 4258, 2056, 3857]
+
+    def tearDown(self):
+        if "http_proxy" in os.environ:
+            del os.environ["http_proxy"]
+        super(MapProxyTestsBase, self).tearDown()
+
+    def hash(self, bits=96):
+        assert bits % 8 == 0
+        return os.urandom(bits / 8).encode('hex')

--- a/chsdi/tests/mapproxy/test_wmtscapabilities.py
+++ b/chsdi/tests/mapproxy/test_wmtscapabilities.py
@@ -1,45 +1,17 @@
 #-*- coding: utf-8 -*-
 
-import os
-
 import requests
+from chsdi.tests.mapproxy import MapProxyTestsBase
 
 
-BAD_REFERER = 'http://foo.ch'
+class TestWmtsGetTileAuth(MapProxyTestsBase):
 
-GOOD_REFERER = 'http://unittest.geo.admin.ch'
-
-EPSGS = [21781, 4326, 4258, 2056, 3857]
-
-
-TILES_IDX = {3857: [(7, 67, 45), (10, 533, 360)],
-             21781: [(17, 5, 6), (18, 11, 13)],
-             2056: [(17, 5, 6), (18, 11, 13)],
-             4326: [(10, 6, 4), (15, 222, 123)],
-             4258: [(10, 6, 4), (15, 222, 123)]
-             }
-
-
-class TestWmtsGetTileAuth():
-
-    def __init__(self):
-        from pyramid.paster import get_app
-        self.app = get_app('development.ini')
-        try:
-            os.environ["http_proxy"] = self.app.registry.settings['http_proxy']
-            apache_base_path = self.app.registry.settings['apache_base_path']
-            self.mapproxy_url = "http://" + self.app.registry.settings['mapproxyhost'] + '/' + apache_base_path if apache_base_path != '/' else ''
-        except KeyError as e:
-            raise e
-
+    def setUp(self):
+        super(TestWmtsGetTileAuth, self).setUp()
         self.paths = ['/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20130903/3857/7/67/45.jpeg',
                       '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/2056/17/5/6.jpeg',
                       '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20130903/4258/10/6/4.jpeg',
-                      '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20120809/4326/10/6/4.jpeg']
-
-    def hash(self, bits=96):
-        assert bits % 8 == 0
-        return os.urandom(bits / 8).encode('hex')
+                      '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20151231/4326/21/132/180.jpeg']
 
     def check_status_code(self, url, referer, code):
         headers = None
@@ -48,25 +20,25 @@ class TestWmtsGetTileAuth():
             resp = requests.get(url, params={'_id': self.hash()}, headers=headers)
         else:
             resp = requests.get(url, params={'_id': self.hash()})
-        assert int(resp.status_code) == code
+        self.failUnless(resp.status_code == code, 'Called Url: ' + url + ' [referer: ' + str(referer) + '] with return code: ' + str(resp.status_code))
 
     def test_bad_referer_get_capabilties(self):
-        self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', BAD_REFERER, 403)
+        self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.BAD_REFERER, 403)
 
     def test_bad_referer_get_tile(self):
         for path in self.paths:
-            yield self.check_status_code, self.mapproxy_url + path, BAD_REFERER, 403
+            self.check_status_code(self.mapproxy_url + path, self.BAD_REFERER, 403)
 
     def test_no_referer_get_capabilties(self):
         self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', None, 403)
 
     def test_no_referer_get_tile(self):
         for path in self.paths:
-            yield self.check_status_code, self.mapproxy_url + path, None, 403
+            self.check_status_code(self.mapproxy_url + path, None, 403)
 
     def test_good_referer_get_capabilties(self):
-        self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', GOOD_REFERER, 200)
+        self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.GOOD_REFERER, 200)
 
     def test_good_referer_get_tile(self):
         for path in self.paths:
-            yield self.check_status_code, self.mapproxy_url + path, GOOD_REFERER, 200
+            self.check_status_code(self.mapproxy_url + path, self.GOOD_REFERER, 200)

--- a/chsdi/tests/varnish/test_varnish.py
+++ b/chsdi/tests/varnish/test_varnish.py
@@ -2,13 +2,11 @@
 
 import os
 import random
-from unittest import TestCase
-
-
 import requests
+from chsdi.tests.integration import TestsBase
 
 
-class TestVarnish(TestCase):
+class TestVarnish(TestsBase):
 
     ''' Testing the Varnish 'security' configuration. As some settings are IP address dependant,
         we use an external HTTP Proxy to make the queries.
@@ -22,20 +20,21 @@ class TestVarnish(TestCase):
         return random.randrange(20140101, 20141001)
 
     def setUp(self):
-        from pyramid.paster import get_app
-        app = get_app('development.ini')
+        super(TestVarnish, self).setUp()
+        self.registry = self.testapp.app.registry
 
         try:
-            os.environ["http_proxy"] = app.registry.settings['http_proxy']
-            self.api_url = "http:" + app.registry.settings['api_url']
-            apache_base_path = app.registry.settings['apache_base_path']
-            self.mapproxy_url = "http://" + app.registry.settings['mapproxyhost'] + ('/' + apache_base_path if apache_base_path != 'main' else '')
+            os.environ["http_proxy"] = self.registry.settings['http_proxy']
+            self.api_url = "http:" + self.registry.settings['api_url']
+            apache_base_path = self.registry.settings['apache_base_path']
+            self.mapproxy_url = "http://" + self.registry.settings['mapproxyhost'] + ('/' + apache_base_path if apache_base_path != 'main' else '')
         except KeyError as e:
             raise e
 
     def tearDown(self):
         if "http_proxy" in os.environ:
             del os.environ["http_proxy"]
+        super(TestVarnish, self).tearDown()
 
     def has_geometric_attributes(self, attrs):
         geometric_attrs = ['x', 'y', 'lon', 'lat', 'geom_st_box2d']

--- a/production.ini.in
+++ b/production.ini.in
@@ -46,6 +46,7 @@ api_url = ${api_url}
 install_directory = ${buildout:directory}
 host = ${host}
 apache_base_path = ${apache_base_path}
+apache_entry_path = ${apache_entry_path}
 address_search_referers = localhost,admin.ch,awk.ch,cadastre.ch,rspp.ch,rollstuhlparkplatz.ch,placehandicape.ch,parcheggiodisabili.chi,zh.ch
 print_temp_dir=${print_temp_dir}
 http_proxy = ${http_proxy}


### PR DESCRIPTION
This PR adapts the Varnish/wmts tests to be run outside mod_wsgi context as well.

It also makes sure that all official wmts adresses are tested (as published in the documentation on api3.geo.admin.ch).

There is some randomisation in the tiles tests now which
a) toggles the official adresses
b) toggles the referers and the expected results.
This might be controversial...

Note: those tests will be run on jenkins.ci only and only for prod (usually) as part of api3 job: https://jenkins.ci.bgdi.ch/job/api3.geo.admin.ch/ (The gettile tests alone will take 15 minutes)

@procrastinatio I would like your comments.