### PR TITLE
Remove reframe redirection configuration

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -69,10 +69,7 @@ RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities_v([0-9]{8})\.xml$ ${bui
 RewriteCond %{HTTP_HOST} ^s.geo.admin.ch$
 RewriteRule ^${apache_entry_path}/(.*)$ ${apache_entry_path}/shorten/$1 [PT]
 
-# Proxy pass for geodesy services
-RewriteRule ^${apache_entry_path}/reframe/lv03tolv95(.*)$ http://tc-geodesy.bgdi.admin.ch/reframe/lv03tolv95$1 [P]
-
-<LocationMatch ^${apache_entry_path}/(loader\.js|shorten|shorten.json|reframe/lv03tolv95)>
+<LocationMatch ^${apache_entry_path}/(loader\.js|shorten|shorten.json)>
     Order allow,deny
     Allow from all
 </LocationMatch>


### PR DESCRIPTION
As we are using [the service now directly](https://github.com/geoadmin/mf-geoadmin3/pull/2375), we can remove the apache rewrite for the reframe service. This gets rid of another mod_proxy usage.

To be merged _after_ todays deploy.