### PR TITLE
Use configuration for allowed hosts and allowed domains for the shortener

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -138,6 +138,9 @@ mapproxy_wsgi_options=processes=4 threads=32
 zadara_dir=/var/local/cartoweb/downloads/
 #http proxy
 http_proxy=http://ec2-54-93-109-29.eu-central-1.compute.amazonaws.com:80
+# shortener
+shortener.allowed_hosts = 
+shortener.allowed_domains = admin.ch, swisstopo.ch, bgdi.ch
 
 [mapproxy]
 recipe = collective.recipe.cmd

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -46,7 +46,7 @@ def make_api_url(request, agnostic=False):
         return ''.join((request.scheme, '://', host))
 
 
-def check_url(url):
+def check_url(url, config):
     if url is None:
         raise HTTPBadRequest('The parameter url is missing from the request')
     parsedUrl = urlparse(url)
@@ -54,7 +54,9 @@ def check_url(url):
     if hostname is None:
         raise HTTPBadRequest('Could not determine the hostname')
     domain = ".".join(hostname.split(".")[-2:])
-    if all(('admin.ch' not in domain, 'swisstopo.ch' not in domain, 'bgdi.ch' not in domain)):
+    allowed_hosts = config['shortener.allowed_hosts'] if 'shortener.allowed_hosts' in config else ''
+    allowed_domains = config['shortener.allowed_domains'] if 'shortener.allowed_domains' in config else ''
+    if domain not in allowed_domains and hostname not in allowed_hosts:
         raise HTTPBadRequest('Shortener can only be used for admin.ch, swisstopo.ch and bgdi.ch domains')
     return url
 

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -57,7 +57,7 @@ def check_url(url, config):
     allowed_hosts = config['shortener.allowed_hosts'] if 'shortener.allowed_hosts' in config else ''
     allowed_domains = config['shortener.allowed_domains'] if 'shortener.allowed_domains' in config else ''
     if domain not in allowed_domains and hostname not in allowed_hosts:
-        raise HTTPBadRequest('Shortener can only be used for admin.ch, swisstopo.ch and bgdi.ch domains')
+        raise HTTPBadRequest('Shortener can only be used for %s domains or %s hosts.' % (allowed_domains, allowed_hosts))
     return url
 
 

--- a/chsdi/tests/functional/test_helpers.py
+++ b/chsdi/tests/functional/test_helpers.py
@@ -47,25 +47,26 @@ class Test_Helpers(unittest.TestCase):
     def test_check_url(self):
         from pyramid.httpexceptions import HTTPBadRequest
         url = None
+        config = {'shortener.allowed_hosts': 'admin.ch,swisstopo.ch,bgdi.ch'}
         try:
-            check_url(url)
+            check_url(url, config)
         except Exception as e:
             self.failUnless(isinstance(e, HTTPBadRequest))
 
         url = 'dummy'
         try:
-            check_url(url)
+            check_url(url, config)
         except Exception as e:
             self.failUnless(isinstance(e, HTTPBadRequest))
 
         url = 'http://dummy.com'
         try:
-            check_url(url)
+            check_url(url, config)
         except Exception as e:
             self.failUnless(isinstance(e, HTTPBadRequest))
 
         url = 'http://admin.ch'
-        self.assertEqual(url, check_url(url))
+        self.assertEqual(url, check_url(url, config))
 
     def test_transformCoordinate(self):
         from osgeo.ogr import Geometry

--- a/chsdi/views/qrcode_generator.py
+++ b/chsdi/views/qrcode_generator.py
@@ -15,7 +15,7 @@ from chsdi.lib.helpers import check_url, make_api_url, quoting
 def qrcode(request):
 
     url = quoting(check_url(
-        request.params.get('url')
+        request.params.get('url'), request.registry.settings
     ))
     url = _shorten_url(request, url)
     img = _make_qrcode_img(url)

--- a/chsdi/views/shortener.py
+++ b/chsdi/views/shortener.py
@@ -45,7 +45,7 @@ def _get_url_short(table, url):
 @view_config(route_name='shorten', renderer='jsonp')
 def shortener(request):
     url = check_url(
-        request.params.get('url')
+        request.params.get('url'), request.registry.settings
     )
     if len(url) >= 2046:
         # we only accept URL shorter or equal to 2046 characters

--- a/production.ini.in
+++ b/production.ini.in
@@ -51,6 +51,9 @@ address_search_referers = localhost,admin.ch,awk.ch,cadastre.ch,rspp.ch,rollstuh
 print_temp_dir=${print_temp_dir}
 http_proxy = ${http_proxy}
 
+shortener.allowed_hosts = ${shortener_allowed_hosts}
+shortener.allowed_domains = ${shortener_allowed_domains}
+
 ###
 # wsgi server configuration
 ###


### PR DESCRIPTION
Add two configuration variables `shortener.allowed_hosts` and `shortener.allowed_domains` to chose more easily which domains or hosts are allowed to use the shortener. These variables must be added to the buildout_*.cfg used to deploy the API.