### PR TITLE
Comment out buggy test

### DIFF
--- a/chsdi/tests/integration/test_wmtscapabilities.py
+++ b/chsdi/tests/integration/test_wmtscapabilities.py
@@ -31,25 +31,25 @@ class TestWmtsCapabilitiesView(TestsBase):
         # mapproxy, host dependant, col/row order
         resp.mustcontain('/1.0.0/ch.kantone.cadastralwebmap-farbe/default/{Time}/21781/{TileMatrix}/{TileCol}/{TileRow}.png"/>')
 
-    def test_validate_wmtscapabilities(self):
-        import socket
-        import subprocess
-        import tempfile
-        import os
-        if socket.gethostname() == 'bgdimf01t':
-            self.fail("Cannot run this test on 'bgdimf0t'. Sorry.")
-        schema_url = os.path.join(os.path.dirname(__file__), "wmts/1.0.1/wmtsGetCapabilities_response.xsd")
-        os.environ['XML_CATALOG_FILES'] = os.path.join(os.path.dirname(__file__), "xml/catalog")
-
-        for lang in ['de', 'fr', 'it', 'en']:
-            for epsg in [4326, 4258, 2056, 3857]:
-                f = tempfile.NamedTemporaryFile(mode='w+t', prefix='WMTSCapabilities-', suffix='-%s-%s' % (lang, epsg))
-                resp = self.testapp.get('/rest/services/api/1.0.0/WMTSCapabilities.xml', params={'lang': lang, 'epsg': epsg}, status=200)
-                f.write(resp.body)
-                f.seek(0)
-                retcode = subprocess.call(["xmllint", "--noout", "--nocatalogs", "--schema", schema_url, f.name])
-                f.close()
-                self.failUnless(retcode == 0)
+#    def test_validate_wmtscapabilities(self):
+#        import socket
+#        import subprocess
+#        import tempfile
+#        import os
+#        if socket.gethostname() == 'bgdimf01t':
+#            self.fail("Cannot run this test on 'bgdimf0t'. Sorry.")
+#        schema_url = os.path.join(os.path.dirname(__file__), "wmts/1.0.1/wmtsGetCapabilities_response.xsd")
+#        os.environ['XML_CATALOG_FILES'] = os.path.join(os.path.dirname(__file__), "xml/catalog")
+#
+#        for lang in ['de', 'fr', 'it', 'en']:
+#            for epsg in [4326, 4258, 2056, 3857]:
+#                f = tempfile.NamedTemporaryFile(mode='w+t', prefix='WMTSCapabilities-', suffix='-%s-%s' % (lang, epsg))
+#                resp = self.testapp.get('/rest/services/api/1.0.0/WMTSCapabilities.xml', params={'lang': lang, 'epsg': epsg}, status=200)
+#                f.write(resp.body)
+#                f.seek(0)
+#                retcode = subprocess.call(["xmllint", "--noout", "--nocatalogs", "--schema", schema_url, f.name])
+#                f.close()
+#                self.failUnless(retcode == 0)
 
     def test_gettile_wmtscapabilities(self):
         resp = self.testapp.get('/rest/services/inspire/1.0.0/WMTSCapabilities.xml', status=200)


### PR DESCRIPTION
This is test is super unstable for 2 reasons:

1. http://www.w3.org/2001/xml.xsd is called and is often to reachable (and other links as well)
2. On dev using subprocess in a loop is buggy because of memory issues

We should find another way to validate our getcap for now.