### PR TITLE
add missing zoomlevel to swissnames3d models

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2295,6 +2295,7 @@ class swissnames3d_raster_13(Base, Vector):
                                dimension=2, srid=21781))
 
 register('ch.swisstopo.swissnames3d', swissnames3d_raster_00)
+register('ch.swisstopo.swissnames3d', swissnames3d_raster_01)
 register('ch.swisstopo.swissnames3d', swissnames3d_raster_02)
 register('ch.swisstopo.swissnames3d', swissnames3d_raster_03)
 register('ch.swisstopo.swissnames3d', swissnames3d_raster_04)


### PR DESCRIPTION
On zoomlevel 1, tooltips are actually not working.
This pr is adding the missing model to the layer.

https://map.geo.admin.ch/?X=196867.50&Y=662492.50&zoom=1&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swissnames3d
