### PR TITLE
Create a template file for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ buildout_branch.cfg
 deploy/deploy-branch.cfg
 deploy/conf/00-branch.conf
 print/WEB-INF/web.xml
+buildout_config.cfg

--- a/buildout_config.cfg.dist
+++ b/buildout_config.cfg.dist
@@ -1,0 +1,57 @@
+[buildout]
+extends = buildout.cfg
+
+[vars]
+# apache
+apache_base_path =
+# urls
+host = api.geoadmin.local
+# api service url
+api_url = //api.geoadmin.local
+# geoadmin host
+geoadminhost = geoadmin.local
+# wms
+wmshost = mapserver.local
+# database host
+dbhost = carto_dev:oeuches45@localhost
+
+# database port
+dbport = 5432
+# database
+server_port = 9000
+
+# robots file
+robots_file = robots.txt
+# deploy_target
+deploy_target = dev
+# print files directory
+print_temp_dir = /tmp
+# Geodata staging
+geodata_staging = prod
+# database staging (not the same as geodata staginga
+db_staging = prod
+
+# mapproxy
+mapproxyhost = api.geoadmin.local
+#mapproxy wsgi options
+mapproxy_wsgi_options = processes=4 threads=32
+#wsgi daemon threads
+wsgi_threads = 30
+# the Unix user under which the modwsgi daemon processes are executed,
+# can be overriden in development-specific buildout config files
+modwsgi_user = apache
+
+#zadara
+zadara_dir =
+#http proxy
+http_proxy =
+# sphinx
+sphinxhost =
+
+
+[modwsgi]
+config-file = ${buildout:directory}/development.ini
+
+
+[deploy]
+git_branch = sigeom


### PR DESCRIPTION
Based on your README, each developer has his/hers own configuration file tracked by git. We think that this pollutes the repository with lots of unnecessary files. Moreover, it makes the addition of variables cumbersome.

Instead, we decide to create a template configuration file which contains all the possible variables. This file, `buildout_config.cfg.dist` is tracked by git. Each developer must then just copy this file without the extension and replace all needed variables by their proper value. Our script then just have to use this file to deploy for development or production.

I don't know if it makes sense in your workflow.