### PR TITLE
lubis - show toposhop links even if no 'ort' information exists in database

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -168,10 +168,10 @@ viewer_url = get_viewer_url(request, params)
 </tr>
 % endif
 
-% if 'contact_web' not in c['attributes'] and c['attributes']['ort'] is not None:
+% if 'contact_web' not in c['attributes']:
 <tr>
   <th class="cell-left">${_('link')} Toposhop</th>
-  <td><a href="http://www.toposhop.admin.ch/${lang}/shop/satair/lubis_1?ext=1&pics=${c['featureId']},${imgtype},${c['attributes']['ort'].strip()},${c['attributes']['x']},${c['attributes']['y']},${toposhopscan}" target="toposhop">Toposhop</a></td>
+  <td><a href="http://www.toposhop.admin.ch/${lang}/shop/satair/lubis_1?ext=1&pics=${c['featureId']},${imgtype},${str(c['attributes']['ort']).strip()},${c['attributes']['x']},${c['attributes']['y']},${toposhopscan}" target="toposhop">Toposhop</a></td>
 </tr>
 % endif
 % if 'contact_web' in c['attributes']:
@@ -263,10 +263,10 @@ viewer_url = get_viewer_url(request, params)
     <tr><th class="cell-left">${_('tt_lubis_filesize_mb')}</th>      <td>${filesize_mb or '-'}</td></tr>
     <tr><th class="cell-left">${_('tt_lubis_bildpfad')}</th>         <td>${filename or '-'}</td></tr>
     <tr><th class="cell-left">${_('tt_lubis_orientierung')}</th>     <td>${orientierung or '-'}</td></tr>
-% if 'contact_web' not in c['attributes'] and c['attributes']['ort'] is not None:
+% if 'contact_web' not in c['attributes']:
   <tr class="chsdi-no-print">
     <th class="cell-left">${_('link')} Toposhop</th>
-    <td><a href="http://www.toposhop.admin.ch/${lang}/shop/satair/lubis_1?ext=1&pics=${c['featureId']},${imgtype},${c['attributes']['ort'].strip()},${c['attributes']['x']},${c['attributes']['y']},${toposhopscan}" target="toposhop">Toposhop</a></td>
+    <td><a href="http://www.toposhop.admin.ch/${lang}/shop/satair/lubis_1?ext=1&pics=${c['featureId']},${imgtype},${str(c['attributes']['ort']).strip()},${c['attributes']['x']},${c['attributes']['y']},${toposhopscan}" target="toposhop">Toposhop</a></td>
   </tr>
 % endif
 % if 'contact_web' in c['attributes']:


### PR DESCRIPTION
issue was reported by @davidoesch via redmine [1].
dataowner confirmed that is not necessary anymore to show toposhop links only if 'ort' information is available. This is information is not needed for the toposhop link. This particularly affecting images in the region abroad [2].

[1] https://redmine.prod.bgdi.ch/issues/3618
[2] http://s.geo.admin.ch/6522a626cc 
