### PR TITLE
Update ol to v3.6.0 - adapt api3 examples

### DIFF
--- a/chsdi/static/doc/examples/cadastralwebmap.js
+++ b/chsdi/static/doc/examples/cadastralwebmap.js
@@ -59,8 +59,7 @@ var mapLeft = new ga.Map({
 
 var mapRight = new ga.Map({
   target: 'map-right',
-  layers: [wmsCadastre]
+  layers: [wmsCadastre],
+  view: mapLeft.getView()
 });
-
-mapRight.bindTo('view', mapLeft);
 

--- a/chsdi/static/doc/examples/geoadmin_geojson.js
+++ b/chsdi/static/doc/examples/geoadmin_geojson.js
@@ -25,7 +25,7 @@ var lyr1 = ga.layer.create('ch.swisstopo.pixelkarte-farbe');
 map.addLayer(lyr1);
 
 // Vector layer variable declaration and initialization
-var olSource = new ol.source.GeoJSON();
+var olSource = new ol.source.Vector();
 var vectorLayer = new ol.layer.Vector({
   source: olSource
 });

--- a/chsdi/static/doc/examples/geoadmin_kml.js
+++ b/chsdi/static/doc/examples/geoadmin_kml.js
@@ -25,9 +25,11 @@ map.addLayer(lyr1);
 
 // Create the KML Layer
 var vector = new ol.layer.Vector({
-  source: new ol.source.KML({
-    projection: 'EPSG:21781',
-    url: 'bln-style.kml'
+  source: new ol.source.Vector({
+    url: 'bln-style.kml',
+    format : new ol.format.KML({
+      projection: 'EPSG:21781'
+    })
   })
 });
 

--- a/chsdi/static/doc/examples/ol3_mercator.js
+++ b/chsdi/static/doc/examples/ol3_mercator.js
@@ -1,6 +1,3 @@
-
-
-
 function qualifyURL(url) {
   var a = document.createElement('a');
   a.href = url;
@@ -53,11 +50,6 @@ var map_right = new ol.Map({
     createLayer('ch.swisstopo.pixelkarte-farbe', 20151231)
   ],
   target: 'map-right',
-  view: new ol.View({
-    maxZoom: 17
-  })
+  view: map_left.getView()
 });
-
-map_right.bindTo('view', map_left);
-
 


### PR DESCRIPTION
Update ol3.6.0

[Test link](http://mf-chsdi3.dev.bgdi.ch/kan_update_ol_3.6)