### PR TITLE
[WIP] Use different dbhost for int/dev/ci

### DIFF
--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -10,6 +10,8 @@ api_url = //mf-chsdi3.dev.bgdi.ch
 host = mf-chsdi3.dev.bgdi.ch
 # geomadmin
 geoadminhost = mf-geoadmin3.dev.bgdi.ch
+# db host (a slave)
+dbhost = pg-backup.bgdi.ch
 # database staging
 db_staging = dev
 # sphinx

--- a/buildout_int.cfg
+++ b/buildout_int.cfg
@@ -7,6 +7,8 @@ api_url = //mf-chsdi3.int.bgdi.ch
 host = mf-chsdi3.int.bgdi.ch
 # geomadin
 geoadminhost = mf-geoadmin3.int.bgdi.ch
+# db host (a slave)
+dbhost = pg-backup.bgdi.ch
 # database staging
 db_staging = int
 # sphinx


### PR DESCRIPTION
This PR changes the dbhost used for int/dev/ci environments. It uses the backup slave who contains exactly the same db's as the production slaves.
The productions slaves will only be used by production environment now.

We have alot of `OperationalError: (OperationalError) FATAL:  remaining connection slots are reserved for non-replication superuser connections` in your Jenkins build. I assume this is because _everything_ uses the same slaves and we are reaching some limits with our nosetests.

Please review/merge quickly. Then we should rebase our PR's.