### PR TITLE
Fixrights, die Dritte

### DIFF
--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -34,7 +34,11 @@ geoadmin_file_storage_bucket=public.dev.bgdi.ch
 [fixrights]
 recipe = collective.recipe.cmd
 shell = bash
-install_cmd = 
+on_install = true
+on_update = true
+cmds = 
+    echo "doing fixrights..."
     chgrp -f -R geodata ${buildout:directory}
-    chmod -f -R g+srwX  ${buildout:directory}
+    chmod -f -R g+srwX ${buildout:directory}
+    echo "doing fixrights done."
 


### PR DESCRIPTION
This fixrights command was not working properly, leading to conflicts in /var/www between different users.

This PR finally fixes it. The golden solution should be to use user deploy only for tasks inside /var/www, but this probably needs some work.