### PR TITLE
Only one war to provide print per instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ If buildout failed previously, you might need to bootstrap the project again, us
 
     python bootstrap.py --version 1.5.2 --distribute --download-base http://pypi.camptocamp.net/distribute-0.6.22_fix-issue-227/ --setup-source http://pypi.camptocamp.net/distribute-0.6.22_fix-issue-227/distribute_setup.py
 
+# Printing
+Per default, printing is handled by one single war file on an instances. This war is installed and handled by the 'main' installation.
+
+If you need to work on printing and use your own war, you have to add the following to your personal buildout configuration:
+
+In the [buildout] section
+```
+parts += print-war
+```
+
+In the [vars] section
+```
+print_war = ltxxx
+```
+
 # Python Code Styling
 
 We are currently using the PEP 8 convention for Python code.

--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -1,11 +1,11 @@
-<Proxy ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}>
+<Proxy ajp://localhost:8009/print-chsdi3-${vars:print_war}>
     Order deny,allow
     Allow from all
 </Proxy>
 
 # JSON print requests to print server
-ProxyPassMatch ${apache_entry_path}/print/(info|create)\.json$ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/$1.json
-ProxyPassReverse ${apache_entry_path}/print/ ajp://localhost:8009/print-chsdi3-${vars:apache_base_path}/pdf/
+ProxyPassMatch ${apache_entry_path}/print/(info|create)\.json$ ajp://localhost:8009/print-chsdi3-${vars:print_war}/pdf/$1.json
+ProxyPassReverse ${apache_entry_path}/print/ ajp://localhost:8009/print-chsdi3-${vars:print_war}/pdf/
 
 # Get resulting files directly from filesystem
 AliasMatch ^${apache_entry_path}/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)$ ${print_temp_dir}/mapfish-print$2$3

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -128,6 +128,8 @@ deploy_target = prod
 wsgi_threads=30
 # print files directory
 print_temp_dir = /var/cache/print
+# using main print or user/branch print
+print_war = main
 #mapproxy wsgi options
 mapproxy_wsgi_options=processes=4 threads=32
 #zadara

--- a/buildout_branch.cfg.in
+++ b/buildout_branch.cfg.in
@@ -1,5 +1,7 @@
 [buildout]
 extends = buildout_${vars:deploy_target}.cfg
+parts -= print-config
+         print-war
 
 [vars]
 # apache

--- a/buildout_ci.cfg
+++ b/buildout_ci.cfg
@@ -2,8 +2,6 @@
 extends = buildout_dev.cfg
 
 [vars]
-# apache
-apache_base_path = main
 # urls
 api_url = //mf-chsdi3.ci.bgdi.ch
 host = mf-chsdi3.ci.bgdi.ch

--- a/buildout_demo.cfg
+++ b/buildout_demo.cfg
@@ -1,10 +1,7 @@
 [buildout]
 extends = buildout_dev.cfg
-parts += fixrights
 
 [vars]
-# apache
-apache_base_path = main
 # urls
 api_url = //mf-chsdi3.demo.bgdi.ch
 host = mf-chsdi3.demo.bgdi.ch

--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -3,8 +3,6 @@ extends = buildout.cfg
 parts += fixrights
 
 [vars]
-# apache
-apache_base_path = main
 # urls
 api_url = //mf-chsdi3.dev.bgdi.ch
 host = mf-chsdi3.dev.bgdi.ch

--- a/buildout_ltalp.cfg
+++ b/buildout_ltalp.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltalp

--- a/buildout_ltclm.cfg
+++ b/buildout_ltclm.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltclm

--- a/buildout_ltfap.cfg
+++ b/buildout_ltfap.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 # apache

--- a/buildout_ltfoa.cfg
+++ b/buildout_ltfoa.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltfoa

--- a/buildout_ltgal.cfg
+++ b/buildout_ltgal.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltgal

--- a/buildout_ltgud.cfg
+++ b/buildout_ltgud.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltgud

--- a/buildout_ltjeg.cfg
+++ b/buildout_ltjeg.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 # apache

--- a/buildout_ltkan.cfg
+++ b/buildout_ltkan.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltkan

--- a/buildout_ltmoc.cfg
+++ b/buildout_ltmoc.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltmoc

--- a/buildout_ltmom.cfg
+++ b/buildout_ltmom.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltmom

--- a/buildout_ltpoa.cfg
+++ b/buildout_ltpoa.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 # apache

--- a/buildout_ltteo.cfg
+++ b/buildout_ltteo.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = buildout_dev.cfg
+extends = buildout_user_base.cfg
 
 [vars]
 apache_base_path = ltteo

--- a/buildout_user_base.cfg
+++ b/buildout_user_base.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends = buildout_dev.cfg
+parts -= print-config
+         print-war
+


### PR DESCRIPTION
Based on idea by @procrastinatio:

This PR assures that:

1) Only one WAR file is created in `/srv/tomcat/tomcat1/webapps/` to reduce print servers that tomcat needs to handle
2) All configurations (user specific, branch specific) are using this single WAR file
3) If you need to work on print, there is an easy way to work on your own specific WAR (see readme file)

Once this is adopted, we can remove all user specific wars from `/srv/tomcat/tomcat1/webapps/`