### PR TITLE
Adding new locations_preview parameter to search

### DIFF
--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -151,7 +151,7 @@ class SearchValidation(MapNameValidation):
 
     @typeInfo.setter
     def typeInfo(self, value):
-        acceptedTypes = ['locations', 'layers', 'featuresearch']
+        acceptedTypes = ['locations', 'layers', 'featuresearch', 'locations_preview']
         if value is None:
             raise HTTPBadRequest('Please provide a type parameter. Possible values are %s' % (', '.join(acceptedTypes)))
         elif value not in acceptedTypes:

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -65,7 +65,7 @@ class Search(SearchValidation):
                 self.request.params.get('searchText')
             )
             self._feature_search()
-        elif self.typeInfo == 'locations':
+        elif self.typeInfo == 'locations' or self.typeInfo == 'locations_preview':
             self.searchText = format_search_text(
                 self.request.params.get('searchText', '')
             )
@@ -110,7 +110,11 @@ class Search(SearchValidation):
 
         if len(searchList) != 0:
             try:
-                temp = self.sphinx.Query(searchTextFinal, index='swisssearch')
+                if self.typeInfo == 'locations_preview':
+                    temp = self.sphinx.Query(searchTextFinal, index='swisssearch_preview')
+                else:
+                    temp = self.sphinx.Query(searchTextFinal, index='swisssearch')
+
             except IOError:
                 raise exc.HTTPGatewayTimeout()
             temp = temp['matches'] if temp is not None else temp
@@ -119,7 +123,10 @@ class Search(SearchValidation):
             # which should be more fuzzy in its results
             if temp is None or len(temp) <= 0:
                 try:
-                    temp = self.sphinx.Query(searchTextFinal, index='swisssearch_fuzzy')
+                    if self.typeInfo == 'locations_preview':
+                        temp = self.sphinx.Query(searchTextFinal, index='swisssearch_preview_fuzzy')
+                    else:
+                        temp = self.sphinx.Query(searchTextFinal, index='swisssearch_fuzzy')
                 except IOError:
                     raise exc.HTTPGatewayTimeout()
                 temp = temp['matches'] if temp is not None else temp
@@ -297,6 +304,7 @@ class Search(SearchValidation):
             'district': 3,
             'kantone': 4,
             'sn25': 5,
+            'gazetteer': 5,
             'address': 6,
             'parcel': 10
         }


### PR DESCRIPTION
This creates a new locations_previes search type which is using the new preview indices from sphinx (replaces sn25 with gazetter -> see https://github.com/geoadmin/service-sphinxsearch/pull/228).

map.geo will use this (PR to follow in there) and other clients will get a chance to adapt their code (api list will be informed) to the new gazetter based indices with this.

Needs review/merge for tomorrows release.