### PR TITLE
Use the `unaccent` function provided by postgresql to remove accents

### DIFF
--- a/chsdi/lib/sqlalchemy_customs.py
+++ b/chsdi/lib/sqlalchemy_customs.py
@@ -10,4 +10,4 @@ class remove_accents(FunctionElement):
 
 @compiles(remove_accents)
 def compile(element, compiler, **kw):
-    return "remove_accents(%s)" % compiler.process(element.clauses)
+    return " unaccent(%s)" % compiler.process(element.clauses)


### PR DESCRIPTION
I think that you are using a custom postgresql function. As far as I know the unaccent function which comes with postgresql (can be in a postgresql-contrib package on some linux distributions) does the same thing.

For more information: http://www.postgresql.org/docs/current/static/unaccent.html