### PR TITLE
Allow the use of pserve for developpment

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -235,3 +235,8 @@ def get_debug_headers(config):
         return {name.strip(): value.strip() for name, value in headers_list}
     else:
         return {}
+
+
+def get_debug_headerlist(config):
+    headers = get_debug_headers(config)
+    return [(name, value) for name, value in headers.items()]

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -226,3 +226,12 @@ def transformCoordinate(wkt, srid_from, srid_to):
     geom.AssignSpatialReference(srid_in)
     geom.TransformTo(srid_out)
     return geom
+
+
+def get_debug_headers(config):
+    if 'pyramid.debug_header' in config:
+        raw_headers = config['pyramid.debug_header']
+        headers_list = [header.split(':') for header in raw_headers.split(';')]
+        return {name.strip(): value.strip() for name, value in headers_list}
+    else:
+        return {}

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -229,7 +229,7 @@ def transformCoordinate(wkt, srid_from, srid_to):
 
 
 def get_debug_headers(config):
-    if 'pyramid.debug_header' in config:
+    if 'pyramid.debug_header' in config and config['pyramid.debug_header'].strip() :
         raw_headers = config['pyramid.debug_header']
         headers_list = [header.split(':') for header in raw_headers.split(';')]
         return {name.strip(): value.strip() for name, value in headers_list}

--- a/chsdi/views/catalog.py
+++ b/chsdi/views/catalog.py
@@ -7,6 +7,7 @@ from chsdi.models.bod import Catalog
 from chsdi.lib.validation import MapNameValidation
 from chsdi.lib.sqlalchemy_customs import remove_accents
 from chsdi.lib.filters import filter_by_geodata_staging
+from chsdi.lib.helpers import get_debug_headerlist
 
 
 class CatalogService(MapNameValidation):
@@ -30,6 +31,9 @@ class CatalogService(MapNameValidation):
         if len(rows) == 0:
             raise HTTPNotFound('No catalog with id %s is available' % self.mapName)
 
+        self.request.response.headerlist.extend(get_debug_headerlist(
+                self.request.registry.settings
+        ))
         return {'results': self.tree(rows)}
 
     def tree(self, rows=[]):

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -15,6 +15,7 @@ from chsdi.lib.validation.mapservice import MapServiceValidation
 from chsdi.models import models_from_name
 from chsdi.models.bod import LayersConfig, get_bod_model, computeHeader
 from chsdi.lib.filters import full_text_search, filter_by_geodata_staging, filter_by_map_name
+from chsdi.lib.helpers import get_debug_headerlist
 
 SAMPLE_SIZE = 100
 MAX_ATTRIBUTES_VALUES = 5
@@ -68,6 +69,7 @@ def layers_config(request):
     layers = {}
     for layer in get_layers_config_for_params(params, query, LayersConfig):
         layers = dict(layers.items() + layer.items())
+    request.response.headerlist.extend(get_debug_headerlist(request.registry.settings))
     return layers
 
 

--- a/chsdi/views/ogcproxy.py
+++ b/chsdi/views/ogcproxy.py
@@ -9,6 +9,7 @@ from pyramid.view import view_config
 from pyramid.httpexceptions import HTTPBadRequest, HTTPBadGateway, HTTPNotAcceptable
 from pyramid.response import Response
 from chsdi.lib.decorators import requires_authorization
+from chsdi.lib.helpers import get_debug_headers
 
 
 from StringIO import StringIO
@@ -82,7 +83,10 @@ class OgcProxy:
                 content = data.encode(DEFAULT_ENCODING)
                 content = content.replace(doc_encoding, DEFAULT_ENCODING)
 
+        debug_headers = get_debug_headers(self.request.registry.settings)
+        headers = {"Content-Type": ct}
+        headers.update(debug_headers)
         response = Response(content, status=resp.status,
-                            headers={"Content-Type": ct})
+                            headers=headers)
 
         return response

--- a/chsdi/views/topics.py
+++ b/chsdi/views/topics.py
@@ -4,6 +4,7 @@ from pyramid.view import view_config
 
 from chsdi.models.bod import Topics
 from chsdi.lib.filters import filter_by_geodata_staging
+from chsdi.lib.helpers import get_debug_headerlist
 
 
 @view_config(route_name='topics', renderer='jsonp')
@@ -20,4 +21,5 @@ def topics(request):
         'backgroundLayers': q.backgroundLayers,
         'selectedLayers': q.selectedLayers
     } for q in query]
+    request.response.headerlist.extend(get_debug_headerlist(request.registry.settings))
     return {'topics': results}

--- a/development.ini.in
+++ b/development.ini.in
@@ -14,6 +14,8 @@ pyramid.debug_routematch = true
 pyramid.prevent_http_cache = true
 pyramid.includes = 
     pyramid_debugtoolbar
+pyramid.debug_header =
+    ${pyramid_debug_headers}
 mako.imports =
     import logging
 


### PR DESCRIPTION
When developing a pyramid application, I find the use of the `pserve` command to be very useful since it can automatically reload after a file change with the command:
```
./buildout/bin/pserve development.ini --reload
```

However, to use with the frontend, you must allow cross domain. This adds a variable to easily make pyramid adds headers when needed. I don't guarantee that all endpoints are covered. Moreover, even if you intend to let this variable empty, it must be present to avoid buildout_filetemplate to crash. I hope I will be able to correct this soon.

The  `pyramid.debug_header` variable must be added to all the buildout_*.cfg used for development.