### PR TITLE
WMTS getcapabilities also in rm, en and it

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -200,6 +200,21 @@ class GetCapDe(Base, GetCap):
     __table_args__ = ({'schema': 're3', 'autoload': False})
 
 
+class GetCapEn(Base, GetCap):
+    __tablename__ = 'view_bod_wmts_getcapabilities_en'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
+class GetCapIt(Base, GetCap):
+    __tablename__ = 'view_bod_wmts_getcapabilities_it'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
+class GetCapRm(Base, GetCap):
+    __tablename__ = 'view_bod_wmts_getcapabilities_rm'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
 class GetCapThemes(object):
     __dbname__ = 'bod'
     id = Column('inspire_id', Text, primary_key=True)
@@ -219,6 +234,21 @@ class GetCapThemesFr(Base, GetCapThemes):
 
 class GetCapThemesDe(Base, GetCapThemes):
     __tablename__ = 'view_bod_wmts_getcapabilities_themes_de'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
+class GetCapThemesEn(Base, GetCapThemes):
+    __tablename__ = 'view_bod_wmts_getcapabilities_themes_en'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
+class GetCapThemesIt(Base, GetCapThemes):
+    __tablename__ = 'view_bod_wmts_getcapabilities_themes_it'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
+class GetCapThemesRm(Base, GetCapThemes):
+    __tablename__ = 'view_bod_wmts_getcapabilities_themes_rm'
     __table_args__ = ({'schema': 're3', 'autoload': False})
 
 
@@ -259,7 +289,23 @@ class ServiceMetadataFr(Base, ServiceMetadata):
     __table_args__ = ({'schema': 're3', 'autoload': False})
 
 
+class ServiceMetadataIt(Base, ServiceMetadata):
+    __tablename__ = 'view_wms_service_metadata_it'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
+class ServiceMetadataRm(Base, ServiceMetadata):
+    __tablename__ = 'view_wms_service_metadata_rm'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
+
+class ServiceMetadataEn(Base, ServiceMetadata):
+    __tablename__ = 'view_wms_service_metadata_en'
+    __table_args__ = ({'schema': 're3', 'autoload': False})
+
 # TODO use GetCap model to fill that up instead
+
+
 def computeHeader(mapName):
     return {
         'mapName': mapName,
@@ -408,11 +454,29 @@ def get_bod_model(lang):
 
 
 def get_wmts_models(lang):
-    if lang in ('fr', 'it'):
+    if lang == 'fr':
         return {
             'GetCap': GetCapFr,
             'GetCapThemes': GetCapThemesFr,
             'ServiceMetadata': ServiceMetadataFr
+        }
+    elif lang == 'it':
+        return {
+            'GetCap': GetCapIt,
+            'GetCapThemes': GetCapThemesFr,
+            'ServiceMetadata': ServiceMetadataIt
+        }
+    elif lang == 'en':
+        return {
+            'GetCap': GetCapEn,
+            'GetCapThemes': GetCapThemesEn,
+            'ServiceMetadata': ServiceMetadataEn
+        }
+    elif lang == 'rm':
+        return {
+            'GetCap': GetCapRm,
+            'GetCapThemes': GetCapThemesDe,
+            'ServiceMetadata': ServiceMetadataRm
         }
     else:
         return {

--- a/chsdi/templates/standardHeader.mako
+++ b/chsdi/templates/standardHeader.mako
@@ -1,19 +1,21 @@
 <!-- Revision: $Rev$ -->
 <ows:ServiceIdentification>
-        <ows:Title>Federal Geodata Infrastructure of Switzerland</ows:Title>
-        <ows:Abstract>Some Geodata are subject to license and fees</ows:Abstract>
+        <ows:Title>${metadata.title}</ows:Title>
+        <ows:Abstract>${metadata.abstract}</ows:Abstract>
+        % if metadata.keywords:
         <ows:Keywords>
-            <ows:Keyword>FGDI</ows:Keyword>
-            <ows:Keyword>Pixelkarte</ows:Keyword>
-            <ows:Keyword>Switzerland</ows:Keyword>
+        %   for keyword in metadata.keywords.split(','):
+            <ows:Keyword>${keyword|trim}</ows:Keyword>
+        %   endfor
         </ows:Keywords>
+        % endif
         <ows:ServiceType>OGC WMTS</ows:ServiceType>
         <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
-        <ows:Fees>yes</ows:Fees>
-        <ows:AccessConstraints>license</ows:AccessConstraints>
+        <ows:Fees>${metadata.fee}</ows:Fees>
+        <ows:AccessConstraints>${metadata.accessconstraint}</ows:AccessConstraints>
 </ows:ServiceIdentification>
 <ows:ServiceProvider>
-        <ows:ProviderName>swisstopo</ows:ProviderName>
+        <ows:ProviderName>${metadata.name}</ows:ProviderName>
         <ows:ProviderSite xlink:href="http://www.swisstopo.admin.ch"/>
         <ows:ServiceContact>
             <ows:IndividualName>David Oesch</ows:IndividualName>


### PR DESCRIPTION
Note:

Content is very partially translated

WMTS Themes views are defined, but empty/uncomplete:
_view_bod_wmts_getcapabilities_rm_
_view_bod_wmts_getcapabilities_it_

WMTS service views for _rm_, _en_ and _it_ have to be deefined:
_view_wms_service_metadata_it_
_view_wms_service_metadata_rm_ and
_view_wms_service_metadata_en_ 


See https://redmine.prod.bgdi.ch/issues/5427

Test:

[RM](http://mf-chsdi3.dev.bgdi.ch/mom_wmts_en_it_rm/rest/services/api/1.0.0/WMTSCapabilities.xml?lang=rm), [IT](http://mf-chsdi3.dev.bgdi.ch/mom_wmts_en_it_rm/rest/services/api/1.0.0/WMTSCapabilities.xml?lang=it) and [EN](http://mf-chsdi3.dev.bgdi.ch/mom_wmts_en_it_rm/rest/services/api/1.0.0/WMTSCapabilities.xml?lang=en)

BEFORE MERGING
- [x ] Apply view from `bod:ltclm`master to `bod_master`
- [x ] Fill the tables `wms_metadata`
- [x ] Remove commit  079f84731b833d41658fd757de20ea5572a4928c
