### PR TITLE
Considering the lang param in mapproxy requests

### DIFF
--- a/apache/mapproxy.conf.in
+++ b/apache/mapproxy.conf.in
@@ -6,13 +6,13 @@ RewriteEngine On
 ExpiresActive On
 
 # MapProxy access control
-RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.EPSG.(\d+).xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,PT]
-RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml [L,PT]
+RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.EPSG.(\d+).xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,QSA,PT]
+RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml [L,QSA,PT]
 # Better ArcGis support
-RewriteRule ^${apache_entry_path}/EPSG/(\d+)/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,PT]
+RewriteRule ^${apache_entry_path}/EPSG/(\d+)/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,QSA,PT]
 RewriteRule ^${apache_entry_path}/EPSG/(\d+)/(de|fr|it|rm|en)/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1&lang=$2 [L,PT]
 
-RewriteRule ^${apache_entry_path}/1.0.0/(.*)/default/(\d+|current|default)/(\d+)/(.*)   ${apache_entry_path}/mapproxy/wmts/1.0.0/$1_$2/default/$2/epsg_$3/$4 [L,PT]
+RewriteRule ^${apache_entry_path}/1.0.0/(.*)/default/(\d+|current|default)/(\d+)/(.*)   ${apache_entry_path}/mapproxy/wmts/1.0.0/$1_$2/default/$2/epsg_$3/$4 [L,QSA,PT]
 
 WSGIDaemonProcess mf-chsdi3:${vars:apache_base_path}-mapproxy display-name=%{GROUP} user=${vars:modwsgi_user} ${vars:mapproxy_wsgi_options}
 

--- a/chsdi/tests/apache/test_wmts.py
+++ b/chsdi/tests/apache/test_wmts.py
@@ -1,0 +1,29 @@
+#-*- coding: utf-8 -*-
+
+import requests
+
+from pyramid.paster import get_app
+
+app = get_app('development.ini')
+
+
+try:
+    api_url = "http:" + app.registry.settings['api_url']
+except KeyError as e:
+    api_url = 'http://api3.geo.admin.ch'
+
+
+def get_getcap_de():
+    resp = requests.get(api_url + '/1.0.0/WMTSCapabilities.EPSG.4326.xml?lang=de')
+
+    words = ['Alpenkonvention', 'Schweiz', 'Verkehrswege ', 'Flachmoor']
+    for w in words:
+        assert w in resp.body
+
+
+def get_getcap_fr():
+    resp = requests.get(api_url + '/1.0.0/WMTSCapabilities.EPSG.4326.xml?lang=fr')
+
+    words = ['Convention', 'Suisse', 'Voies', 'marécage']
+    for w in words:
+        assert w in resp.body


### PR DESCRIPTION
Even though *en* and *it* are usually not translated

See https://github.com/geoadmin/mf-chsdi3/issues/1478