### PR TITLE
Removing boto credentials for dynamodb

### DIFF
--- a/chsdi/views/files.py
+++ b/chsdi/views/files.py
@@ -26,17 +26,18 @@ from chsdi.lib.decorators import requires_authorization, validate_kml_input
 
 
 def _get_dynamodb_table():
-    PROFILE_NAME = 'Credentials'
+    # PROFILE_NAME = 'Credentials'
     DYNAMODB_TABLE_NAME = 'geoadmin-file-storage'
     user_cfg = os.path.join(os.path.expanduser("~"), '.boto')
     config = ConfigParser.ConfigParser()
     config.read(["/etc/boto.cfg", user_cfg])
 
-    access_key = config.get(PROFILE_NAME, 'aws_access_key_id')
-    secret_key = config.get(PROFILE_NAME, 'aws_secret_access_key')
+    # access_key = config.get(PROFILE_NAME, 'aws_access_key_id')
+    # secret_key = config.get(PROFILE_NAME, 'aws_secret_access_key')
 
-    conn = connect_to_region('eu-west-1', aws_access_key_id=access_key,
-                             aws_secret_access_key=secret_key)
+    # conn = connect_to_region('eu-west-1', aws_access_key_id=access_key,
+    #                          aws_secret_access_key=secret_key)
+    conn = connect_to_region('eu-west-1')
 
     table = Table(DYNAMODB_TABLE_NAME, connection=conn)
 


### PR DESCRIPTION
I seems like those are not needed. At least, it works wihtout those and we don't have them in the shortener service to access dynamodb. Maybe this is what causes prod to fail on the files service.

This is for the deploy branch only for now.