### PR TITLE
Improved fail message for htmlpopup tests

### DIFF
--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -437,7 +437,9 @@ class TestMapServiceView(TestsBase):
             for layer in getLayers(query):
                 try:
                     FeatDBSession = scoped_session(sessionmaker())
-                    model = models_from_name(layer)[0]
+                    models = models_from_name(layer)
+                    self.failUnless(models is not None and len(models) > 0, layer)
+                    model = models[0]
                     query = FeatDBSession.query(model.primary_key_column()).limit(1)
                     ID = [q[0] for q in query]
                     if ID:


### PR DESCRIPTION
When the html popup tests fail, it's hard to say which layer caused it when a model is missing.

This adds the model name to the failure output.

Self-merge.