### PR TITLE
Silence warnings on the fixrights task (as in ga3)

### DIFF
--- a/buildout_demo.cfg
+++ b/buildout_demo.cfg
@@ -24,7 +24,7 @@ wsgi_threads=15
 [fixrights]
 recipe = cp.recipe.cmd
 install_cmd = 
-               chgrp -R geodata ${buildout:directory}   
-               chmod -R g+swX  ${buildout:directory}   
+               chgrp -f -R geodata ${buildout:directory}
+               chmod -f -R g+srwX  ${buildout:directory}
                
 

--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -36,6 +36,6 @@ geoadmin_file_storage_bucket=public.dev.bgdi.ch
 [fixrights]
 recipe = cp.recipe.cmd
 install_cmd = 
-               chgrp -R geodata ${buildout:directory} || :
-               chmod -R g+swX  ${buildout:directory} || :
+               chgrp -f -R geodata ${buildout:directory}
+               chmod -f -R g+srwX  ${buildout:directory}
 


### PR DESCRIPTION
This PR silences the fixrights command (chgrp and chmod), whitout changing functionality. This way, we get rid of useless messages in console, both when deploying by hand and in jenkins logs.

If something is wrong with rights, we'll know anyway.