### PR TITLE
Remove loader caching mechanism

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -46,13 +46,6 @@ RedirectMatch ^${apache_entry_path}$ ${apache_entry_path}/
 RewriteRule ^${apache_entry_path}/[0-9]+/(.*)$ ${apache_entry_path}/$1 [E=${vars:apache_base_path}setyearcache:true,PT]
 Header merge Cache-Control "max-age=31536013, public" env=${vars:apache_base_path}setyearcache
 
-# We rewrite loader to versioned loader, which is cached
-RewriteRule ^${apache_entry_path}/loader.js$ ${apache_entry_path}/${app_version}/uncached_loader.js [P]
-<LocationMatch ^${apache_entry_path}/loader.js>
-    Header unset Cache-Control
-    Header merge Cache-Control "no-cache"
-</LocationMatch>
-
 # Static for cross domain flash/arcgis
 RewriteRule ^${apache_entry_path}/(crossdomain.xml|clientaccesspolicy.xml) ${apache_entry_path}/static/$1 [PT]
 <LocationMatch ^${apache_entry_path}/static/(crossdomain.xml|clientaccesspolicy.xml)>

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -58,7 +58,7 @@ def main(global_config, **settings):
     config.add_route('print_progress', '/printprogress')
     config.add_route('print_cancel', '/printcancel')
     config.add_route('dev', '/dev')
-    config.add_route('ga_api', '/uncached_loader.js')
+    config.add_route('ga_api', '/loader.js')
     config.add_route('testi18n', '/testi18n')
     config.add_route('topics', '/rest/services')
     config.add_route('mapservice', '/rest/services/{map}/MapServer')

--- a/chsdi/static/doc/examples/cadastralwebmap.html
+++ b/chsdi/static/doc/examples/cadastralwebmap.html
@@ -39,7 +39,7 @@
         </div>
       </div>
     </div>
-    <script src="../uncached_loader.js" type="text/javascript"></script> 
+    <script src="../loader.js" type="text/javascript"></script> 
     <script src="cadastralwebmap.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_catalog.html
+++ b/chsdi/static/doc/examples/geoadmin_catalog.html
@@ -121,7 +121,7 @@
     <script type="text/javascript" src="/static/js/jquery-2.0.3.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.2/jquery.xdomainrequest.min.js"></script>
     <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="../uncached_loader.js"></script>
+    <script type="text/javascript" src="../loader.js"></script>
     <script type="text/javascript" src="geoadmin_catalog.js"></script>
   </body>
 

--- a/chsdi/static/doc/examples/geoadmin_geocoder.html
+++ b/chsdi/static/doc/examples/geoadmin_geocoder.html
@@ -15,7 +15,7 @@
     <div id="map" style="width:100%;height:350px;"></div>
     This examples presents the usage of the geocoder.<br>
     <a href="geoadmin_geocoder.js">See the code</a>
-    <script src="../uncached_loader.js" type="text/javascript"></script>
+    <script src="../loader.js" type="text/javascript"></script>
     <script src="geoadmin_geocoder.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_kml.html
+++ b/chsdi/static/doc/examples/geoadmin_kml.html
@@ -33,7 +33,7 @@
     <a href="http://www.kmlvalidator.com/home.htm">here.</a></p>
     <script src="//code.jquery.com/jquery-1.10.1.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-    <script src="../uncached_loader.js" type="text/javascript"></script> 
+    <script src="../loader.js" type="text/javascript"></script> 
     <script src="geoadmin_kml.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_localisation.html
+++ b/chsdi/static/doc/examples/geoadmin_localisation.html
@@ -56,7 +56,7 @@
     <br>
     <script type="text/javascript" src="/static/js/jquery-2.0.3.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.2/jquery.xdomainrequest.min.js"></script>
-    <script type="text/javascript" src="../uncached_loader.js"></script>
+    <script type="text/javascript" src="../loader.js"></script>
     <script type="text/javascript" src="geoadmin_localisation.js"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_mapoverlay.html
+++ b/chsdi/static/doc/examples/geoadmin_mapoverlay.html
@@ -18,7 +18,7 @@
       <br>
       <a href="geoadmin_mapoverlay.js">See the code</a>
     </p>
-    <script src="../uncached_loader.js" type="text/javascript"></script>
+    <script src="../loader.js" type="text/javascript"></script>
     <script src="geoadmin_mapoverlay.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_rectangle.html
+++ b/chsdi/static/doc/examples/geoadmin_rectangle.html
@@ -63,7 +63,7 @@
     </p>
     <br>  
     <script src="/static/js/jquery-2.0.3.min.js"></script>
-    <script src="../uncached_loader.js" type="text/javascript"></script>
+    <script src="../loader.js" type="text/javascript"></script>
     <script src="geoadmin_rectangle.js" type="text/javascript"></script>   
   </body>
 </html>

--- a/chsdi/static/doc/examples/geoadmin_search.html
+++ b/chsdi/static/doc/examples/geoadmin_search.html
@@ -100,7 +100,7 @@
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.2/jquery.xdomainrequest.min.js"></script>
     <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.10.4/dist/typeahead.bundle.js"></script>
-    <script type="text/javascript" src="../uncached_loader.js"></script>
+    <script type="text/javascript" src="../loader.js"></script>
     <script type="text/javascript" src="geoadmin_search.js"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/ol3_lv95.html
+++ b/chsdi/static/doc/examples/ol3_lv95.html
@@ -38,7 +38,7 @@
    </div>
     <script src="/static/js/jquery-2.0.3.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-    <script src="../uncached_loader.js" type="text/javascript"></script> 
+    <script src="../loader.js" type="text/javascript"></script> 
     <script src="ol3_lv95.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/ol3_lv95_all.html
+++ b/chsdi/static/doc/examples/ol3_lv95_all.html
@@ -38,7 +38,7 @@
    </div>
     <script src="/static/js/jquery-2.0.3.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-    <script src="../uncached_loader.js" type="text/javascript"></script> 
+    <script src="../loader.js" type="text/javascript"></script> 
     <script src="ol3_lv95_all.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/ol3_mercator.html
+++ b/chsdi/static/doc/examples/ol3_mercator.html
@@ -37,7 +37,7 @@
    </div>
      <script src="/static/js/jquery-2.0.3.min.js"></script>
      <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
-    <script src="../uncached_loader.js" type="text/javascript"></script> 
+    <script src="../loader.js" type="text/javascript"></script> 
     <script src="ol3_mercator.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/quickstart.html
+++ b/chsdi/static/doc/examples/quickstart.html
@@ -7,7 +7,7 @@
         width: 100%;
       }
     </style>
-    <script src="../uncached_loader.js?lang=en" type="text/javascript"></script>
+    <script src="../loader.js?lang=en" type="text/javascript"></script>
     <title>GeoAdmin API example</title>
   </head>
   <body>

--- a/chsdi/static/doc/source/index.rst
+++ b/chsdi/static/doc/source/index.rst
@@ -46,7 +46,7 @@ Use the GeoAdmin API Forum to ask questions: http://groups.google.com/group/geoa
   </style>
   <body>
     <div id="map"></div>
-    <script type="text/javascript" src="uncached_loader.js"></script>
+    <script type="text/javascript" src="loader.js"></script>
     <script type="text/javascript">
       var layer = ga.layer.create('ch.swisstopo.pixelkarte-farbe');
       var map = new ga.Map({

--- a/chsdi/static/robots_prod.txt
+++ b/chsdi/static/robots_prod.txt
@@ -1,6 +1,5 @@
 User-agent: *
 Disallow: /loader.js
-Disallow: /uncached_loader.js
 Disallow: /dev
 Disallow: /testi18n
 Disallow: /checker

--- a/chsdi/templates/index.mako
+++ b/chsdi/templates/index.mako
@@ -22,10 +22,6 @@
           <a href="testi18n?lang=toto">If not in available languages to de</a> <br>
       <h1 id="title">Services</h1>
       <h2 id="loaderjs">Loader js</h2>
-          <a href="uncached_loader.js">Link to api</a> <br>
-          <a href="uncached_loader.js?lang=fr">Link to api in french</a> <br>
-          <a href="uncached_loader.js?mode=debug">Link to api in debug mode</a> <br>
-      <h3>Apache only links (does not work with pserve)</h3>
           <a href="loader.js">Link to api</a> <br>
           <a href="loader.js?lang=fr">Link to api in french</a> <br>
           <a href="loader.js?mode=debug">Link to api in debug mode</a> <br>

--- a/chsdi/tests/integration/test_loader.py
+++ b/chsdi/tests/integration/test_loader.py
@@ -6,7 +6,7 @@ from chsdi.tests.integration import TestsBase
 class TestLoaderJs(TestsBase):
 
     def test_loaderjs(self):
-        resp = self.testapp.get('/uncached_loader.js', status=200)
+        resp = self.testapp.get('/loader.js', status=200)
         self.failUnless(resp.content_type == 'application/javascript')
         resp.mustcontain('ga.js')
         resp.mustcontain('ga.css')
@@ -15,7 +15,7 @@ class TestLoaderJs(TestsBase):
         resp.mustcontain('EPSG2056.js')
 
     def test_loaderjs_lang(self):
-        resp = self.testapp.get('/uncached_loader.js', params={'lang': 'en'}, status=200)
+        resp = self.testapp.get('/loader.js', params={'lang': 'en'}, status=200)
         self.failUnless(resp.content_type == 'application/javascript')
         resp.mustcontain('ga.js')
         resp.mustcontain('ga.css')
@@ -24,7 +24,7 @@ class TestLoaderJs(TestsBase):
         resp.mustcontain('EPSG2056.js')
 
     def test_loaderjs_debug(self):
-        resp = self.testapp.get('/uncached_loader.js', params={'mode': 'debug'}, status=200)
+        resp = self.testapp.get('/loader.js', params={'mode': 'debug'}, status=200)
         self.failUnless(resp.content_type == 'application/javascript')
         resp.mustcontain('ga-debug.js')
         resp.mustcontain('ga.css')
@@ -33,7 +33,7 @@ class TestLoaderJs(TestsBase):
         resp.mustcontain('EPSG2056.js')
 
     def test_loaderjs_waf(self):
-        resp = self.testapp.get('/uncached_loader.js', params={'mode': 'waf'}, status=200)
+        resp = self.testapp.get('/loader.js', params={'mode': 'waf'}, status=200)
         self.failUnless(resp.content_type == 'application/javascript')
         resp.mustcontain('old-ga-waf.js')
         resp.mustcontain('ga.css')
@@ -42,7 +42,7 @@ class TestLoaderJs(TestsBase):
         resp.mustcontain('EPSG2056.js')
 
     def test_loaderjs_wafint(self):
-        resp = self.testapp.get('/uncached_loader.js', params={'mode': 'wafint'}, status=200)
+        resp = self.testapp.get('/loader.js', params={'mode': 'wafint'}, status=200)
         self.failUnless(resp.content_type == 'application/javascript')
         resp.mustcontain('old-ga-wafint.js')
         resp.mustcontain('ga.css')


### PR DESCRIPTION
As discussed between @cedricmoullet and @procrastinatio , this removes the caching mechanism of our loader, which results in ca. 10ms slower response times of the loader but will hopefully get rid of the 5xx errors we sometimes observe.