### PR TITLE
Use pg-sandbox for dev, demo and ci environments

### DIFF
--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -10,6 +10,8 @@ api_url = //mf-chsdi3.dev.bgdi.ch
 host = mf-chsdi3.dev.bgdi.ch
 # geomadmin
 geoadminhost = mf-geoadmin3.dev.bgdi.ch
+# database host
+dbhost = pg-sandbox.bgdi.ch
 # database staging
 db_staging = dev
 # sphinx


### PR DESCRIPTION
This switches the db backends for `dev`, `demo` and `ci` environments to pg-sandbox.bgdi.ch.

Note: pg-sandbox.bgdi.ch have to be inside the .pgpass file.

