### PR TITLE
Better error handling, centralize dyanomdb conns and tables

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -37,7 +37,7 @@ bin-directory = buildout/bin
 # (to be copied from the dumppickedversions output)
 autopep8 = 0.9.3
 Babel = 0.9.6
-boto = 2.29.1
+boto = 2.38.0
 c2c.recipe.msgfmt = 0.2.1
 collective.recipe.cmd = 0.8
 collective.recipe.modwsgi = 1.7-ga3

--- a/chsdi/models/clientdata_dynamodb.py
+++ b/chsdi/models/clientdata_dynamodb.py
@@ -2,7 +2,9 @@
 
 import pyramid.httpexceptions as exc
 
-from boto.dynamodb import connect_to_region
+from boto import connect_s3
+from boto.dynamodb2 import connect_to_region
+from boto.dynamodb2.table import Table
 
 '''
 CREATE a table
@@ -42,11 +44,39 @@ table.delete()
 # http://boto.readthedocs.org/en/latest/boto_config_tut.html
 
 
-def get_table(table_name='shorturl'):
-
-    # url_short is the pkey
+def _get_dynamodb_conn(region='eu-west-1'):
     try:
-        conn = connect_to_region(region_name='eu-west-1')
-        return conn.get_table(table_name)
+        conn = connect_to_region(region)
+    except Exception as e:
+        raise exc.HTTPBadRequest('DynamoDB: Error during connection init %s' % e)
+    return conn
+
+
+def _get_s3_conn(profile_name='geoadmin_filestorage'):
+    # TODO use profile instead when correctly installed
+    try:
+        conn = connect_s3(profile_name=profile_name)
+    except Exception as e:
+        raise exc.HTTPBadRequest('S3: Error during connection %s' % e)
+    return conn
+
+
+conn_dynamodb = _get_dynamodb_conn()
+conn_s3 = _get_s3_conn()
+
+
+def get_dynamodb_table(table_name='shorturl'):
+    try:
+        table = Table(table_name, connection=conn_dynamodb)
+    except Exception as e:
+        raise exc.HTTPBadRequest('Error during connection to the table %s' % e)
+    return table
+
+
+def get_bucket(request):
+    bucket_name = request.registry.settings['geoadmin_file_storage_bucket']
+    try:
+        bucket = conn_s3.get_bucket(bucket_name)
     except Exception as e:
         raise exc.HTTPBadRequest('Error during connection %s' % e)
+    return bucket

--- a/chsdi/views/files.py
+++ b/chsdi/views/files.py
@@ -5,12 +5,12 @@ import base64
 import time
 import zipfile
 import StringIO
-import datetime
 
 from boto.dynamodb2.exceptions import ItemNotFound
 
 from boto.exception import S3ResponseError
 from boto.s3.key import Key
+from boto.utils import parse_ts
 
 from pyramid.view import view_config, view_defaults
 import pyramid.httpexceptions as exc
@@ -18,33 +18,6 @@ from pyramid.response import Response
 
 from chsdi.models.clientdata_dynamodb import get_dynamodb_table, get_bucket
 from chsdi.lib.decorators import requires_authorization, validate_kml_input
-
-ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
-ISO8601_MS = '%Y-%m-%dT%H:%M:%S.%fZ'
-RFC1123 = '%a, %d %b %Y %H:%M:%S %Z'
-
-
-def _parse_ts(ts):
-    dt = None
-    ts = ts.strip()
-    try:
-        dt = datetime.datetime.strptime(ts, ISO8601)
-    except:
-        dt = None
-
-    if dt is None:
-        try:
-            dt = datetime.datetime.strptime(ts, ISO8601_MS)
-        except:
-            dt = None
-
-    if dt is None:
-        try:
-            dt = datetime.datetime.strptime(ts, RFC1123)
-        except:
-            dt = None
-
-    return dt
 
 
 def _add_item(id, file_id=False):
@@ -176,7 +149,7 @@ class FileView(object):
                 k.set_metadata('Content-Type', mime)
                 k.set_contents_from_string(data, replace=False)
                 key = self.bucket.get_key(k.key)
-                last_updated = _parse_ts(key.last_modified)
+                last_updated = parse_ts(key.last_modified)
             except Exception as e:
                 raise exc.HTTPInternalServerError('Error while configuring S3 key (%s) %s' % (self.file_id, e))
             try:
@@ -189,7 +162,7 @@ class FileView(object):
                     data = ziped_data
                 self.key.set_contents_from_string(data, replace=True)
                 key = self.bucket.get_key(self.key.key)
-                last_updated = _parse_ts(key.last_modified)
+                last_updated = parse_ts(key.last_modified)
             except:
                 raise exc.HTTPInternalServerError('Error while updating S3 key (%s) %s' % (self.key.key, e))
             try:

--- a/chsdi/views/files.py
+++ b/chsdi/views/files.py
@@ -1,27 +1,22 @@
 # -*- coding: utf-8 -*-
 
-import os.path
 import uuid
 import base64
 import time
 import zipfile
-import ConfigParser
 import StringIO
 import datetime
 
-from boto.dynamodb2.table import Table
-from boto.dynamodb2 import connect_to_region
 from boto.dynamodb2.exceptions import ItemNotFound
 
-#from chsdi.models.clientdata_dynamodb import get_table
-
-from boto.s3.connection import S3Connection
+from boto.exception import S3ResponseError
 from boto.s3.key import Key
 
 from pyramid.view import view_config, view_defaults
 import pyramid.httpexceptions as exc
 from pyramid.response import Response
 
+from chsdi.models.clientdata_dynamodb import get_dynamodb_table, get_bucket
 from chsdi.lib.decorators import requires_authorization, validate_kml_input
 
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
@@ -52,33 +47,8 @@ def _parse_ts(ts):
     return dt
 
 
-def _get_dynamodb_table():
-    table = None
-    DYNAMODB_TABLE_NAME = 'geoadmin-file-storage'
-    try:
-        PROFILE_NAME = 'Credentials'
-        user_cfg = os.path.join(os.path.expanduser("~"), '.boto')
-        config = ConfigParser.ConfigParser()
-        config.read(["/etc/boto.cfg", user_cfg])
-        access_key = config.get(PROFILE_NAME, 'aws_access_key_id')
-        secret_key = config.get(PROFILE_NAME, 'aws_secret_access_key')
-        conn = connect_to_region('eu-west-1', aws_access_key_id=access_key,
-                                 aws_secret_access_key=secret_key)
-        table = Table(DYNAMODB_TABLE_NAME, connection=conn)
-    except:
-        table = None
-
-    if table is None:
-        try:
-            table = Table(DYNAMODB_TABLE_NAME, connection=connect_to_region('eu-west-1'))
-        except Exception as e:
-            raise exc.HTTPInternalServerError('Unable to access dynamodb table (%s)' % e)
-
-    return table
-
-
 def _add_item(id, file_id=False):
-    table = _get_dynamodb_table()
+    table = get_dynamodb_table(table_name='geoadmin-file-storage')
     try:
         table.put_item(
             data={
@@ -88,18 +58,17 @@ def _add_item(id, file_id=False):
             }
         )
     except Exception as e:
-            raise exc.HTTPBadRequest('Error during put item %s' % e)
+        raise exc.HTTPBadRequest('Error during put item %s' % e)
     return True
 
 
 def _save_item(admin_id, file_id=None, last_updated=None):
-    table = _get_dynamodb_table()
+    table = get_dynamodb_table(table_name='geoadmin-file-storage')
     item = None
     if last_updated is not None:
         timestamp = last_updated.strftime('%Y-%m-%d %X')
     else:
         timestamp = time.strftime('%Y-%m-%d %X', time.localtime())
-
     if file_id is not None:
         try:
             table.put_item(
@@ -110,7 +79,7 @@ def _save_item(admin_id, file_id=None, last_updated=None):
                 }
             )
         except Exception as e:
-                raise exc.HTTPBadRequest('Error during put item %s' % e)
+            raise exc.HTTPBadRequest('Error during put item %s' % e)
         return True
 
     else:
@@ -126,7 +95,7 @@ def _save_item(admin_id, file_id=None, last_updated=None):
 
 
 def _is_admin_id(admin_id):
-    table = _get_dynamodb_table()
+    table = get_dynamodb_table(table_name='geoadmin-file-storage')
     try:
         table.get_item(adminId=str(admin_id))
     except ItemNotFound:
@@ -137,7 +106,7 @@ def _is_admin_id(admin_id):
 
 def _get_file_id_from_admin_id(admin_id):
     fileId = None
-    table = _get_dynamodb_table()
+    table = get_dynamodb_table(table_name='geoadmin-file-storage')
     try:
         item = table.get_item(adminId=str(admin_id))
         fileId = item.get('fileId')
@@ -153,7 +122,7 @@ class FileView(object):
 
     def __init__(self, request):
         self.request = request
-        self.bucket = self._get_bucket()
+        self.bucket = get_bucket(request)
         if request.matched_route.name == 'files':
             self.admin_id = None
             self.key = None
@@ -165,8 +134,11 @@ class FileView(object):
                 self.file_id = id
             try:
                 key = self.bucket.get_key(self.file_id)
-            except:
-                raise exc.HTTPInternalServerError('Cannot access file with id=%s' % self.file_id)
+            except S3ResponseError as e:
+                raise exc.HTTPInternalServerError('Cannot access file with id=%s: %s' % (self.file_id, e))
+            except Exception as e:
+                raise exc.HTTPInternalServerError('Cannot access file with id=%s: %s' % (self.file_id, e))
+
             if key is not None:
                 self.key = key
             else:
@@ -174,27 +146,6 @@ class FileView(object):
 
     def _get_uuid(self):
         return base64.urlsafe_b64encode(uuid.uuid4().bytes).replace('=', '')
-
-    def _get_bucket(self):
-        # TODO use profile instead when correctly installed
-        PROFILE_NAME = 'profile geoadmin_filestorage'
-        BUCKET_NAME = self.request.registry.settings['geoadmin_file_storage_bucket']
-        user_cfg = os.path.join(os.path.expanduser("~"), '.boto')
-        config = ConfigParser.ConfigParser()
-        config.read(["/etc/boto.cfg", user_cfg])
-        try:
-            access_key = config.get(PROFILE_NAME, 'aws_access_key_id')
-            secret_key = config.get(PROFILE_NAME, 'aws_secret_access_key')
-        except Exception as e:
-            raise exc.HTTPInternalServerError('Error while trying to configure file access (%s)' % e)
-
-        try:
-            conn = S3Connection(aws_access_key_id=access_key, aws_secret_access_key=secret_key)
-            bucket = conn.get_bucket(BUCKET_NAME)
-        except Exception as e:
-            raise exc.HTTPBadRequest('Error during connection %s' % e)
-
-        return bucket
 
     @view_config(route_name='files_collection', request_method='OPTIONS', renderer='string')
     def options_files_collection(self):
@@ -226,9 +177,12 @@ class FileView(object):
                 k.set_contents_from_string(data, replace=False)
                 key = self.bucket.get_key(k.key)
                 last_updated = _parse_ts(key.last_modified)
+            except Exception as e:
+                raise exc.HTTPInternalServerError('Error while configuring S3 key (%s) %s' % (self.file_id, e))
+            try:
                 _save_item(self.admin_id, file_id=self.file_id, last_updated=last_updated)
             except Exception as e:
-                raise exc.HTTPInternalServerError('Cannot create file on S3 (%s)' % e)
+                raise exc.HTTPInternalServerError('Cannot create file on Dynamodb (%s)' % e)
         else:
             try:
                 if self.key.content_type == 'application/vnd.google-earth.kmz' and ziped_data is not None:
@@ -236,9 +190,12 @@ class FileView(object):
                 self.key.set_contents_from_string(data, replace=True)
                 key = self.bucket.get_key(self.key.key)
                 last_updated = _parse_ts(key.last_modified)
+            except:
+                raise exc.HTTPInternalServerError('Error while updating S3 key (%s) %s' % (self.key.key, e))
+            try:
                 _save_item(self.admin_id, last_updated=last_updated)
             except Exception as e:
-                raise exc.HTTPInternalServerError('Cannot update file on S3 (%s)' % e)
+                raise exc.HTTPInternalServerError('Cannot update file on Dynamodb (%s) %s' % (self.file_id, e))
 
     @view_config(route_name='files_collection', request_method='POST')
     @requires_authorization()
@@ -260,8 +217,8 @@ class FileView(object):
             else:
                 data = self.key.get_contents_as_string()
                 return Response(data, content_type=self.key.content_type)
-        except:
-            raise exc.HTTPNotFound('File %s not found' % self.file_id)
+        except Exception as e:
+            raise exc.HTTPNotFound('File %s not found %s' % (self.file_id, e))
 
     @view_config(request_method='POST')
     @requires_authorization()
@@ -275,8 +232,8 @@ class FileView(object):
                 self._save_to_s3(data, mime, update=True)
 
                 return {'adminId': self.admin_id, 'fileId': self.file_id, 'status': 'updated'}
-            except:
-                raise exc.HTTPInternalServerError('Cannot update file with id=%s' % self.admin_id)
+            except Exception as e:
+                raise exc.HTTPInternalServerError('Cannot update file with id=%s %s' % (self.admin_id, e))
         else:
             # Fork file, get new file ids
             self.file_id = self._get_uuid()
@@ -295,8 +252,8 @@ class FileView(object):
             try:
                 self.bucket.delete_key(self.key)
                 return {'success': True}
-            except:
-                raise exc.HTTPInternalServerError('Error while deleting file %s' % self.file_id)
+            except Exception as e:
+                raise exc.HTTPInternalServerError('Error while deleting file %s. %e' % (self.file_id, e))
         else:
             raise exc.HTTPUnauthorized('You are not authorized to delete file %s' % self.file_id)
 
@@ -305,5 +262,6 @@ class FileView(object):
         # TODO: doesn't seem to be applied
         self.request.response.headers.update({
             'Access-Control-Allow-Methods': 'POST,GET,DELETE,OPTIONS',
-            'Access-Control-Allow-Credentials': 'true'})
+            'Access-Control-Allow-Credentials': 'true'
+        })
         return ''

--- a/chsdi/views/shortener.py
+++ b/chsdi/views/shortener.py
@@ -5,9 +5,7 @@ import pyramid.httpexceptions as exc
 
 import time
 
-from boto.dynamodb2.table import Table
-from boto.dynamodb2 import connect_to_region
-from chsdi.models.clientdata_dynamodb import get_table
+from chsdi.models.clientdata_dynamodb import get_dynamodb_table
 from chsdi.lib.helpers import check_url, make_api_url
 
 
@@ -54,7 +52,7 @@ def shortener(request):
     else:
         # DynamoDB v2 high-level abstraction
         try:
-            table = Table('shorturl', connection=connect_to_region('eu-west-1'))
+            table = get_dynamodb_table(table_name='shorturl')
         except Exception as e:
             raise exc.HTTPBadRequest('Error during connection %s' % e)
 
@@ -76,12 +74,11 @@ def shorten_redirect(request):
     url_short = request.matchdict.get('id')
     if url_short is None:
         raise exc.HTTPBadRequest('Please provide an id')
-    table = get_table()
+    table = get_dynamodb_table(table_name='shorturl')
     if url_short == 'toolong':
         raise exc.HTTPFound(location='http://map.geo.admin.ch')
-
     try:
-        url_short = table.get_item(url_short)
+        url_short = table.get_item(url_short=url_short)
         url = url_short.get('url')
     except Exception as e:
         raise exc.HTTPBadRequest('This short url doesn\'t exist: s.geo.admin.ch/%s Error is: %s' % (url_short, e))


### PR DESCRIPTION
With this PR everyone should have a .boto file to serve the application in dev mode.
Connections are created once and reused over time (best practice).
Only boto layer2 interface is used now.