### PR TITLE
Fix tt translation error for rm and en

### DIFF
--- a/chsdi/templates/htmlpopup/suel_facilities.mako
+++ b/chsdi/templates/htmlpopup/suel_facilities.mako
@@ -2,12 +2,10 @@
 
 <%def name="table_body(c, lang)">
 <%
+    lang = lang if lang in ('fr','it') else 'de'
     doc_title = c['layerBodId'] + '.' + 'doc_title'
     name = c['layerBodId'] + '.' + 'facname_%s' % lang
-%>
-<% 
     import datetime
-    lang = lang if lang in ('fr','it') else 'de'
     facname = 'facname_%s' % lang
     fackind_text = 'fackind_text_%s' % lang
     facstatus_text = 'facstatus_text_%s' % lang
@@ -15,14 +13,14 @@
     objectname = 'objname_%s' % lang
     datefrom = c['attributes']['validfrom']
 %>
-    <tr><td class="cell-left">${_(name)}</td>                  <td>${c['attributes'][facname]}</td></tr>
-    <tr><td class="cell-left">${_('tt_sachplan_facility_anlageart')}</td>             <td>${c['attributes'][fackind_text] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('tt_sachplan_facility_anlagestatus')}</td>          <td>${c['attributes'][facstatus_text] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>        <td>${datefrom or '-'}</td></tr>
-    <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>                   <td>${c['attributes'][description_text] or '-' | n}</td></tr>
+    <tr><td class="cell-left">${_(name)}</td>                                   <td>${c['attributes'][facname]}</td></tr>
+    <tr><td class="cell-left">${_('tt_sachplan_facility_anlageart')}</td>       <td>${c['attributes'][fackind_text] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('tt_sachplan_facility_anlagestatus')}</td>    <td>${c['attributes'][facstatus_text] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>  <td>${datefrom or '-'}</td></tr>
+    <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>             <td>${c['attributes'][description_text] or '-' | n}</td></tr>
 % if 'doc_web' in c['attributes']:
-    <tr><td class="cell-left">${_(doc_title)}</td>                    <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
+    <tr><td class="cell-left">${_(doc_title)}</td>                              <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
 % else:
-    <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                    <td> - </td></tr>
+    <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>              <td> - </td></tr>
 %endif
 </%def>


### PR DESCRIPTION
Test link on dev 
https://mf-chsdi3.dev.bgdi.ch/rest/services/ech/MapServer/ch.bfe.sachplan-uebertragungsleitungen_kraft/fa14/htmlPopup?imageDisplay=1153,645,96&lang=en&mapExtent=371750,28750,948250,351250
The second line left attribute not translated : ch.bfe.sachplan-uebertragungsleitungen_kraft.facname_en same problem with rm