### PR TITLE
OWSChecker: do not attempts to check WMS-10 if WMS-09 fails

### DIFF
--- a/ows_checker/_checker.py
+++ b/ows_checker/_checker.py
@@ -3503,7 +3503,11 @@ class OWSCheck(object):
         results = []
         
         #check Formats in GC:
-        formats = self.gc_xmlroot.Capability.Request.GetFeatureInfo.Format
+        try:
+           formats = self.gc_xmlroot.Capability.Request.GetFeatureInfo.Format
+        except KeyError:
+             return ResponseDict("wms_GetFeatureInfoMIME", ['Not checked, depends on WMS-09'], True)
+
         if isinstance(formats, dict):
             formats = [formats,]
         if isinstance(formats, str):


### PR DESCRIPTION

The support of `GetFeatureInfo`is not mandatory in WMS (but is in _egeo0056_). So if a service has no support for `GetFeatureInfo`(WMS-09), do not try to get which mie-type are supported (WMS-10).

See https://github.com/geoadmin/mf-chsdi3/issues/1522