### PR TITLE
Adding ch.swisstopo.zeitreiehen to WMTS

### DIFF
--- a/chsdi/static/doc/examples/ol3_lv95_all.js
+++ b/chsdi/static/doc/examples/ol3_lv95_all.js
@@ -59,6 +59,7 @@ $.ajax({
     var timestamps_nb = 0;
     var config = data[layer];
     data['ch.kantone.cadastralwebmap-farbe'] = cadastralCfg;
+    data['ch.swisstopo.zeitreihen'].format = 'png';
     $.each(data, function(index, layerConfig) {
         if (layerConfig.type == 'wmts') {
             var layerId = index;
@@ -126,6 +127,7 @@ var base_layer = new ol.layer.Tile({
 var layerConfig = GeoAdmin.getConfig()[layer];
 
 if (timestamp) layerConfig.timestamp = timestamp;
+if (format) layerConfig.format = format;
 
 var wmts_src = wmtsSource(layerConfig.serverLayerName, layerConfig);
 

--- a/chsdi/templates/wmtscapabilities.mako
+++ b/chsdi/templates/wmtscapabilities.mako
@@ -57,7 +57,8 @@ elif epsg != '21781':
      onlineressource = onlineressources['mapproxy']
 else:
      onlineressource = onlineressources['s3']
-
+if layer.id == 'ch.swisstopo.zeitreihen' and epsg != '21781':
+    layer.arr_all_formats = 'png'
 %>
         <Layer>
             <ows:Title>${layer.kurzbezeichnung|n,x,trim}</ows:Title>
@@ -79,6 +80,9 @@ else:
                 <LegendURL format="image/png" xlink:href="${scheme}://api3.geo.admin.ch/static/images/legends/${layer.id|n,x,trim}_${request.lang|n,x,trim}.png" />
                 % endif
             </Style>
+            % if layer.id == 'ch.swisstopo.zeitreihen' and epsg == '21781':
+            <Format>image/png</Format>
+            % endif
             <Format>image/${str(layer.arr_all_formats).split(',')[0]}</Format>
             ## All dimensions
             <Dimension>
@@ -100,6 +104,10 @@ else:
                     <TileMatrixSet>${epsg}</TileMatrixSet>
                 % endif
             </TileMatrixSetLink>
+            ## Zeitreihen has two formats available 'png' (desktop GIS) and (pngjpeg) web gis
+            % if layer.id == 'ch.swisstopo.zeitreihen' and epsg == '21781':
+                <ResourceURL format="image/png" resourceType="tile" template="${onlineressource}1.0.0/${layer.id|n,x,trim}/default/{Time}/${epsg}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+            % endif
             ## ACHTUNG: s3 tiles have a row/col order, mapproxy ones the standard col/row
             % if epsg in ['21781'] and layer.id != 'ch.kantone.cadastralwebmap-farbe':
                 <ResourceURL format="image/${str(layer.arr_all_formats).split(',')[0]}" resourceType="tile" template="${onlineressource}1.0.0/${layer.id|n,x,trim}/default/{Time}/${epsg}/{TileMatrix}/{TileRow}/{TileCol}.${str(layer.arr_all_formats).split(',')[0]}"/>

--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -405,10 +405,22 @@ caches:
   ch.bafu.bundesinventare-vogelreservate_20090617_cache_out:
     disable_storage: true
     format: image/png
-    grids: [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id009 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.bundesinventare-vogelreservate_20090617_cache]
+  ch.bafu.bundesinventare-vogelreservate_20150622_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bafu.bundesinventare-vogelreservate_20150622_source]
+  ch.bafu.bundesinventare-vogelreservate_20150622_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id009
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bafu.bundesinventare-vogelreservate_20150622_cache]
   ch.bafu.fauna-steinbockkolonien_20020114_cache:
     disable_storage: true
     format: image/png
@@ -417,7 +429,7 @@ caches:
   ch.bafu.fauna-steinbockkolonien_20020114_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id009 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id010 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.fauna-steinbockkolonien_20020114_cache]
@@ -429,7 +441,7 @@ caches:
   ch.bafu.fauna-steinbockkolonien_20150506_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id009
+    grids: *id010
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.fauna-steinbockkolonien_20150506_cache]
@@ -477,7 +489,7 @@ caches:
   ch.bafu.hydrologie-hydromessstationen_20081201_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id010 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id011 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.hydrologie-hydromessstationen_20081201_cache]
@@ -489,7 +501,7 @@ caches:
   ch.bafu.hydrologie-hydromessstationen_20141201_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id010
+    grids: *id011
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.hydrologie-hydromessstationen_20141201_cache]
@@ -501,7 +513,7 @@ caches:
   ch.bafu.hydrologie-wassertemperaturmessstationen_20130322_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id011 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id012 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20130322_cache]
@@ -513,7 +525,7 @@ caches:
   ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id011
+    grids: *id012
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache]
@@ -705,7 +717,7 @@ caches:
   ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20110103_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id012 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id013 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20110103_cache]
@@ -717,7 +729,7 @@ caches:
   ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20120127_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id012
+    grids: *id013
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20120127_cache]
@@ -729,7 +741,7 @@ caches:
   ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20121023_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id012
+    grids: *id013
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20121023_cache]
@@ -741,7 +753,7 @@ caches:
   ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20130416_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id012
+    grids: *id013
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20130416_cache]
@@ -753,7 +765,7 @@ caches:
   ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20140402_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id012
+    grids: *id013
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20140402_cache]
@@ -765,7 +777,7 @@ caches:
   ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id012
+    grids: *id013
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache]
@@ -777,7 +789,7 @@ caches:
   ch.bafu.schutzgebiete-ramsar_20050202_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id013 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id014 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-ramsar_20050202_cache]
@@ -789,7 +801,7 @@ caches:
   ch.bafu.schutzgebiete-ramsar_20110830_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id013
+    grids: *id014
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.schutzgebiete-ramsar_20110830_cache]
@@ -813,7 +825,7 @@ caches:
   ch.bafu.showme-gemeinden_hochwasser_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id014 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id015 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_hochwasser_20100101_cache]
@@ -825,7 +837,7 @@ caches:
   ch.bafu.showme-gemeinden_hochwasser_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id014
+    grids: *id015
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_hochwasser_20110101_cache]
@@ -837,7 +849,7 @@ caches:
   ch.bafu.showme-gemeinden_hochwasser_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id014
+    grids: *id015
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_hochwasser_20120101_cache]
@@ -849,7 +861,7 @@ caches:
   ch.bafu.showme-gemeinden_hochwasser_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id014
+    grids: *id015
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_hochwasser_20130101_cache]
@@ -861,7 +873,7 @@ caches:
   ch.bafu.showme-gemeinden_hochwasser_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id014
+    grids: *id015
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_hochwasser_20140101_cache]
@@ -873,7 +885,7 @@ caches:
   ch.bafu.showme-gemeinden_hochwasser_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id014
+    grids: *id015
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
@@ -885,7 +897,7 @@ caches:
   ch.bafu.showme-gemeinden_lawinen_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id015 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id016 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_lawinen_20100101_cache]
@@ -897,7 +909,7 @@ caches:
   ch.bafu.showme-gemeinden_lawinen_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id015
+    grids: *id016
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_lawinen_20110101_cache]
@@ -909,7 +921,7 @@ caches:
   ch.bafu.showme-gemeinden_lawinen_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id015
+    grids: *id016
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_lawinen_20120101_cache]
@@ -921,7 +933,7 @@ caches:
   ch.bafu.showme-gemeinden_lawinen_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id015
+    grids: *id016
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_lawinen_20130101_cache]
@@ -933,7 +945,7 @@ caches:
   ch.bafu.showme-gemeinden_lawinen_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id015
+    grids: *id016
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_lawinen_20140101_cache]
@@ -945,7 +957,7 @@ caches:
   ch.bafu.showme-gemeinden_lawinen_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id015
+    grids: *id016
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
@@ -957,7 +969,7 @@ caches:
   ch.bafu.showme-gemeinden_rutschungen_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id016 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id017 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_rutschungen_20100101_cache]
@@ -969,7 +981,7 @@ caches:
   ch.bafu.showme-gemeinden_rutschungen_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id016
+    grids: *id017
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_rutschungen_20110101_cache]
@@ -981,7 +993,7 @@ caches:
   ch.bafu.showme-gemeinden_rutschungen_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id016
+    grids: *id017
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_rutschungen_20120101_cache]
@@ -993,7 +1005,7 @@ caches:
   ch.bafu.showme-gemeinden_rutschungen_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id016
+    grids: *id017
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_rutschungen_20130101_cache]
@@ -1005,7 +1017,7 @@ caches:
   ch.bafu.showme-gemeinden_rutschungen_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id016
+    grids: *id017
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_rutschungen_20140101_cache]
@@ -1017,7 +1029,7 @@ caches:
   ch.bafu.showme-gemeinden_rutschungen_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id016
+    grids: *id017
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
@@ -1029,7 +1041,7 @@ caches:
   ch.bafu.showme-gemeinden_sturzprozesse_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id017 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id018 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_sturzprozesse_20100101_cache]
@@ -1041,7 +1053,7 @@ caches:
   ch.bafu.showme-gemeinden_sturzprozesse_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id017
+    grids: *id018
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_sturzprozesse_20110101_cache]
@@ -1053,7 +1065,7 @@ caches:
   ch.bafu.showme-gemeinden_sturzprozesse_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id017
+    grids: *id018
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_sturzprozesse_20120101_cache]
@@ -1065,7 +1077,7 @@ caches:
   ch.bafu.showme-gemeinden_sturzprozesse_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id017
+    grids: *id018
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_sturzprozesse_20130101_cache]
@@ -1077,7 +1089,7 @@ caches:
   ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id017
+    grids: *id018
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache]
@@ -1089,7 +1101,7 @@ caches:
   ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id017
+    grids: *id018
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
@@ -1101,7 +1113,7 @@ caches:
   ch.bafu.showme-kantone_hochwasser_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id018 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id019 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_hochwasser_20100101_cache]
@@ -1113,7 +1125,7 @@ caches:
   ch.bafu.showme-kantone_hochwasser_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id018
+    grids: *id019
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_hochwasser_20110101_cache]
@@ -1125,7 +1137,7 @@ caches:
   ch.bafu.showme-kantone_hochwasser_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id018
+    grids: *id019
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_hochwasser_20120101_cache]
@@ -1137,7 +1149,7 @@ caches:
   ch.bafu.showme-kantone_hochwasser_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id018
+    grids: *id019
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_hochwasser_20130101_cache]
@@ -1149,7 +1161,7 @@ caches:
   ch.bafu.showme-kantone_hochwasser_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id018
+    grids: *id019
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_hochwasser_20140101_cache]
@@ -1161,7 +1173,7 @@ caches:
   ch.bafu.showme-kantone_hochwasser_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id018
+    grids: *id019
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
@@ -1173,7 +1185,7 @@ caches:
   ch.bafu.showme-kantone_lawinen_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id019 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id020 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_lawinen_20100101_cache]
@@ -1185,7 +1197,7 @@ caches:
   ch.bafu.showme-kantone_lawinen_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id019
+    grids: *id020
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_lawinen_20110101_cache]
@@ -1197,7 +1209,7 @@ caches:
   ch.bafu.showme-kantone_lawinen_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id019
+    grids: *id020
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_lawinen_20120101_cache]
@@ -1209,7 +1221,7 @@ caches:
   ch.bafu.showme-kantone_lawinen_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id019
+    grids: *id020
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_lawinen_20130101_cache]
@@ -1221,7 +1233,7 @@ caches:
   ch.bafu.showme-kantone_lawinen_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id019
+    grids: *id020
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_lawinen_20140101_cache]
@@ -1233,7 +1245,7 @@ caches:
   ch.bafu.showme-kantone_lawinen_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id019
+    grids: *id020
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
@@ -1245,7 +1257,7 @@ caches:
   ch.bafu.showme-kantone_rutschungen_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id020 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id021 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_rutschungen_20100101_cache]
@@ -1257,7 +1269,7 @@ caches:
   ch.bafu.showme-kantone_rutschungen_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id020
+    grids: *id021
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_rutschungen_20110101_cache]
@@ -1269,7 +1281,7 @@ caches:
   ch.bafu.showme-kantone_rutschungen_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id020
+    grids: *id021
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_rutschungen_20120101_cache]
@@ -1281,7 +1293,7 @@ caches:
   ch.bafu.showme-kantone_rutschungen_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id020
+    grids: *id021
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_rutschungen_20130101_cache]
@@ -1293,7 +1305,7 @@ caches:
   ch.bafu.showme-kantone_rutschungen_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id020
+    grids: *id021
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_rutschungen_20140101_cache]
@@ -1305,7 +1317,7 @@ caches:
   ch.bafu.showme-kantone_rutschungen_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id020
+    grids: *id021
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
@@ -1317,7 +1329,7 @@ caches:
   ch.bafu.showme-kantone_sturzprozesse_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id021 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id022 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_sturzprozesse_20100101_cache]
@@ -1329,7 +1341,7 @@ caches:
   ch.bafu.showme-kantone_sturzprozesse_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id021
+    grids: *id022
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_sturzprozesse_20110101_cache]
@@ -1341,7 +1353,7 @@ caches:
   ch.bafu.showme-kantone_sturzprozesse_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id021
+    grids: *id022
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_sturzprozesse_20120101_cache]
@@ -1353,7 +1365,7 @@ caches:
   ch.bafu.showme-kantone_sturzprozesse_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id021
+    grids: *id022
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_sturzprozesse_20130101_cache]
@@ -1365,7 +1377,7 @@ caches:
   ch.bafu.showme-kantone_sturzprozesse_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id021
+    grids: *id022
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_sturzprozesse_20140101_cache]
@@ -1377,7 +1389,7 @@ caches:
   ch.bafu.showme-kantone_sturzprozesse_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id021
+    grids: *id022
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
@@ -1485,7 +1497,7 @@ caches:
   ch.bafu.swissprtr_20110222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id022 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id023 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.swissprtr_20110222_cache]
@@ -1497,7 +1509,7 @@ caches:
   ch.bafu.swissprtr_20120404_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id022
+    grids: *id023
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.swissprtr_20120404_cache]
@@ -1509,7 +1521,7 @@ caches:
   ch.bafu.swissprtr_20130207_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id022
+    grids: *id023
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.swissprtr_20130207_cache]
@@ -1521,7 +1533,7 @@ caches:
   ch.bafu.swissprtr_20140213_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id022
+    grids: *id023
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.swissprtr_20140213_cache]
@@ -1533,7 +1545,7 @@ caches:
   ch.bafu.swissprtr_20150226_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id022
+    grids: *id023
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.swissprtr_20150226_cache]
@@ -1629,7 +1641,7 @@ caches:
   ch.bafu.wrz-wildruhezonen_portal_20130111_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id023 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id024 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.wrz-wildruhezonen_portal_20130111_cache]
@@ -1641,7 +1653,7 @@ caches:
   ch.bafu.wrz-wildruhezonen_portal_20131118_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id023
+    grids: *id024
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.wrz-wildruhezonen_portal_20131118_cache]
@@ -1653,7 +1665,7 @@ caches:
   ch.bafu.wrz-wildruhezonen_portal_20140107_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id023
+    grids: *id024
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache]
@@ -1665,7 +1677,7 @@ caches:
   ch.bafu.wrz-wildruhezonen_portal_20141105_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id023
+    grids: *id024
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache]
@@ -1677,7 +1689,7 @@ caches:
   ch.bafu.wrz-wildruhezonen_portal_20150106_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id023
+    grids: *id024
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache]
@@ -1689,7 +1701,7 @@ caches:
   ch.bag.zecken-fsme-faelle_20121231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id024 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id025 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bag.zecken-fsme-faelle_20121231_cache]
@@ -1701,7 +1713,7 @@ caches:
   ch.bag.zecken-fsme-faelle_20140220_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id024
+    grids: *id025
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bag.zecken-fsme-faelle_20140220_cache]
@@ -1713,7 +1725,7 @@ caches:
   ch.bag.zecken-fsme-faelle_20141231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id024
+    grids: *id025
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
@@ -1725,7 +1737,7 @@ caches:
   ch.bag.zecken-fsme-impfung_20121231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id025 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id026 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bag.zecken-fsme-impfung_20121231_cache]
@@ -1737,7 +1749,7 @@ caches:
   ch.bag.zecken-fsme-impfung_20140220_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id025
+    grids: *id026
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bag.zecken-fsme-impfung_20140220_cache]
@@ -1749,7 +1761,7 @@ caches:
   ch.bag.zecken-fsme-impfung_20141231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id025
+    grids: *id026
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
@@ -1773,7 +1785,7 @@ caches:
   ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id026 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id027 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache]
@@ -1785,7 +1797,7 @@ caches:
   ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id026
+    grids: *id027
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache]
@@ -1797,7 +1809,7 @@ caches:
   ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id026
+    grids: *id027
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache]
@@ -1809,7 +1821,7 @@ caches:
   ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id026
+    grids: *id027
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache]
@@ -1821,7 +1833,7 @@ caches:
   ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id026
+    grids: *id027
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache]
@@ -1833,7 +1845,7 @@ caches:
   ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id026
+    grids: *id027
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache]
@@ -1857,7 +1869,7 @@ caches:
   ch.bakom.anbieter-eigenes_festnetz_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id027 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id028 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anbieter-eigenes_festnetz_20121222_cache]
@@ -1869,7 +1881,7 @@ caches:
   ch.bakom.anbieter-eigenes_festnetz_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id027
+    grids: *id028
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anbieter-eigenes_festnetz_20130601_cache]
@@ -1881,7 +1893,7 @@ caches:
   ch.bakom.anbieter-eigenes_festnetz_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id027
+    grids: *id028
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anbieter-eigenes_festnetz_20130901_cache]
@@ -1893,7 +1905,7 @@ caches:
   ch.bakom.anbieter-eigenes_festnetz_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id027
+    grids: *id028
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anbieter-eigenes_festnetz_20131212_cache]
@@ -1905,7 +1917,7 @@ caches:
   ch.bakom.anbieter-eigenes_festnetz_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id027
+    grids: *id028
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anbieter-eigenes_festnetz_20140625_cache]
@@ -1917,7 +1929,7 @@ caches:
   ch.bakom.anbieter-eigenes_festnetz_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id027
+    grids: *id028
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache]
@@ -1929,10 +1941,22 @@ caches:
   ch.bakom.anbieter-eigenes_festnetz_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id027
+    grids: *id028
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anbieter-eigenes_festnetz_20141120_cache]
+  ch.bakom.anbieter-eigenes_festnetz_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_source]
+  ch.bakom.anbieter-eigenes_festnetz_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id028
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_cache]
   ch.bakom.anschlussart-glasfaser_20121222_cache:
     disable_storage: true
     format: image/png
@@ -1941,7 +1965,7 @@ caches:
   ch.bakom.anschlussart-glasfaser_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id028 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id029 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-glasfaser_20121222_cache]
@@ -1953,7 +1977,7 @@ caches:
   ch.bakom.anschlussart-glasfaser_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id028
+    grids: *id029
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-glasfaser_20130601_cache]
@@ -1965,7 +1989,7 @@ caches:
   ch.bakom.anschlussart-glasfaser_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id028
+    grids: *id029
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-glasfaser_20130901_cache]
@@ -1977,7 +2001,7 @@ caches:
   ch.bakom.anschlussart-glasfaser_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id028
+    grids: *id029
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-glasfaser_20131212_cache]
@@ -1989,7 +2013,7 @@ caches:
   ch.bakom.anschlussart-glasfaser_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id028
+    grids: *id029
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-glasfaser_20140625_cache]
@@ -2001,7 +2025,7 @@ caches:
   ch.bakom.anschlussart-glasfaser_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id028
+    grids: *id029
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-glasfaser_20141021_cache]
@@ -2013,10 +2037,22 @@ caches:
   ch.bakom.anschlussart-glasfaser_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id028
+    grids: *id029
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-glasfaser_20141120_cache]
+  ch.bakom.anschlussart-glasfaser_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.anschlussart-glasfaser_20150521_source]
+  ch.bakom.anschlussart-glasfaser_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id029
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.anschlussart-glasfaser_20150521_cache]
   ch.bakom.anschlussart-koaxialkabel_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2025,7 +2061,7 @@ caches:
   ch.bakom.anschlussart-koaxialkabel_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id029 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id030 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-koaxialkabel_20121222_cache]
@@ -2037,7 +2073,7 @@ caches:
   ch.bakom.anschlussart-koaxialkabel_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id029
+    grids: *id030
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-koaxialkabel_20130601_cache]
@@ -2049,7 +2085,7 @@ caches:
   ch.bakom.anschlussart-koaxialkabel_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id029
+    grids: *id030
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-koaxialkabel_20130901_cache]
@@ -2061,7 +2097,7 @@ caches:
   ch.bakom.anschlussart-koaxialkabel_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id029
+    grids: *id030
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-koaxialkabel_20131212_cache]
@@ -2073,7 +2109,7 @@ caches:
   ch.bakom.anschlussart-koaxialkabel_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id029
+    grids: *id030
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-koaxialkabel_20140625_cache]
@@ -2085,7 +2121,7 @@ caches:
   ch.bakom.anschlussart-koaxialkabel_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id029
+    grids: *id030
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache]
@@ -2097,10 +2133,22 @@ caches:
   ch.bakom.anschlussart-koaxialkabel_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id029
+    grids: *id030
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-koaxialkabel_20141120_cache]
+  ch.bakom.anschlussart-koaxialkabel_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.anschlussart-koaxialkabel_20150521_source]
+  ch.bakom.anschlussart-koaxialkabel_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id030
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.anschlussart-koaxialkabel_20150521_cache]
   ch.bakom.anschlussart-kupferdraht_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2109,7 +2157,7 @@ caches:
   ch.bakom.anschlussart-kupferdraht_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id030 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id031 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-kupferdraht_20121222_cache]
@@ -2121,7 +2169,7 @@ caches:
   ch.bakom.anschlussart-kupferdraht_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id030
+    grids: *id031
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-kupferdraht_20130601_cache]
@@ -2133,7 +2181,7 @@ caches:
   ch.bakom.anschlussart-kupferdraht_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id030
+    grids: *id031
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-kupferdraht_20130901_cache]
@@ -2145,7 +2193,7 @@ caches:
   ch.bakom.anschlussart-kupferdraht_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id030
+    grids: *id031
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-kupferdraht_20131212_cache]
@@ -2157,7 +2205,7 @@ caches:
   ch.bakom.anschlussart-kupferdraht_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id030
+    grids: *id031
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-kupferdraht_20140625_cache]
@@ -2169,7 +2217,7 @@ caches:
   ch.bakom.anschlussart-kupferdraht_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id030
+    grids: *id031
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache]
@@ -2181,10 +2229,22 @@ caches:
   ch.bakom.anschlussart-kupferdraht_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id030
+    grids: *id031
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.anschlussart-kupferdraht_20141120_cache]
+  ch.bakom.anschlussart-kupferdraht_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.anschlussart-kupferdraht_20150521_source]
+  ch.bakom.anschlussart-kupferdraht_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id031
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.anschlussart-kupferdraht_20150521_cache]
   ch.bakom.downlink100_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2193,7 +2253,7 @@ caches:
   ch.bakom.downlink100_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id031 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id032 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink100_20121222_cache]
@@ -2205,7 +2265,7 @@ caches:
   ch.bakom.downlink100_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id031
+    grids: *id032
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink100_20130601_cache]
@@ -2217,7 +2277,7 @@ caches:
   ch.bakom.downlink100_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id031
+    grids: *id032
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink100_20130901_cache]
@@ -2229,7 +2289,7 @@ caches:
   ch.bakom.downlink100_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id031
+    grids: *id032
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink100_20131212_cache]
@@ -2241,7 +2301,7 @@ caches:
   ch.bakom.downlink100_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id031
+    grids: *id032
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink100_20140625_cache]
@@ -2253,7 +2313,7 @@ caches:
   ch.bakom.downlink100_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id031
+    grids: *id032
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink100_20141021_cache]
@@ -2265,10 +2325,22 @@ caches:
   ch.bakom.downlink100_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id031
+    grids: *id032
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink100_20141120_cache]
+  ch.bakom.downlink100_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.downlink100_20150521_source]
+  ch.bakom.downlink100_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id032
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.downlink100_20150521_cache]
   ch.bakom.downlink10_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2277,7 +2349,7 @@ caches:
   ch.bakom.downlink10_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id032 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id033 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink10_20121222_cache]
@@ -2289,7 +2361,7 @@ caches:
   ch.bakom.downlink10_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id032
+    grids: *id033
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink10_20130601_cache]
@@ -2301,7 +2373,7 @@ caches:
   ch.bakom.downlink10_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id032
+    grids: *id033
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink10_20130901_cache]
@@ -2313,7 +2385,7 @@ caches:
   ch.bakom.downlink10_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id032
+    grids: *id033
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink10_20131212_cache]
@@ -2325,7 +2397,7 @@ caches:
   ch.bakom.downlink10_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id032
+    grids: *id033
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink10_20140625_cache]
@@ -2337,7 +2409,7 @@ caches:
   ch.bakom.downlink10_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id032
+    grids: *id033
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink10_20141021_cache]
@@ -2349,10 +2421,22 @@ caches:
   ch.bakom.downlink10_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id032
+    grids: *id033
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink10_20141120_cache]
+  ch.bakom.downlink10_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.downlink10_20150521_source]
+  ch.bakom.downlink10_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id033
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.downlink10_20150521_cache]
   ch.bakom.downlink1_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2361,7 +2445,7 @@ caches:
   ch.bakom.downlink1_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id033 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id034 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink1_20121222_cache]
@@ -2373,7 +2457,7 @@ caches:
   ch.bakom.downlink1_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id033
+    grids: *id034
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink1_20130601_cache]
@@ -2385,7 +2469,7 @@ caches:
   ch.bakom.downlink1_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id033
+    grids: *id034
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink1_20130901_cache]
@@ -2397,7 +2481,7 @@ caches:
   ch.bakom.downlink1_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id033
+    grids: *id034
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink1_20131212_cache]
@@ -2409,7 +2493,7 @@ caches:
   ch.bakom.downlink1_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id033
+    grids: *id034
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink1_20140625_cache]
@@ -2421,7 +2505,7 @@ caches:
   ch.bakom.downlink1_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id033
+    grids: *id034
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink1_20141021_cache]
@@ -2433,10 +2517,22 @@ caches:
   ch.bakom.downlink1_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id033
+    grids: *id034
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink1_20141120_cache]
+  ch.bakom.downlink1_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.downlink1_20150521_source]
+  ch.bakom.downlink1_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id034
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.downlink1_20150521_cache]
   ch.bakom.downlink20_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2445,7 +2541,7 @@ caches:
   ch.bakom.downlink20_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id034 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id035 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink20_20121222_cache]
@@ -2457,7 +2553,7 @@ caches:
   ch.bakom.downlink20_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id034
+    grids: *id035
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink20_20130601_cache]
@@ -2469,7 +2565,7 @@ caches:
   ch.bakom.downlink20_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id034
+    grids: *id035
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink20_20130901_cache]
@@ -2481,7 +2577,7 @@ caches:
   ch.bakom.downlink20_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id034
+    grids: *id035
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink20_20131212_cache]
@@ -2493,7 +2589,7 @@ caches:
   ch.bakom.downlink20_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id034
+    grids: *id035
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink20_20140625_cache]
@@ -2505,7 +2601,7 @@ caches:
   ch.bakom.downlink20_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id034
+    grids: *id035
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink20_20141021_cache]
@@ -2517,10 +2613,22 @@ caches:
   ch.bakom.downlink20_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id034
+    grids: *id035
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink20_20141120_cache]
+  ch.bakom.downlink20_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.downlink20_20150521_source]
+  ch.bakom.downlink20_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id035
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.downlink20_20150521_cache]
   ch.bakom.downlink2_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2529,7 +2637,7 @@ caches:
   ch.bakom.downlink2_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id035 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id036 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink2_20121222_cache]
@@ -2541,7 +2649,7 @@ caches:
   ch.bakom.downlink2_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id035
+    grids: *id036
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink2_20130601_cache]
@@ -2553,7 +2661,7 @@ caches:
   ch.bakom.downlink2_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id035
+    grids: *id036
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink2_20130901_cache]
@@ -2565,7 +2673,7 @@ caches:
   ch.bakom.downlink2_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id035
+    grids: *id036
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink2_20131212_cache]
@@ -2577,7 +2685,7 @@ caches:
   ch.bakom.downlink2_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id035
+    grids: *id036
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink2_20140625_cache]
@@ -2589,7 +2697,7 @@ caches:
   ch.bakom.downlink2_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id035
+    grids: *id036
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink2_20141021_cache]
@@ -2601,10 +2709,22 @@ caches:
   ch.bakom.downlink2_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id035
+    grids: *id036
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink2_20141120_cache]
+  ch.bakom.downlink2_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.downlink2_20150521_source]
+  ch.bakom.downlink2_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id036
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.downlink2_20150521_cache]
   ch.bakom.downlink50_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2613,7 +2733,7 @@ caches:
   ch.bakom.downlink50_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id036 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id037 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink50_20121222_cache]
@@ -2625,7 +2745,7 @@ caches:
   ch.bakom.downlink50_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id036
+    grids: *id037
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink50_20130601_cache]
@@ -2637,7 +2757,7 @@ caches:
   ch.bakom.downlink50_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id036
+    grids: *id037
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink50_20130901_cache]
@@ -2649,7 +2769,7 @@ caches:
   ch.bakom.downlink50_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id036
+    grids: *id037
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink50_20131212_cache]
@@ -2661,7 +2781,7 @@ caches:
   ch.bakom.downlink50_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id036
+    grids: *id037
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink50_20140625_cache]
@@ -2673,7 +2793,7 @@ caches:
   ch.bakom.downlink50_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id036
+    grids: *id037
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink50_20141021_cache]
@@ -2685,10 +2805,22 @@ caches:
   ch.bakom.downlink50_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id036
+    grids: *id037
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.downlink50_20141120_cache]
+  ch.bakom.downlink50_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.downlink50_20150521_source]
+  ch.bakom.downlink50_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id037
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.downlink50_20150521_cache]
   ch.bakom.uplink100_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2697,7 +2829,7 @@ caches:
   ch.bakom.uplink100_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id037 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id038 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink100_20121222_cache]
@@ -2709,7 +2841,7 @@ caches:
   ch.bakom.uplink100_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id037
+    grids: *id038
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink100_20130601_cache]
@@ -2721,7 +2853,7 @@ caches:
   ch.bakom.uplink100_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id037
+    grids: *id038
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink100_20130901_cache]
@@ -2733,7 +2865,7 @@ caches:
   ch.bakom.uplink100_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id037
+    grids: *id038
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink100_20131212_cache]
@@ -2745,7 +2877,7 @@ caches:
   ch.bakom.uplink100_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id037
+    grids: *id038
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink100_20140625_cache]
@@ -2757,7 +2889,7 @@ caches:
   ch.bakom.uplink100_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id037
+    grids: *id038
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink100_20141021_cache]
@@ -2769,10 +2901,22 @@ caches:
   ch.bakom.uplink100_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id037
+    grids: *id038
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink100_20141120_cache]
+  ch.bakom.uplink100_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.uplink100_20150521_source]
+  ch.bakom.uplink100_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id038
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.uplink100_20150521_cache]
   ch.bakom.uplink10_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2781,7 +2925,7 @@ caches:
   ch.bakom.uplink10_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id038 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id039 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink10_20121222_cache]
@@ -2793,7 +2937,7 @@ caches:
   ch.bakom.uplink10_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id038
+    grids: *id039
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink10_20130601_cache]
@@ -2805,7 +2949,7 @@ caches:
   ch.bakom.uplink10_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id038
+    grids: *id039
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink10_20130901_cache]
@@ -2817,7 +2961,7 @@ caches:
   ch.bakom.uplink10_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id038
+    grids: *id039
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink10_20131212_cache]
@@ -2829,7 +2973,7 @@ caches:
   ch.bakom.uplink10_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id038
+    grids: *id039
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink10_20140625_cache]
@@ -2841,7 +2985,7 @@ caches:
   ch.bakom.uplink10_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id038
+    grids: *id039
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink10_20141021_cache]
@@ -2853,10 +2997,22 @@ caches:
   ch.bakom.uplink10_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id038
+    grids: *id039
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink10_20141120_cache]
+  ch.bakom.uplink10_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.uplink10_20150521_source]
+  ch.bakom.uplink10_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id039
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.uplink10_20150521_cache]
   ch.bakom.uplink1_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2865,7 +3021,7 @@ caches:
   ch.bakom.uplink1_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id039 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id040 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink1_20121222_cache]
@@ -2877,7 +3033,7 @@ caches:
   ch.bakom.uplink1_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id039
+    grids: *id040
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink1_20130601_cache]
@@ -2889,7 +3045,7 @@ caches:
   ch.bakom.uplink1_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id039
+    grids: *id040
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink1_20130901_cache]
@@ -2901,7 +3057,7 @@ caches:
   ch.bakom.uplink1_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id039
+    grids: *id040
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink1_20131212_cache]
@@ -2913,7 +3069,7 @@ caches:
   ch.bakom.uplink1_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id039
+    grids: *id040
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink1_20140625_cache]
@@ -2925,7 +3081,7 @@ caches:
   ch.bakom.uplink1_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id039
+    grids: *id040
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink1_20141021_cache]
@@ -2937,10 +3093,22 @@ caches:
   ch.bakom.uplink1_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id039
+    grids: *id040
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink1_20141120_cache]
+  ch.bakom.uplink1_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.uplink1_20150521_source]
+  ch.bakom.uplink1_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id040
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.uplink1_20150521_cache]
   ch.bakom.uplink20_20121222_cache:
     disable_storage: true
     format: image/png
@@ -2949,7 +3117,7 @@ caches:
   ch.bakom.uplink20_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id040 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id041 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink20_20121222_cache]
@@ -2961,7 +3129,7 @@ caches:
   ch.bakom.uplink20_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id040
+    grids: *id041
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink20_20130601_cache]
@@ -2973,7 +3141,7 @@ caches:
   ch.bakom.uplink20_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id040
+    grids: *id041
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink20_20130901_cache]
@@ -2985,7 +3153,7 @@ caches:
   ch.bakom.uplink20_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id040
+    grids: *id041
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink20_20131212_cache]
@@ -2997,7 +3165,7 @@ caches:
   ch.bakom.uplink20_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id040
+    grids: *id041
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink20_20140625_cache]
@@ -3009,7 +3177,7 @@ caches:
   ch.bakom.uplink20_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id040
+    grids: *id041
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink20_20141021_cache]
@@ -3021,10 +3189,22 @@ caches:
   ch.bakom.uplink20_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id040
+    grids: *id041
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink20_20141120_cache]
+  ch.bakom.uplink20_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.uplink20_20150521_source]
+  ch.bakom.uplink20_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id041
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.uplink20_20150521_cache]
   ch.bakom.uplink2_20121222_cache:
     disable_storage: true
     format: image/png
@@ -3033,7 +3213,7 @@ caches:
   ch.bakom.uplink2_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id041 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id042 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink2_20121222_cache]
@@ -3045,7 +3225,7 @@ caches:
   ch.bakom.uplink2_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id041
+    grids: *id042
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink2_20130601_cache]
@@ -3057,7 +3237,7 @@ caches:
   ch.bakom.uplink2_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id041
+    grids: *id042
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink2_20130901_cache]
@@ -3069,7 +3249,7 @@ caches:
   ch.bakom.uplink2_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id041
+    grids: *id042
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink2_20131212_cache]
@@ -3081,7 +3261,7 @@ caches:
   ch.bakom.uplink2_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id041
+    grids: *id042
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink2_20140625_cache]
@@ -3093,7 +3273,7 @@ caches:
   ch.bakom.uplink2_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id041
+    grids: *id042
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink2_20141021_cache]
@@ -3105,10 +3285,22 @@ caches:
   ch.bakom.uplink2_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id041
+    grids: *id042
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink2_20141120_cache]
+  ch.bakom.uplink2_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.uplink2_20150521_source]
+  ch.bakom.uplink2_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id042
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.uplink2_20150521_cache]
   ch.bakom.uplink50_20121222_cache:
     disable_storage: true
     format: image/png
@@ -3117,7 +3309,7 @@ caches:
   ch.bakom.uplink50_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id042 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id043 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink50_20121222_cache]
@@ -3129,7 +3321,7 @@ caches:
   ch.bakom.uplink50_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id042
+    grids: *id043
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink50_20130601_cache]
@@ -3141,7 +3333,7 @@ caches:
   ch.bakom.uplink50_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id042
+    grids: *id043
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink50_20130901_cache]
@@ -3153,7 +3345,7 @@ caches:
   ch.bakom.uplink50_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id042
+    grids: *id043
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink50_20131212_cache]
@@ -3165,7 +3357,7 @@ caches:
   ch.bakom.uplink50_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id042
+    grids: *id043
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink50_20140625_cache]
@@ -3177,7 +3369,7 @@ caches:
   ch.bakom.uplink50_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id042
+    grids: *id043
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink50_20141021_cache]
@@ -3189,10 +3381,22 @@ caches:
   ch.bakom.uplink50_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id042
+    grids: *id043
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.uplink50_20141120_cache]
+  ch.bakom.uplink50_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.uplink50_20150521_source]
+  ch.bakom.uplink50_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id043
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.uplink50_20150521_cache]
   ch.bakom.verfuegbarkeit-hdtv_20121222_cache:
     disable_storage: true
     format: image/png
@@ -3201,7 +3405,7 @@ caches:
   ch.bakom.verfuegbarkeit-hdtv_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id043 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id044 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-hdtv_20121222_cache]
@@ -3213,7 +3417,7 @@ caches:
   ch.bakom.verfuegbarkeit-hdtv_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id043
+    grids: *id044
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-hdtv_20130601_cache]
@@ -3225,7 +3429,7 @@ caches:
   ch.bakom.verfuegbarkeit-hdtv_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id043
+    grids: *id044
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-hdtv_20130901_cache]
@@ -3237,7 +3441,7 @@ caches:
   ch.bakom.verfuegbarkeit-hdtv_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id043
+    grids: *id044
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-hdtv_20131212_cache]
@@ -3249,7 +3453,7 @@ caches:
   ch.bakom.verfuegbarkeit-hdtv_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id043
+    grids: *id044
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-hdtv_20140625_cache]
@@ -3261,7 +3465,7 @@ caches:
   ch.bakom.verfuegbarkeit-hdtv_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id043
+    grids: *id044
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache]
@@ -3273,10 +3477,22 @@ caches:
   ch.bakom.verfuegbarkeit-hdtv_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id043
+    grids: *id044
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-hdtv_20141120_cache]
+  ch.bakom.verfuegbarkeit-hdtv_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_source]
+  ch.bakom.verfuegbarkeit-hdtv_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id044
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_cache]
   ch.bakom.verfuegbarkeit-tv_20121222_cache:
     disable_storage: true
     format: image/png
@@ -3285,7 +3501,7 @@ caches:
   ch.bakom.verfuegbarkeit-tv_20121222_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id044 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id045 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-tv_20121222_cache]
@@ -3297,7 +3513,7 @@ caches:
   ch.bakom.verfuegbarkeit-tv_20130601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id044
+    grids: *id045
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-tv_20130601_cache]
@@ -3309,7 +3525,7 @@ caches:
   ch.bakom.verfuegbarkeit-tv_20130901_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id044
+    grids: *id045
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-tv_20130901_cache]
@@ -3321,7 +3537,7 @@ caches:
   ch.bakom.verfuegbarkeit-tv_20131212_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id044
+    grids: *id045
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-tv_20131212_cache]
@@ -3333,7 +3549,7 @@ caches:
   ch.bakom.verfuegbarkeit-tv_20140625_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id044
+    grids: *id045
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-tv_20140625_cache]
@@ -3345,7 +3561,7 @@ caches:
   ch.bakom.verfuegbarkeit-tv_20141021_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id044
+    grids: *id045
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache]
@@ -3357,10 +3573,22 @@ caches:
   ch.bakom.verfuegbarkeit-tv_20141120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id044
+    grids: *id045
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bakom.verfuegbarkeit-tv_20141120_cache]
+  ch.bakom.verfuegbarkeit-tv_20150521_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.bakom.verfuegbarkeit-tv_20150521_source]
+  ch.bakom.verfuegbarkeit-tv_20150521_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id045
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.bakom.verfuegbarkeit-tv_20150521_cache]
   ch.bakom.versorgungsgebiet-tv_20070704_cache:
     disable_storage: true
     format: image/png
@@ -3393,7 +3621,7 @@ caches:
   ch.bazl.luftfahrtkarten-icao_20110310_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id045 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id046 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.luftfahrtkarten-icao_20110310_cache]
@@ -3405,7 +3633,7 @@ caches:
   ch.bazl.luftfahrtkarten-icao_20120308_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id045
+    grids: *id046
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.luftfahrtkarten-icao_20120308_cache]
@@ -3417,7 +3645,7 @@ caches:
   ch.bazl.luftfahrtkarten-icao_20130307_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id045
+    grids: *id046
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.luftfahrtkarten-icao_20130307_cache]
@@ -3429,7 +3657,7 @@ caches:
   ch.bazl.luftfahrtkarten-icao_20140306_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id045
+    grids: *id046
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache]
@@ -3441,7 +3669,7 @@ caches:
   ch.bazl.luftfahrtkarten-icao_20150305_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id045
+    grids: *id046
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache]
@@ -3465,7 +3693,7 @@ caches:
   ch.bazl.segelflugkarte_20120308_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id046 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id047 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.segelflugkarte_20120308_cache]
@@ -3477,7 +3705,7 @@ caches:
   ch.bazl.segelflugkarte_20130307_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id046
+    grids: *id047
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.segelflugkarte_20130307_cache]
@@ -3489,7 +3717,7 @@ caches:
   ch.bazl.segelflugkarte_20140306_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id046
+    grids: *id047
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.segelflugkarte_20140306_cache]
@@ -3501,7 +3729,7 @@ caches:
   ch.bazl.segelflugkarte_20150305_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id046
+    grids: *id047
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bazl.segelflugkarte_20150305_cache]
@@ -3549,7 +3777,7 @@ caches:
   ch.bfs.arealstatistik-1985_19790101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id047 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id048 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bfs.arealstatistik-1985_19790101_cache]
@@ -3561,7 +3789,7 @@ caches:
   ch.bfs.arealstatistik-1985_20131121_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id047
+    grids: *id048
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bfs.arealstatistik-1985_20131121_cache]
@@ -3573,7 +3801,7 @@ caches:
   ch.bfs.arealstatistik-1997_19920101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id048 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id049 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bfs.arealstatistik-1997_19920101_cache]
@@ -3585,7 +3813,7 @@ caches:
   ch.bfs.arealstatistik-1997_20131121_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id048
+    grids: *id049
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.bfs.arealstatistik-1997_20131121_cache]
@@ -3717,7 +3945,7 @@ caches:
   ch.blw.alpprodukte_20081024_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id049 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id050 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.alpprodukte_20081024_cache]
@@ -3729,7 +3957,7 @@ caches:
   ch.blw.alpprodukte_20130531_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id049
+    grids: *id050
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.alpprodukte_20130531_cache]
@@ -3741,7 +3969,7 @@ caches:
   ch.blw.alpprodukte_20150422_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id049
+    grids: *id050
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.alpprodukte_20150422_cache]
@@ -3753,7 +3981,7 @@ caches:
   ch.blw.bergprodukte_20081024_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id050 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id051 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.bergprodukte_20081024_cache]
@@ -3765,7 +3993,7 @@ caches:
   ch.blw.bergprodukte_20130531_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id050
+    grids: *id051
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.bergprodukte_20130531_cache]
@@ -3777,7 +4005,7 @@ caches:
   ch.blw.bergprodukte_20150422_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id050
+    grids: *id051
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.bergprodukte_20150422_cache]
@@ -3969,7 +4197,7 @@ caches:
   ch.blw.hang_steillagen_20100501_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id051 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id052 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.hang_steillagen_20100501_cache]
@@ -3981,7 +4209,7 @@ caches:
   ch.blw.hang_steillagen_20121231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id051
+    grids: *id052
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.hang_steillagen_20121231_cache]
@@ -4089,7 +4317,7 @@ caches:
   ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id052 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id053 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache]
@@ -4101,7 +4329,7 @@ caches:
   ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id052
+    grids: *id053
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache]
@@ -4113,7 +4341,7 @@ caches:
   ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id052
+    grids: *id053
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache]
@@ -4125,7 +4353,7 @@ caches:
   ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id052
+    grids: *id053
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache]
@@ -4137,7 +4365,7 @@ caches:
   ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id052
+    grids: *id053
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache]
@@ -4149,10 +4377,22 @@ caches:
   ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id052
+    grids: *id053
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache]
+  ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_source]
+  ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id053
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache]
   ch.blw.niederschlagshaushalt_20081024_cache:
     disable_storage: true
     format: image/png
@@ -4173,7 +4413,7 @@ caches:
   ch.blw.steil_terrassenlagen_rebbau_20100501_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id053 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id054 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.steil_terrassenlagen_rebbau_20100501_cache]
@@ -4185,7 +4425,7 @@ caches:
   ch.blw.steil_terrassenlagen_rebbau_20121231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id053
+    grids: *id054
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
@@ -4197,7 +4437,7 @@ caches:
   ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id054 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id055 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache]
@@ -4209,7 +4449,7 @@ caches:
   ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id054
+    grids: *id055
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
@@ -4269,7 +4509,7 @@ caches:
   ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id055 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id056 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache]
@@ -4281,7 +4521,7 @@ caches:
   ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id055
+    grids: *id056
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
@@ -4323,7 +4563,7 @@ caches:
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id056 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id057 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache]
@@ -4335,7 +4575,7 @@ caches:
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id056
+    grids: *id057
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache]
@@ -4347,7 +4587,7 @@ caches:
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id056
+    grids: *id057
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache]
@@ -4359,7 +4599,7 @@ caches:
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id056
+    grids: *id057
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache]
@@ -4371,7 +4611,7 @@ caches:
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id056
+    grids: *id057
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache]
@@ -4383,7 +4623,7 @@ caches:
   ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id056
+    grids: *id057
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
@@ -4395,7 +4635,7 @@ caches:
   ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id057 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id058 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache]
@@ -4407,7 +4647,7 @@ caches:
   ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id057
+    grids: *id058
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache]
@@ -4419,7 +4659,7 @@ caches:
   ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id057
+    grids: *id058
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache]
@@ -4431,7 +4671,7 @@ caches:
   ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id057
+    grids: *id058
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
@@ -4455,7 +4695,7 @@ caches:
   ch.swisstopo.fixpunkte-agnes_20110509_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id058 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id059 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.fixpunkte-agnes_20110509_cache]
@@ -4467,7 +4707,7 @@ caches:
   ch.swisstopo.fixpunkte-agnes_20120622_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id058
+    grids: *id059
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.fixpunkte-agnes_20120622_cache]
@@ -4479,7 +4719,7 @@ caches:
   ch.swisstopo.fixpunkte-agnes_20140924_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id058
+    grids: *id059
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
@@ -4587,7 +4827,7 @@ caches:
   ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id059 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id060 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache]
@@ -4599,7 +4839,7 @@ caches:
   ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id059
+    grids: *id060
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache]
@@ -4635,7 +4875,7 @@ caches:
   ch.swisstopo.geologie-geologische_karte_20051231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id060 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id061 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geologische_karte_20051231_cache]
@@ -4647,7 +4887,7 @@ caches:
   ch.swisstopo.geologie-geologische_karte_20080630_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id060
+    grids: *id061
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
@@ -4659,7 +4899,7 @@ caches:
   ch.swisstopo.geologie-geologischer_atlas_20101221_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id061 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id062 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geologischer_atlas_20101221_cache]
@@ -4671,7 +4911,7 @@ caches:
   ch.swisstopo.geologie-geologischer_atlas_20120601_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id061
+    grids: *id062
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geologischer_atlas_20120601_cache]
@@ -4683,7 +4923,7 @@ caches:
   ch.swisstopo.geologie-geologischer_atlas_20131120_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id061
+    grids: *id062
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
@@ -4707,7 +4947,7 @@ caches:
   ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id062 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id063 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache]
@@ -4719,7 +4959,7 @@ caches:
   ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id062
+    grids: *id063
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
@@ -4731,7 +4971,7 @@ caches:
   ch.swisstopo.geologie-geophysik-deklination_19791231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id063 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id064 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-deklination_19791231_cache]
@@ -4743,7 +4983,7 @@ caches:
   ch.swisstopo.geologie-geophysik-deklination_20011203_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id063
+    grids: *id064
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
@@ -4755,7 +4995,7 @@ caches:
   ch.swisstopo.geologie-geophysik-geothermie_19821231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id064 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id065 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-geothermie_19821231_cache]
@@ -4767,7 +5007,7 @@ caches:
   ch.swisstopo.geologie-geophysik-geothermie_20111121_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id064
+    grids: *id065
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
@@ -4779,7 +5019,7 @@ caches:
   ch.swisstopo.geologie-geophysik-inklination_19791231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id065 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id066 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-inklination_19791231_cache]
@@ -4791,7 +5031,7 @@ caches:
   ch.swisstopo.geologie-geophysik-inklination_20111128_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id065
+    grids: *id066
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
@@ -4803,7 +5043,7 @@ caches:
   ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id066 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id067 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache]
@@ -4815,7 +5055,7 @@ caches:
   ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id066
+    grids: *id067
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
@@ -4839,7 +5079,7 @@ caches:
   ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id067 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id068 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache]
@@ -4851,7 +5091,7 @@ caches:
   ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id067
+    grids: *id068
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
@@ -4863,7 +5103,7 @@ caches:
   ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id068 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id069 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache]
@@ -4875,7 +5115,7 @@ caches:
   ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id068
+    grids: *id069
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
@@ -4887,7 +5127,7 @@ caches:
   ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id069 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id070 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache]
@@ -4899,7 +5139,7 @@ caches:
   ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id069
+    grids: *id070
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
@@ -4935,7 +5175,7 @@ caches:
   ch.swisstopo.geologie-geotope_20110201_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id070 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id071 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotope_20110201_cache]
@@ -4947,7 +5187,7 @@ caches:
   ch.swisstopo.geologie-geotope_20130107_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id070
+    grids: *id071
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-geotope_20130107_cache]
@@ -4983,7 +5223,7 @@ caches:
   ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id071 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id072 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache]
@@ -4995,7 +5235,7 @@ caches:
   ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id071
+    grids: *id072
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
@@ -5007,7 +5247,7 @@ caches:
   ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id072 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id073 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache]
@@ -5019,7 +5259,7 @@ caches:
   ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id072
+    grids: *id073
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
@@ -5043,7 +5283,7 @@ caches:
   ch.swisstopo.geologie-tektonische_karte_20051231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id073 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id074 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-tektonische_karte_20051231_cache]
@@ -5055,7 +5295,7 @@ caches:
   ch.swisstopo.geologie-tektonische_karte_20080522_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id073
+    grids: *id074
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
@@ -5103,7 +5343,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id074 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id075 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache]
@@ -5115,7 +5355,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache]
@@ -5127,7 +5367,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache]
@@ -5139,7 +5379,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache]
@@ -5151,7 +5391,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache]
@@ -5163,7 +5403,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache]
@@ -5175,7 +5415,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache]
@@ -5187,7 +5427,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache]
@@ -5199,7 +5439,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache]
@@ -5211,7 +5451,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache]
@@ -5223,7 +5463,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache]
@@ -5235,7 +5475,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache]
@@ -5247,7 +5487,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache]
@@ -5259,7 +5499,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache]
@@ -5271,7 +5511,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache]
@@ -5283,7 +5523,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache]
@@ -5295,7 +5535,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache]
@@ -5307,7 +5547,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache]
@@ -5319,7 +5559,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache]
@@ -5331,7 +5571,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache]
@@ -5343,7 +5583,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache]
@@ -5355,7 +5595,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id074
+    grids: *id075
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
@@ -5367,7 +5607,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id075 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id076 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache]
@@ -5379,7 +5619,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache]
@@ -5391,7 +5631,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache]
@@ -5403,7 +5643,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache]
@@ -5415,7 +5655,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache]
@@ -5427,7 +5667,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache]
@@ -5439,7 +5679,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache]
@@ -5451,7 +5691,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache]
@@ -5463,7 +5703,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache]
@@ -5475,7 +5715,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache]
@@ -5487,7 +5727,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache]
@@ -5499,7 +5739,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache]
@@ -5511,7 +5751,7 @@ caches:
   ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id075
+    grids: *id076
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
@@ -5523,7 +5763,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19811231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id076 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id077 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache]
@@ -5535,7 +5775,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19821231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache]
@@ -5547,7 +5787,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19831231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache]
@@ -5559,7 +5799,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19841231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache]
@@ -5571,7 +5811,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19851231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache]
@@ -5583,7 +5823,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19861231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache]
@@ -5595,7 +5835,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19871231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache]
@@ -5607,7 +5847,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19881231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache]
@@ -5619,7 +5859,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19891231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache]
@@ -5631,7 +5871,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19901231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache]
@@ -5643,7 +5883,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19911231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache]
@@ -5655,7 +5895,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19921231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache]
@@ -5667,7 +5907,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19931231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache]
@@ -5679,7 +5919,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19941231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache]
@@ -5691,7 +5931,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19951231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache]
@@ -5703,7 +5943,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19961231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache]
@@ -5715,7 +5955,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19971231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache]
@@ -5727,7 +5967,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19981231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache]
@@ -5739,7 +5979,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_19991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache]
@@ -5751,7 +5991,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20001231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache]
@@ -5763,7 +6003,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20011231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache]
@@ -5775,7 +6015,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20021231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache]
@@ -5787,7 +6027,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20031231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache]
@@ -5799,7 +6039,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20041231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache]
@@ -5811,7 +6051,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20051231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache]
@@ -5823,7 +6063,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20061231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache]
@@ -5835,7 +6075,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20071231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache]
@@ -5847,7 +6087,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20081231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache]
@@ -5859,7 +6099,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20091231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache]
@@ -5871,7 +6111,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_20101231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache]
@@ -5883,7 +6123,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_farbe_99991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id076
+    grids: *id077
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
@@ -5895,7 +6135,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id077 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id078 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache]
@@ -5907,7 +6147,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache]
@@ -5919,7 +6159,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache]
@@ -5931,7 +6171,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache]
@@ -5943,7 +6183,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache]
@@ -5955,7 +6195,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache]
@@ -5967,7 +6207,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache]
@@ -5979,7 +6219,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache]
@@ -5991,7 +6231,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache]
@@ -6003,7 +6243,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache]
@@ -6015,7 +6255,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache]
@@ -6027,7 +6267,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache]
@@ -6039,7 +6279,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache]
@@ -6051,7 +6291,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache]
@@ -6063,7 +6303,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache]
@@ -6075,7 +6315,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache]
@@ -6087,7 +6327,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache]
@@ -6099,7 +6339,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache]
@@ -6111,7 +6351,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache]
@@ -6123,7 +6363,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache]
@@ -6135,7 +6375,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache]
@@ -6147,7 +6387,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache]
@@ -6159,7 +6399,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache]
@@ -6171,7 +6411,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache]
@@ -6183,7 +6423,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache]
@@ -6195,7 +6435,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache]
@@ -6207,7 +6447,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache]
@@ -6219,7 +6459,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache]
@@ -6231,7 +6471,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id077
+    grids: *id078
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
@@ -6243,7 +6483,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id078 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id079 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache]
@@ -6255,7 +6495,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache]
@@ -6267,7 +6507,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache]
@@ -6279,7 +6519,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache]
@@ -6291,7 +6531,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache]
@@ -6303,7 +6543,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache]
@@ -6315,7 +6555,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache]
@@ -6327,7 +6567,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache]
@@ -6339,7 +6579,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache]
@@ -6351,7 +6591,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache]
@@ -6363,7 +6603,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache]
@@ -6375,7 +6615,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache]
@@ -6387,7 +6627,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache]
@@ -6399,7 +6639,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache]
@@ -6411,7 +6651,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache]
@@ -6423,7 +6663,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache]
@@ -6435,7 +6675,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache]
@@ -6447,7 +6687,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache]
@@ -6459,7 +6699,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache]
@@ -6471,7 +6711,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache]
@@ -6483,7 +6723,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache]
@@ -6495,7 +6735,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache]
@@ -6507,7 +6747,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache]
@@ -6519,7 +6759,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache]
@@ -6531,7 +6771,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache]
@@ -6543,7 +6783,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache]
@@ -6555,7 +6795,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache]
@@ -6567,7 +6807,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache]
@@ -6579,7 +6819,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache]
@@ -6591,7 +6831,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache]
@@ -6603,7 +6843,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache]
@@ -6615,7 +6855,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache]
@@ -6627,7 +6867,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache]
@@ -6639,7 +6879,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache]
@@ -6651,7 +6891,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache]
@@ -6663,7 +6903,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache]
@@ -6675,7 +6915,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache]
@@ -6687,7 +6927,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache]
@@ -6699,7 +6939,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache]
@@ -6711,7 +6951,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache]
@@ -6723,7 +6963,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache]
@@ -6735,7 +6975,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache]
@@ -6747,7 +6987,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache]
@@ -6759,7 +6999,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache]
@@ -6771,7 +7011,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache]
@@ -6783,7 +7023,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache]
@@ -6795,7 +7035,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache]
@@ -6807,7 +7047,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache]
@@ -6819,7 +7059,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache]
@@ -6831,7 +7071,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache]
@@ -6843,7 +7083,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache]
@@ -6855,7 +7095,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache]
@@ -6867,7 +7107,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache]
@@ -6879,7 +7119,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache]
@@ -6891,7 +7131,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache]
@@ -6903,7 +7143,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache]
@@ -6915,7 +7155,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache]
@@ -6927,7 +7167,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache]
@@ -6939,7 +7179,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache]
@@ -6951,7 +7191,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache]
@@ -6963,7 +7203,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache]
@@ -6975,7 +7215,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache]
@@ -6987,7 +7227,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache]
@@ -6999,7 +7239,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache]
@@ -7011,7 +7251,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache]
@@ -7023,7 +7263,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache]
@@ -7035,7 +7275,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache]
@@ -7047,7 +7287,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache]
@@ -7059,7 +7299,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache]
@@ -7071,7 +7311,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache]
@@ -7083,7 +7323,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache]
@@ -7095,7 +7335,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache]
@@ -7107,7 +7347,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache]
@@ -7119,7 +7359,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache]
@@ -7131,7 +7371,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache]
@@ -7143,7 +7383,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache]
@@ -7155,7 +7395,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache]
@@ -7167,7 +7407,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache]
@@ -7179,7 +7419,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache]
@@ -7191,7 +7431,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache]
@@ -7203,7 +7443,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache]
@@ -7215,7 +7455,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache]
@@ -7227,7 +7467,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache]
@@ -7239,7 +7479,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache]
@@ -7251,7 +7491,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache]
@@ -7263,7 +7503,7 @@ caches:
   ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id078
+    grids: *id079
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
@@ -7275,7 +7515,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id079 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id080 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache]
@@ -7287,7 +7527,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id079
+    grids: *id080
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache]
@@ -7299,7 +7539,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id079
+    grids: *id080
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache]
@@ -7311,7 +7551,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id079
+    grids: *id080
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache]
@@ -7323,7 +7563,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id079
+    grids: *id080
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache]
@@ -7335,7 +7575,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id079
+    grids: *id080
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache]
@@ -7347,7 +7587,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id079
+    grids: *id080
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
@@ -7359,7 +7599,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id080 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id081 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache]
@@ -7371,7 +7611,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id080
+    grids: *id081
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache]
@@ -7383,7 +7623,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id080
+    grids: *id081
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
@@ -7395,7 +7635,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id081 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id082 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache]
@@ -7407,7 +7647,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id081
+    grids: *id082
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
@@ -7419,7 +7659,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id082 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id083 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_cache]
@@ -7431,7 +7671,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id082
+    grids: *id083
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_cache]
@@ -7443,7 +7683,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id082
+    grids: *id083
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_cache]
@@ -7455,7 +7695,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id082
+    grids: *id083
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_cache]
@@ -7467,7 +7707,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id082
+    grids: *id083
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_cache]
@@ -7479,7 +7719,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id082
+    grids: *id083
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_cache]
@@ -7491,7 +7731,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id082
+    grids: *id083
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
@@ -7503,7 +7743,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id083 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id084 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache]
@@ -7515,7 +7755,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id083
+    grids: *id084
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache]
@@ -7527,7 +7767,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id083
+    grids: *id084
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache]
@@ -7539,7 +7779,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id083
+    grids: *id084
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache]
@@ -7551,7 +7791,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id083
+    grids: *id084
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache]
@@ -7563,7 +7803,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id083
+    grids: *id084
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache]
@@ -7575,7 +7815,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id083
+    grids: *id084
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
@@ -7587,7 +7827,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id084 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id085 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache]
@@ -7599,7 +7839,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id084
+    grids: *id085
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
@@ -7611,7 +7851,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20110401_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id085 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id086 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache]
@@ -7623,7 +7863,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache]
@@ -7635,7 +7875,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20111206_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache]
@@ -7647,7 +7887,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache]
@@ -7659,7 +7899,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20130213_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache]
@@ -7671,7 +7911,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20130903_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache]
@@ -7683,7 +7923,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20140106_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache]
@@ -7695,7 +7935,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20140520_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache]
@@ -7707,7 +7947,7 @@ caches:
   ch.swisstopo.pixelkarte-farbe_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id085
+    grids: *id086
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
@@ -7719,7 +7959,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20110401_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id086 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id087 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20110401_cache]
@@ -7731,7 +7971,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20111027_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20111027_cache]
@@ -7743,7 +7983,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20111206_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20111206_cache]
@@ -7755,7 +7995,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20120809_cache]
@@ -7767,7 +8007,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20130213_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20130213_cache]
@@ -7779,7 +8019,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20130903_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20130903_cache]
@@ -7791,7 +8031,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20140106_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20140106_cache]
@@ -7803,7 +8043,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20140520_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20140520_cache]
@@ -7815,7 +8055,7 @@ caches:
   ch.swisstopo.pixelkarte-grau_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id086
+    grids: *id087
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
@@ -7827,7 +8067,7 @@ caches:
   ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id087 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id088 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache]
@@ -7839,7 +8079,7 @@ caches:
   ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id087
+    grids: *id088
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache]
@@ -7851,7 +8091,7 @@ caches:
   ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id087
+    grids: *id088
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache]
@@ -7863,7 +8103,7 @@ caches:
   ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id087
+    grids: *id088
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache]
@@ -7875,7 +8115,7 @@ caches:
   ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id087
+    grids: *id088
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
@@ -7887,7 +8127,7 @@ caches:
   ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id088 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id089 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache]
@@ -7899,7 +8139,7 @@ caches:
   ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id088
+    grids: *id089
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache]
@@ -7911,7 +8151,7 @@ caches:
   ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id088
+    grids: *id089
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache]
@@ -7923,7 +8163,7 @@ caches:
   ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id088
+    grids: *id089
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
@@ -7935,7 +8175,7 @@ caches:
   ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id089 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id090 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache]
@@ -7947,7 +8187,7 @@ caches:
   ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id089
+    grids: *id090
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache]
@@ -7959,7 +8199,7 @@ caches:
   ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id089
+    grids: *id090
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache]
@@ -7971,7 +8211,7 @@ caches:
   ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id089
+    grids: *id090
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
@@ -7983,7 +8223,7 @@ caches:
   ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id090 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id091 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache]
@@ -7995,7 +8235,7 @@ caches:
   ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id090
+    grids: *id091
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache]
@@ -8007,7 +8247,7 @@ caches:
   ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id090
+    grids: *id091
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache]
@@ -8019,7 +8259,7 @@ caches:
   ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id090
+    grids: *id091
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
@@ -8031,7 +8271,7 @@ caches:
   ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id091 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id092 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache]
@@ -8043,7 +8283,7 @@ caches:
   ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id091
+    grids: *id092
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache]
@@ -8055,7 +8295,7 @@ caches:
   ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id091
+    grids: *id092
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache]
@@ -8067,7 +8307,7 @@ caches:
   ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id091
+    grids: *id092
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
@@ -8091,7 +8331,7 @@ caches:
   ch.swisstopo.swissimage_20110228_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: &id092 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id093 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8104,7 +8344,7 @@ caches:
   ch.swisstopo.swissimage_20110914_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8117,7 +8357,7 @@ caches:
   ch.swisstopo.swissimage_20120225_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8130,7 +8370,7 @@ caches:
   ch.swisstopo.swissimage_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8143,7 +8383,7 @@ caches:
   ch.swisstopo.swissimage_20130422_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8156,7 +8396,7 @@ caches:
   ch.swisstopo.swissimage_20130916_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8169,7 +8409,7 @@ caches:
   ch.swisstopo.swissimage_20131107_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8182,7 +8422,7 @@ caches:
   ch.swisstopo.swissimage_20140620_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8195,11 +8435,23 @@ caches:
   ch.swisstopo.swissimage_20151231_cache_out:
     disable_storage: true
     format: image/jpeg
-    grids: *id092
+    grids: *id093
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissimage_20151231_cache]
+  ch.swisstopo.swissnames3d_20150101_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.swissnames3d_20150101_source]
+  ch.swisstopo.swissnames3d_20150101_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.swissnames3d_20150101_cache]
   ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache:
     disable_storage: true
     format: image/png
@@ -8234,7 +8486,7 @@ caches:
   ch.swisstopo.swisstlm3d-wanderwege_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id093 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id094 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swisstlm3d-wanderwege_20130101_cache]
@@ -8246,7 +8498,7 @@ caches:
   ch.swisstopo.swisstlm3d-wanderwege_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id093
+    grids: *id094
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache]
@@ -8258,7 +8510,7 @@ caches:
   ch.swisstopo.swisstlm3d-wanderwege_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id093
+    grids: *id094
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
@@ -8270,7 +8522,7 @@ caches:
   ch.swisstopo.transformationsgenauigkeit_20100531_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id094 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id095 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.transformationsgenauigkeit_20100531_cache]
@@ -8282,7 +8534,7 @@ caches:
   ch.swisstopo.transformationsgenauigkeit_20131028_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id094
+    grids: *id095
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache]
@@ -8294,7 +8546,7 @@ caches:
   ch.swisstopo.transformationsgenauigkeit_20141101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id094
+    grids: *id095
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
@@ -8306,7 +8558,7 @@ caches:
   ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id095 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id096 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache]
@@ -8318,7 +8570,7 @@ caches:
   ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id095
+    grids: *id096
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache]
@@ -8330,7 +8582,7 @@ caches:
   ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id095
+    grids: *id096
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache]
@@ -8342,7 +8594,7 @@ caches:
   ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id095
+    grids: *id096
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache]
@@ -8354,7 +8606,7 @@ caches:
   ch.swisstopo.vec200-building_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id096 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id097 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-building_20100101_cache]
@@ -8366,7 +8618,7 @@ caches:
   ch.swisstopo.vec200-building_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id096
+    grids: *id097
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-building_20130101_cache]
@@ -8378,7 +8630,7 @@ caches:
   ch.swisstopo.vec200-building_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id096
+    grids: *id097
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-building_20140101_cache]
@@ -8390,7 +8642,7 @@ caches:
   ch.swisstopo.vec200-building_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id096
+    grids: *id097
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-building_20150101_cache]
@@ -8402,7 +8654,7 @@ caches:
   ch.swisstopo.vec200-hydrography_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id097 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id098 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-hydrography_20100101_cache]
@@ -8414,7 +8666,7 @@ caches:
   ch.swisstopo.vec200-hydrography_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id097
+    grids: *id098
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-hydrography_20130101_cache]
@@ -8426,7 +8678,7 @@ caches:
   ch.swisstopo.vec200-hydrography_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id097
+    grids: *id098
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-hydrography_20140101_cache]
@@ -8438,7 +8690,7 @@ caches:
   ch.swisstopo.vec200-hydrography_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id097
+    grids: *id098
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
@@ -8450,7 +8702,7 @@ caches:
   ch.swisstopo.vec200-landcover-wald_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id098 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id099 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-landcover-wald_20130101_cache]
@@ -8462,7 +8714,7 @@ caches:
   ch.swisstopo.vec200-landcover-wald_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id098
+    grids: *id099
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache]
@@ -8474,7 +8726,7 @@ caches:
   ch.swisstopo.vec200-landcover-wald_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id098
+    grids: *id099
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
@@ -8486,7 +8738,7 @@ caches:
   ch.swisstopo.vec200-landcover_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id099 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id100 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-landcover_20100101_cache]
@@ -8498,7 +8750,7 @@ caches:
   ch.swisstopo.vec200-landcover_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id099
+    grids: *id100
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-landcover_20130101_cache]
@@ -8510,7 +8762,7 @@ caches:
   ch.swisstopo.vec200-landcover_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id099
+    grids: *id100
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-landcover_20140101_cache]
@@ -8522,7 +8774,7 @@ caches:
   ch.swisstopo.vec200-landcover_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id099
+    grids: *id100
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-landcover_20150101_cache]
@@ -8534,7 +8786,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id100 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id101 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache]
@@ -8546,7 +8798,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id100
+    grids: *id101
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache]
@@ -8558,7 +8810,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id100
+    grids: *id101
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache]
@@ -8570,7 +8822,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id100
+    grids: *id101
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache]
@@ -8582,7 +8834,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id101 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id102 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous_20100101_cache]
@@ -8594,7 +8846,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id101
+    grids: *id102
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous_20130101_cache]
@@ -8606,7 +8858,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id101
+    grids: *id102
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache]
@@ -8618,7 +8870,7 @@ caches:
   ch.swisstopo.vec200-miscellaneous_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id101
+    grids: *id102
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
@@ -8630,7 +8882,7 @@ caches:
   ch.swisstopo.vec200-names-namedlocation_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id102 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id103 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-names-namedlocation_20100101_cache]
@@ -8642,7 +8894,7 @@ caches:
   ch.swisstopo.vec200-names-namedlocation_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id102
+    grids: *id103
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-names-namedlocation_20130101_cache]
@@ -8654,7 +8906,7 @@ caches:
   ch.swisstopo.vec200-names-namedlocation_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id102
+    grids: *id103
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache]
@@ -8666,7 +8918,7 @@ caches:
   ch.swisstopo.vec200-names-namedlocation_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id102
+    grids: *id103
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache]
@@ -8678,7 +8930,7 @@ caches:
   ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id103 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id104 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache]
@@ -8690,7 +8942,7 @@ caches:
   ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id103
+    grids: *id104
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache]
@@ -8702,7 +8954,7 @@ caches:
   ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id103
+    grids: *id104
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache]
@@ -8714,7 +8966,7 @@ caches:
   ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id103
+    grids: *id104
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
@@ -8726,7 +8978,7 @@ caches:
   ch.swisstopo.vec200-transportation-strassennetz_20100101_cache_out:
     disable_storage: true
     format: image/png
-    grids: &id104 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    grids: &id105 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-strassennetz_20100101_cache]
@@ -8738,7 +8990,7 @@ caches:
   ch.swisstopo.vec200-transportation-strassennetz_20130101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id104
+    grids: *id105
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-strassennetz_20130101_cache]
@@ -8750,7 +9002,7 @@ caches:
   ch.swisstopo.vec200-transportation-strassennetz_20140101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id104
+    grids: *id105
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache]
@@ -8762,7 +9014,7 @@ caches:
   ch.swisstopo.vec200-transportation-strassennetz_20150101_cache_out:
     disable_storage: true
     format: image/png
-    grids: *id104
+    grids: *id105
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
@@ -8898,6 +9150,2046 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
+  ch.swisstopo.zeitreihen_18441231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18441231_source]
+  ch.swisstopo.zeitreihen_18441231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: &id106 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18441231_cache]
+  ch.swisstopo.zeitreihen_18451231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18451231_source]
+  ch.swisstopo.zeitreihen_18451231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18451231_cache]
+  ch.swisstopo.zeitreihen_18461231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18461231_source]
+  ch.swisstopo.zeitreihen_18461231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18461231_cache]
+  ch.swisstopo.zeitreihen_18471231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18471231_source]
+  ch.swisstopo.zeitreihen_18471231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18471231_cache]
+  ch.swisstopo.zeitreihen_18481231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18481231_source]
+  ch.swisstopo.zeitreihen_18481231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18481231_cache]
+  ch.swisstopo.zeitreihen_18491231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18491231_source]
+  ch.swisstopo.zeitreihen_18491231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18491231_cache]
+  ch.swisstopo.zeitreihen_18501231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18501231_source]
+  ch.swisstopo.zeitreihen_18501231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18501231_cache]
+  ch.swisstopo.zeitreihen_18511231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18511231_source]
+  ch.swisstopo.zeitreihen_18511231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18511231_cache]
+  ch.swisstopo.zeitreihen_18521231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18521231_source]
+  ch.swisstopo.zeitreihen_18521231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18521231_cache]
+  ch.swisstopo.zeitreihen_18531231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18531231_source]
+  ch.swisstopo.zeitreihen_18531231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18531231_cache]
+  ch.swisstopo.zeitreihen_18541231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18541231_source]
+  ch.swisstopo.zeitreihen_18541231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18541231_cache]
+  ch.swisstopo.zeitreihen_18551231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18551231_source]
+  ch.swisstopo.zeitreihen_18551231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18551231_cache]
+  ch.swisstopo.zeitreihen_18561231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18561231_source]
+  ch.swisstopo.zeitreihen_18561231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18561231_cache]
+  ch.swisstopo.zeitreihen_18571231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18571231_source]
+  ch.swisstopo.zeitreihen_18571231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18571231_cache]
+  ch.swisstopo.zeitreihen_18581231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18581231_source]
+  ch.swisstopo.zeitreihen_18581231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18581231_cache]
+  ch.swisstopo.zeitreihen_18591231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18591231_source]
+  ch.swisstopo.zeitreihen_18591231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18591231_cache]
+  ch.swisstopo.zeitreihen_18601231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18601231_source]
+  ch.swisstopo.zeitreihen_18601231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18601231_cache]
+  ch.swisstopo.zeitreihen_18611231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18611231_source]
+  ch.swisstopo.zeitreihen_18611231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18611231_cache]
+  ch.swisstopo.zeitreihen_18621231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18621231_source]
+  ch.swisstopo.zeitreihen_18621231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18621231_cache]
+  ch.swisstopo.zeitreihen_18631231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18631231_source]
+  ch.swisstopo.zeitreihen_18631231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18631231_cache]
+  ch.swisstopo.zeitreihen_18641231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18641231_source]
+  ch.swisstopo.zeitreihen_18641231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18641231_cache]
+  ch.swisstopo.zeitreihen_18651231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18651231_source]
+  ch.swisstopo.zeitreihen_18651231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18651231_cache]
+  ch.swisstopo.zeitreihen_18661231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18661231_source]
+  ch.swisstopo.zeitreihen_18661231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18661231_cache]
+  ch.swisstopo.zeitreihen_18671231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18671231_source]
+  ch.swisstopo.zeitreihen_18671231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18671231_cache]
+  ch.swisstopo.zeitreihen_18681231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18681231_source]
+  ch.swisstopo.zeitreihen_18681231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18681231_cache]
+  ch.swisstopo.zeitreihen_18691231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18691231_source]
+  ch.swisstopo.zeitreihen_18691231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18691231_cache]
+  ch.swisstopo.zeitreihen_18701231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18701231_source]
+  ch.swisstopo.zeitreihen_18701231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18701231_cache]
+  ch.swisstopo.zeitreihen_18711231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18711231_source]
+  ch.swisstopo.zeitreihen_18711231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18711231_cache]
+  ch.swisstopo.zeitreihen_18721231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18721231_source]
+  ch.swisstopo.zeitreihen_18721231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18721231_cache]
+  ch.swisstopo.zeitreihen_18731231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18731231_source]
+  ch.swisstopo.zeitreihen_18731231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18731231_cache]
+  ch.swisstopo.zeitreihen_18741231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18741231_source]
+  ch.swisstopo.zeitreihen_18741231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18741231_cache]
+  ch.swisstopo.zeitreihen_18751231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18751231_source]
+  ch.swisstopo.zeitreihen_18751231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18751231_cache]
+  ch.swisstopo.zeitreihen_18761231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18761231_source]
+  ch.swisstopo.zeitreihen_18761231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18761231_cache]
+  ch.swisstopo.zeitreihen_18771231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18771231_source]
+  ch.swisstopo.zeitreihen_18771231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18771231_cache]
+  ch.swisstopo.zeitreihen_18781231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18781231_source]
+  ch.swisstopo.zeitreihen_18781231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18781231_cache]
+  ch.swisstopo.zeitreihen_18791231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18791231_source]
+  ch.swisstopo.zeitreihen_18791231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18791231_cache]
+  ch.swisstopo.zeitreihen_18801231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18801231_source]
+  ch.swisstopo.zeitreihen_18801231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18801231_cache]
+  ch.swisstopo.zeitreihen_18811231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18811231_source]
+  ch.swisstopo.zeitreihen_18811231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18811231_cache]
+  ch.swisstopo.zeitreihen_18821231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18821231_source]
+  ch.swisstopo.zeitreihen_18821231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18821231_cache]
+  ch.swisstopo.zeitreihen_18831231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18831231_source]
+  ch.swisstopo.zeitreihen_18831231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18831231_cache]
+  ch.swisstopo.zeitreihen_18841231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18841231_source]
+  ch.swisstopo.zeitreihen_18841231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18841231_cache]
+  ch.swisstopo.zeitreihen_18851231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18851231_source]
+  ch.swisstopo.zeitreihen_18851231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18851231_cache]
+  ch.swisstopo.zeitreihen_18861231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18861231_source]
+  ch.swisstopo.zeitreihen_18861231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18861231_cache]
+  ch.swisstopo.zeitreihen_18871231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18871231_source]
+  ch.swisstopo.zeitreihen_18871231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18871231_cache]
+  ch.swisstopo.zeitreihen_18881231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18881231_source]
+  ch.swisstopo.zeitreihen_18881231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18881231_cache]
+  ch.swisstopo.zeitreihen_18891231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18891231_source]
+  ch.swisstopo.zeitreihen_18891231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18891231_cache]
+  ch.swisstopo.zeitreihen_18901231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18901231_source]
+  ch.swisstopo.zeitreihen_18901231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18901231_cache]
+  ch.swisstopo.zeitreihen_18911231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18911231_source]
+  ch.swisstopo.zeitreihen_18911231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18911231_cache]
+  ch.swisstopo.zeitreihen_18921231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18921231_source]
+  ch.swisstopo.zeitreihen_18921231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18921231_cache]
+  ch.swisstopo.zeitreihen_18931231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18931231_source]
+  ch.swisstopo.zeitreihen_18931231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18931231_cache]
+  ch.swisstopo.zeitreihen_18941231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18941231_source]
+  ch.swisstopo.zeitreihen_18941231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18941231_cache]
+  ch.swisstopo.zeitreihen_18951231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18951231_source]
+  ch.swisstopo.zeitreihen_18951231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18951231_cache]
+  ch.swisstopo.zeitreihen_18961231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18961231_source]
+  ch.swisstopo.zeitreihen_18961231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18961231_cache]
+  ch.swisstopo.zeitreihen_18971231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18971231_source]
+  ch.swisstopo.zeitreihen_18971231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18971231_cache]
+  ch.swisstopo.zeitreihen_18981231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18981231_source]
+  ch.swisstopo.zeitreihen_18981231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18981231_cache]
+  ch.swisstopo.zeitreihen_18991231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_18991231_source]
+  ch.swisstopo.zeitreihen_18991231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_18991231_cache]
+  ch.swisstopo.zeitreihen_19001231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19001231_source]
+  ch.swisstopo.zeitreihen_19001231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19001231_cache]
+  ch.swisstopo.zeitreihen_19011231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19011231_source]
+  ch.swisstopo.zeitreihen_19011231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19011231_cache]
+  ch.swisstopo.zeitreihen_19021231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19021231_source]
+  ch.swisstopo.zeitreihen_19021231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19021231_cache]
+  ch.swisstopo.zeitreihen_19031231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19031231_source]
+  ch.swisstopo.zeitreihen_19031231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19031231_cache]
+  ch.swisstopo.zeitreihen_19041231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19041231_source]
+  ch.swisstopo.zeitreihen_19041231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19041231_cache]
+  ch.swisstopo.zeitreihen_19051231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19051231_source]
+  ch.swisstopo.zeitreihen_19051231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19051231_cache]
+  ch.swisstopo.zeitreihen_19061231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19061231_source]
+  ch.swisstopo.zeitreihen_19061231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19061231_cache]
+  ch.swisstopo.zeitreihen_19071231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19071231_source]
+  ch.swisstopo.zeitreihen_19071231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19071231_cache]
+  ch.swisstopo.zeitreihen_19081231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19081231_source]
+  ch.swisstopo.zeitreihen_19081231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19081231_cache]
+  ch.swisstopo.zeitreihen_19091231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19091231_source]
+  ch.swisstopo.zeitreihen_19091231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19091231_cache]
+  ch.swisstopo.zeitreihen_19101231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19101231_source]
+  ch.swisstopo.zeitreihen_19101231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19101231_cache]
+  ch.swisstopo.zeitreihen_19111231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19111231_source]
+  ch.swisstopo.zeitreihen_19111231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19111231_cache]
+  ch.swisstopo.zeitreihen_19121231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19121231_source]
+  ch.swisstopo.zeitreihen_19121231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19121231_cache]
+  ch.swisstopo.zeitreihen_19131231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19131231_source]
+  ch.swisstopo.zeitreihen_19131231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19131231_cache]
+  ch.swisstopo.zeitreihen_19141231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19141231_source]
+  ch.swisstopo.zeitreihen_19141231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19141231_cache]
+  ch.swisstopo.zeitreihen_19151231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19151231_source]
+  ch.swisstopo.zeitreihen_19151231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19151231_cache]
+  ch.swisstopo.zeitreihen_19161231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19161231_source]
+  ch.swisstopo.zeitreihen_19161231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19161231_cache]
+  ch.swisstopo.zeitreihen_19171231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19171231_source]
+  ch.swisstopo.zeitreihen_19171231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19171231_cache]
+  ch.swisstopo.zeitreihen_19181231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19181231_source]
+  ch.swisstopo.zeitreihen_19181231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19181231_cache]
+  ch.swisstopo.zeitreihen_19191231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19191231_source]
+  ch.swisstopo.zeitreihen_19191231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19191231_cache]
+  ch.swisstopo.zeitreihen_19201231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19201231_source]
+  ch.swisstopo.zeitreihen_19201231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19201231_cache]
+  ch.swisstopo.zeitreihen_19211231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19211231_source]
+  ch.swisstopo.zeitreihen_19211231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19211231_cache]
+  ch.swisstopo.zeitreihen_19221231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19221231_source]
+  ch.swisstopo.zeitreihen_19221231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19221231_cache]
+  ch.swisstopo.zeitreihen_19231231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19231231_source]
+  ch.swisstopo.zeitreihen_19231231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19231231_cache]
+  ch.swisstopo.zeitreihen_19241231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19241231_source]
+  ch.swisstopo.zeitreihen_19241231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19241231_cache]
+  ch.swisstopo.zeitreihen_19251231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19251231_source]
+  ch.swisstopo.zeitreihen_19251231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19251231_cache]
+  ch.swisstopo.zeitreihen_19261231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19261231_source]
+  ch.swisstopo.zeitreihen_19261231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19261231_cache]
+  ch.swisstopo.zeitreihen_19271231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19271231_source]
+  ch.swisstopo.zeitreihen_19271231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19271231_cache]
+  ch.swisstopo.zeitreihen_19281231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19281231_source]
+  ch.swisstopo.zeitreihen_19281231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19281231_cache]
+  ch.swisstopo.zeitreihen_19291231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19291231_source]
+  ch.swisstopo.zeitreihen_19291231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19291231_cache]
+  ch.swisstopo.zeitreihen_19301231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19301231_source]
+  ch.swisstopo.zeitreihen_19301231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19301231_cache]
+  ch.swisstopo.zeitreihen_19311231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19311231_source]
+  ch.swisstopo.zeitreihen_19311231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19311231_cache]
+  ch.swisstopo.zeitreihen_19321231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19321231_source]
+  ch.swisstopo.zeitreihen_19321231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19321231_cache]
+  ch.swisstopo.zeitreihen_19331231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19331231_source]
+  ch.swisstopo.zeitreihen_19331231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19331231_cache]
+  ch.swisstopo.zeitreihen_19341231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19341231_source]
+  ch.swisstopo.zeitreihen_19341231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19341231_cache]
+  ch.swisstopo.zeitreihen_19351231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19351231_source]
+  ch.swisstopo.zeitreihen_19351231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19351231_cache]
+  ch.swisstopo.zeitreihen_19361231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19361231_source]
+  ch.swisstopo.zeitreihen_19361231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19361231_cache]
+  ch.swisstopo.zeitreihen_19371231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19371231_source]
+  ch.swisstopo.zeitreihen_19371231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19371231_cache]
+  ch.swisstopo.zeitreihen_19381231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19381231_source]
+  ch.swisstopo.zeitreihen_19381231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19381231_cache]
+  ch.swisstopo.zeitreihen_19391231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19391231_source]
+  ch.swisstopo.zeitreihen_19391231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19391231_cache]
+  ch.swisstopo.zeitreihen_19401231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19401231_source]
+  ch.swisstopo.zeitreihen_19401231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19401231_cache]
+  ch.swisstopo.zeitreihen_19411231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19411231_source]
+  ch.swisstopo.zeitreihen_19411231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19411231_cache]
+  ch.swisstopo.zeitreihen_19421231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19421231_source]
+  ch.swisstopo.zeitreihen_19421231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19421231_cache]
+  ch.swisstopo.zeitreihen_19431231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19431231_source]
+  ch.swisstopo.zeitreihen_19431231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19431231_cache]
+  ch.swisstopo.zeitreihen_19441231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19441231_source]
+  ch.swisstopo.zeitreihen_19441231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19441231_cache]
+  ch.swisstopo.zeitreihen_19451231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19451231_source]
+  ch.swisstopo.zeitreihen_19451231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19451231_cache]
+  ch.swisstopo.zeitreihen_19461231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19461231_source]
+  ch.swisstopo.zeitreihen_19461231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19461231_cache]
+  ch.swisstopo.zeitreihen_19471231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19471231_source]
+  ch.swisstopo.zeitreihen_19471231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19471231_cache]
+  ch.swisstopo.zeitreihen_19481231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19481231_source]
+  ch.swisstopo.zeitreihen_19481231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19481231_cache]
+  ch.swisstopo.zeitreihen_19491231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19491231_source]
+  ch.swisstopo.zeitreihen_19491231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19491231_cache]
+  ch.swisstopo.zeitreihen_19501231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19501231_source]
+  ch.swisstopo.zeitreihen_19501231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19501231_cache]
+  ch.swisstopo.zeitreihen_19511231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19511231_source]
+  ch.swisstopo.zeitreihen_19511231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19511231_cache]
+  ch.swisstopo.zeitreihen_19521231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19521231_source]
+  ch.swisstopo.zeitreihen_19521231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19521231_cache]
+  ch.swisstopo.zeitreihen_19531231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19531231_source]
+  ch.swisstopo.zeitreihen_19531231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19531231_cache]
+  ch.swisstopo.zeitreihen_19541231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19541231_source]
+  ch.swisstopo.zeitreihen_19541231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19541231_cache]
+  ch.swisstopo.zeitreihen_19551231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19551231_source]
+  ch.swisstopo.zeitreihen_19551231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19551231_cache]
+  ch.swisstopo.zeitreihen_19561231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19561231_source]
+  ch.swisstopo.zeitreihen_19561231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19561231_cache]
+  ch.swisstopo.zeitreihen_19571231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19571231_source]
+  ch.swisstopo.zeitreihen_19571231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19571231_cache]
+  ch.swisstopo.zeitreihen_19581231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19581231_source]
+  ch.swisstopo.zeitreihen_19581231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19581231_cache]
+  ch.swisstopo.zeitreihen_19591231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19591231_source]
+  ch.swisstopo.zeitreihen_19591231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19591231_cache]
+  ch.swisstopo.zeitreihen_19601231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19601231_source]
+  ch.swisstopo.zeitreihen_19601231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19601231_cache]
+  ch.swisstopo.zeitreihen_19611231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19611231_source]
+  ch.swisstopo.zeitreihen_19611231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19611231_cache]
+  ch.swisstopo.zeitreihen_19621231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19621231_source]
+  ch.swisstopo.zeitreihen_19621231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19621231_cache]
+  ch.swisstopo.zeitreihen_19631231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19631231_source]
+  ch.swisstopo.zeitreihen_19631231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19631231_cache]
+  ch.swisstopo.zeitreihen_19641231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19641231_source]
+  ch.swisstopo.zeitreihen_19641231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19641231_cache]
+  ch.swisstopo.zeitreihen_19651231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19651231_source]
+  ch.swisstopo.zeitreihen_19651231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19651231_cache]
+  ch.swisstopo.zeitreihen_19661231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19661231_source]
+  ch.swisstopo.zeitreihen_19661231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19661231_cache]
+  ch.swisstopo.zeitreihen_19671231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19671231_source]
+  ch.swisstopo.zeitreihen_19671231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19671231_cache]
+  ch.swisstopo.zeitreihen_19681231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19681231_source]
+  ch.swisstopo.zeitreihen_19681231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19681231_cache]
+  ch.swisstopo.zeitreihen_19691231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19691231_source]
+  ch.swisstopo.zeitreihen_19691231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19691231_cache]
+  ch.swisstopo.zeitreihen_19701231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19701231_source]
+  ch.swisstopo.zeitreihen_19701231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19701231_cache]
+  ch.swisstopo.zeitreihen_19711231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19711231_source]
+  ch.swisstopo.zeitreihen_19711231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19711231_cache]
+  ch.swisstopo.zeitreihen_19721231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19721231_source]
+  ch.swisstopo.zeitreihen_19721231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19721231_cache]
+  ch.swisstopo.zeitreihen_19731231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19731231_source]
+  ch.swisstopo.zeitreihen_19731231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19731231_cache]
+  ch.swisstopo.zeitreihen_19741231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19741231_source]
+  ch.swisstopo.zeitreihen_19741231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19741231_cache]
+  ch.swisstopo.zeitreihen_19751231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19751231_source]
+  ch.swisstopo.zeitreihen_19751231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19751231_cache]
+  ch.swisstopo.zeitreihen_19761231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19761231_source]
+  ch.swisstopo.zeitreihen_19761231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19761231_cache]
+  ch.swisstopo.zeitreihen_19771231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19771231_source]
+  ch.swisstopo.zeitreihen_19771231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19771231_cache]
+  ch.swisstopo.zeitreihen_19781231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19781231_source]
+  ch.swisstopo.zeitreihen_19781231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19781231_cache]
+  ch.swisstopo.zeitreihen_19791231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19791231_source]
+  ch.swisstopo.zeitreihen_19791231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19791231_cache]
+  ch.swisstopo.zeitreihen_19801231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19801231_source]
+  ch.swisstopo.zeitreihen_19801231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19801231_cache]
+  ch.swisstopo.zeitreihen_19811231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19811231_source]
+  ch.swisstopo.zeitreihen_19811231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19811231_cache]
+  ch.swisstopo.zeitreihen_19821231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19821231_source]
+  ch.swisstopo.zeitreihen_19821231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19821231_cache]
+  ch.swisstopo.zeitreihen_19831231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19831231_source]
+  ch.swisstopo.zeitreihen_19831231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19831231_cache]
+  ch.swisstopo.zeitreihen_19841231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19841231_source]
+  ch.swisstopo.zeitreihen_19841231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19841231_cache]
+  ch.swisstopo.zeitreihen_19851231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19851231_source]
+  ch.swisstopo.zeitreihen_19851231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19851231_cache]
+  ch.swisstopo.zeitreihen_19861231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19861231_source]
+  ch.swisstopo.zeitreihen_19861231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19861231_cache]
+  ch.swisstopo.zeitreihen_19871231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19871231_source]
+  ch.swisstopo.zeitreihen_19871231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19871231_cache]
+  ch.swisstopo.zeitreihen_19881231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19881231_source]
+  ch.swisstopo.zeitreihen_19881231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19881231_cache]
+  ch.swisstopo.zeitreihen_19891231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19891231_source]
+  ch.swisstopo.zeitreihen_19891231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19891231_cache]
+  ch.swisstopo.zeitreihen_19901231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19901231_source]
+  ch.swisstopo.zeitreihen_19901231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19901231_cache]
+  ch.swisstopo.zeitreihen_19911231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19911231_source]
+  ch.swisstopo.zeitreihen_19911231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19911231_cache]
+  ch.swisstopo.zeitreihen_19921231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19921231_source]
+  ch.swisstopo.zeitreihen_19921231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19921231_cache]
+  ch.swisstopo.zeitreihen_19931231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19931231_source]
+  ch.swisstopo.zeitreihen_19931231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19931231_cache]
+  ch.swisstopo.zeitreihen_19941231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19941231_source]
+  ch.swisstopo.zeitreihen_19941231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19941231_cache]
+  ch.swisstopo.zeitreihen_19951231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19951231_source]
+  ch.swisstopo.zeitreihen_19951231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19951231_cache]
+  ch.swisstopo.zeitreihen_19961231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19961231_source]
+  ch.swisstopo.zeitreihen_19961231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19961231_cache]
+  ch.swisstopo.zeitreihen_19971231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19971231_source]
+  ch.swisstopo.zeitreihen_19971231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19971231_cache]
+  ch.swisstopo.zeitreihen_19981231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19981231_source]
+  ch.swisstopo.zeitreihen_19981231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19981231_cache]
+  ch.swisstopo.zeitreihen_19991231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_19991231_source]
+  ch.swisstopo.zeitreihen_19991231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_19991231_cache]
+  ch.swisstopo.zeitreihen_20001231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20001231_source]
+  ch.swisstopo.zeitreihen_20001231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20001231_cache]
+  ch.swisstopo.zeitreihen_20011231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20011231_source]
+  ch.swisstopo.zeitreihen_20011231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20011231_cache]
+  ch.swisstopo.zeitreihen_20021231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20021231_source]
+  ch.swisstopo.zeitreihen_20021231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20021231_cache]
+  ch.swisstopo.zeitreihen_20031231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20031231_source]
+  ch.swisstopo.zeitreihen_20031231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20031231_cache]
+  ch.swisstopo.zeitreihen_20041231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20041231_source]
+  ch.swisstopo.zeitreihen_20041231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20041231_cache]
+  ch.swisstopo.zeitreihen_20051231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20051231_source]
+  ch.swisstopo.zeitreihen_20051231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20051231_cache]
+  ch.swisstopo.zeitreihen_20061231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20061231_source]
+  ch.swisstopo.zeitreihen_20061231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20061231_cache]
+  ch.swisstopo.zeitreihen_20071231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20071231_source]
+  ch.swisstopo.zeitreihen_20071231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20071231_cache]
+  ch.swisstopo.zeitreihen_20081231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20081231_source]
+  ch.swisstopo.zeitreihen_20081231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20081231_cache]
+  ch.swisstopo.zeitreihen_20091231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20091231_source]
+  ch.swisstopo.zeitreihen_20091231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20091231_cache]
+  ch.swisstopo.zeitreihen_20101231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20101231_source]
+  ch.swisstopo.zeitreihen_20101231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20101231_cache]
+  ch.swisstopo.zeitreihen_20111231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20111231_source]
+  ch.swisstopo.zeitreihen_20111231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20111231_cache]
+  ch.swisstopo.zeitreihen_20121231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20121231_source]
+  ch.swisstopo.zeitreihen_20121231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20121231_cache]
+  ch.swisstopo.zeitreihen_20131231_cache:
+    disable_storage: true
+    format: image/png
+    grids: [swisstopo-pixelkarte]
+    sources: [ch.swisstopo.zeitreihen_20131231_source]
+  ch.swisstopo.zeitreihen_20131231_cache_out:
+    disable_storage: true
+    format: image/png
+    grids: *id106
+    meta_buffer: 0
+    meta_size: [1, 1]
+    sources: [ch.swisstopo.zeitreihen_20131231_cache]
   ch.vbs.territorialregionen_20110501_cache:
     disable_storage: true
     format: image/png
@@ -9001,9094 +11293,11203 @@ layers:
   name: ch.kantone.cadastralwebmap-farbe_current
   sources: [ch.kantone.cadastralwebmap-farbe_wms_cache]
   title: CadastralWebMap
-- dimensions: &id105
+- dimensions: &id107
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.are.agglomerationen_isolierte_staedte_20140101
   sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache_out]
   title: "Agglomerationen und isolierte St\xE4dte (20140101)"
-- dimensions: *id105
+- dimensions: *id107
   name: ch.are.agglomerationen_isolierte_staedte
   sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache]
   title: "Agglomerationen und isolierte St\xE4dte ('current')"
-- dimensions: *id105
+- dimensions: *id107
   name: ch.are.agglomerationen_isolierte_staedte_20140101_source
   sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache]
   title: "Agglomerationen und isolierte St\xE4dte (20140101, source)"
-- dimensions: &id106
+- dimensions: &id108
     Time:
       default: '20090101'
       values: ['20090101']
   name: ch.are.alpenkonvention_20090101
   sources: [ch.are.alpenkonvention_20090101_cache_out]
   title: Alpenkonvention (20090101)
-- dimensions: *id106
+- dimensions: *id108
   name: ch.are.alpenkonvention
   sources: [ch.are.alpenkonvention_20090101_cache]
   title: Alpenkonvention ('current')
-- dimensions: *id106
+- dimensions: *id108
   name: ch.are.alpenkonvention_20090101_source
   sources: [ch.are.alpenkonvention_20090101_cache]
   title: Alpenkonvention (20090101, source)
-- dimensions: &id107
+- dimensions: &id109
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.are.gemeindetypen_20140101
   sources: [ch.are.gemeindetypen_20140101_cache_out]
   title: Gemeindetypologie ARE (20140101)
-- dimensions: *id107
+- dimensions: *id109
   name: ch.are.gemeindetypen
   sources: [ch.are.gemeindetypen_20140101_cache]
   title: Gemeindetypologie ARE ('current')
-- dimensions: *id107
+- dimensions: *id109
   name: ch.are.gemeindetypen_20140101_source
   sources: [ch.are.gemeindetypen_20140101_cache]
   title: Gemeindetypologie ARE (20140101, source)
-- dimensions: &id108
+- dimensions: &id110
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.are.gemeindetypen_20120101
   sources: [ch.are.gemeindetypen_20120101_cache_out]
   title: Gemeindetypologie ARE (20120101)
-- dimensions: *id108
+- dimensions: *id110
   name: ch.are.gemeindetypen_20120101_source
   sources: [ch.are.gemeindetypen_20120101_cache]
   title: Gemeindetypologie ARE (20120101, source)
-- dimensions: &id109
+- dimensions: &id111
     Time:
       default: '20150211'
       values: ['20150211']
   name: ch.astra.ausnahmetransportrouten_20150211
   sources: [ch.astra.ausnahmetransportrouten_20150211_cache_out]
   title: Ausnahmetransportrouten (20150211)
-- dimensions: *id109
+- dimensions: *id111
   name: ch.astra.ausnahmetransportrouten
   sources: [ch.astra.ausnahmetransportrouten_20150211_cache]
   title: Ausnahmetransportrouten ('current')
-- dimensions: *id109
+- dimensions: *id111
   name: ch.astra.ausnahmetransportrouten_20150211_source
   sources: [ch.astra.ausnahmetransportrouten_20150211_cache]
   title: Ausnahmetransportrouten (20150211, source)
-- dimensions: &id110
+- dimensions: &id112
     Time:
       default: '20141022'
       values: ['20141022']
   name: ch.astra.ausnahmetransportrouten_20141022
   sources: [ch.astra.ausnahmetransportrouten_20141022_cache_out]
   title: Ausnahmetransportrouten (20141022)
-- dimensions: *id110
+- dimensions: *id112
   name: ch.astra.ausnahmetransportrouten_20141022_source
   sources: [ch.astra.ausnahmetransportrouten_20141022_cache]
   title: Ausnahmetransportrouten (20141022, source)
-- dimensions: &id111
+- dimensions: &id113
     Time:
       default: '20141003'
       values: ['20141003']
   name: ch.astra.ausnahmetransportrouten_20141003
   sources: [ch.astra.ausnahmetransportrouten_20141003_cache_out]
   title: Ausnahmetransportrouten (20141003)
-- dimensions: *id111
+- dimensions: *id113
   name: ch.astra.ausnahmetransportrouten_20141003_source
   sources: [ch.astra.ausnahmetransportrouten_20141003_cache]
   title: Ausnahmetransportrouten (20141003, source)
-- dimensions: &id112
+- dimensions: &id114
     Time:
       default: '20111010'
       values: ['20111010']
   name: ch.astra.ausnahmetransportrouten_20111010
   sources: [ch.astra.ausnahmetransportrouten_20111010_cache_out]
   title: Ausnahmetransportrouten (20111010)
-- dimensions: *id112
+- dimensions: *id114
   name: ch.astra.ausnahmetransportrouten_20111010_source
   sources: [ch.astra.ausnahmetransportrouten_20111010_cache]
   title: Ausnahmetransportrouten (20111010, source)
-- dimensions: &id113
+- dimensions: &id115
     Time:
       default: '19980816'
       values: ['19980816']
   name: ch.astra.ivs-gelaendekarte_19980816
   sources: [ch.astra.ivs-gelaendekarte_19980816_cache_out]
   title: "IVS Gel\xE4ndekarte (19980816)"
-- dimensions: *id113
+- dimensions: *id115
   name: ch.astra.ivs-gelaendekarte
   sources: [ch.astra.ivs-gelaendekarte_19980816_cache]
   title: "IVS Gel\xE4ndekarte ('current')"
-- dimensions: *id113
+- dimensions: *id115
   name: ch.astra.ivs-gelaendekarte_19980816_source
   sources: [ch.astra.ivs-gelaendekarte_19980816_cache]
   title: "IVS Gel\xE4ndekarte (19980816, source)"
-- dimensions: &id114
+- dimensions: &id116
     Time:
       default: '20100416'
       values: ['20100416']
   name: ch.astra.ivs-nat_20100416
   sources: [ch.astra.ivs-nat_20100416_cache_out]
   title: IVS National (20100416)
-- dimensions: *id114
+- dimensions: *id116
   name: ch.astra.ivs-nat
   sources: [ch.astra.ivs-nat_20100416_cache]
   title: IVS National ('current')
-- dimensions: *id114
+- dimensions: *id116
   name: ch.astra.ivs-nat_20100416_source
   sources: [ch.astra.ivs-nat_20100416_cache]
   title: IVS National (20100416, source)
-- dimensions: &id115
+- dimensions: &id117
     Time:
       default: '20070712'
       values: ['20070712']
   name: ch.astra.ivs-nat_20070712
   sources: [ch.astra.ivs-nat_20070712_cache_out]
   title: IVS National (20070712)
-- dimensions: *id115
+- dimensions: *id117
   name: ch.astra.ivs-nat_20070712_source
   sources: [ch.astra.ivs-nat_20070712_cache]
   title: IVS National (20070712, source)
-- dimensions: &id116
+- dimensions: &id118
     Time:
       default: '20100414'
       values: ['20100414']
   name: ch.astra.ivs-nat_abgrenzungen_20100414
   sources: [ch.astra.ivs-nat_abgrenzungen_20100414_cache_out]
   title: IVS Abgrenzungen (20100414)
-- dimensions: *id116
+- dimensions: *id118
   name: ch.astra.ivs-nat_abgrenzungen
   sources: [ch.astra.ivs-nat_abgrenzungen_20100414_cache]
   title: IVS Abgrenzungen ('current')
-- dimensions: *id116
+- dimensions: *id118
   name: ch.astra.ivs-nat_abgrenzungen_20100414_source
   sources: [ch.astra.ivs-nat_abgrenzungen_20100414_cache]
   title: IVS Abgrenzungen (20100414, source)
-- dimensions: &id117
+- dimensions: &id119
     Time:
       default: '20100416'
       values: ['20100416']
   name: ch.astra.ivs-nat-verlaeufe_20100416
   sources: [ch.astra.ivs-nat-verlaeufe_20100416_cache_out]
   title: IVS historischer Verlauf (20100416)
-- dimensions: *id117
+- dimensions: *id119
   name: ch.astra.ivs-nat-verlaeufe
   sources: [ch.astra.ivs-nat-verlaeufe_20100416_cache]
   title: IVS historischer Verlauf ('current')
-- dimensions: *id117
+- dimensions: *id119
   name: ch.astra.ivs-nat-verlaeufe_20100416_source
   sources: [ch.astra.ivs-nat-verlaeufe_20100416_cache]
   title: IVS historischer Verlauf (20100416, source)
-- dimensions: &id118
+- dimensions: &id120
     Time:
       default: '20100414'
       values: ['20100414']
   name: ch.astra.ivs-nat_wegbegleiter_20100414
   sources: [ch.astra.ivs-nat_wegbegleiter_20100414_cache_out]
   title: IVS Wegbegleiter (20100414)
-- dimensions: *id118
+- dimensions: *id120
   name: ch.astra.ivs-nat_wegbegleiter
   sources: [ch.astra.ivs-nat_wegbegleiter_20100414_cache]
   title: IVS Wegbegleiter ('current')
-- dimensions: *id118
+- dimensions: *id120
   name: ch.astra.ivs-nat_wegbegleiter_20100414_source
   sources: [ch.astra.ivs-nat_wegbegleiter_20100414_cache]
   title: IVS Wegbegleiter (20100414, source)
-- dimensions: &id119
+- dimensions: &id121
     Time:
       default: '20100416'
       values: ['20100416']
   name: ch.astra.ivs-reg_loc_20100416
   sources: [ch.astra.ivs-reg_loc_20100416_cache_out]
   title: IVS Regional und Lokal (20100416)
-- dimensions: *id119
+- dimensions: *id121
   name: ch.astra.ivs-reg_loc
   sources: [ch.astra.ivs-reg_loc_20100416_cache]
   title: IVS Regional und Lokal ('current')
-- dimensions: *id119
+- dimensions: *id121
   name: ch.astra.ivs-reg_loc_20100416_source
   sources: [ch.astra.ivs-reg_loc_20100416_cache]
   title: IVS Regional und Lokal (20100416, source)
-- dimensions: &id120
+- dimensions: &id122
     Time:
       default: '20070712'
       values: ['20070712']
   name: ch.astra.ivs-reg_loc_20070712
   sources: [ch.astra.ivs-reg_loc_20070712_cache_out]
   title: IVS Regional und Lokal (20070712)
-- dimensions: *id120
+- dimensions: *id122
   name: ch.astra.ivs-reg_loc_20070712_source
   sources: [ch.astra.ivs-reg_loc_20070712_cache]
   title: IVS Regional und Lokal (20070712, source)
-- dimensions: &id121
+- dimensions: &id123
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.babs.kulturgueter_20150101
   sources: [ch.babs.kulturgueter_20150101_cache_out]
   title: KGS Inventar (20150101)
-- dimensions: *id121
+- dimensions: *id123
   name: ch.babs.kulturgueter
   sources: [ch.babs.kulturgueter_20150101_cache]
   title: KGS Inventar ('current')
-- dimensions: *id121
+- dimensions: *id123
   name: ch.babs.kulturgueter_20150101_source
   sources: [ch.babs.kulturgueter_20150101_cache]
   title: KGS Inventar (20150101, source)
-- dimensions: &id122
+- dimensions: &id124
     Time:
       default: '20140120'
       values: ['20140120']
   name: ch.babs.kulturgueter_20140120
   sources: [ch.babs.kulturgueter_20140120_cache_out]
   title: KGS Inventar (20140120)
-- dimensions: *id122
+- dimensions: *id124
   name: ch.babs.kulturgueter_20140120_source
   sources: [ch.babs.kulturgueter_20140120_cache]
   title: KGS Inventar (20140120, source)
-- dimensions: &id123
+- dimensions: &id125
     Time:
       default: '20130220'
       values: ['20130220']
   name: ch.babs.kulturgueter_20130220
   sources: [ch.babs.kulturgueter_20130220_cache_out]
   title: KGS Inventar (20130220)
-- dimensions: *id123
+- dimensions: *id125
   name: ch.babs.kulturgueter_20130220_source
   sources: [ch.babs.kulturgueter_20130220_cache]
   title: KGS Inventar (20130220, source)
-- dimensions: &id124
+- dimensions: &id126
     Time:
       default: '20091127'
       values: ['20091127']
   name: ch.babs.kulturgueter_20091127
   sources: [ch.babs.kulturgueter_20091127_cache_out]
   title: KGS Inventar (20091127)
-- dimensions: *id124
+- dimensions: *id126
   name: ch.babs.kulturgueter_20091127_source
   sources: [ch.babs.kulturgueter_20091127_cache]
   title: KGS Inventar (20091127, source)
-- dimensions: &id125
+- dimensions: &id127
     Time:
       default: '20070702'
       values: ['20070702']
   name: ch.bafu.bundesinventare-amphibien_20070702
   sources: [ch.bafu.bundesinventare-amphibien_20070702_cache_out]
   title: Amphibien Ortsfeste Objekte (20070702)
-- dimensions: *id125
+- dimensions: *id127
   name: ch.bafu.bundesinventare-amphibien
   sources: [ch.bafu.bundesinventare-amphibien_20070702_cache]
   title: Amphibien Ortsfeste Objekte ('current')
-- dimensions: *id125
+- dimensions: *id127
   name: ch.bafu.bundesinventare-amphibien_20070702_source
   sources: [ch.bafu.bundesinventare-amphibien_20070702_cache]
   title: Amphibien Ortsfeste Objekte (20070702, source)
-- dimensions: &id126
+- dimensions: &id128
     Time:
       default: '20070702'
       values: ['20070702']
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_cache_out]
   title: Amphibien Wanderobjekte (20070702)
-- dimensions: *id126
+- dimensions: *id128
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_cache]
   title: Amphibien Wanderobjekte ('current')
-- dimensions: *id126
+- dimensions: *id128
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_source
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_cache]
   title: Amphibien Wanderobjekte (20070702, source)
-- dimensions: &id127
+- dimensions: &id129
     Time:
       default: '20070701'
       values: ['20070701']
   name: ch.bafu.bundesinventare-auen_20070701
   sources: [ch.bafu.bundesinventare-auen_20070701_cache_out]
   title: Auengebiete (20070701)
-- dimensions: *id127
+- dimensions: *id129
   name: ch.bafu.bundesinventare-auen
   sources: [ch.bafu.bundesinventare-auen_20070701_cache]
   title: Auengebiete ('current')
-- dimensions: *id127
+- dimensions: *id129
   name: ch.bafu.bundesinventare-auen_20070701_source
   sources: [ch.bafu.bundesinventare-auen_20070701_cache]
   title: Auengebiete (20070701, source)
-- dimensions: &id128
+- dimensions: &id130
     Time:
       default: '20010809'
       values: ['20010809']
   name: ch.bafu.bundesinventare-bln_20010809
   sources: [ch.bafu.bundesinventare-bln_20010809_cache_out]
   title: BLN (20010809)
-- dimensions: *id128
+- dimensions: *id130
   name: ch.bafu.bundesinventare-bln
   sources: [ch.bafu.bundesinventare-bln_20010809_cache]
   title: BLN ('current')
-- dimensions: *id128
+- dimensions: *id130
   name: ch.bafu.bundesinventare-bln_20010809_source
   sources: [ch.bafu.bundesinventare-bln_20010809_cache]
   title: BLN (20010809, source)
-- dimensions: &id129
+- dimensions: &id131
     Time:
       default: '20100623'
       values: ['20100623']
   name: ch.bafu.bundesinventare-flachmoore_20100623
   sources: [ch.bafu.bundesinventare-flachmoore_20100623_cache_out]
   title: Flachmoore (20100623)
-- dimensions: *id129
+- dimensions: *id131
   name: ch.bafu.bundesinventare-flachmoore
   sources: [ch.bafu.bundesinventare-flachmoore_20100623_cache]
   title: Flachmoore ('current')
-- dimensions: *id129
+- dimensions: *id131
   name: ch.bafu.bundesinventare-flachmoore_20100623_source
   sources: [ch.bafu.bundesinventare-flachmoore_20100623_cache]
   title: Flachmoore (20100623, source)
-- dimensions: &id130
+- dimensions: &id132
     Time:
       default: '20080721'
       values: ['20080721']
   name: ch.bafu.bundesinventare-hochmoore_20080721
   sources: [ch.bafu.bundesinventare-hochmoore_20080721_cache_out]
   title: Hochmoore (20080721)
-- dimensions: *id130
+- dimensions: *id132
   name: ch.bafu.bundesinventare-hochmoore
   sources: [ch.bafu.bundesinventare-hochmoore_20080721_cache]
   title: Hochmoore ('current')
-- dimensions: *id130
+- dimensions: *id132
   name: ch.bafu.bundesinventare-hochmoore_20080721_source
   sources: [ch.bafu.bundesinventare-hochmoore_20080721_cache]
   title: Hochmoore (20080721, source)
-- dimensions: &id131
+- dimensions: &id133
     Time:
       default: '20131202'
       values: ['20131202']
   name: ch.bafu.bundesinventare-jagdbanngebiete_20131202
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20131202_cache_out]
   title: Jagdbanngebiete (20131202)
-- dimensions: *id131
+- dimensions: *id133
   name: ch.bafu.bundesinventare-jagdbanngebiete
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20131202_cache]
   title: Jagdbanngebiete ('current')
-- dimensions: *id131
+- dimensions: *id133
   name: ch.bafu.bundesinventare-jagdbanngebiete_20131202_source
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20131202_cache]
   title: Jagdbanngebiete (20131202, source)
-- dimensions: &id132
+- dimensions: &id134
     Time:
       default: '20100801'
       values: ['20100801']
   name: ch.bafu.bundesinventare-jagdbanngebiete_20100801
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20100801_cache_out]
   title: Jagdbanngebiete (20100801)
-- dimensions: *id132
+- dimensions: *id134
   name: ch.bafu.bundesinventare-jagdbanngebiete_20100801_source
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20100801_cache]
   title: Jagdbanngebiete (20100801, source)
-- dimensions: &id133
+- dimensions: &id135
     Time:
       default: '20150202'
       values: ['20150202']
   name: ch.bafu.bundesinventare-moorlandschaften_20150202
   sources: [ch.bafu.bundesinventare-moorlandschaften_20150202_cache_out]
   title: Moorlandschaften (20150202)
-- dimensions: *id133
+- dimensions: *id135
   name: ch.bafu.bundesinventare-moorlandschaften
   sources: [ch.bafu.bundesinventare-moorlandschaften_20150202_cache]
   title: Moorlandschaften ('current')
-- dimensions: *id133
+- dimensions: *id135
   name: ch.bafu.bundesinventare-moorlandschaften_20150202_source
   sources: [ch.bafu.bundesinventare-moorlandschaften_20150202_cache]
   title: Moorlandschaften (20150202, source)
-- dimensions: &id134
+- dimensions: &id136
     Time:
       default: '20070701'
       values: ['20070701']
   name: ch.bafu.bundesinventare-moorlandschaften_20070701
   sources: [ch.bafu.bundesinventare-moorlandschaften_20070701_cache_out]
   title: Moorlandschaften (20070701)
-- dimensions: *id134
+- dimensions: *id136
   name: ch.bafu.bundesinventare-moorlandschaften_20070701_source
   sources: [ch.bafu.bundesinventare-moorlandschaften_20070701_cache]
   title: Moorlandschaften (20070701, source)
-- dimensions: &id135
+- dimensions: &id137
     Time:
       default: '20130624'
       values: ['20130624']
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_cache_out]
   title: Trockenwiesen und -weiden (TWW) (20130624)
-- dimensions: *id135
+- dimensions: *id137
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_cache]
   title: Trockenwiesen und -weiden (TWW) ('current')
-- dimensions: *id135
+- dimensions: *id137
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_source
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_cache]
   title: Trockenwiesen und -weiden (TWW) (20130624, source)
-- dimensions: &id136
+- dimensions: &id138
     Time:
       default: '20120312'
       values: ['20120312']
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20120312
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20120312_cache_out]
   title: Trockenwiesen und -weiden (TWW) (20120312)
-- dimensions: *id136
+- dimensions: *id138
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20120312_source
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20120312_cache]
   title: Trockenwiesen und -weiden (TWW) (20120312, source)
-- dimensions: &id137
+- dimensions: &id139
     Time:
       default: '20100201'
       values: ['20100201']
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20100201
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20100201_cache_out]
   title: Trockenwiesen und -weiden (TWW) (20100201)
-- dimensions: *id137
+- dimensions: *id139
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20100201_source
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20100201_cache]
   title: Trockenwiesen und -weiden (TWW) (20100201, source)
-- dimensions: &id138
+- dimensions: &id140
+    Time:
+      default: '20150622'
+      values: ['20150622']
+  name: ch.bafu.bundesinventare-vogelreservate_20150622
+  sources: [ch.bafu.bundesinventare-vogelreservate_20150622_cache_out]
+  title: Wasser- und Zugvogelreservate (20150622)
+- dimensions: *id140
+  name: ch.bafu.bundesinventare-vogelreservate
+  sources: [ch.bafu.bundesinventare-vogelreservate_20150622_cache]
+  title: Wasser- und Zugvogelreservate ('current')
+- dimensions: *id140
+  name: ch.bafu.bundesinventare-vogelreservate_20150622_source
+  sources: [ch.bafu.bundesinventare-vogelreservate_20150622_cache]
+  title: Wasser- und Zugvogelreservate (20150622, source)
+- dimensions: &id141
     Time:
       default: '20090617'
       values: ['20090617']
   name: ch.bafu.bundesinventare-vogelreservate_20090617
   sources: [ch.bafu.bundesinventare-vogelreservate_20090617_cache_out]
   title: Wasser- und Zugvogelreservate (20090617)
-- dimensions: *id138
-  name: ch.bafu.bundesinventare-vogelreservate
-  sources: [ch.bafu.bundesinventare-vogelreservate_20090617_cache]
-  title: Wasser- und Zugvogelreservate ('current')
-- dimensions: *id138
+- dimensions: *id141
   name: ch.bafu.bundesinventare-vogelreservate_20090617_source
   sources: [ch.bafu.bundesinventare-vogelreservate_20090617_cache]
   title: Wasser- und Zugvogelreservate (20090617, source)
-- dimensions: &id139
+- dimensions: &id142
     Time:
       default: '20150506'
       values: ['20150506']
   name: ch.bafu.fauna-steinbockkolonien_20150506
   sources: [ch.bafu.fauna-steinbockkolonien_20150506_cache_out]
   title: Steinbockkolonien (20150506)
-- dimensions: *id139
+- dimensions: *id142
   name: ch.bafu.fauna-steinbockkolonien
   sources: [ch.bafu.fauna-steinbockkolonien_20150506_cache]
   title: Steinbockkolonien ('current')
-- dimensions: *id139
+- dimensions: *id142
   name: ch.bafu.fauna-steinbockkolonien_20150506_source
   sources: [ch.bafu.fauna-steinbockkolonien_20150506_cache]
   title: Steinbockkolonien (20150506, source)
-- dimensions: &id140
+- dimensions: &id143
     Time:
       default: '20020114'
       values: ['20020114']
   name: ch.bafu.fauna-steinbockkolonien_20020114
   sources: [ch.bafu.fauna-steinbockkolonien_20020114_cache_out]
   title: Steinbockkolonien (20020114)
-- dimensions: *id140
+- dimensions: *id143
   name: ch.bafu.fauna-steinbockkolonien_20020114_source
   sources: [ch.bafu.fauna-steinbockkolonien_20020114_cache]
   title: Steinbockkolonien (20020114, source)
-- dimensions: &id141
+- dimensions: &id144
     Time:
       default: '20140805'
       values: ['20140805']
   name: ch.bafu.flussordnungszahlen-strahler_20140805
   sources: [ch.bafu.flussordnungszahlen-strahler_20140805_cache_out]
   title: Flussordnung (20140805)
-- dimensions: *id141
+- dimensions: *id144
   name: ch.bafu.flussordnungszahlen-strahler
   sources: [ch.bafu.flussordnungszahlen-strahler_20140805_cache]
   title: Flussordnung ('current')
-- dimensions: *id141
+- dimensions: *id144
   name: ch.bafu.flussordnungszahlen-strahler_20140805_source
   sources: [ch.bafu.flussordnungszahlen-strahler_20140805_cache]
   title: Flussordnung (20140805, source)
-- dimensions: &id142
+- dimensions: &id145
     Time:
       default: '20130301'
       values: ['20130301']
   name: ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301
   sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_cache_out]
   title: "Messstandorte Gew\xE4sserzustand (20130301)"
-- dimensions: *id142
+- dimensions: *id145
   name: ch.bafu.hydrologie-gewaesserzustandsmessstationen
   sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_cache]
   title: "Messstandorte Gew\xE4sserzustand ('current')"
-- dimensions: *id142
+- dimensions: *id145
   name: ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_source
   sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_cache]
   title: "Messstandorte Gew\xE4sserzustand (20130301, source)"
-- dimensions: &id143
+- dimensions: &id146
     Time:
       default: '20141023'
       values: ['20141023']
   name: ch.bafu.hydrologie-hintergrundkarte_20141023
   sources: [ch.bafu.hydrologie-hintergrundkarte_20141023_cache_out]
   title: Hintergrundkarte hydrol. Daten (20141023)
-- dimensions: *id143
+- dimensions: *id146
   name: ch.bafu.hydrologie-hintergrundkarte
   sources: [ch.bafu.hydrologie-hintergrundkarte_20141023_cache]
   title: Hintergrundkarte hydrol. Daten ('current')
-- dimensions: *id143
+- dimensions: *id146
   name: ch.bafu.hydrologie-hintergrundkarte_20141023_source
   sources: [ch.bafu.hydrologie-hintergrundkarte_20141023_cache]
   title: Hintergrundkarte hydrol. Daten (20141023, source)
-- dimensions: &id144
+- dimensions: &id147
     Time:
       default: '20141201'
       values: ['20141201']
   name: ch.bafu.hydrologie-hydromessstationen_20141201
   sources: [ch.bafu.hydrologie-hydromessstationen_20141201_cache_out]
   title: Hydrologische Messstationen (20141201)
-- dimensions: *id144
+- dimensions: *id147
   name: ch.bafu.hydrologie-hydromessstationen
   sources: [ch.bafu.hydrologie-hydromessstationen_20141201_cache]
   title: Hydrologische Messstationen ('current')
-- dimensions: *id144
+- dimensions: *id147
   name: ch.bafu.hydrologie-hydromessstationen_20141201_source
   sources: [ch.bafu.hydrologie-hydromessstationen_20141201_cache]
   title: Hydrologische Messstationen (20141201, source)
-- dimensions: &id145
+- dimensions: &id148
     Time:
       default: '20081201'
       values: ['20081201']
   name: ch.bafu.hydrologie-hydromessstationen_20081201
   sources: [ch.bafu.hydrologie-hydromessstationen_20081201_cache_out]
   title: Hydrologische Messstationen (20081201)
-- dimensions: *id145
+- dimensions: *id148
   name: ch.bafu.hydrologie-hydromessstationen_20081201_source
   sources: [ch.bafu.hydrologie-hydromessstationen_20081201_cache]
   title: Hydrologische Messstationen (20081201, source)
-- dimensions: &id146
+- dimensions: &id149
     Time:
       default: '20141201'
       values: ['20141201']
   name: ch.bafu.hydrologie-wassertemperaturmessstationen_20141201
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache_out]
   title: Messstationen Wassertemperatur (20141201)
-- dimensions: *id146
+- dimensions: *id149
   name: ch.bafu.hydrologie-wassertemperaturmessstationen
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache]
   title: Messstationen Wassertemperatur ('current')
-- dimensions: *id146
+- dimensions: *id149
   name: ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_source
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache]
   title: Messstationen Wassertemperatur (20141201, source)
-- dimensions: &id147
+- dimensions: &id150
     Time:
       default: '20130322'
       values: ['20130322']
   name: ch.bafu.hydrologie-wassertemperaturmessstationen_20130322
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20130322_cache_out]
   title: Messstationen Wassertemperatur (20130322)
-- dimensions: *id147
+- dimensions: *id150
   name: ch.bafu.hydrologie-wassertemperaturmessstationen_20130322_source
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20130322_cache]
   title: Messstationen Wassertemperatur (20130322, source)
-- dimensions: &id148
+- dimensions: &id151
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.bafu.laerm-bahnlaerm_nacht_20061231
   sources: [ch.bafu.laerm-bahnlaerm_nacht_20061231_cache_out]
   title: "Eisenbahnl\xE4rm Nacht (20061231)"
-- dimensions: *id148
+- dimensions: *id151
   name: ch.bafu.laerm-bahnlaerm_nacht
   sources: [ch.bafu.laerm-bahnlaerm_nacht_20061231_cache]
   title: "Eisenbahnl\xE4rm Nacht ('current')"
-- dimensions: *id148
+- dimensions: *id151
   name: ch.bafu.laerm-bahnlaerm_nacht_20061231_source
   sources: [ch.bafu.laerm-bahnlaerm_nacht_20061231_cache]
   title: "Eisenbahnl\xE4rm Nacht (20061231, source)"
-- dimensions: &id149
+- dimensions: &id152
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.bafu.laerm-bahnlaerm_tag_20061231
   sources: [ch.bafu.laerm-bahnlaerm_tag_20061231_cache_out]
   title: "Eisenbahnl\xE4rm Tag (20061231)"
-- dimensions: *id149
+- dimensions: *id152
   name: ch.bafu.laerm-bahnlaerm_tag
   sources: [ch.bafu.laerm-bahnlaerm_tag_20061231_cache]
   title: "Eisenbahnl\xE4rm Tag ('current')"
-- dimensions: *id149
+- dimensions: *id152
   name: ch.bafu.laerm-bahnlaerm_tag_20061231_source
   sources: [ch.bafu.laerm-bahnlaerm_tag_20061231_cache]
   title: "Eisenbahnl\xE4rm Tag (20061231, source)"
-- dimensions: &id150
+- dimensions: &id153
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.bafu.laerm-strassenlaerm_nacht_20101231
   sources: [ch.bafu.laerm-strassenlaerm_nacht_20101231_cache_out]
   title: "Strassenverkehrsl\xE4rm Nacht (20101231)"
-- dimensions: *id150
+- dimensions: *id153
   name: ch.bafu.laerm-strassenlaerm_nacht
   sources: [ch.bafu.laerm-strassenlaerm_nacht_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Nacht ('current')"
-- dimensions: *id150
+- dimensions: *id153
   name: ch.bafu.laerm-strassenlaerm_nacht_20101231_source
   sources: [ch.bafu.laerm-strassenlaerm_nacht_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Nacht (20101231, source)"
-- dimensions: &id151
+- dimensions: &id154
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.bafu.laerm-strassenlaerm_tag_20101231
   sources: [ch.bafu.laerm-strassenlaerm_tag_20101231_cache_out]
   title: "Strassenverkehrsl\xE4rm Tag (20101231)"
-- dimensions: *id151
+- dimensions: *id154
   name: ch.bafu.laerm-strassenlaerm_tag
   sources: [ch.bafu.laerm-strassenlaerm_tag_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Tag ('current')"
-- dimensions: *id151
+- dimensions: *id154
   name: ch.bafu.laerm-strassenlaerm_tag_20101231_source
   sources: [ch.bafu.laerm-strassenlaerm_tag_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Tag (20101231, source)"
-- dimensions: &id152
+- dimensions: &id155
     Time:
       default: '20120416'
       values: ['20120416']
   name: ch.bafu.moose_20120416
   sources: [ch.bafu.moose_20120416_cache_out]
   title: Rote Liste Moose (20120416)
-- dimensions: *id152
+- dimensions: *id155
   name: ch.bafu.moose
   sources: [ch.bafu.moose_20120416_cache]
   title: Rote Liste Moose ('current')
-- dimensions: *id152
+- dimensions: *id155
   name: ch.bafu.moose_20120416_source
   sources: [ch.bafu.moose_20120416_cache]
   title: Rote Liste Moose (20120416, source)
-- dimensions: &id153
+- dimensions: &id156
     Time:
       default: '20110309'
       values: ['20110309']
   name: ch.bafu.nabelstationen_20110309
   sources: [ch.bafu.nabelstationen_20110309_cache_out]
   title: 'Luftbelastung: Stationen NABEL (20110309)'
-- dimensions: *id153
+- dimensions: *id156
   name: ch.bafu.nabelstationen
   sources: [ch.bafu.nabelstationen_20110309_cache]
   title: 'Luftbelastung: Stationen NABEL (''current'')'
-- dimensions: *id153
+- dimensions: *id156
   name: ch.bafu.nabelstationen_20110309_source
   sources: [ch.bafu.nabelstationen_20110309_cache]
   title: 'Luftbelastung: Stationen NABEL (20110309, source)'
-- dimensions: &id154
+- dimensions: &id157
     Time:
       default: '20080913'
       values: ['20080913']
   name: ch.bafu.oekomorphologie-f_abschnitte_20080913
   sources: [ch.bafu.oekomorphologie-f_abschnitte_20080913_cache_out]
   title: "\xD6komorphologie F - Abschnitte (20080913)"
-- dimensions: *id154
+- dimensions: *id157
   name: ch.bafu.oekomorphologie-f_abschnitte
   sources: [ch.bafu.oekomorphologie-f_abschnitte_20080913_cache]
   title: "\xD6komorphologie F - Abschnitte ('current')"
-- dimensions: *id154
+- dimensions: *id157
   name: ch.bafu.oekomorphologie-f_abschnitte_20080913_source
   sources: [ch.bafu.oekomorphologie-f_abschnitte_20080913_cache]
   title: "\xD6komorphologie F - Abschnitte (20080913, source)"
-- dimensions: &id155
+- dimensions: &id158
     Time:
       default: '20110912'
       values: ['20110912']
   name: ch.bafu.oekomorphologie-f_abstuerze_20110912
   sources: [ch.bafu.oekomorphologie-f_abstuerze_20110912_cache_out]
   title: "\xD6komorphologie F - Abst\xFCrze (20110912)"
-- dimensions: *id155
+- dimensions: *id158
   name: ch.bafu.oekomorphologie-f_abstuerze
   sources: [ch.bafu.oekomorphologie-f_abstuerze_20110912_cache]
   title: "\xD6komorphologie F - Abst\xFCrze ('current')"
-- dimensions: *id155
+- dimensions: *id158
   name: ch.bafu.oekomorphologie-f_abstuerze_20110912_source
   sources: [ch.bafu.oekomorphologie-f_abstuerze_20110912_cache]
   title: "\xD6komorphologie F - Abst\xFCrze (20110912, source)"
-- dimensions: &id156
+- dimensions: &id159
     Time:
       default: '20110912'
       values: ['20110912']
   name: ch.bafu.oekomorphologie-f_bauwerke_20110912
   sources: [ch.bafu.oekomorphologie-f_bauwerke_20110912_cache_out]
   title: "\xD6komorphologie F - Bauwerke (20110912)"
-- dimensions: *id156
+- dimensions: *id159
   name: ch.bafu.oekomorphologie-f_bauwerke
   sources: [ch.bafu.oekomorphologie-f_bauwerke_20110912_cache]
   title: "\xD6komorphologie F - Bauwerke ('current')"
-- dimensions: *id156
+- dimensions: *id159
   name: ch.bafu.oekomorphologie-f_bauwerke_20110912_source
   sources: [ch.bafu.oekomorphologie-f_bauwerke_20110912_cache]
   title: "\xD6komorphologie F - Bauwerke (20110912, source)"
-- dimensions: &id157
+- dimensions: &id160
     Time:
       default: '20110317'
       values: ['20110317']
   name: ch.bafu.permafrost_20110317
   sources: [ch.bafu.permafrost_20110317_cache_out]
   title: Permafrosthinweiskarte (20110317)
-- dimensions: *id157
+- dimensions: *id160
   name: ch.bafu.permafrost
   sources: [ch.bafu.permafrost_20110317_cache]
   title: Permafrosthinweiskarte ('current')
-- dimensions: *id157
+- dimensions: *id160
   name: ch.bafu.permafrost_20110317_source
   sources: [ch.bafu.permafrost_20110317_cache]
   title: Permafrosthinweiskarte (20110317, source)
-- dimensions: &id158
+- dimensions: &id161
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214
   sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_cache_out]
   title: REN  Extensives Landwirtschaftsgebiet (20110214)
-- dimensions: *id158
+- dimensions: *id161
   name: ch.bafu.ren-extensive_landwirtschaftsgebiete
   sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_cache]
   title: REN  Extensives Landwirtschaftsgebiet ('current')
-- dimensions: *id158
+- dimensions: *id161
   name: ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_source
   sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_cache]
   title: REN  Extensives Landwirtschaftsgebiet (20110214, source)
-- dimensions: &id159
+- dimensions: &id162
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-feuchtgebiete_20110214
   sources: [ch.bafu.ren-feuchtgebiete_20110214_cache_out]
   title: REN  Feuchtgebiet (20110214)
-- dimensions: *id159
+- dimensions: *id162
   name: ch.bafu.ren-feuchtgebiete
   sources: [ch.bafu.ren-feuchtgebiete_20110214_cache]
   title: REN  Feuchtgebiet ('current')
-- dimensions: *id159
+- dimensions: *id162
   name: ch.bafu.ren-feuchtgebiete_20110214_source
   sources: [ch.bafu.ren-feuchtgebiete_20110214_cache]
   title: REN  Feuchtgebiet (20110214, source)
-- dimensions: &id160
+- dimensions: &id163
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-fliessgewaesser_seen_20110214
   sources: [ch.bafu.ren-fliessgewaesser_seen_20110214_cache_out]
   title: "REN  Fliessgew\xE4sser / Seen (20110214)"
-- dimensions: *id160
+- dimensions: *id163
   name: ch.bafu.ren-fliessgewaesser_seen
   sources: [ch.bafu.ren-fliessgewaesser_seen_20110214_cache]
   title: "REN  Fliessgew\xE4sser / Seen ('current')"
-- dimensions: *id160
+- dimensions: *id163
   name: ch.bafu.ren-fliessgewaesser_seen_20110214_source
   sources: [ch.bafu.ren-fliessgewaesser_seen_20110214_cache]
   title: "REN  Fliessgew\xE4sser / Seen (20110214, source)"
-- dimensions: &id161
+- dimensions: &id164
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-trockenstandorte_20110214
   sources: [ch.bafu.ren-trockenstandorte_20110214_cache_out]
   title: REN  Trockenstandort (20110214)
-- dimensions: *id161
+- dimensions: *id164
   name: ch.bafu.ren-trockenstandorte
   sources: [ch.bafu.ren-trockenstandorte_20110214_cache]
   title: REN  Trockenstandort ('current')
-- dimensions: *id161
+- dimensions: *id164
   name: ch.bafu.ren-trockenstandorte_20110214_source
   sources: [ch.bafu.ren-trockenstandorte_20110214_cache]
   title: REN  Trockenstandort (20110214, source)
-- dimensions: &id162
+- dimensions: &id165
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-wald_20110214
   sources: [ch.bafu.ren-wald_20110214_cache_out]
   title: REN  Wald (20110214)
-- dimensions: *id162
+- dimensions: *id165
   name: ch.bafu.ren-wald
   sources: [ch.bafu.ren-wald_20110214_cache]
   title: REN  Wald ('current')
-- dimensions: *id162
+- dimensions: *id165
   name: ch.bafu.ren-wald_20110214_source
   sources: [ch.bafu.ren-wald_20110214_cache]
   title: REN  Wald (20110214, source)
-- dimensions: &id163
+- dimensions: &id166
     Time:
       default: '20150422'
       values: ['20150422']
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache_out]
   title: "P\xE4rke (20150422)"
-- dimensions: *id163
+- dimensions: *id166
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache]
   title: "P\xE4rke ('current')"
-- dimensions: *id163
+- dimensions: *id166
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_source
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache]
   title: "P\xE4rke (20150422, source)"
-- dimensions: &id164
+- dimensions: &id167
     Time:
       default: '20140402'
       values: ['20140402']
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20140402
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20140402_cache_out]
   title: "P\xE4rke (20140402)"
-- dimensions: *id164
+- dimensions: *id167
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20140402_source
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20140402_cache]
   title: "P\xE4rke (20140402, source)"
-- dimensions: &id165
+- dimensions: &id168
     Time:
       default: '20130416'
       values: ['20130416']
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20130416
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20130416_cache_out]
   title: "P\xE4rke (20130416)"
-- dimensions: *id165
+- dimensions: *id168
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20130416_source
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20130416_cache]
   title: "P\xE4rke (20130416, source)"
-- dimensions: &id166
+- dimensions: &id169
     Time:
       default: '20121023'
       values: ['20121023']
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20121023
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20121023_cache_out]
   title: "P\xE4rke (20121023)"
-- dimensions: *id166
+- dimensions: *id169
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20121023_source
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20121023_cache]
   title: "P\xE4rke (20121023, source)"
-- dimensions: &id167
+- dimensions: &id170
     Time:
       default: '20120127'
       values: ['20120127']
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20120127
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20120127_cache_out]
   title: "P\xE4rke (20120127)"
-- dimensions: *id167
+- dimensions: *id170
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20120127_source
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20120127_cache]
   title: "P\xE4rke (20120127, source)"
-- dimensions: &id168
+- dimensions: &id171
     Time:
       default: '20110103'
       values: ['20110103']
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20110103
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20110103_cache_out]
   title: "P\xE4rke (20110103)"
-- dimensions: *id168
+- dimensions: *id171
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20110103_source
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20110103_cache]
   title: "P\xE4rke (20110103, source)"
-- dimensions: &id169
+- dimensions: &id172
     Time:
       default: '20110830'
       values: ['20110830']
   name: ch.bafu.schutzgebiete-ramsar_20110830
   sources: [ch.bafu.schutzgebiete-ramsar_20110830_cache_out]
   title: Ramsar (20110830)
-- dimensions: *id169
+- dimensions: *id172
   name: ch.bafu.schutzgebiete-ramsar
   sources: [ch.bafu.schutzgebiete-ramsar_20110830_cache]
   title: Ramsar ('current')
-- dimensions: *id169
+- dimensions: *id172
   name: ch.bafu.schutzgebiete-ramsar_20110830_source
   sources: [ch.bafu.schutzgebiete-ramsar_20110830_cache]
   title: Ramsar (20110830, source)
-- dimensions: &id170
+- dimensions: &id173
     Time:
       default: '20050202'
       values: ['20050202']
   name: ch.bafu.schutzgebiete-ramsar_20050202
   sources: [ch.bafu.schutzgebiete-ramsar_20050202_cache_out]
   title: Ramsar (20050202)
-- dimensions: *id170
+- dimensions: *id173
   name: ch.bafu.schutzgebiete-ramsar_20050202_source
   sources: [ch.bafu.schutzgebiete-ramsar_20050202_cache]
   title: Ramsar (20050202, source)
-- dimensions: &id171
+- dimensions: &id174
     Time:
       default: '20010117'
       values: ['20010117']
   name: ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117
   sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_cache_out]
   title: Nationalpark (20010117)
-- dimensions: *id171
+- dimensions: *id174
   name: ch.bafu.schutzgebiete-schweizerischer_nationalpark
   sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_cache]
   title: Nationalpark ('current')
-- dimensions: *id171
+- dimensions: *id174
   name: ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_source
   sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_cache]
   title: Nationalpark (20010117, source)
-- dimensions: &id172
+- dimensions: &id175
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_hochwasser_20150101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20150101)'
-- dimensions: *id172
+- dimensions: *id175
   name: ch.bafu.showme-gemeinden_hochwasser
   sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (''current'')'
-- dimensions: *id172
+- dimensions: *id175
   name: ch.bafu.showme-gemeinden_hochwasser_20150101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20150101, source)'
-- dimensions: &id173
+- dimensions: &id176
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_hochwasser_20140101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20140101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20140101)'
-- dimensions: *id173
+- dimensions: *id176
   name: ch.bafu.showme-gemeinden_hochwasser_20140101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20140101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20140101, source)'
-- dimensions: &id174
+- dimensions: &id177
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_hochwasser_20130101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20130101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20130101)'
-- dimensions: *id174
+- dimensions: *id177
   name: ch.bafu.showme-gemeinden_hochwasser_20130101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20130101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20130101, source)'
-- dimensions: &id175
+- dimensions: &id178
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_hochwasser_20120101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20120101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20120101)'
-- dimensions: *id175
+- dimensions: *id178
   name: ch.bafu.showme-gemeinden_hochwasser_20120101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20120101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20120101, source)'
-- dimensions: &id176
+- dimensions: &id179
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_hochwasser_20110101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20110101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20110101)'
-- dimensions: *id176
+- dimensions: *id179
   name: ch.bafu.showme-gemeinden_hochwasser_20110101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20110101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20110101, source)'
-- dimensions: &id177
+- dimensions: &id180
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_hochwasser_20100101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20100101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20100101)'
-- dimensions: *id177
+- dimensions: *id180
   name: ch.bafu.showme-gemeinden_hochwasser_20100101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20100101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20100101, source)'
-- dimensions: &id178
+- dimensions: &id181
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_lawinen_20150101
   sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20150101)'
-- dimensions: *id178
+- dimensions: *id181
   name: ch.bafu.showme-gemeinden_lawinen
   sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
   title: 'ShowMe Gemeinden: Lawinen (''current'')'
-- dimensions: *id178
+- dimensions: *id181
   name: ch.bafu.showme-gemeinden_lawinen_20150101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20150101, source)'
-- dimensions: &id179
+- dimensions: &id182
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_lawinen_20140101
   sources: [ch.bafu.showme-gemeinden_lawinen_20140101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20140101)'
-- dimensions: *id179
+- dimensions: *id182
   name: ch.bafu.showme-gemeinden_lawinen_20140101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20140101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20140101, source)'
-- dimensions: &id180
+- dimensions: &id183
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_lawinen_20130101
   sources: [ch.bafu.showme-gemeinden_lawinen_20130101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20130101)'
-- dimensions: *id180
+- dimensions: *id183
   name: ch.bafu.showme-gemeinden_lawinen_20130101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20130101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20130101, source)'
-- dimensions: &id181
+- dimensions: &id184
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_lawinen_20120101
   sources: [ch.bafu.showme-gemeinden_lawinen_20120101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20120101)'
-- dimensions: *id181
+- dimensions: *id184
   name: ch.bafu.showme-gemeinden_lawinen_20120101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20120101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20120101, source)'
-- dimensions: &id182
+- dimensions: &id185
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_lawinen_20110101
   sources: [ch.bafu.showme-gemeinden_lawinen_20110101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20110101)'
-- dimensions: *id182
+- dimensions: *id185
   name: ch.bafu.showme-gemeinden_lawinen_20110101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20110101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20110101, source)'
-- dimensions: &id183
+- dimensions: &id186
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_lawinen_20100101
   sources: [ch.bafu.showme-gemeinden_lawinen_20100101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20100101)'
-- dimensions: *id183
+- dimensions: *id186
   name: ch.bafu.showme-gemeinden_lawinen_20100101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20100101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20100101, source)'
-- dimensions: &id184
+- dimensions: &id187
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_rutschungen_20150101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20150101)'
-- dimensions: *id184
+- dimensions: *id187
   name: ch.bafu.showme-gemeinden_rutschungen
   sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (''current'')'
-- dimensions: *id184
+- dimensions: *id187
   name: ch.bafu.showme-gemeinden_rutschungen_20150101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20150101, source)'
-- dimensions: &id185
+- dimensions: &id188
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_rutschungen_20140101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20140101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20140101)'
-- dimensions: *id185
+- dimensions: *id188
   name: ch.bafu.showme-gemeinden_rutschungen_20140101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20140101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20140101, source)'
-- dimensions: &id186
+- dimensions: &id189
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_rutschungen_20130101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20130101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20130101)'
-- dimensions: *id186
+- dimensions: *id189
   name: ch.bafu.showme-gemeinden_rutschungen_20130101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20130101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20130101, source)'
-- dimensions: &id187
+- dimensions: &id190
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_rutschungen_20120101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20120101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20120101)'
-- dimensions: *id187
+- dimensions: *id190
   name: ch.bafu.showme-gemeinden_rutschungen_20120101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20120101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20120101, source)'
-- dimensions: &id188
+- dimensions: &id191
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_rutschungen_20110101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20110101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20110101)'
-- dimensions: *id188
+- dimensions: *id191
   name: ch.bafu.showme-gemeinden_rutschungen_20110101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20110101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20110101, source)'
-- dimensions: &id189
+- dimensions: &id192
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_rutschungen_20100101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20100101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20100101)'
-- dimensions: *id189
+- dimensions: *id192
   name: ch.bafu.showme-gemeinden_rutschungen_20100101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20100101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20100101, source)'
-- dimensions: &id190
+- dimensions: &id193
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20150101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20150101)'
-- dimensions: *id190
+- dimensions: *id193
   name: ch.bafu.showme-gemeinden_sturzprozesse
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (''current'')'
-- dimensions: *id190
+- dimensions: *id193
   name: ch.bafu.showme-gemeinden_sturzprozesse_20150101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20150101, source)'
-- dimensions: &id191
+- dimensions: &id194
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20140101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20140101)'
-- dimensions: *id191
+- dimensions: *id194
   name: ch.bafu.showme-gemeinden_sturzprozesse_20140101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20140101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20140101, source)'
-- dimensions: &id192
+- dimensions: &id195
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20130101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20130101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20130101)'
-- dimensions: *id192
+- dimensions: *id195
   name: ch.bafu.showme-gemeinden_sturzprozesse_20130101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20130101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20130101, source)'
-- dimensions: &id193
+- dimensions: &id196
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20120101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20120101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20120101)'
-- dimensions: *id193
+- dimensions: *id196
   name: ch.bafu.showme-gemeinden_sturzprozesse_20120101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20120101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20120101, source)'
-- dimensions: &id194
+- dimensions: &id197
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20110101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20110101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20110101)'
-- dimensions: *id194
+- dimensions: *id197
   name: ch.bafu.showme-gemeinden_sturzprozesse_20110101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20110101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20110101, source)'
-- dimensions: &id195
+- dimensions: &id198
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20100101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20100101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20100101)'
-- dimensions: *id195
+- dimensions: *id198
   name: ch.bafu.showme-gemeinden_sturzprozesse_20100101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20100101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20100101, source)'
-- dimensions: &id196
+- dimensions: &id199
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_hochwasser_20150101
   sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20150101)'
-- dimensions: *id196
+- dimensions: *id199
   name: ch.bafu.showme-kantone_hochwasser
   sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
   title: 'ShowMe Kantone: Hochwasser (''current'')'
-- dimensions: *id196
+- dimensions: *id199
   name: ch.bafu.showme-kantone_hochwasser_20150101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
   title: 'ShowMe Kantone: Hochwasser (20150101, source)'
-- dimensions: &id197
+- dimensions: &id200
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_hochwasser_20140101
   sources: [ch.bafu.showme-kantone_hochwasser_20140101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20140101)'
-- dimensions: *id197
+- dimensions: *id200
   name: ch.bafu.showme-kantone_hochwasser_20140101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20140101_cache]
   title: 'ShowMe Kantone: Hochwasser (20140101, source)'
-- dimensions: &id198
+- dimensions: &id201
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_hochwasser_20130101
   sources: [ch.bafu.showme-kantone_hochwasser_20130101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20130101)'
-- dimensions: *id198
+- dimensions: *id201
   name: ch.bafu.showme-kantone_hochwasser_20130101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20130101_cache]
   title: 'ShowMe Kantone: Hochwasser (20130101, source)'
-- dimensions: &id199
+- dimensions: &id202
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_hochwasser_20120101
   sources: [ch.bafu.showme-kantone_hochwasser_20120101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20120101)'
-- dimensions: *id199
+- dimensions: *id202
   name: ch.bafu.showme-kantone_hochwasser_20120101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20120101_cache]
   title: 'ShowMe Kantone: Hochwasser (20120101, source)'
-- dimensions: &id200
+- dimensions: &id203
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_hochwasser_20110101
   sources: [ch.bafu.showme-kantone_hochwasser_20110101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20110101)'
-- dimensions: *id200
+- dimensions: *id203
   name: ch.bafu.showme-kantone_hochwasser_20110101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20110101_cache]
   title: 'ShowMe Kantone: Hochwasser (20110101, source)'
-- dimensions: &id201
+- dimensions: &id204
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_hochwasser_20100101
   sources: [ch.bafu.showme-kantone_hochwasser_20100101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20100101)'
-- dimensions: *id201
+- dimensions: *id204
   name: ch.bafu.showme-kantone_hochwasser_20100101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20100101_cache]
   title: 'ShowMe Kantone: Hochwasser (20100101, source)'
-- dimensions: &id202
+- dimensions: &id205
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_lawinen_20150101
   sources: [ch.bafu.showme-kantone_lawinen_20150101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20150101)'
-- dimensions: *id202
+- dimensions: *id205
   name: ch.bafu.showme-kantone_lawinen
   sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
   title: 'ShowMe Kantone: Lawinen (''current'')'
-- dimensions: *id202
+- dimensions: *id205
   name: ch.bafu.showme-kantone_lawinen_20150101_source
   sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
   title: 'ShowMe Kantone: Lawinen (20150101, source)'
-- dimensions: &id203
+- dimensions: &id206
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_lawinen_20140101
   sources: [ch.bafu.showme-kantone_lawinen_20140101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20140101)'
-- dimensions: *id203
+- dimensions: *id206
   name: ch.bafu.showme-kantone_lawinen_20140101_source
   sources: [ch.bafu.showme-kantone_lawinen_20140101_cache]
   title: 'ShowMe Kantone: Lawinen (20140101, source)'
-- dimensions: &id204
+- dimensions: &id207
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_lawinen_20130101
   sources: [ch.bafu.showme-kantone_lawinen_20130101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20130101)'
-- dimensions: *id204
+- dimensions: *id207
   name: ch.bafu.showme-kantone_lawinen_20130101_source
   sources: [ch.bafu.showme-kantone_lawinen_20130101_cache]
   title: 'ShowMe Kantone: Lawinen (20130101, source)'
-- dimensions: &id205
+- dimensions: &id208
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_lawinen_20120101
   sources: [ch.bafu.showme-kantone_lawinen_20120101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20120101)'
-- dimensions: *id205
+- dimensions: *id208
   name: ch.bafu.showme-kantone_lawinen_20120101_source
   sources: [ch.bafu.showme-kantone_lawinen_20120101_cache]
   title: 'ShowMe Kantone: Lawinen (20120101, source)'
-- dimensions: &id206
+- dimensions: &id209
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_lawinen_20110101
   sources: [ch.bafu.showme-kantone_lawinen_20110101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20110101)'
-- dimensions: *id206
+- dimensions: *id209
   name: ch.bafu.showme-kantone_lawinen_20110101_source
   sources: [ch.bafu.showme-kantone_lawinen_20110101_cache]
   title: 'ShowMe Kantone: Lawinen (20110101, source)'
-- dimensions: &id207
+- dimensions: &id210
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_lawinen_20100101
   sources: [ch.bafu.showme-kantone_lawinen_20100101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20100101)'
-- dimensions: *id207
+- dimensions: *id210
   name: ch.bafu.showme-kantone_lawinen_20100101_source
   sources: [ch.bafu.showme-kantone_lawinen_20100101_cache]
   title: 'ShowMe Kantone: Lawinen (20100101, source)'
-- dimensions: &id208
+- dimensions: &id211
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_rutschungen_20150101
   sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20150101)'
-- dimensions: *id208
+- dimensions: *id211
   name: ch.bafu.showme-kantone_rutschungen
   sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
   title: 'ShowMe Kantone: Rutschungen (''current'')'
-- dimensions: *id208
+- dimensions: *id211
   name: ch.bafu.showme-kantone_rutschungen_20150101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
   title: 'ShowMe Kantone: Rutschungen (20150101, source)'
-- dimensions: &id209
+- dimensions: &id212
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_rutschungen_20140101
   sources: [ch.bafu.showme-kantone_rutschungen_20140101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20140101)'
-- dimensions: *id209
+- dimensions: *id212
   name: ch.bafu.showme-kantone_rutschungen_20140101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20140101_cache]
   title: 'ShowMe Kantone: Rutschungen (20140101, source)'
-- dimensions: &id210
+- dimensions: &id213
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_rutschungen_20130101
   sources: [ch.bafu.showme-kantone_rutschungen_20130101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20130101)'
-- dimensions: *id210
+- dimensions: *id213
   name: ch.bafu.showme-kantone_rutschungen_20130101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20130101_cache]
   title: 'ShowMe Kantone: Rutschungen (20130101, source)'
-- dimensions: &id211
+- dimensions: &id214
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_rutschungen_20120101
   sources: [ch.bafu.showme-kantone_rutschungen_20120101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20120101)'
-- dimensions: *id211
+- dimensions: *id214
   name: ch.bafu.showme-kantone_rutschungen_20120101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20120101_cache]
   title: 'ShowMe Kantone: Rutschungen (20120101, source)'
-- dimensions: &id212
+- dimensions: &id215
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_rutschungen_20110101
   sources: [ch.bafu.showme-kantone_rutschungen_20110101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20110101)'
-- dimensions: *id212
+- dimensions: *id215
   name: ch.bafu.showme-kantone_rutschungen_20110101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20110101_cache]
   title: 'ShowMe Kantone: Rutschungen (20110101, source)'
-- dimensions: &id213
+- dimensions: &id216
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_rutschungen_20100101
   sources: [ch.bafu.showme-kantone_rutschungen_20100101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20100101)'
-- dimensions: *id213
+- dimensions: *id216
   name: ch.bafu.showme-kantone_rutschungen_20100101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20100101_cache]
   title: 'ShowMe Kantone: Rutschungen (20100101, source)'
-- dimensions: &id214
+- dimensions: &id217
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_sturzprozesse_20150101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20150101)'
-- dimensions: *id214
+- dimensions: *id217
   name: ch.bafu.showme-kantone_sturzprozesse
   sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (''current'')'
-- dimensions: *id214
+- dimensions: *id217
   name: ch.bafu.showme-kantone_sturzprozesse_20150101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20150101, source)'
-- dimensions: &id215
+- dimensions: &id218
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bafu.showme-kantone_sturzprozesse_20140101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20140101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20140101)'
-- dimensions: *id215
+- dimensions: *id218
   name: ch.bafu.showme-kantone_sturzprozesse_20140101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20140101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20140101, source)'
-- dimensions: &id216
+- dimensions: &id219
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.bafu.showme-kantone_sturzprozesse_20130101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20130101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20130101)'
-- dimensions: *id216
+- dimensions: *id219
   name: ch.bafu.showme-kantone_sturzprozesse_20130101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20130101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20130101, source)'
-- dimensions: &id217
+- dimensions: &id220
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.bafu.showme-kantone_sturzprozesse_20120101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20120101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20120101)'
-- dimensions: *id217
+- dimensions: *id220
   name: ch.bafu.showme-kantone_sturzprozesse_20120101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20120101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20120101, source)'
-- dimensions: &id218
+- dimensions: &id221
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.bafu.showme-kantone_sturzprozesse_20110101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20110101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20110101)'
-- dimensions: *id218
+- dimensions: *id221
   name: ch.bafu.showme-kantone_sturzprozesse_20110101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20110101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20110101, source)'
-- dimensions: &id219
+- dimensions: &id222
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.bafu.showme-kantone_sturzprozesse_20100101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20100101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20100101)'
-- dimensions: *id219
+- dimensions: *id222
   name: ch.bafu.showme-kantone_sturzprozesse_20100101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20100101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20100101, source)'
-- dimensions: &id220
+- dimensions: &id223
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_100_20141107
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 (20141107)"
-- dimensions: *id220
+- dimensions: *id223
   name: ch.bafu.sturm-boeenspitzen_100
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 ('current')"
-- dimensions: *id220
+- dimensions: *id223
   name: ch.bafu.sturm-boeenspitzen_100_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 (20141107, source)"
-- dimensions: &id221
+- dimensions: &id224
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_30_20141107
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 (20141107)"
-- dimensions: *id221
+- dimensions: *id224
   name: ch.bafu.sturm-boeenspitzen_30
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 ('current')"
-- dimensions: *id221
+- dimensions: *id224
   name: ch.bafu.sturm-boeenspitzen_30_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 (20141107, source)"
-- dimensions: &id222
+- dimensions: &id225
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_300_20141107
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 (20141107)"
-- dimensions: *id222
+- dimensions: *id225
   name: ch.bafu.sturm-boeenspitzen_300
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 ('current')"
-- dimensions: *id222
+- dimensions: *id225
   name: ch.bafu.sturm-boeenspitzen_300_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 (20141107, source)"
-- dimensions: &id223
+- dimensions: &id226
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_50_20141107
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 (20141107)"
-- dimensions: *id223
+- dimensions: *id226
   name: ch.bafu.sturm-boeenspitzen_50
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 ('current')"
-- dimensions: *id223
+- dimensions: *id226
   name: ch.bafu.sturm-boeenspitzen_50_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 (20141107, source)"
-- dimensions: &id224
+- dimensions: &id227
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_100_20141107
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 100 (20141107)"
-- dimensions: *id224
+- dimensions: *id227
   name: ch.bafu.sturm-staudruck_100
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 100 ('current')"
-- dimensions: *id224
+- dimensions: *id227
   name: ch.bafu.sturm-staudruck_100_20141107_source
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 100 (20141107, source)"
-- dimensions: &id225
+- dimensions: &id228
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_30_20141107
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 30 (20141107)"
-- dimensions: *id225
+- dimensions: *id228
   name: ch.bafu.sturm-staudruck_30
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 30 ('current')"
-- dimensions: *id225
+- dimensions: *id228
   name: ch.bafu.sturm-staudruck_30_20141107_source
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 30 (20141107, source)"
-- dimensions: &id226
+- dimensions: &id229
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_300_20141107
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 300 (20141107)"
-- dimensions: *id226
+- dimensions: *id229
   name: ch.bafu.sturm-staudruck_300
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 300 ('current')"
-- dimensions: *id226
+- dimensions: *id229
   name: ch.bafu.sturm-staudruck_300_20141107_source
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 300 (20141107, source)"
-- dimensions: &id227
+- dimensions: &id230
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_50_20141107
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 50 (20141107)"
-- dimensions: *id227
+- dimensions: *id230
   name: ch.bafu.sturm-staudruck_50
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 50 ('current')"
-- dimensions: *id227
+- dimensions: *id230
   name: ch.bafu.sturm-staudruck_50_20141107_source
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 50 (20141107, source)"
-- dimensions: &id228
+- dimensions: &id231
     Time:
       default: '20150226'
       values: ['20150226']
   name: ch.bafu.swissprtr_20150226
   sources: [ch.bafu.swissprtr_20150226_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20150226)
-- dimensions: *id228
+- dimensions: *id231
   name: ch.bafu.swissprtr
   sources: [ch.bafu.swissprtr_20150226_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) ('current')
-- dimensions: *id228
+- dimensions: *id231
   name: ch.bafu.swissprtr_20150226_source
   sources: [ch.bafu.swissprtr_20150226_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20150226, source)
-- dimensions: &id229
+- dimensions: &id232
     Time:
       default: '20140213'
       values: ['20140213']
   name: ch.bafu.swissprtr_20140213
   sources: [ch.bafu.swissprtr_20140213_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20140213)
-- dimensions: *id229
+- dimensions: *id232
   name: ch.bafu.swissprtr_20140213_source
   sources: [ch.bafu.swissprtr_20140213_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20140213, source)
-- dimensions: &id230
+- dimensions: &id233
     Time:
       default: '20130207'
       values: ['20130207']
   name: ch.bafu.swissprtr_20130207
   sources: [ch.bafu.swissprtr_20130207_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20130207)
-- dimensions: *id230
+- dimensions: *id233
   name: ch.bafu.swissprtr_20130207_source
   sources: [ch.bafu.swissprtr_20130207_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20130207, source)
-- dimensions: &id231
+- dimensions: &id234
     Time:
       default: '20120404'
       values: ['20120404']
   name: ch.bafu.swissprtr_20120404
   sources: [ch.bafu.swissprtr_20120404_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20120404)
-- dimensions: *id231
+- dimensions: *id234
   name: ch.bafu.swissprtr_20120404_source
   sources: [ch.bafu.swissprtr_20120404_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20120404, source)
-- dimensions: &id232
+- dimensions: &id235
     Time:
       default: '20110222'
       values: ['20110222']
   name: ch.bafu.swissprtr_20110222
   sources: [ch.bafu.swissprtr_20110222_cache_out]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20110222)
-- dimensions: *id232
+- dimensions: *id235
   name: ch.bafu.swissprtr_20110222_source
   sources: [ch.bafu.swissprtr_20110222_cache]
   title: Schadstoff-Freisetzungen (SwissPRTR) (20110222, source)
-- dimensions: &id233
+- dimensions: &id236
     Time:
       default: '20080724'
       values: ['20080724']
   name: ch.bafu.unesco-weltnaturerbe_20080724
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache_out]
   title: "UNESCO-Welterbe Naturst\xE4tten (20080724)"
-- dimensions: *id233
+- dimensions: *id236
   name: ch.bafu.unesco-weltnaturerbe
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache]
   title: "UNESCO-Welterbe Naturst\xE4tten ('current')"
-- dimensions: *id233
+- dimensions: *id236
   name: ch.bafu.unesco-weltnaturerbe_20080724_source
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache]
   title: "UNESCO-Welterbe Naturst\xE4tten (20080724, source)"
-- dimensions: &id234
+- dimensions: &id237
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-entnahme_20040101
   sources: [ch.bafu.wasser-entnahme_20040101_cache_out]
   title: Wasserentnahme (20040101)
-- dimensions: *id234
+- dimensions: *id237
   name: ch.bafu.wasser-entnahme
   sources: [ch.bafu.wasser-entnahme_20040101_cache]
   title: Wasserentnahme ('current')
-- dimensions: *id234
+- dimensions: *id237
   name: ch.bafu.wasser-entnahme_20040101_source
   sources: [ch.bafu.wasser-entnahme_20040101_cache]
   title: Wasserentnahme (20040101, source)
-- dimensions: &id235
+- dimensions: &id238
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-gebietsauslaesse_20120701
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache_out]
   title: "Gebietsausl\xE4sse (20120701)"
-- dimensions: *id235
+- dimensions: *id238
   name: ch.bafu.wasser-gebietsauslaesse
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache]
   title: "Gebietsausl\xE4sse ('current')"
-- dimensions: *id235
+- dimensions: *id238
   name: ch.bafu.wasser-gebietsauslaesse_20120701_source
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache]
   title: "Gebietsausl\xE4sse (20120701, source)"
-- dimensions: &id236
+- dimensions: &id239
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-leitungen_20040101
   sources: [ch.bafu.wasser-leitungen_20040101_cache_out]
   title: Zuleitung (20040101)
-- dimensions: *id236
+- dimensions: *id239
   name: ch.bafu.wasser-leitungen
   sources: [ch.bafu.wasser-leitungen_20040101_cache]
   title: Zuleitung ('current')
-- dimensions: *id236
+- dimensions: *id239
   name: ch.bafu.wasser-leitungen_20040101_source
   sources: [ch.bafu.wasser-leitungen_20040101_cache]
   title: Zuleitung (20040101, source)
-- dimensions: &id237
+- dimensions: &id240
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-rueckgabe_20040101
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache_out]
   title: "Wasserr\xFCckgabe (20040101)"
-- dimensions: *id237
+- dimensions: *id240
   name: ch.bafu.wasser-rueckgabe
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache]
   title: "Wasserr\xFCckgabe ('current')"
-- dimensions: *id237
+- dimensions: *id240
   name: ch.bafu.wasser-rueckgabe_20040101_source
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache]
   title: "Wasserr\xFCckgabe (20040101, source)"
-- dimensions: &id238
+- dimensions: &id241
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-teileinzugsgebiete_2_20120701
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache_out]
   title: Teileinzugsgebiete 2km2 (20120701)
-- dimensions: *id238
+- dimensions: *id241
   name: ch.bafu.wasser-teileinzugsgebiete_2
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache]
   title: Teileinzugsgebiete 2km2 ('current')
-- dimensions: *id238
+- dimensions: *id241
   name: ch.bafu.wasser-teileinzugsgebiete_2_20120701_source
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache]
   title: Teileinzugsgebiete 2km2 (20120701, source)
-- dimensions: &id239
+- dimensions: &id242
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-teileinzugsgebiete_40_20120701
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache_out]
   title: Teileinzugsgebiete 40km2 (20120701)
-- dimensions: *id239
+- dimensions: *id242
   name: ch.bafu.wasser-teileinzugsgebiete_40
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache]
   title: Teileinzugsgebiete 40km2 ('current')
-- dimensions: *id239
+- dimensions: *id242
   name: ch.bafu.wasser-teileinzugsgebiete_40_20120701_source
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache]
   title: Teileinzugsgebiete 40km2 (20120701, source)
-- dimensions: &id240
+- dimensions: &id243
     Time:
       default: '20150106'
       values: ['20150106']
   name: ch.bafu.wrz-wildruhezonen_portal_20150106
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache_out]
   title: Wildruhezonen (20150106)
-- dimensions: *id240
+- dimensions: *id243
   name: ch.bafu.wrz-wildruhezonen_portal
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache]
   title: Wildruhezonen ('current')
-- dimensions: *id240
+- dimensions: *id243
   name: ch.bafu.wrz-wildruhezonen_portal_20150106_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache]
   title: Wildruhezonen (20150106, source)
-- dimensions: &id241
+- dimensions: &id244
     Time:
       default: '20141105'
       values: ['20141105']
   name: ch.bafu.wrz-wildruhezonen_portal_20141105
   sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache_out]
   title: Wildruhezonen (20141105)
-- dimensions: *id241
+- dimensions: *id244
   name: ch.bafu.wrz-wildruhezonen_portal_20141105_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20141105_cache]
   title: Wildruhezonen (20141105, source)
-- dimensions: &id242
+- dimensions: &id245
     Time:
       default: '20140107'
       values: ['20140107']
   name: ch.bafu.wrz-wildruhezonen_portal_20140107
   sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache_out]
   title: Wildruhezonen (20140107)
-- dimensions: *id242
+- dimensions: *id245
   name: ch.bafu.wrz-wildruhezonen_portal_20140107_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20140107_cache]
   title: Wildruhezonen (20140107, source)
-- dimensions: &id243
+- dimensions: &id246
     Time:
       default: '20131118'
       values: ['20131118']
   name: ch.bafu.wrz-wildruhezonen_portal_20131118
   sources: [ch.bafu.wrz-wildruhezonen_portal_20131118_cache_out]
   title: Wildruhezonen (20131118)
-- dimensions: *id243
+- dimensions: *id246
   name: ch.bafu.wrz-wildruhezonen_portal_20131118_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20131118_cache]
   title: Wildruhezonen (20131118, source)
-- dimensions: &id244
+- dimensions: &id247
     Time:
       default: '20130111'
       values: ['20130111']
   name: ch.bafu.wrz-wildruhezonen_portal_20130111
   sources: [ch.bafu.wrz-wildruhezonen_portal_20130111_cache_out]
   title: Wildruhezonen (20130111)
-- dimensions: *id244
+- dimensions: *id247
   name: ch.bafu.wrz-wildruhezonen_portal_20130111_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20130111_cache]
   title: Wildruhezonen (20130111, source)
-- dimensions: &id245
+- dimensions: &id248
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.bag.zecken-fsme-faelle_20141231
   sources: [ch.bag.zecken-fsme-faelle_20141231_cache_out]
   title: "FSME - Lokale H\xE4ufungen (20141231)"
-- dimensions: *id245
+- dimensions: *id248
   name: ch.bag.zecken-fsme-faelle
   sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
   title: "FSME - Lokale H\xE4ufungen ('current')"
-- dimensions: *id245
+- dimensions: *id248
   name: ch.bag.zecken-fsme-faelle_20141231_source
   sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
   title: "FSME - Lokale H\xE4ufungen (20141231, source)"
-- dimensions: &id246
+- dimensions: &id249
     Time:
       default: '20140220'
       values: ['20140220']
   name: ch.bag.zecken-fsme-faelle_20140220
   sources: [ch.bag.zecken-fsme-faelle_20140220_cache_out]
   title: "FSME - Lokale H\xE4ufungen (20140220)"
-- dimensions: *id246
+- dimensions: *id249
   name: ch.bag.zecken-fsme-faelle_20140220_source
   sources: [ch.bag.zecken-fsme-faelle_20140220_cache]
   title: "FSME - Lokale H\xE4ufungen (20140220, source)"
-- dimensions: &id247
+- dimensions: &id250
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.bag.zecken-fsme-faelle_20121231
   sources: [ch.bag.zecken-fsme-faelle_20121231_cache_out]
   title: "FSME - Lokale H\xE4ufungen (20121231)"
-- dimensions: *id247
+- dimensions: *id250
   name: ch.bag.zecken-fsme-faelle_20121231_source
   sources: [ch.bag.zecken-fsme-faelle_20121231_cache]
   title: "FSME - Lokale H\xE4ufungen (20121231, source)"
-- dimensions: &id248
+- dimensions: &id251
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.bag.zecken-fsme-impfung_20141231
   sources: [ch.bag.zecken-fsme-impfung_20141231_cache_out]
   title: FSME - Impfempfehlung (20141231)
-- dimensions: *id248
+- dimensions: *id251
   name: ch.bag.zecken-fsme-impfung
   sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
   title: FSME - Impfempfehlung ('current')
-- dimensions: *id248
+- dimensions: *id251
   name: ch.bag.zecken-fsme-impfung_20141231_source
   sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
   title: FSME - Impfempfehlung (20141231, source)
-- dimensions: &id249
+- dimensions: &id252
     Time:
       default: '20140220'
       values: ['20140220']
   name: ch.bag.zecken-fsme-impfung_20140220
   sources: [ch.bag.zecken-fsme-impfung_20140220_cache_out]
   title: FSME - Impfempfehlung (20140220)
-- dimensions: *id249
+- dimensions: *id252
   name: ch.bag.zecken-fsme-impfung_20140220_source
   sources: [ch.bag.zecken-fsme-impfung_20140220_cache]
   title: FSME - Impfempfehlung (20140220, source)
-- dimensions: &id250
+- dimensions: &id253
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.bag.zecken-fsme-impfung_20121231
   sources: [ch.bag.zecken-fsme-impfung_20121231_cache_out]
   title: FSME - Impfempfehlung (20121231)
-- dimensions: *id250
+- dimensions: *id253
   name: ch.bag.zecken-fsme-impfung_20121231_source
   sources: [ch.bag.zecken-fsme-impfung_20121231_cache]
   title: FSME - Impfempfehlung (20121231, source)
-- dimensions: &id251
+- dimensions: &id254
     Time:
       default: '20110613'
       values: ['20110613']
   name: ch.bag.zecken-lyme_20110613
   sources: [ch.bag.zecken-lyme_20110613_cache_out]
   title: Borreliose Risikogebiete (20110613)
-- dimensions: *id251
+- dimensions: *id254
   name: ch.bag.zecken-lyme
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete ('current')
-- dimensions: *id251
+- dimensions: *id254
   name: ch.bag.zecken-lyme_20110613_source
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete (20110613, source)
-- dimensions: &id252
+- dimensions: &id255
     Time:
       default: '20150511'
       values: ['20150511']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache_out]
   title: Bundesinventar ISOS (20150511)
-- dimensions: *id252
+- dimensions: *id255
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache]
   title: Bundesinventar ISOS ('current')
-- dimensions: *id252
+- dimensions: *id255
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache]
   title: Bundesinventar ISOS (20150511, source)
-- dimensions: &id253
+- dimensions: &id256
     Time:
       default: '20140801'
       values: ['20140801']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache_out]
   title: Bundesinventar ISOS (20140801)
-- dimensions: *id253
+- dimensions: *id256
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20140801_cache]
   title: Bundesinventar ISOS (20140801, source)
-- dimensions: &id254
+- dimensions: &id257
     Time:
       default: '20131113'
       values: ['20131113']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache_out]
   title: Bundesinventar ISOS (20131113)
-- dimensions: *id254
+- dimensions: *id257
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20131113_cache]
   title: Bundesinventar ISOS (20131113, source)
-- dimensions: &id255
+- dimensions: &id258
     Time:
       default: '20121218'
       values: ['20121218']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache_out]
   title: Bundesinventar ISOS (20121218)
-- dimensions: *id255
+- dimensions: *id258
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20121218_cache]
   title: Bundesinventar ISOS (20121218, source)
-- dimensions: &id256
+- dimensions: &id259
     Time:
       default: '20120510'
       values: ['20120510']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache_out]
   title: Bundesinventar ISOS (20120510)
-- dimensions: *id256
+- dimensions: *id259
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20120510_cache]
   title: Bundesinventar ISOS (20120510, source)
-- dimensions: &id257
+- dimensions: &id260
     Time:
       default: '20110915'
       values: ['20110915']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache_out]
   title: Bundesinventar ISOS (20110915)
-- dimensions: *id257
+- dimensions: *id260
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20110915_cache]
   title: Bundesinventar ISOS (20110915, source)
-- dimensions: &id258
+- dimensions: &id261
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.anbieter-eigenes_festnetz_20150521
+  sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_cache_out]
+  title: Anzahl Leitungsanbieter (20150521)
+- dimensions: *id261
+  name: ch.bakom.anbieter-eigenes_festnetz
+  sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_cache]
+  title: Anzahl Leitungsanbieter ('current')
+- dimensions: *id261
+  name: ch.bakom.anbieter-eigenes_festnetz_20150521_source
+  sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_cache]
+  title: Anzahl Leitungsanbieter (20150521, source)
+- dimensions: &id262
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anbieter-eigenes_festnetz_20141120
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141120_cache_out]
   title: Anzahl Leitungsanbieter (20141120)
-- dimensions: *id258
-  name: ch.bakom.anbieter-eigenes_festnetz
-  sources: [ch.bakom.anbieter-eigenes_festnetz_20141120_cache]
-  title: Anzahl Leitungsanbieter ('current')
-- dimensions: *id258
+- dimensions: *id262
   name: ch.bakom.anbieter-eigenes_festnetz_20141120_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141120_cache]
   title: Anzahl Leitungsanbieter (20141120, source)
-- dimensions: &id259
+- dimensions: &id263
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anbieter-eigenes_festnetz_20141021
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache_out]
   title: Anzahl Leitungsanbieter (20141021)
-- dimensions: *id259
+- dimensions: *id263
   name: ch.bakom.anbieter-eigenes_festnetz_20141021_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20141021_cache]
   title: Anzahl Leitungsanbieter (20141021, source)
-- dimensions: &id260
+- dimensions: &id264
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anbieter-eigenes_festnetz_20140625
   sources: [ch.bakom.anbieter-eigenes_festnetz_20140625_cache_out]
   title: Anzahl Leitungsanbieter (20140625)
-- dimensions: *id260
+- dimensions: *id264
   name: ch.bakom.anbieter-eigenes_festnetz_20140625_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20140625_cache]
   title: Anzahl Leitungsanbieter (20140625, source)
-- dimensions: &id261
+- dimensions: &id265
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anbieter-eigenes_festnetz_20131212
   sources: [ch.bakom.anbieter-eigenes_festnetz_20131212_cache_out]
   title: Anzahl Leitungsanbieter (20131212)
-- dimensions: *id261
+- dimensions: *id265
   name: ch.bakom.anbieter-eigenes_festnetz_20131212_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20131212_cache]
   title: Anzahl Leitungsanbieter (20131212, source)
-- dimensions: &id262
+- dimensions: &id266
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anbieter-eigenes_festnetz_20130901
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130901_cache_out]
   title: Anzahl Leitungsanbieter (20130901)
-- dimensions: *id262
+- dimensions: *id266
   name: ch.bakom.anbieter-eigenes_festnetz_20130901_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130901_cache]
   title: Anzahl Leitungsanbieter (20130901, source)
-- dimensions: &id263
+- dimensions: &id267
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anbieter-eigenes_festnetz_20130601
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130601_cache_out]
   title: Anzahl Leitungsanbieter (20130601)
-- dimensions: *id263
+- dimensions: *id267
   name: ch.bakom.anbieter-eigenes_festnetz_20130601_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20130601_cache]
   title: Anzahl Leitungsanbieter (20130601, source)
-- dimensions: &id264
+- dimensions: &id268
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anbieter-eigenes_festnetz_20121222
   sources: [ch.bakom.anbieter-eigenes_festnetz_20121222_cache_out]
   title: Anzahl Leitungsanbieter (20121222)
-- dimensions: *id264
+- dimensions: *id268
   name: ch.bakom.anbieter-eigenes_festnetz_20121222_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20121222_cache]
   title: Anzahl Leitungsanbieter (20121222, source)
-- dimensions: &id265
+- dimensions: &id269
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.anschlussart-glasfaser_20150521
+  sources: [ch.bakom.anschlussart-glasfaser_20150521_cache_out]
+  title: Glasfaser (20150521)
+- dimensions: *id269
+  name: ch.bakom.anschlussart-glasfaser
+  sources: [ch.bakom.anschlussart-glasfaser_20150521_cache]
+  title: Glasfaser ('current')
+- dimensions: *id269
+  name: ch.bakom.anschlussart-glasfaser_20150521_source
+  sources: [ch.bakom.anschlussart-glasfaser_20150521_cache]
+  title: Glasfaser (20150521, source)
+- dimensions: &id270
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anschlussart-glasfaser_20141120
   sources: [ch.bakom.anschlussart-glasfaser_20141120_cache_out]
   title: Glasfaser (20141120)
-- dimensions: *id265
-  name: ch.bakom.anschlussart-glasfaser
-  sources: [ch.bakom.anschlussart-glasfaser_20141120_cache]
-  title: Glasfaser ('current')
-- dimensions: *id265
+- dimensions: *id270
   name: ch.bakom.anschlussart-glasfaser_20141120_source
   sources: [ch.bakom.anschlussart-glasfaser_20141120_cache]
   title: Glasfaser (20141120, source)
-- dimensions: &id266
+- dimensions: &id271
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-glasfaser_20141021
   sources: [ch.bakom.anschlussart-glasfaser_20141021_cache_out]
   title: Glasfaser (20141021)
-- dimensions: *id266
+- dimensions: *id271
   name: ch.bakom.anschlussart-glasfaser_20141021_source
   sources: [ch.bakom.anschlussart-glasfaser_20141021_cache]
   title: Glasfaser (20141021, source)
-- dimensions: &id267
+- dimensions: &id272
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-glasfaser_20140625
   sources: [ch.bakom.anschlussart-glasfaser_20140625_cache_out]
   title: Glasfaser (20140625)
-- dimensions: *id267
+- dimensions: *id272
   name: ch.bakom.anschlussart-glasfaser_20140625_source
   sources: [ch.bakom.anschlussart-glasfaser_20140625_cache]
   title: Glasfaser (20140625, source)
-- dimensions: &id268
+- dimensions: &id273
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-glasfaser_20131212
   sources: [ch.bakom.anschlussart-glasfaser_20131212_cache_out]
   title: Glasfaser (20131212)
-- dimensions: *id268
+- dimensions: *id273
   name: ch.bakom.anschlussart-glasfaser_20131212_source
   sources: [ch.bakom.anschlussart-glasfaser_20131212_cache]
   title: Glasfaser (20131212, source)
-- dimensions: &id269
+- dimensions: &id274
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-glasfaser_20130901
   sources: [ch.bakom.anschlussart-glasfaser_20130901_cache_out]
   title: Glasfaser (20130901)
-- dimensions: *id269
+- dimensions: *id274
   name: ch.bakom.anschlussart-glasfaser_20130901_source
   sources: [ch.bakom.anschlussart-glasfaser_20130901_cache]
   title: Glasfaser (20130901, source)
-- dimensions: &id270
+- dimensions: &id275
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-glasfaser_20130601
   sources: [ch.bakom.anschlussart-glasfaser_20130601_cache_out]
   title: Glasfaser (20130601)
-- dimensions: *id270
+- dimensions: *id275
   name: ch.bakom.anschlussart-glasfaser_20130601_source
   sources: [ch.bakom.anschlussart-glasfaser_20130601_cache]
   title: Glasfaser (20130601, source)
-- dimensions: &id271
+- dimensions: &id276
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-glasfaser_20121222
   sources: [ch.bakom.anschlussart-glasfaser_20121222_cache_out]
   title: Glasfaser (20121222)
-- dimensions: *id271
+- dimensions: *id276
   name: ch.bakom.anschlussart-glasfaser_20121222_source
   sources: [ch.bakom.anschlussart-glasfaser_20121222_cache]
   title: Glasfaser (20121222, source)
-- dimensions: &id272
+- dimensions: &id277
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.anschlussart-koaxialkabel_20150521
+  sources: [ch.bakom.anschlussart-koaxialkabel_20150521_cache_out]
+  title: Koaxial-Kabel (20150521)
+- dimensions: *id277
+  name: ch.bakom.anschlussart-koaxialkabel
+  sources: [ch.bakom.anschlussart-koaxialkabel_20150521_cache]
+  title: Koaxial-Kabel ('current')
+- dimensions: *id277
+  name: ch.bakom.anschlussart-koaxialkabel_20150521_source
+  sources: [ch.bakom.anschlussart-koaxialkabel_20150521_cache]
+  title: Koaxial-Kabel (20150521, source)
+- dimensions: &id278
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anschlussart-koaxialkabel_20141120
   sources: [ch.bakom.anschlussart-koaxialkabel_20141120_cache_out]
   title: Koaxial-Kabel (20141120)
-- dimensions: *id272
-  name: ch.bakom.anschlussart-koaxialkabel
-  sources: [ch.bakom.anschlussart-koaxialkabel_20141120_cache]
-  title: Koaxial-Kabel ('current')
-- dimensions: *id272
+- dimensions: *id278
   name: ch.bakom.anschlussart-koaxialkabel_20141120_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20141120_cache]
   title: Koaxial-Kabel (20141120, source)
-- dimensions: &id273
+- dimensions: &id279
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-koaxialkabel_20141021
   sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache_out]
   title: Koaxial-Kabel (20141021)
-- dimensions: *id273
+- dimensions: *id279
   name: ch.bakom.anschlussart-koaxialkabel_20141021_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20141021_cache]
   title: Koaxial-Kabel (20141021, source)
-- dimensions: &id274
+- dimensions: &id280
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-koaxialkabel_20140625
   sources: [ch.bakom.anschlussart-koaxialkabel_20140625_cache_out]
   title: Koaxial-Kabel (20140625)
-- dimensions: *id274
+- dimensions: *id280
   name: ch.bakom.anschlussart-koaxialkabel_20140625_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20140625_cache]
   title: Koaxial-Kabel (20140625, source)
-- dimensions: &id275
+- dimensions: &id281
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-koaxialkabel_20131212
   sources: [ch.bakom.anschlussart-koaxialkabel_20131212_cache_out]
   title: Koaxial-Kabel (20131212)
-- dimensions: *id275
+- dimensions: *id281
   name: ch.bakom.anschlussart-koaxialkabel_20131212_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20131212_cache]
   title: Koaxial-Kabel (20131212, source)
-- dimensions: &id276
+- dimensions: &id282
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-koaxialkabel_20130901
   sources: [ch.bakom.anschlussart-koaxialkabel_20130901_cache_out]
   title: Koaxial-Kabel (20130901)
-- dimensions: *id276
+- dimensions: *id282
   name: ch.bakom.anschlussart-koaxialkabel_20130901_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20130901_cache]
   title: Koaxial-Kabel (20130901, source)
-- dimensions: &id277
+- dimensions: &id283
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-koaxialkabel_20130601
   sources: [ch.bakom.anschlussart-koaxialkabel_20130601_cache_out]
   title: Koaxial-Kabel (20130601)
-- dimensions: *id277
+- dimensions: *id283
   name: ch.bakom.anschlussart-koaxialkabel_20130601_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20130601_cache]
   title: Koaxial-Kabel (20130601, source)
-- dimensions: &id278
+- dimensions: &id284
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-koaxialkabel_20121222
   sources: [ch.bakom.anschlussart-koaxialkabel_20121222_cache_out]
   title: Koaxial-Kabel (20121222)
-- dimensions: *id278
+- dimensions: *id284
   name: ch.bakom.anschlussart-koaxialkabel_20121222_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20121222_cache]
   title: Koaxial-Kabel (20121222, source)
-- dimensions: &id279
+- dimensions: &id285
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.anschlussart-kupferdraht_20150521
+  sources: [ch.bakom.anschlussart-kupferdraht_20150521_cache_out]
+  title: Kupfer-Draht (20150521)
+- dimensions: *id285
+  name: ch.bakom.anschlussart-kupferdraht
+  sources: [ch.bakom.anschlussart-kupferdraht_20150521_cache]
+  title: Kupfer-Draht ('current')
+- dimensions: *id285
+  name: ch.bakom.anschlussart-kupferdraht_20150521_source
+  sources: [ch.bakom.anschlussart-kupferdraht_20150521_cache]
+  title: Kupfer-Draht (20150521, source)
+- dimensions: &id286
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.anschlussart-kupferdraht_20141120
   sources: [ch.bakom.anschlussart-kupferdraht_20141120_cache_out]
   title: Kupfer-Draht (20141120)
-- dimensions: *id279
-  name: ch.bakom.anschlussart-kupferdraht
-  sources: [ch.bakom.anschlussart-kupferdraht_20141120_cache]
-  title: Kupfer-Draht ('current')
-- dimensions: *id279
+- dimensions: *id286
   name: ch.bakom.anschlussart-kupferdraht_20141120_source
   sources: [ch.bakom.anschlussart-kupferdraht_20141120_cache]
   title: Kupfer-Draht (20141120, source)
-- dimensions: &id280
+- dimensions: &id287
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.anschlussart-kupferdraht_20141021
   sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache_out]
   title: Kupfer-Draht (20141021)
-- dimensions: *id280
+- dimensions: *id287
   name: ch.bakom.anschlussart-kupferdraht_20141021_source
   sources: [ch.bakom.anschlussart-kupferdraht_20141021_cache]
   title: Kupfer-Draht (20141021, source)
-- dimensions: &id281
+- dimensions: &id288
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.anschlussart-kupferdraht_20140625
   sources: [ch.bakom.anschlussart-kupferdraht_20140625_cache_out]
   title: Kupfer-Draht (20140625)
-- dimensions: *id281
+- dimensions: *id288
   name: ch.bakom.anschlussart-kupferdraht_20140625_source
   sources: [ch.bakom.anschlussart-kupferdraht_20140625_cache]
   title: Kupfer-Draht (20140625, source)
-- dimensions: &id282
+- dimensions: &id289
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.anschlussart-kupferdraht_20131212
   sources: [ch.bakom.anschlussart-kupferdraht_20131212_cache_out]
   title: Kupfer-Draht (20131212)
-- dimensions: *id282
+- dimensions: *id289
   name: ch.bakom.anschlussart-kupferdraht_20131212_source
   sources: [ch.bakom.anschlussart-kupferdraht_20131212_cache]
   title: Kupfer-Draht (20131212, source)
-- dimensions: &id283
+- dimensions: &id290
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.anschlussart-kupferdraht_20130901
   sources: [ch.bakom.anschlussart-kupferdraht_20130901_cache_out]
   title: Kupfer-Draht (20130901)
-- dimensions: *id283
+- dimensions: *id290
   name: ch.bakom.anschlussart-kupferdraht_20130901_source
   sources: [ch.bakom.anschlussart-kupferdraht_20130901_cache]
   title: Kupfer-Draht (20130901, source)
-- dimensions: &id284
+- dimensions: &id291
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.anschlussart-kupferdraht_20130601
   sources: [ch.bakom.anschlussart-kupferdraht_20130601_cache_out]
   title: Kupfer-Draht (20130601)
-- dimensions: *id284
+- dimensions: *id291
   name: ch.bakom.anschlussart-kupferdraht_20130601_source
   sources: [ch.bakom.anschlussart-kupferdraht_20130601_cache]
   title: Kupfer-Draht (20130601, source)
-- dimensions: &id285
+- dimensions: &id292
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.anschlussart-kupferdraht_20121222
   sources: [ch.bakom.anschlussart-kupferdraht_20121222_cache_out]
   title: Kupfer-Draht (20121222)
-- dimensions: *id285
+- dimensions: *id292
   name: ch.bakom.anschlussart-kupferdraht_20121222_source
   sources: [ch.bakom.anschlussart-kupferdraht_20121222_cache]
   title: Kupfer-Draht (20121222, source)
-- dimensions: &id286
+- dimensions: &id293
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.downlink1_20150521
+  sources: [ch.bakom.downlink1_20150521_cache_out]
+  title: "Download \u2265 1 Mbit/s (20150521)"
+- dimensions: *id293
+  name: ch.bakom.downlink1
+  sources: [ch.bakom.downlink1_20150521_cache]
+  title: "Download \u2265 1 Mbit/s ('current')"
+- dimensions: *id293
+  name: ch.bakom.downlink1_20150521_source
+  sources: [ch.bakom.downlink1_20150521_cache]
+  title: "Download \u2265 1 Mbit/s (20150521, source)"
+- dimensions: &id294
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink1_20141120
   sources: [ch.bakom.downlink1_20141120_cache_out]
   title: "Download \u2265 1 Mbit/s (20141120)"
-- dimensions: *id286
-  name: ch.bakom.downlink1
-  sources: [ch.bakom.downlink1_20141120_cache]
-  title: "Download \u2265 1 Mbit/s ('current')"
-- dimensions: *id286
+- dimensions: *id294
   name: ch.bakom.downlink1_20141120_source
   sources: [ch.bakom.downlink1_20141120_cache]
   title: "Download \u2265 1 Mbit/s (20141120, source)"
-- dimensions: &id287
+- dimensions: &id295
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink1_20141021
   sources: [ch.bakom.downlink1_20141021_cache_out]
   title: "Download \u2265 1 Mbit/s (20141021)"
-- dimensions: *id287
+- dimensions: *id295
   name: ch.bakom.downlink1_20141021_source
   sources: [ch.bakom.downlink1_20141021_cache]
   title: "Download \u2265 1 Mbit/s (20141021, source)"
-- dimensions: &id288
+- dimensions: &id296
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink1_20140625
   sources: [ch.bakom.downlink1_20140625_cache_out]
   title: "Download \u2265 1 Mbit/s (20140625)"
-- dimensions: *id288
+- dimensions: *id296
   name: ch.bakom.downlink1_20140625_source
   sources: [ch.bakom.downlink1_20140625_cache]
   title: "Download \u2265 1 Mbit/s (20140625, source)"
-- dimensions: &id289
+- dimensions: &id297
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink1_20131212
   sources: [ch.bakom.downlink1_20131212_cache_out]
   title: "Download \u2265 1 Mbit/s (20131212)"
-- dimensions: *id289
+- dimensions: *id297
   name: ch.bakom.downlink1_20131212_source
   sources: [ch.bakom.downlink1_20131212_cache]
   title: "Download \u2265 1 Mbit/s (20131212, source)"
-- dimensions: &id290
+- dimensions: &id298
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink1_20130901
   sources: [ch.bakom.downlink1_20130901_cache_out]
   title: "Download \u2265 1 Mbit/s (20130901)"
-- dimensions: *id290
+- dimensions: *id298
   name: ch.bakom.downlink1_20130901_source
   sources: [ch.bakom.downlink1_20130901_cache]
   title: "Download \u2265 1 Mbit/s (20130901, source)"
-- dimensions: &id291
+- dimensions: &id299
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink1_20130601
   sources: [ch.bakom.downlink1_20130601_cache_out]
   title: "Download \u2265 1 Mbit/s (20130601)"
-- dimensions: *id291
+- dimensions: *id299
   name: ch.bakom.downlink1_20130601_source
   sources: [ch.bakom.downlink1_20130601_cache]
   title: "Download \u2265 1 Mbit/s (20130601, source)"
-- dimensions: &id292
+- dimensions: &id300
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink1_20121222
   sources: [ch.bakom.downlink1_20121222_cache_out]
   title: "Download \u2265 1 Mbit/s (20121222)"
-- dimensions: *id292
+- dimensions: *id300
   name: ch.bakom.downlink1_20121222_source
   sources: [ch.bakom.downlink1_20121222_cache]
   title: "Download \u2265 1 Mbit/s (20121222, source)"
-- dimensions: &id293
+- dimensions: &id301
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.downlink10_20150521
+  sources: [ch.bakom.downlink10_20150521_cache_out]
+  title: "Download \u2265 10 Mbit/s (20150521)"
+- dimensions: *id301
+  name: ch.bakom.downlink10
+  sources: [ch.bakom.downlink10_20150521_cache]
+  title: "Download \u2265 10 Mbit/s ('current')"
+- dimensions: *id301
+  name: ch.bakom.downlink10_20150521_source
+  sources: [ch.bakom.downlink10_20150521_cache]
+  title: "Download \u2265 10 Mbit/s (20150521, source)"
+- dimensions: &id302
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink10_20141120
   sources: [ch.bakom.downlink10_20141120_cache_out]
   title: "Download \u2265 10 Mbit/s (20141120)"
-- dimensions: *id293
-  name: ch.bakom.downlink10
-  sources: [ch.bakom.downlink10_20141120_cache]
-  title: "Download \u2265 10 Mbit/s ('current')"
-- dimensions: *id293
+- dimensions: *id302
   name: ch.bakom.downlink10_20141120_source
   sources: [ch.bakom.downlink10_20141120_cache]
   title: "Download \u2265 10 Mbit/s (20141120, source)"
-- dimensions: &id294
+- dimensions: &id303
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink10_20141021
   sources: [ch.bakom.downlink10_20141021_cache_out]
   title: "Download \u2265 10 Mbit/s (20141021)"
-- dimensions: *id294
+- dimensions: *id303
   name: ch.bakom.downlink10_20141021_source
   sources: [ch.bakom.downlink10_20141021_cache]
   title: "Download \u2265 10 Mbit/s (20141021, source)"
-- dimensions: &id295
+- dimensions: &id304
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink10_20140625
   sources: [ch.bakom.downlink10_20140625_cache_out]
   title: "Download \u2265 10 Mbit/s (20140625)"
-- dimensions: *id295
+- dimensions: *id304
   name: ch.bakom.downlink10_20140625_source
   sources: [ch.bakom.downlink10_20140625_cache]
   title: "Download \u2265 10 Mbit/s (20140625, source)"
-- dimensions: &id296
+- dimensions: &id305
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink10_20131212
   sources: [ch.bakom.downlink10_20131212_cache_out]
   title: "Download \u2265 10 Mbit/s (20131212)"
-- dimensions: *id296
+- dimensions: *id305
   name: ch.bakom.downlink10_20131212_source
   sources: [ch.bakom.downlink10_20131212_cache]
   title: "Download \u2265 10 Mbit/s (20131212, source)"
-- dimensions: &id297
+- dimensions: &id306
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink10_20130901
   sources: [ch.bakom.downlink10_20130901_cache_out]
   title: "Download \u2265 10 Mbit/s (20130901)"
-- dimensions: *id297
+- dimensions: *id306
   name: ch.bakom.downlink10_20130901_source
   sources: [ch.bakom.downlink10_20130901_cache]
   title: "Download \u2265 10 Mbit/s (20130901, source)"
-- dimensions: &id298
+- dimensions: &id307
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink10_20130601
   sources: [ch.bakom.downlink10_20130601_cache_out]
   title: "Download \u2265 10 Mbit/s (20130601)"
-- dimensions: *id298
+- dimensions: *id307
   name: ch.bakom.downlink10_20130601_source
   sources: [ch.bakom.downlink10_20130601_cache]
   title: "Download \u2265 10 Mbit/s (20130601, source)"
-- dimensions: &id299
+- dimensions: &id308
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink10_20121222
   sources: [ch.bakom.downlink10_20121222_cache_out]
   title: "Download \u2265 10 Mbit/s (20121222)"
-- dimensions: *id299
+- dimensions: *id308
   name: ch.bakom.downlink10_20121222_source
   sources: [ch.bakom.downlink10_20121222_cache]
   title: "Download \u2265 10 Mbit/s (20121222, source)"
-- dimensions: &id300
+- dimensions: &id309
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.downlink100_20150521
+  sources: [ch.bakom.downlink100_20150521_cache_out]
+  title: "Download \u2265 100 Mbit/s (20150521)"
+- dimensions: *id309
+  name: ch.bakom.downlink100
+  sources: [ch.bakom.downlink100_20150521_cache]
+  title: "Download \u2265 100 Mbit/s ('current')"
+- dimensions: *id309
+  name: ch.bakom.downlink100_20150521_source
+  sources: [ch.bakom.downlink100_20150521_cache]
+  title: "Download \u2265 100 Mbit/s (20150521, source)"
+- dimensions: &id310
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink100_20141120
   sources: [ch.bakom.downlink100_20141120_cache_out]
   title: "Download \u2265 100 Mbit/s (20141120)"
-- dimensions: *id300
-  name: ch.bakom.downlink100
-  sources: [ch.bakom.downlink100_20141120_cache]
-  title: "Download \u2265 100 Mbit/s ('current')"
-- dimensions: *id300
+- dimensions: *id310
   name: ch.bakom.downlink100_20141120_source
   sources: [ch.bakom.downlink100_20141120_cache]
   title: "Download \u2265 100 Mbit/s (20141120, source)"
-- dimensions: &id301
+- dimensions: &id311
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink100_20141021
   sources: [ch.bakom.downlink100_20141021_cache_out]
   title: "Download \u2265 100 Mbit/s (20141021)"
-- dimensions: *id301
+- dimensions: *id311
   name: ch.bakom.downlink100_20141021_source
   sources: [ch.bakom.downlink100_20141021_cache]
   title: "Download \u2265 100 Mbit/s (20141021, source)"
-- dimensions: &id302
+- dimensions: &id312
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink100_20140625
   sources: [ch.bakom.downlink100_20140625_cache_out]
   title: "Download \u2265 100 Mbit/s (20140625)"
-- dimensions: *id302
+- dimensions: *id312
   name: ch.bakom.downlink100_20140625_source
   sources: [ch.bakom.downlink100_20140625_cache]
   title: "Download \u2265 100 Mbit/s (20140625, source)"
-- dimensions: &id303
+- dimensions: &id313
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink100_20131212
   sources: [ch.bakom.downlink100_20131212_cache_out]
   title: "Download \u2265 100 Mbit/s (20131212)"
-- dimensions: *id303
+- dimensions: *id313
   name: ch.bakom.downlink100_20131212_source
   sources: [ch.bakom.downlink100_20131212_cache]
   title: "Download \u2265 100 Mbit/s (20131212, source)"
-- dimensions: &id304
+- dimensions: &id314
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink100_20130901
   sources: [ch.bakom.downlink100_20130901_cache_out]
   title: "Download \u2265 100 Mbit/s (20130901)"
-- dimensions: *id304
+- dimensions: *id314
   name: ch.bakom.downlink100_20130901_source
   sources: [ch.bakom.downlink100_20130901_cache]
   title: "Download \u2265 100 Mbit/s (20130901, source)"
-- dimensions: &id305
+- dimensions: &id315
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink100_20130601
   sources: [ch.bakom.downlink100_20130601_cache_out]
   title: "Download \u2265 100 Mbit/s (20130601)"
-- dimensions: *id305
+- dimensions: *id315
   name: ch.bakom.downlink100_20130601_source
   sources: [ch.bakom.downlink100_20130601_cache]
   title: "Download \u2265 100 Mbit/s (20130601, source)"
-- dimensions: &id306
+- dimensions: &id316
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink100_20121222
   sources: [ch.bakom.downlink100_20121222_cache_out]
   title: "Download \u2265 100 Mbit/s (20121222)"
-- dimensions: *id306
+- dimensions: *id316
   name: ch.bakom.downlink100_20121222_source
   sources: [ch.bakom.downlink100_20121222_cache]
   title: "Download \u2265 100 Mbit/s (20121222, source)"
-- dimensions: &id307
+- dimensions: &id317
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.downlink2_20150521
+  sources: [ch.bakom.downlink2_20150521_cache_out]
+  title: "Download \u2265 2 Mbit/s (20150521)"
+- dimensions: *id317
+  name: ch.bakom.downlink2
+  sources: [ch.bakom.downlink2_20150521_cache]
+  title: "Download \u2265 2 Mbit/s ('current')"
+- dimensions: *id317
+  name: ch.bakom.downlink2_20150521_source
+  sources: [ch.bakom.downlink2_20150521_cache]
+  title: "Download \u2265 2 Mbit/s (20150521, source)"
+- dimensions: &id318
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink2_20141120
   sources: [ch.bakom.downlink2_20141120_cache_out]
   title: "Download \u2265 2 Mbit/s (20141120)"
-- dimensions: *id307
-  name: ch.bakom.downlink2
-  sources: [ch.bakom.downlink2_20141120_cache]
-  title: "Download \u2265 2 Mbit/s ('current')"
-- dimensions: *id307
+- dimensions: *id318
   name: ch.bakom.downlink2_20141120_source
   sources: [ch.bakom.downlink2_20141120_cache]
   title: "Download \u2265 2 Mbit/s (20141120, source)"
-- dimensions: &id308
+- dimensions: &id319
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink2_20141021
   sources: [ch.bakom.downlink2_20141021_cache_out]
   title: "Download \u2265 2 Mbit/s (20141021)"
-- dimensions: *id308
+- dimensions: *id319
   name: ch.bakom.downlink2_20141021_source
   sources: [ch.bakom.downlink2_20141021_cache]
   title: "Download \u2265 2 Mbit/s (20141021, source)"
-- dimensions: &id309
+- dimensions: &id320
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink2_20140625
   sources: [ch.bakom.downlink2_20140625_cache_out]
   title: "Download \u2265 2 Mbit/s (20140625)"
-- dimensions: *id309
+- dimensions: *id320
   name: ch.bakom.downlink2_20140625_source
   sources: [ch.bakom.downlink2_20140625_cache]
   title: "Download \u2265 2 Mbit/s (20140625, source)"
-- dimensions: &id310
+- dimensions: &id321
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink2_20131212
   sources: [ch.bakom.downlink2_20131212_cache_out]
   title: "Download \u2265 2 Mbit/s (20131212)"
-- dimensions: *id310
+- dimensions: *id321
   name: ch.bakom.downlink2_20131212_source
   sources: [ch.bakom.downlink2_20131212_cache]
   title: "Download \u2265 2 Mbit/s (20131212, source)"
-- dimensions: &id311
+- dimensions: &id322
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink2_20130901
   sources: [ch.bakom.downlink2_20130901_cache_out]
   title: "Download \u2265 2 Mbit/s (20130901)"
-- dimensions: *id311
+- dimensions: *id322
   name: ch.bakom.downlink2_20130901_source
   sources: [ch.bakom.downlink2_20130901_cache]
   title: "Download \u2265 2 Mbit/s (20130901, source)"
-- dimensions: &id312
+- dimensions: &id323
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink2_20130601
   sources: [ch.bakom.downlink2_20130601_cache_out]
   title: "Download \u2265 2 Mbit/s (20130601)"
-- dimensions: *id312
+- dimensions: *id323
   name: ch.bakom.downlink2_20130601_source
   sources: [ch.bakom.downlink2_20130601_cache]
   title: "Download \u2265 2 Mbit/s (20130601, source)"
-- dimensions: &id313
+- dimensions: &id324
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink2_20121222
   sources: [ch.bakom.downlink2_20121222_cache_out]
   title: "Download \u2265 2 Mbit/s (20121222)"
-- dimensions: *id313
+- dimensions: *id324
   name: ch.bakom.downlink2_20121222_source
   sources: [ch.bakom.downlink2_20121222_cache]
   title: "Download \u2265 2 Mbit/s (20121222, source)"
-- dimensions: &id314
+- dimensions: &id325
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.downlink20_20150521
+  sources: [ch.bakom.downlink20_20150521_cache_out]
+  title: "Download \u2265 20 Mbit/s (20150521)"
+- dimensions: *id325
+  name: ch.bakom.downlink20
+  sources: [ch.bakom.downlink20_20150521_cache]
+  title: "Download \u2265 20 Mbit/s ('current')"
+- dimensions: *id325
+  name: ch.bakom.downlink20_20150521_source
+  sources: [ch.bakom.downlink20_20150521_cache]
+  title: "Download \u2265 20 Mbit/s (20150521, source)"
+- dimensions: &id326
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink20_20141120
   sources: [ch.bakom.downlink20_20141120_cache_out]
   title: "Download \u2265 20 Mbit/s (20141120)"
-- dimensions: *id314
-  name: ch.bakom.downlink20
-  sources: [ch.bakom.downlink20_20141120_cache]
-  title: "Download \u2265 20 Mbit/s ('current')"
-- dimensions: *id314
+- dimensions: *id326
   name: ch.bakom.downlink20_20141120_source
   sources: [ch.bakom.downlink20_20141120_cache]
   title: "Download \u2265 20 Mbit/s (20141120, source)"
-- dimensions: &id315
+- dimensions: &id327
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink20_20141021
   sources: [ch.bakom.downlink20_20141021_cache_out]
   title: "Download \u2265 20 Mbit/s (20141021)"
-- dimensions: *id315
+- dimensions: *id327
   name: ch.bakom.downlink20_20141021_source
   sources: [ch.bakom.downlink20_20141021_cache]
   title: "Download \u2265 20 Mbit/s (20141021, source)"
-- dimensions: &id316
+- dimensions: &id328
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink20_20140625
   sources: [ch.bakom.downlink20_20140625_cache_out]
   title: "Download \u2265 20 Mbit/s (20140625)"
-- dimensions: *id316
+- dimensions: *id328
   name: ch.bakom.downlink20_20140625_source
   sources: [ch.bakom.downlink20_20140625_cache]
   title: "Download \u2265 20 Mbit/s (20140625, source)"
-- dimensions: &id317
+- dimensions: &id329
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink20_20131212
   sources: [ch.bakom.downlink20_20131212_cache_out]
   title: "Download \u2265 20 Mbit/s (20131212)"
-- dimensions: *id317
+- dimensions: *id329
   name: ch.bakom.downlink20_20131212_source
   sources: [ch.bakom.downlink20_20131212_cache]
   title: "Download \u2265 20 Mbit/s (20131212, source)"
-- dimensions: &id318
+- dimensions: &id330
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink20_20130901
   sources: [ch.bakom.downlink20_20130901_cache_out]
   title: "Download \u2265 20 Mbit/s (20130901)"
-- dimensions: *id318
+- dimensions: *id330
   name: ch.bakom.downlink20_20130901_source
   sources: [ch.bakom.downlink20_20130901_cache]
   title: "Download \u2265 20 Mbit/s (20130901, source)"
-- dimensions: &id319
+- dimensions: &id331
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink20_20130601
   sources: [ch.bakom.downlink20_20130601_cache_out]
   title: "Download \u2265 20 Mbit/s (20130601)"
-- dimensions: *id319
+- dimensions: *id331
   name: ch.bakom.downlink20_20130601_source
   sources: [ch.bakom.downlink20_20130601_cache]
   title: "Download \u2265 20 Mbit/s (20130601, source)"
-- dimensions: &id320
+- dimensions: &id332
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink20_20121222
   sources: [ch.bakom.downlink20_20121222_cache_out]
   title: "Download \u2265 20 Mbit/s (20121222)"
-- dimensions: *id320
+- dimensions: *id332
   name: ch.bakom.downlink20_20121222_source
   sources: [ch.bakom.downlink20_20121222_cache]
   title: "Download \u2265 20 Mbit/s (20121222, source)"
-- dimensions: &id321
+- dimensions: &id333
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.downlink50_20150521
+  sources: [ch.bakom.downlink50_20150521_cache_out]
+  title: "Download \u2265 50 Mbit/s (20150521)"
+- dimensions: *id333
+  name: ch.bakom.downlink50
+  sources: [ch.bakom.downlink50_20150521_cache]
+  title: "Download \u2265 50 Mbit/s ('current')"
+- dimensions: *id333
+  name: ch.bakom.downlink50_20150521_source
+  sources: [ch.bakom.downlink50_20150521_cache]
+  title: "Download \u2265 50 Mbit/s (20150521, source)"
+- dimensions: &id334
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.downlink50_20141120
   sources: [ch.bakom.downlink50_20141120_cache_out]
   title: "Download \u2265 50 Mbit/s (20141120)"
-- dimensions: *id321
-  name: ch.bakom.downlink50
-  sources: [ch.bakom.downlink50_20141120_cache]
-  title: "Download \u2265 50 Mbit/s ('current')"
-- dimensions: *id321
+- dimensions: *id334
   name: ch.bakom.downlink50_20141120_source
   sources: [ch.bakom.downlink50_20141120_cache]
   title: "Download \u2265 50 Mbit/s (20141120, source)"
-- dimensions: &id322
+- dimensions: &id335
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.downlink50_20141021
   sources: [ch.bakom.downlink50_20141021_cache_out]
   title: "Download \u2265 50 Mbit/s (20141021)"
-- dimensions: *id322
+- dimensions: *id335
   name: ch.bakom.downlink50_20141021_source
   sources: [ch.bakom.downlink50_20141021_cache]
   title: "Download \u2265 50 Mbit/s (20141021, source)"
-- dimensions: &id323
+- dimensions: &id336
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.downlink50_20140625
   sources: [ch.bakom.downlink50_20140625_cache_out]
   title: "Download \u2265 50 Mbit/s (20140625)"
-- dimensions: *id323
+- dimensions: *id336
   name: ch.bakom.downlink50_20140625_source
   sources: [ch.bakom.downlink50_20140625_cache]
   title: "Download \u2265 50 Mbit/s (20140625, source)"
-- dimensions: &id324
+- dimensions: &id337
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.downlink50_20131212
   sources: [ch.bakom.downlink50_20131212_cache_out]
   title: "Download \u2265 50 Mbit/s (20131212)"
-- dimensions: *id324
+- dimensions: *id337
   name: ch.bakom.downlink50_20131212_source
   sources: [ch.bakom.downlink50_20131212_cache]
   title: "Download \u2265 50 Mbit/s (20131212, source)"
-- dimensions: &id325
+- dimensions: &id338
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.downlink50_20130901
   sources: [ch.bakom.downlink50_20130901_cache_out]
   title: "Download \u2265 50 Mbit/s (20130901)"
-- dimensions: *id325
+- dimensions: *id338
   name: ch.bakom.downlink50_20130901_source
   sources: [ch.bakom.downlink50_20130901_cache]
   title: "Download \u2265 50 Mbit/s (20130901, source)"
-- dimensions: &id326
+- dimensions: &id339
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.downlink50_20130601
   sources: [ch.bakom.downlink50_20130601_cache_out]
   title: "Download \u2265 50 Mbit/s (20130601)"
-- dimensions: *id326
+- dimensions: *id339
   name: ch.bakom.downlink50_20130601_source
   sources: [ch.bakom.downlink50_20130601_cache]
   title: "Download \u2265 50 Mbit/s (20130601, source)"
-- dimensions: &id327
+- dimensions: &id340
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.downlink50_20121222
   sources: [ch.bakom.downlink50_20121222_cache_out]
   title: "Download \u2265 50 Mbit/s (20121222)"
-- dimensions: *id327
+- dimensions: *id340
   name: ch.bakom.downlink50_20121222_source
   sources: [ch.bakom.downlink50_20121222_cache]
   title: "Download \u2265 50 Mbit/s (20121222, source)"
-- dimensions: &id328
+- dimensions: &id341
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.uplink1_20150521
+  sources: [ch.bakom.uplink1_20150521_cache_out]
+  title: "Upload \u2265 1 Mbit/s (20150521)"
+- dimensions: *id341
+  name: ch.bakom.uplink1
+  sources: [ch.bakom.uplink1_20150521_cache]
+  title: "Upload \u2265 1 Mbit/s ('current')"
+- dimensions: *id341
+  name: ch.bakom.uplink1_20150521_source
+  sources: [ch.bakom.uplink1_20150521_cache]
+  title: "Upload \u2265 1 Mbit/s (20150521, source)"
+- dimensions: &id342
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink1_20141120
   sources: [ch.bakom.uplink1_20141120_cache_out]
   title: "Upload \u2265 1 Mbit/s (20141120)"
-- dimensions: *id328
-  name: ch.bakom.uplink1
-  sources: [ch.bakom.uplink1_20141120_cache]
-  title: "Upload \u2265 1 Mbit/s ('current')"
-- dimensions: *id328
+- dimensions: *id342
   name: ch.bakom.uplink1_20141120_source
   sources: [ch.bakom.uplink1_20141120_cache]
   title: "Upload \u2265 1 Mbit/s (20141120, source)"
-- dimensions: &id329
+- dimensions: &id343
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink1_20141021
   sources: [ch.bakom.uplink1_20141021_cache_out]
   title: "Upload \u2265 1 Mbit/s (20141021)"
-- dimensions: *id329
+- dimensions: *id343
   name: ch.bakom.uplink1_20141021_source
   sources: [ch.bakom.uplink1_20141021_cache]
   title: "Upload \u2265 1 Mbit/s (20141021, source)"
-- dimensions: &id330
+- dimensions: &id344
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink1_20140625
   sources: [ch.bakom.uplink1_20140625_cache_out]
   title: "Upload \u2265 1 Mbit/s (20140625)"
-- dimensions: *id330
+- dimensions: *id344
   name: ch.bakom.uplink1_20140625_source
   sources: [ch.bakom.uplink1_20140625_cache]
   title: "Upload \u2265 1 Mbit/s (20140625, source)"
-- dimensions: &id331
+- dimensions: &id345
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink1_20131212
   sources: [ch.bakom.uplink1_20131212_cache_out]
   title: "Upload \u2265 1 Mbit/s (20131212)"
-- dimensions: *id331
+- dimensions: *id345
   name: ch.bakom.uplink1_20131212_source
   sources: [ch.bakom.uplink1_20131212_cache]
   title: "Upload \u2265 1 Mbit/s (20131212, source)"
-- dimensions: &id332
+- dimensions: &id346
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink1_20130901
   sources: [ch.bakom.uplink1_20130901_cache_out]
   title: "Upload \u2265 1 Mbit/s (20130901)"
-- dimensions: *id332
+- dimensions: *id346
   name: ch.bakom.uplink1_20130901_source
   sources: [ch.bakom.uplink1_20130901_cache]
   title: "Upload \u2265 1 Mbit/s (20130901, source)"
-- dimensions: &id333
+- dimensions: &id347
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink1_20130601
   sources: [ch.bakom.uplink1_20130601_cache_out]
   title: "Upload \u2265 1 Mbit/s (20130601)"
-- dimensions: *id333
+- dimensions: *id347
   name: ch.bakom.uplink1_20130601_source
   sources: [ch.bakom.uplink1_20130601_cache]
   title: "Upload \u2265 1 Mbit/s (20130601, source)"
-- dimensions: &id334
+- dimensions: &id348
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink1_20121222
   sources: [ch.bakom.uplink1_20121222_cache_out]
   title: "Upload \u2265 1 Mbit/s (20121222)"
-- dimensions: *id334
+- dimensions: *id348
   name: ch.bakom.uplink1_20121222_source
   sources: [ch.bakom.uplink1_20121222_cache]
   title: "Upload \u2265 1 Mbit/s (20121222, source)"
-- dimensions: &id335
+- dimensions: &id349
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.uplink10_20150521
+  sources: [ch.bakom.uplink10_20150521_cache_out]
+  title: "Upload \u2265 10 Mbit/s (20150521)"
+- dimensions: *id349
+  name: ch.bakom.uplink10
+  sources: [ch.bakom.uplink10_20150521_cache]
+  title: "Upload \u2265 10 Mbit/s ('current')"
+- dimensions: *id349
+  name: ch.bakom.uplink10_20150521_source
+  sources: [ch.bakom.uplink10_20150521_cache]
+  title: "Upload \u2265 10 Mbit/s (20150521, source)"
+- dimensions: &id350
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink10_20141120
   sources: [ch.bakom.uplink10_20141120_cache_out]
   title: "Upload \u2265 10 Mbit/s (20141120)"
-- dimensions: *id335
-  name: ch.bakom.uplink10
-  sources: [ch.bakom.uplink10_20141120_cache]
-  title: "Upload \u2265 10 Mbit/s ('current')"
-- dimensions: *id335
+- dimensions: *id350
   name: ch.bakom.uplink10_20141120_source
   sources: [ch.bakom.uplink10_20141120_cache]
   title: "Upload \u2265 10 Mbit/s (20141120, source)"
-- dimensions: &id336
+- dimensions: &id351
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink10_20141021
   sources: [ch.bakom.uplink10_20141021_cache_out]
   title: "Upload \u2265 10 Mbit/s (20141021)"
-- dimensions: *id336
+- dimensions: *id351
   name: ch.bakom.uplink10_20141021_source
   sources: [ch.bakom.uplink10_20141021_cache]
   title: "Upload \u2265 10 Mbit/s (20141021, source)"
-- dimensions: &id337
+- dimensions: &id352
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink10_20140625
   sources: [ch.bakom.uplink10_20140625_cache_out]
   title: "Upload \u2265 10 Mbit/s (20140625)"
-- dimensions: *id337
+- dimensions: *id352
   name: ch.bakom.uplink10_20140625_source
   sources: [ch.bakom.uplink10_20140625_cache]
   title: "Upload \u2265 10 Mbit/s (20140625, source)"
-- dimensions: &id338
+- dimensions: &id353
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink10_20131212
   sources: [ch.bakom.uplink10_20131212_cache_out]
   title: "Upload \u2265 10 Mbit/s (20131212)"
-- dimensions: *id338
+- dimensions: *id353
   name: ch.bakom.uplink10_20131212_source
   sources: [ch.bakom.uplink10_20131212_cache]
   title: "Upload \u2265 10 Mbit/s (20131212, source)"
-- dimensions: &id339
+- dimensions: &id354
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink10_20130901
   sources: [ch.bakom.uplink10_20130901_cache_out]
   title: "Upload \u2265 10 Mbit/s (20130901)"
-- dimensions: *id339
+- dimensions: *id354
   name: ch.bakom.uplink10_20130901_source
   sources: [ch.bakom.uplink10_20130901_cache]
   title: "Upload \u2265 10 Mbit/s (20130901, source)"
-- dimensions: &id340
+- dimensions: &id355
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink10_20130601
   sources: [ch.bakom.uplink10_20130601_cache_out]
   title: "Upload \u2265 10 Mbit/s (20130601)"
-- dimensions: *id340
+- dimensions: *id355
   name: ch.bakom.uplink10_20130601_source
   sources: [ch.bakom.uplink10_20130601_cache]
   title: "Upload \u2265 10 Mbit/s (20130601, source)"
-- dimensions: &id341
+- dimensions: &id356
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink10_20121222
   sources: [ch.bakom.uplink10_20121222_cache_out]
   title: "Upload \u2265 10 Mbit/s (20121222)"
-- dimensions: *id341
+- dimensions: *id356
   name: ch.bakom.uplink10_20121222_source
   sources: [ch.bakom.uplink10_20121222_cache]
   title: "Upload \u2265 10 Mbit/s (20121222, source)"
-- dimensions: &id342
+- dimensions: &id357
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.uplink100_20150521
+  sources: [ch.bakom.uplink100_20150521_cache_out]
+  title: ch.bakom.uplink100 (20150521)
+- dimensions: *id357
+  name: ch.bakom.uplink100
+  sources: [ch.bakom.uplink100_20150521_cache]
+  title: ch.bakom.uplink100 ('current')
+- dimensions: *id357
+  name: ch.bakom.uplink100_20150521_source
+  sources: [ch.bakom.uplink100_20150521_cache]
+  title: ch.bakom.uplink100 (20150521, source)
+- dimensions: &id358
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink100_20141120
   sources: [ch.bakom.uplink100_20141120_cache_out]
   title: ch.bakom.uplink100 (20141120)
-- dimensions: *id342
-  name: ch.bakom.uplink100
-  sources: [ch.bakom.uplink100_20141120_cache]
-  title: ch.bakom.uplink100 ('current')
-- dimensions: *id342
+- dimensions: *id358
   name: ch.bakom.uplink100_20141120_source
   sources: [ch.bakom.uplink100_20141120_cache]
   title: ch.bakom.uplink100 (20141120, source)
-- dimensions: &id343
+- dimensions: &id359
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink100_20141021
   sources: [ch.bakom.uplink100_20141021_cache_out]
   title: ch.bakom.uplink100 (20141021)
-- dimensions: *id343
+- dimensions: *id359
   name: ch.bakom.uplink100_20141021_source
   sources: [ch.bakom.uplink100_20141021_cache]
   title: ch.bakom.uplink100 (20141021, source)
-- dimensions: &id344
+- dimensions: &id360
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink100_20140625
   sources: [ch.bakom.uplink100_20140625_cache_out]
   title: ch.bakom.uplink100 (20140625)
-- dimensions: *id344
+- dimensions: *id360
   name: ch.bakom.uplink100_20140625_source
   sources: [ch.bakom.uplink100_20140625_cache]
   title: ch.bakom.uplink100 (20140625, source)
-- dimensions: &id345
+- dimensions: &id361
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink100_20131212
   sources: [ch.bakom.uplink100_20131212_cache_out]
   title: ch.bakom.uplink100 (20131212)
-- dimensions: *id345
+- dimensions: *id361
   name: ch.bakom.uplink100_20131212_source
   sources: [ch.bakom.uplink100_20131212_cache]
   title: ch.bakom.uplink100 (20131212, source)
-- dimensions: &id346
+- dimensions: &id362
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink100_20130901
   sources: [ch.bakom.uplink100_20130901_cache_out]
   title: ch.bakom.uplink100 (20130901)
-- dimensions: *id346
+- dimensions: *id362
   name: ch.bakom.uplink100_20130901_source
   sources: [ch.bakom.uplink100_20130901_cache]
   title: ch.bakom.uplink100 (20130901, source)
-- dimensions: &id347
+- dimensions: &id363
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink100_20130601
   sources: [ch.bakom.uplink100_20130601_cache_out]
   title: ch.bakom.uplink100 (20130601)
-- dimensions: *id347
+- dimensions: *id363
   name: ch.bakom.uplink100_20130601_source
   sources: [ch.bakom.uplink100_20130601_cache]
   title: ch.bakom.uplink100 (20130601, source)
-- dimensions: &id348
+- dimensions: &id364
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink100_20121222
   sources: [ch.bakom.uplink100_20121222_cache_out]
   title: ch.bakom.uplink100 (20121222)
-- dimensions: *id348
+- dimensions: *id364
   name: ch.bakom.uplink100_20121222_source
   sources: [ch.bakom.uplink100_20121222_cache]
   title: ch.bakom.uplink100 (20121222, source)
-- dimensions: &id349
+- dimensions: &id365
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.uplink2_20150521
+  sources: [ch.bakom.uplink2_20150521_cache_out]
+  title: "Upload \u2265 2 Mbit/s (20150521)"
+- dimensions: *id365
+  name: ch.bakom.uplink2
+  sources: [ch.bakom.uplink2_20150521_cache]
+  title: "Upload \u2265 2 Mbit/s ('current')"
+- dimensions: *id365
+  name: ch.bakom.uplink2_20150521_source
+  sources: [ch.bakom.uplink2_20150521_cache]
+  title: "Upload \u2265 2 Mbit/s (20150521, source)"
+- dimensions: &id366
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink2_20141120
   sources: [ch.bakom.uplink2_20141120_cache_out]
   title: "Upload \u2265 2 Mbit/s (20141120)"
-- dimensions: *id349
-  name: ch.bakom.uplink2
-  sources: [ch.bakom.uplink2_20141120_cache]
-  title: "Upload \u2265 2 Mbit/s ('current')"
-- dimensions: *id349
+- dimensions: *id366
   name: ch.bakom.uplink2_20141120_source
   sources: [ch.bakom.uplink2_20141120_cache]
   title: "Upload \u2265 2 Mbit/s (20141120, source)"
-- dimensions: &id350
+- dimensions: &id367
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink2_20141021
   sources: [ch.bakom.uplink2_20141021_cache_out]
   title: "Upload \u2265 2 Mbit/s (20141021)"
-- dimensions: *id350
+- dimensions: *id367
   name: ch.bakom.uplink2_20141021_source
   sources: [ch.bakom.uplink2_20141021_cache]
   title: "Upload \u2265 2 Mbit/s (20141021, source)"
-- dimensions: &id351
+- dimensions: &id368
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink2_20140625
   sources: [ch.bakom.uplink2_20140625_cache_out]
   title: "Upload \u2265 2 Mbit/s (20140625)"
-- dimensions: *id351
+- dimensions: *id368
   name: ch.bakom.uplink2_20140625_source
   sources: [ch.bakom.uplink2_20140625_cache]
   title: "Upload \u2265 2 Mbit/s (20140625, source)"
-- dimensions: &id352
+- dimensions: &id369
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink2_20131212
   sources: [ch.bakom.uplink2_20131212_cache_out]
   title: "Upload \u2265 2 Mbit/s (20131212)"
-- dimensions: *id352
+- dimensions: *id369
   name: ch.bakom.uplink2_20131212_source
   sources: [ch.bakom.uplink2_20131212_cache]
   title: "Upload \u2265 2 Mbit/s (20131212, source)"
-- dimensions: &id353
+- dimensions: &id370
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink2_20130901
   sources: [ch.bakom.uplink2_20130901_cache_out]
   title: "Upload \u2265 2 Mbit/s (20130901)"
-- dimensions: *id353
+- dimensions: *id370
   name: ch.bakom.uplink2_20130901_source
   sources: [ch.bakom.uplink2_20130901_cache]
   title: "Upload \u2265 2 Mbit/s (20130901, source)"
-- dimensions: &id354
+- dimensions: &id371
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink2_20130601
   sources: [ch.bakom.uplink2_20130601_cache_out]
   title: "Upload \u2265 2 Mbit/s (20130601)"
-- dimensions: *id354
+- dimensions: *id371
   name: ch.bakom.uplink2_20130601_source
   sources: [ch.bakom.uplink2_20130601_cache]
   title: "Upload \u2265 2 Mbit/s (20130601, source)"
-- dimensions: &id355
+- dimensions: &id372
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink2_20121222
   sources: [ch.bakom.uplink2_20121222_cache_out]
   title: "Upload \u2265 2 Mbit/s (20121222)"
-- dimensions: *id355
+- dimensions: *id372
   name: ch.bakom.uplink2_20121222_source
   sources: [ch.bakom.uplink2_20121222_cache]
   title: "Upload \u2265 2 Mbit/s (20121222, source)"
-- dimensions: &id356
+- dimensions: &id373
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.uplink20_20150521
+  sources: [ch.bakom.uplink20_20150521_cache_out]
+  title: "Upload \u2265 20 Mbit/s (20150521)"
+- dimensions: *id373
+  name: ch.bakom.uplink20
+  sources: [ch.bakom.uplink20_20150521_cache]
+  title: "Upload \u2265 20 Mbit/s ('current')"
+- dimensions: *id373
+  name: ch.bakom.uplink20_20150521_source
+  sources: [ch.bakom.uplink20_20150521_cache]
+  title: "Upload \u2265 20 Mbit/s (20150521, source)"
+- dimensions: &id374
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink20_20141120
   sources: [ch.bakom.uplink20_20141120_cache_out]
   title: "Upload \u2265 20 Mbit/s (20141120)"
-- dimensions: *id356
-  name: ch.bakom.uplink20
-  sources: [ch.bakom.uplink20_20141120_cache]
-  title: "Upload \u2265 20 Mbit/s ('current')"
-- dimensions: *id356
+- dimensions: *id374
   name: ch.bakom.uplink20_20141120_source
   sources: [ch.bakom.uplink20_20141120_cache]
   title: "Upload \u2265 20 Mbit/s (20141120, source)"
-- dimensions: &id357
+- dimensions: &id375
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink20_20141021
   sources: [ch.bakom.uplink20_20141021_cache_out]
   title: "Upload \u2265 20 Mbit/s (20141021)"
-- dimensions: *id357
+- dimensions: *id375
   name: ch.bakom.uplink20_20141021_source
   sources: [ch.bakom.uplink20_20141021_cache]
   title: "Upload \u2265 20 Mbit/s (20141021, source)"
-- dimensions: &id358
+- dimensions: &id376
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink20_20140625
   sources: [ch.bakom.uplink20_20140625_cache_out]
   title: "Upload \u2265 20 Mbit/s (20140625)"
-- dimensions: *id358
+- dimensions: *id376
   name: ch.bakom.uplink20_20140625_source
   sources: [ch.bakom.uplink20_20140625_cache]
   title: "Upload \u2265 20 Mbit/s (20140625, source)"
-- dimensions: &id359
+- dimensions: &id377
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink20_20131212
   sources: [ch.bakom.uplink20_20131212_cache_out]
   title: "Upload \u2265 20 Mbit/s (20131212)"
-- dimensions: *id359
+- dimensions: *id377
   name: ch.bakom.uplink20_20131212_source
   sources: [ch.bakom.uplink20_20131212_cache]
   title: "Upload \u2265 20 Mbit/s (20131212, source)"
-- dimensions: &id360
+- dimensions: &id378
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink20_20130901
   sources: [ch.bakom.uplink20_20130901_cache_out]
   title: "Upload \u2265 20 Mbit/s (20130901)"
-- dimensions: *id360
+- dimensions: *id378
   name: ch.bakom.uplink20_20130901_source
   sources: [ch.bakom.uplink20_20130901_cache]
   title: "Upload \u2265 20 Mbit/s (20130901, source)"
-- dimensions: &id361
+- dimensions: &id379
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink20_20130601
   sources: [ch.bakom.uplink20_20130601_cache_out]
   title: "Upload \u2265 20 Mbit/s (20130601)"
-- dimensions: *id361
+- dimensions: *id379
   name: ch.bakom.uplink20_20130601_source
   sources: [ch.bakom.uplink20_20130601_cache]
   title: "Upload \u2265 20 Mbit/s (20130601, source)"
-- dimensions: &id362
+- dimensions: &id380
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink20_20121222
   sources: [ch.bakom.uplink20_20121222_cache_out]
   title: "Upload \u2265 20 Mbit/s (20121222)"
-- dimensions: *id362
+- dimensions: *id380
   name: ch.bakom.uplink20_20121222_source
   sources: [ch.bakom.uplink20_20121222_cache]
   title: "Upload \u2265 20 Mbit/s (20121222, source)"
-- dimensions: &id363
+- dimensions: &id381
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.uplink50_20150521
+  sources: [ch.bakom.uplink50_20150521_cache_out]
+  title: "Upload \u2265 50 Mbit/s (20150521)"
+- dimensions: *id381
+  name: ch.bakom.uplink50
+  sources: [ch.bakom.uplink50_20150521_cache]
+  title: "Upload \u2265 50 Mbit/s ('current')"
+- dimensions: *id381
+  name: ch.bakom.uplink50_20150521_source
+  sources: [ch.bakom.uplink50_20150521_cache]
+  title: "Upload \u2265 50 Mbit/s (20150521, source)"
+- dimensions: &id382
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.uplink50_20141120
   sources: [ch.bakom.uplink50_20141120_cache_out]
   title: "Upload \u2265 50 Mbit/s (20141120)"
-- dimensions: *id363
-  name: ch.bakom.uplink50
-  sources: [ch.bakom.uplink50_20141120_cache]
-  title: "Upload \u2265 50 Mbit/s ('current')"
-- dimensions: *id363
+- dimensions: *id382
   name: ch.bakom.uplink50_20141120_source
   sources: [ch.bakom.uplink50_20141120_cache]
   title: "Upload \u2265 50 Mbit/s (20141120, source)"
-- dimensions: &id364
+- dimensions: &id383
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.uplink50_20141021
   sources: [ch.bakom.uplink50_20141021_cache_out]
   title: "Upload \u2265 50 Mbit/s (20141021)"
-- dimensions: *id364
+- dimensions: *id383
   name: ch.bakom.uplink50_20141021_source
   sources: [ch.bakom.uplink50_20141021_cache]
   title: "Upload \u2265 50 Mbit/s (20141021, source)"
-- dimensions: &id365
+- dimensions: &id384
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.uplink50_20140625
   sources: [ch.bakom.uplink50_20140625_cache_out]
   title: "Upload \u2265 50 Mbit/s (20140625)"
-- dimensions: *id365
+- dimensions: *id384
   name: ch.bakom.uplink50_20140625_source
   sources: [ch.bakom.uplink50_20140625_cache]
   title: "Upload \u2265 50 Mbit/s (20140625, source)"
-- dimensions: &id366
+- dimensions: &id385
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.uplink50_20131212
   sources: [ch.bakom.uplink50_20131212_cache_out]
   title: "Upload \u2265 50 Mbit/s (20131212)"
-- dimensions: *id366
+- dimensions: *id385
   name: ch.bakom.uplink50_20131212_source
   sources: [ch.bakom.uplink50_20131212_cache]
   title: "Upload \u2265 50 Mbit/s (20131212, source)"
-- dimensions: &id367
+- dimensions: &id386
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.uplink50_20130901
   sources: [ch.bakom.uplink50_20130901_cache_out]
   title: "Upload \u2265 50 Mbit/s (20130901)"
-- dimensions: *id367
+- dimensions: *id386
   name: ch.bakom.uplink50_20130901_source
   sources: [ch.bakom.uplink50_20130901_cache]
   title: "Upload \u2265 50 Mbit/s (20130901, source)"
-- dimensions: &id368
+- dimensions: &id387
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.uplink50_20130601
   sources: [ch.bakom.uplink50_20130601_cache_out]
   title: "Upload \u2265 50 Mbit/s (20130601)"
-- dimensions: *id368
+- dimensions: *id387
   name: ch.bakom.uplink50_20130601_source
   sources: [ch.bakom.uplink50_20130601_cache]
   title: "Upload \u2265 50 Mbit/s (20130601, source)"
-- dimensions: &id369
+- dimensions: &id388
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.uplink50_20121222
   sources: [ch.bakom.uplink50_20121222_cache_out]
   title: "Upload \u2265 50 Mbit/s (20121222)"
-- dimensions: *id369
+- dimensions: *id388
   name: ch.bakom.uplink50_20121222_source
   sources: [ch.bakom.uplink50_20121222_cache]
   title: "Upload \u2265 50 Mbit/s (20121222, source)"
-- dimensions: &id370
+- dimensions: &id389
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.verfuegbarkeit-hdtv_20150521
+  sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_cache_out]
+  title: "HDTV-Verf\xFCgbarkeit Festnetz (20150521)"
+- dimensions: *id389
+  name: ch.bakom.verfuegbarkeit-hdtv
+  sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_cache]
+  title: "HDTV-Verf\xFCgbarkeit Festnetz ('current')"
+- dimensions: *id389
+  name: ch.bakom.verfuegbarkeit-hdtv_20150521_source
+  sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_cache]
+  title: "HDTV-Verf\xFCgbarkeit Festnetz (20150521, source)"
+- dimensions: &id390
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.verfuegbarkeit-hdtv_20141120
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141120_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141120)"
-- dimensions: *id370
-  name: ch.bakom.verfuegbarkeit-hdtv
-  sources: [ch.bakom.verfuegbarkeit-hdtv_20141120_cache]
-  title: "HDTV-Verf\xFCgbarkeit Festnetz ('current')"
-- dimensions: *id370
+- dimensions: *id390
   name: ch.bakom.verfuegbarkeit-hdtv_20141120_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141120_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141120, source)"
-- dimensions: &id371
+- dimensions: &id391
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.verfuegbarkeit-hdtv_20141021
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141021)"
-- dimensions: *id371
+- dimensions: *id391
   name: ch.bakom.verfuegbarkeit-hdtv_20141021_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20141021_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20141021, source)"
-- dimensions: &id372
+- dimensions: &id392
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.verfuegbarkeit-hdtv_20140625
   sources: [ch.bakom.verfuegbarkeit-hdtv_20140625_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20140625)"
-- dimensions: *id372
+- dimensions: *id392
   name: ch.bakom.verfuegbarkeit-hdtv_20140625_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20140625_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20140625, source)"
-- dimensions: &id373
+- dimensions: &id393
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.verfuegbarkeit-hdtv_20131212
   sources: [ch.bakom.verfuegbarkeit-hdtv_20131212_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20131212)"
-- dimensions: *id373
+- dimensions: *id393
   name: ch.bakom.verfuegbarkeit-hdtv_20131212_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20131212_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20131212, source)"
-- dimensions: &id374
+- dimensions: &id394
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.verfuegbarkeit-hdtv_20130901
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130901_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130901)"
-- dimensions: *id374
+- dimensions: *id394
   name: ch.bakom.verfuegbarkeit-hdtv_20130901_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130901_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130901, source)"
-- dimensions: &id375
+- dimensions: &id395
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.verfuegbarkeit-hdtv_20130601
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130601_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130601)"
-- dimensions: *id375
+- dimensions: *id395
   name: ch.bakom.verfuegbarkeit-hdtv_20130601_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20130601_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20130601, source)"
-- dimensions: &id376
+- dimensions: &id396
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.verfuegbarkeit-hdtv_20121222
   sources: [ch.bakom.verfuegbarkeit-hdtv_20121222_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20121222)"
-- dimensions: *id376
+- dimensions: *id396
   name: ch.bakom.verfuegbarkeit-hdtv_20121222_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20121222_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20121222, source)"
-- dimensions: &id377
+- dimensions: &id397
+    Time:
+      default: '20150521'
+      values: ['20150521']
+  name: ch.bakom.verfuegbarkeit-tv_20150521
+  sources: [ch.bakom.verfuegbarkeit-tv_20150521_cache_out]
+  title: "TV-Verf\xFCgbarkeit via Festnetz (20150521)"
+- dimensions: *id397
+  name: ch.bakom.verfuegbarkeit-tv
+  sources: [ch.bakom.verfuegbarkeit-tv_20150521_cache]
+  title: "TV-Verf\xFCgbarkeit via Festnetz ('current')"
+- dimensions: *id397
+  name: ch.bakom.verfuegbarkeit-tv_20150521_source
+  sources: [ch.bakom.verfuegbarkeit-tv_20150521_cache]
+  title: "TV-Verf\xFCgbarkeit via Festnetz (20150521, source)"
+- dimensions: &id398
     Time:
       default: '20141120'
       values: ['20141120']
   name: ch.bakom.verfuegbarkeit-tv_20141120
   sources: [ch.bakom.verfuegbarkeit-tv_20141120_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141120)"
-- dimensions: *id377
-  name: ch.bakom.verfuegbarkeit-tv
-  sources: [ch.bakom.verfuegbarkeit-tv_20141120_cache]
-  title: "TV-Verf\xFCgbarkeit via Festnetz ('current')"
-- dimensions: *id377
+- dimensions: *id398
   name: ch.bakom.verfuegbarkeit-tv_20141120_source
   sources: [ch.bakom.verfuegbarkeit-tv_20141120_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141120, source)"
-- dimensions: &id378
+- dimensions: &id399
     Time:
       default: '20141021'
       values: ['20141021']
   name: ch.bakom.verfuegbarkeit-tv_20141021
   sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141021)"
-- dimensions: *id378
+- dimensions: *id399
   name: ch.bakom.verfuegbarkeit-tv_20141021_source
   sources: [ch.bakom.verfuegbarkeit-tv_20141021_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20141021, source)"
-- dimensions: &id379
+- dimensions: &id400
     Time:
       default: '20140625'
       values: ['20140625']
   name: ch.bakom.verfuegbarkeit-tv_20140625
   sources: [ch.bakom.verfuegbarkeit-tv_20140625_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20140625)"
-- dimensions: *id379
+- dimensions: *id400
   name: ch.bakom.verfuegbarkeit-tv_20140625_source
   sources: [ch.bakom.verfuegbarkeit-tv_20140625_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20140625, source)"
-- dimensions: &id380
+- dimensions: &id401
     Time:
       default: '20131212'
       values: ['20131212']
   name: ch.bakom.verfuegbarkeit-tv_20131212
   sources: [ch.bakom.verfuegbarkeit-tv_20131212_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20131212)"
-- dimensions: *id380
+- dimensions: *id401
   name: ch.bakom.verfuegbarkeit-tv_20131212_source
   sources: [ch.bakom.verfuegbarkeit-tv_20131212_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20131212, source)"
-- dimensions: &id381
+- dimensions: &id402
     Time:
       default: '20130901'
       values: ['20130901']
   name: ch.bakom.verfuegbarkeit-tv_20130901
   sources: [ch.bakom.verfuegbarkeit-tv_20130901_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130901)"
-- dimensions: *id381
+- dimensions: *id402
   name: ch.bakom.verfuegbarkeit-tv_20130901_source
   sources: [ch.bakom.verfuegbarkeit-tv_20130901_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130901, source)"
-- dimensions: &id382
+- dimensions: &id403
     Time:
       default: '20130601'
       values: ['20130601']
   name: ch.bakom.verfuegbarkeit-tv_20130601
   sources: [ch.bakom.verfuegbarkeit-tv_20130601_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130601)"
-- dimensions: *id382
+- dimensions: *id403
   name: ch.bakom.verfuegbarkeit-tv_20130601_source
   sources: [ch.bakom.verfuegbarkeit-tv_20130601_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20130601, source)"
-- dimensions: &id383
+- dimensions: &id404
     Time:
       default: '20121222'
       values: ['20121222']
   name: ch.bakom.verfuegbarkeit-tv_20121222
   sources: [ch.bakom.verfuegbarkeit-tv_20121222_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20121222)"
-- dimensions: *id383
+- dimensions: *id404
   name: ch.bakom.verfuegbarkeit-tv_20121222_source
   sources: [ch.bakom.verfuegbarkeit-tv_20121222_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20121222, source)"
-- dimensions: &id384
+- dimensions: &id405
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-tv_20070704
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache_out]
   title: Versorgungsgebiete TV (20070704)
-- dimensions: *id384
+- dimensions: *id405
   name: ch.bakom.versorgungsgebiet-tv
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV ('current')
-- dimensions: *id384
+- dimensions: *id405
   name: ch.bakom.versorgungsgebiet-tv_20070704_source
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV (20070704, source)
-- dimensions: &id385
+- dimensions: &id406
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-ukw_20070704
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache_out]
   title: Versorgungsgebiete Radio (20070704)
-- dimensions: *id385
+- dimensions: *id406
   name: ch.bakom.versorgungsgebiet-ukw
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio ('current')
-- dimensions: *id385
+- dimensions: *id406
   name: ch.bakom.versorgungsgebiet-ukw_20070704_source
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio (20070704, source)
-- dimensions: &id386
+- dimensions: &id407
     Time:
       default: '20120203'
       values: ['20120203']
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache_out]
   title: "UNESCO-Welterbe Kulturst\xE4tten (20120203)"
-- dimensions: *id386
+- dimensions: *id407
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten ('current')"
-- dimensions: *id386
+- dimensions: *id407
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_source
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten (20120203, source)"
-- dimensions: &id387
+- dimensions: &id408
     Time:
       default: '20150305'
       values: ['20150305']
   name: ch.bazl.luftfahrtkarten-icao_20150305
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache_out]
   title: Luftfahrtkarte ICAO (20150305)
-- dimensions: *id387
+- dimensions: *id408
   name: ch.bazl.luftfahrtkarten-icao
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache]
   title: Luftfahrtkarte ICAO ('current')
-- dimensions: *id387
+- dimensions: *id408
   name: ch.bazl.luftfahrtkarten-icao_20150305_source
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache]
   title: Luftfahrtkarte ICAO (20150305, source)
-- dimensions: &id388
+- dimensions: &id409
     Time:
       default: '20140306'
       values: ['20140306']
   name: ch.bazl.luftfahrtkarten-icao_20140306
   sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache_out]
   title: Luftfahrtkarte ICAO (20140306)
-- dimensions: *id388
+- dimensions: *id409
   name: ch.bazl.luftfahrtkarten-icao_20140306_source
   sources: [ch.bazl.luftfahrtkarten-icao_20140306_cache]
   title: Luftfahrtkarte ICAO (20140306, source)
-- dimensions: &id389
+- dimensions: &id410
     Time:
       default: '20130307'
       values: ['20130307']
   name: ch.bazl.luftfahrtkarten-icao_20130307
   sources: [ch.bazl.luftfahrtkarten-icao_20130307_cache_out]
   title: Luftfahrtkarte ICAO (20130307)
-- dimensions: *id389
+- dimensions: *id410
   name: ch.bazl.luftfahrtkarten-icao_20130307_source
   sources: [ch.bazl.luftfahrtkarten-icao_20130307_cache]
   title: Luftfahrtkarte ICAO (20130307, source)
-- dimensions: &id390
+- dimensions: &id411
     Time:
       default: '20120308'
       values: ['20120308']
   name: ch.bazl.luftfahrtkarten-icao_20120308
   sources: [ch.bazl.luftfahrtkarten-icao_20120308_cache_out]
   title: Luftfahrtkarte ICAO (20120308)
-- dimensions: *id390
+- dimensions: *id411
   name: ch.bazl.luftfahrtkarten-icao_20120308_source
   sources: [ch.bazl.luftfahrtkarten-icao_20120308_cache]
   title: Luftfahrtkarte ICAO (20120308, source)
-- dimensions: &id391
+- dimensions: &id412
     Time:
       default: '20110310'
       values: ['20110310']
   name: ch.bazl.luftfahrtkarten-icao_20110310
   sources: [ch.bazl.luftfahrtkarten-icao_20110310_cache_out]
   title: Luftfahrtkarte ICAO (20110310)
-- dimensions: *id391
+- dimensions: *id412
   name: ch.bazl.luftfahrtkarten-icao_20110310_source
   sources: [ch.bazl.luftfahrtkarten-icao_20110310_cache]
   title: Luftfahrtkarte ICAO (20110310, source)
-- dimensions: &id392
+- dimensions: &id413
     Time:
       default: '20130822'
       values: ['20130822']
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache_out]
   title: "Projektierungszonen: Flugh\xE4fen (20130822)"
-- dimensions: *id392
+- dimensions: *id413
   name: ch.bazl.projektierungszonen-flughafenanlagen
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen ('current')"
-- dimensions: *id392
+- dimensions: *id413
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822_source
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen (20130822, source)"
-- dimensions: &id393
+- dimensions: &id414
     Time:
       default: '20150305'
       values: ['20150305']
   name: ch.bazl.segelflugkarte_20150305
   sources: [ch.bazl.segelflugkarte_20150305_cache_out]
   title: Segelflugkarte (20150305)
-- dimensions: *id393
+- dimensions: *id414
   name: ch.bazl.segelflugkarte
   sources: [ch.bazl.segelflugkarte_20150305_cache]
   title: Segelflugkarte ('current')
-- dimensions: *id393
+- dimensions: *id414
   name: ch.bazl.segelflugkarte_20150305_source
   sources: [ch.bazl.segelflugkarte_20150305_cache]
   title: Segelflugkarte (20150305, source)
-- dimensions: &id394
+- dimensions: &id415
     Time:
       default: '20140306'
       values: ['20140306']
   name: ch.bazl.segelflugkarte_20140306
   sources: [ch.bazl.segelflugkarte_20140306_cache_out]
   title: Segelflugkarte (20140306)
-- dimensions: *id394
+- dimensions: *id415
   name: ch.bazl.segelflugkarte_20140306_source
   sources: [ch.bazl.segelflugkarte_20140306_cache]
   title: Segelflugkarte (20140306, source)
-- dimensions: &id395
+- dimensions: &id416
     Time:
       default: '20130307'
       values: ['20130307']
   name: ch.bazl.segelflugkarte_20130307
   sources: [ch.bazl.segelflugkarte_20130307_cache_out]
   title: Segelflugkarte (20130307)
-- dimensions: *id395
+- dimensions: *id416
   name: ch.bazl.segelflugkarte_20130307_source
   sources: [ch.bazl.segelflugkarte_20130307_cache]
   title: Segelflugkarte (20130307, source)
-- dimensions: &id396
+- dimensions: &id417
     Time:
       default: '20120308'
       values: ['20120308']
   name: ch.bazl.segelflugkarte_20120308
   sources: [ch.bazl.segelflugkarte_20120308_cache_out]
   title: Segelflugkarte (20120308)
-- dimensions: *id396
+- dimensions: *id417
   name: ch.bazl.segelflugkarte_20120308_source
   sources: [ch.bazl.segelflugkarte_20120308_cache]
   title: Segelflugkarte (20120308, source)
-- dimensions: &id397
+- dimensions: &id418
     Time:
       default: '20120911'
       values: ['20120911']
   name: ch.bfe.kernkraftwerke_20120911
   sources: [ch.bfe.kernkraftwerke_20120911_cache_out]
   title: Kernkraftwerke (20120911)
-- dimensions: *id397
+- dimensions: *id418
   name: ch.bfe.kernkraftwerke
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke ('current')
-- dimensions: *id397
+- dimensions: *id418
   name: ch.bfe.kernkraftwerke_20120911_source
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke (20120911, source)
-- dimensions: &id398
+- dimensions: &id419
     Time:
       default: '20120531'
       values: ['20120531']
   name: ch.bfe.kleinwasserkraftpotentiale_20120531
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache_out]
   title: Kleinwasserkraftpotentiale (20120531)
-- dimensions: *id398
+- dimensions: *id419
   name: ch.bfe.kleinwasserkraftpotentiale
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale ('current')
-- dimensions: *id398
+- dimensions: *id419
   name: ch.bfe.kleinwasserkraftpotentiale_20120531_source
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale (20120531, source)
-- dimensions: &id399
+- dimensions: &id420
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bfe.windenergieanlagen_20140101
   sources: [ch.bfe.windenergieanlagen_20140101_cache_out]
   title: Windenergieanlagen (20140101)
-- dimensions: *id399
+- dimensions: *id420
   name: ch.bfe.windenergieanlagen
   sources: [ch.bfe.windenergieanlagen_20140101_cache]
   title: Windenergieanlagen ('current')
-- dimensions: *id399
+- dimensions: *id420
   name: ch.bfe.windenergieanlagen_20140101_source
   sources: [ch.bfe.windenergieanlagen_20140101_cache]
   title: Windenergieanlagen (20140101, source)
-- dimensions: &id400
+- dimensions: &id421
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik_20131121
   sources: [ch.bfs.arealstatistik_20131121_cache_out]
   title: Arealstatistik 2004/09 NOAS04 (20131121)
-- dimensions: *id400
+- dimensions: *id421
   name: ch.bfs.arealstatistik
   sources: [ch.bfs.arealstatistik_20131121_cache]
   title: Arealstatistik 2004/09 NOAS04 ('current')
-- dimensions: *id400
+- dimensions: *id421
   name: ch.bfs.arealstatistik_20131121_source
   sources: [ch.bfs.arealstatistik_20131121_cache]
   title: Arealstatistik 2004/09 NOAS04 (20131121, source)
-- dimensions: &id401
+- dimensions: &id422
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-1985_20131121
   sources: [ch.bfs.arealstatistik-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOAS04 (20131121)
-- dimensions: *id401
+- dimensions: *id422
   name: ch.bfs.arealstatistik-1985
   sources: [ch.bfs.arealstatistik-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOAS04 ('current')
-- dimensions: *id401
+- dimensions: *id422
   name: ch.bfs.arealstatistik-1985_20131121_source
   sources: [ch.bfs.arealstatistik-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOAS04 (20131121, source)
-- dimensions: &id402
+- dimensions: &id423
     Time:
       default: '19790101'
       values: ['19790101']
   name: ch.bfs.arealstatistik-1985_19790101
   sources: [ch.bfs.arealstatistik-1985_19790101_cache_out]
   title: Arealstatistik 1979/85 NOAS04 (19790101)
-- dimensions: *id402
+- dimensions: *id423
   name: ch.bfs.arealstatistik-1985_19790101_source
   sources: [ch.bfs.arealstatistik-1985_19790101_cache]
   title: Arealstatistik 1979/85 NOAS04 (19790101, source)
-- dimensions: &id403
+- dimensions: &id424
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-1997_20131121
   sources: [ch.bfs.arealstatistik-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOAS04 (20131121)
-- dimensions: *id403
+- dimensions: *id424
   name: ch.bfs.arealstatistik-1997
   sources: [ch.bfs.arealstatistik-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOAS04 ('current')
-- dimensions: *id403
+- dimensions: *id424
   name: ch.bfs.arealstatistik-1997_20131121_source
   sources: [ch.bfs.arealstatistik-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOAS04 (20131121, source)
-- dimensions: &id404
+- dimensions: &id425
     Time:
       default: '19920101'
       values: ['19920101']
   name: ch.bfs.arealstatistik-1997_19920101
   sources: [ch.bfs.arealstatistik-1997_19920101_cache_out]
   title: Arealstatistik 1992/97 NOAS04 (19920101)
-- dimensions: *id404
+- dimensions: *id425
   name: ch.bfs.arealstatistik-1997_19920101_source
   sources: [ch.bfs.arealstatistik-1997_19920101_cache]
   title: Arealstatistik 1992/97 NOAS04 (19920101, source)
-- dimensions: &id405
+- dimensions: &id426
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache_out]
   title: Arealstatistik 2004/09 NOLC04 (20131121)
-- dimensions: *id405
+- dimensions: *id426
   name: ch.bfs.arealstatistik-bodenbedeckung
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04 ('current')
-- dimensions: *id405
+- dimensions: *id426
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04 (20131121, source)
-- dimensions: &id406
+- dimensions: &id427
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLC04 (20131121)
-- dimensions: *id406
+- dimensions: *id427
   name: ch.bfs.arealstatistik-bodenbedeckung-1985
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04 ('current')
-- dimensions: *id406
+- dimensions: *id427
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04 (20131121, source)
-- dimensions: &id407
+- dimensions: &id428
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLC04 (20131121)
-- dimensions: *id407
+- dimensions: *id428
   name: ch.bfs.arealstatistik-bodenbedeckung-1997
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04 ('current')
-- dimensions: *id407
+- dimensions: *id428
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04 (20131121, source)
-- dimensions: &id408
+- dimensions: &id429
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache_out]
   title: Arealstatistik 2004/09 NOLU04  (20131121)
-- dimensions: *id408
+- dimensions: *id429
   name: ch.bfs.arealstatistik-bodennutzung
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: Arealstatistik 2004/09 NOLU04  ('current')
-- dimensions: *id408
+- dimensions: *id429
   name: ch.bfs.arealstatistik-bodennutzung_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: Arealstatistik 2004/09 NOLU04  (20131121, source)
-- dimensions: &id409
+- dimensions: &id430
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLU04 (20131121)
-- dimensions: *id409
+- dimensions: *id430
   name: ch.bfs.arealstatistik-bodennutzung-1985
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04 ('current')
-- dimensions: *id409
+- dimensions: *id430
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04 (20131121, source)
-- dimensions: &id410
+- dimensions: &id431
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLU04 (20131121)
-- dimensions: *id410
+- dimensions: *id431
   name: ch.bfs.arealstatistik-bodennutzung-1997
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04 ('current')
-- dimensions: *id410
+- dimensions: *id431
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04 (20131121, source)
-- dimensions: &id411
+- dimensions: &id432
     Time:
       default: '20070116'
       values: ['20070116']
   name: ch.bfs.arealstatistik-hintergrund_20070116
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache_out]
   title: Vereinfachte Bodennutzung (20070116)
-- dimensions: *id411
+- dimensions: *id432
   name: ch.bfs.arealstatistik-hintergrund
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
   title: Vereinfachte Bodennutzung ('current')
-- dimensions: *id411
+- dimensions: *id432
   name: ch.bfs.arealstatistik-hintergrund_20070116_source
   sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
   title: Vereinfachte Bodennutzung (20070116, source)
-- dimensions: &id412
+- dimensions: &id433
     Time:
       default: '19970901'
       values: ['19970901']
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache_out]
   title: Waldmischungsgrad 1990/1992 (19970901)
-- dimensions: *id412
+- dimensions: *id433
   name: ch.bfs.arealstatistik-waldmischungsgrad
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992 ('current')
-- dimensions: *id412
+- dimensions: *id433
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901_source
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992 (19970901, source)
-- dimensions: &id413
+- dimensions: &id434
     Time:
       default: '20130212'
       values: ['20130212']
   name: ch.bfs.gebaeude_wohnungs_register_20130212
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache_out]
   title: "Geb\xE4ude- und Wohnungsregister (20130212)"
-- dimensions: *id413
+- dimensions: *id434
   name: ch.bfs.gebaeude_wohnungs_register
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
   title: "Geb\xE4ude- und Wohnungsregister ('current')"
-- dimensions: *id413
+- dimensions: *id434
   name: ch.bfs.gebaeude_wohnungs_register_20130212_source
   sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
   title: "Geb\xE4ude- und Wohnungsregister (20130212, source)"
-- dimensions: &id414
+- dimensions: &id435
     Time:
       default: '20150422'
       values: ['20150422']
   name: ch.blw.alpprodukte_20150422
   sources: [ch.blw.alpprodukte_20150422_cache_out]
   title: Alpprodukte (20150422)
-- dimensions: *id414
+- dimensions: *id435
   name: ch.blw.alpprodukte
   sources: [ch.blw.alpprodukte_20150422_cache]
   title: Alpprodukte ('current')
-- dimensions: *id414
+- dimensions: *id435
   name: ch.blw.alpprodukte_20150422_source
   sources: [ch.blw.alpprodukte_20150422_cache]
   title: Alpprodukte (20150422, source)
-- dimensions: &id415
+- dimensions: &id436
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.alpprodukte_20130531
   sources: [ch.blw.alpprodukte_20130531_cache_out]
   title: Alpprodukte (20130531)
-- dimensions: *id415
+- dimensions: *id436
   name: ch.blw.alpprodukte_20130531_source
   sources: [ch.blw.alpprodukte_20130531_cache]
   title: Alpprodukte (20130531, source)
-- dimensions: &id416
+- dimensions: &id437
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.alpprodukte_20081024
   sources: [ch.blw.alpprodukte_20081024_cache_out]
   title: Alpprodukte (20081024)
-- dimensions: *id416
+- dimensions: *id437
   name: ch.blw.alpprodukte_20081024_source
   sources: [ch.blw.alpprodukte_20081024_cache]
   title: Alpprodukte (20081024, source)
-- dimensions: &id417
+- dimensions: &id438
     Time:
       default: '20150422'
       values: ['20150422']
   name: ch.blw.bergprodukte_20150422
   sources: [ch.blw.bergprodukte_20150422_cache_out]
   title: Bergprodukte (20150422)
-- dimensions: *id417
+- dimensions: *id438
   name: ch.blw.bergprodukte
   sources: [ch.blw.bergprodukte_20150422_cache]
   title: Bergprodukte ('current')
-- dimensions: *id417
+- dimensions: *id438
   name: ch.blw.bergprodukte_20150422_source
   sources: [ch.blw.bergprodukte_20150422_cache]
   title: Bergprodukte (20150422, source)
-- dimensions: &id418
+- dimensions: &id439
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.bergprodukte_20130531
   sources: [ch.blw.bergprodukte_20130531_cache_out]
   title: Bergprodukte (20130531)
-- dimensions: *id418
+- dimensions: *id439
   name: ch.blw.bergprodukte_20130531_source
   sources: [ch.blw.bergprodukte_20130531_cache]
   title: Bergprodukte (20130531, source)
-- dimensions: &id419
+- dimensions: &id440
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bergprodukte_20081024
   sources: [ch.blw.bergprodukte_20081024_cache_out]
   title: Bergprodukte (20081024)
-- dimensions: *id419
+- dimensions: *id440
   name: ch.blw.bergprodukte_20081024_source
   sources: [ch.blw.bergprodukte_20081024_cache]
   title: Bergprodukte (20081024, source)
-- dimensions: &id420
+- dimensions: &id441
     Time:
       default: '20091110'
       values: ['20091110']
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache_out]
   title: "Bew\xE4sserungsbed\xFCrftigkeit (20091110)"
-- dimensions: *id420
+- dimensions: *id441
   name: ch.blw.bewaesserungsbeduerftigkeit
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit ('current')"
-- dimensions: *id420
+- dimensions: *id441
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110_source
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit (20091110, source)"
-- dimensions: &id421
+- dimensions: &id442
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-gruendigkeit_20120601
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache_out]
   title: "Gr\xFCndigkeit (20120601)"
-- dimensions: *id421
+- dimensions: *id442
   name: ch.blw.bodeneignung-gruendigkeit
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit ('current')"
-- dimensions: *id421
+- dimensions: *id442
   name: ch.blw.bodeneignung-gruendigkeit_20120601_source
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit (20120601, source)"
-- dimensions: &id422
+- dimensions: &id443
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturland_20081024
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache_out]
   title: "Bodeneignung f\xFCr Kulturland (20081024)"
-- dimensions: *id422
+- dimensions: *id443
   name: ch.blw.bodeneignung-kulturland
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland ('current')"
-- dimensions: *id422
+- dimensions: *id443
   name: ch.blw.bodeneignung-kulturland_20081024_source
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland (20081024, source)"
-- dimensions: &id423
+- dimensions: &id444
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturtyp_20081024
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache_out]
   title: 'Bodeneignung: Kulturtyp (20081024)'
-- dimensions: *id423
+- dimensions: *id444
   name: ch.blw.bodeneignung-kulturtyp
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp (''current'')'
-- dimensions: *id423
+- dimensions: *id444
   name: ch.blw.bodeneignung-kulturtyp_20081024_source
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp (20081024, source)'
-- dimensions: &id424
+- dimensions: &id445
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache_out]
   title: "N\xE4hrstoffspeicherverm\xF6gen (20120601)"
-- dimensions: *id424
+- dimensions: *id445
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen ('current')"
-- dimensions: *id424
+- dimensions: *id445
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen (20120601, source)"
-- dimensions: &id425
+- dimensions: &id446
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-skelettgehalt_20120601
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache_out]
   title: Skelettgehalt (20120601)
-- dimensions: *id425
+- dimensions: *id446
   name: ch.blw.bodeneignung-skelettgehalt
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt ('current')
-- dimensions: *id425
+- dimensions: *id446
   name: ch.blw.bodeneignung-skelettgehalt_20120601_source
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt (20120601, source)
-- dimensions: &id426
+- dimensions: &id447
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-vernaessung_20120601
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache_out]
   title: "Vern\xE4ssung (20120601)"
-- dimensions: *id426
+- dimensions: *id447
   name: ch.blw.bodeneignung-vernaessung
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung ('current')"
-- dimensions: *id426
+- dimensions: *id447
   name: ch.blw.bodeneignung-vernaessung_20120601_source
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung (20120601, source)"
-- dimensions: &id427
+- dimensions: &id448
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache_out]
   title: "Wasserdurchl\xE4ssigkeit (20120601)"
-- dimensions: *id427
+- dimensions: *id448
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit ('current')"
-- dimensions: *id427
+- dimensions: *id448
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_source
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit (20120601, source)"
-- dimensions: &id428
+- dimensions: &id449
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache_out]
   title: "Wasserspeicherverm\xF6gen (20120601)"
-- dimensions: *id428
+- dimensions: *id449
   name: ch.blw.bodeneignung-wasserspeichervermoegen
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen ('current')"
-- dimensions: *id428
+- dimensions: *id449
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen (20120601, source)"
-- dimensions: &id429
+- dimensions: &id450
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion_20100103
   sources: [ch.blw.erosion_20100103_cache_out]
   title: Erosionsrisiko qualitativ 1 (20100103)
-- dimensions: *id429
+- dimensions: *id450
   name: ch.blw.erosion
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1 ('current')
-- dimensions: *id429
+- dimensions: *id450
   name: ch.blw.erosion_20100103_source
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1 (20100103, source)
-- dimensions: &id430
+- dimensions: &id451
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion-mit_bergzonen_20100103
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache_out]
   title: Erosionsrisiko qualitativ 2 (20100103)
-- dimensions: *id430
+- dimensions: *id451
   name: ch.blw.erosion-mit_bergzonen
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2 ('current')
-- dimensions: *id430
+- dimensions: *id451
   name: ch.blw.erosion-mit_bergzonen_20100103_source
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2 (20100103, source)
-- dimensions: &id431
+- dimensions: &id452
     Time:
       default: '20100601'
       values: ['20100601']
   name: ch.blw.erosion-quantitativ_20100601
   sources: [ch.blw.erosion-quantitativ_20100601_cache_out]
   title: Erosionsrisiko quantitativ (20100601)
-- dimensions: *id431
+- dimensions: *id452
   name: ch.blw.erosion-quantitativ
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ ('current')
-- dimensions: *id431
+- dimensions: *id452
   name: ch.blw.erosion-quantitativ_20100601_source
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ (20100601, source)
-- dimensions: &id432
+- dimensions: &id453
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.feldblockkarte_20120601
   sources: [ch.blw.feldblockkarte_20120601_cache_out]
   title: Feldblockkarte (20120601)
-- dimensions: *id432
+- dimensions: *id453
   name: ch.blw.feldblockkarte
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte ('current')
-- dimensions: *id432
+- dimensions: *id453
   name: ch.blw.feldblockkarte_20120601_source
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte (20120601, source)
-- dimensions: &id433
+- dimensions: &id454
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte_20121201
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache_out]
   title: "Gew\xE4sseranschluss (20121201)"
-- dimensions: *id433
+- dimensions: *id454
   name: ch.blw.gewaesseranschlusskarte
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss ('current')"
-- dimensions: *id433
+- dimensions: *id454
   name: ch.blw.gewaesseranschlusskarte_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss (20121201, source)"
-- dimensions: &id434
+- dimensions: &id455
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache_out]
   title: "Gew\xE4sseranschluss erweitert (20121201)"
-- dimensions: *id434
+- dimensions: *id455
   name: ch.blw.gewaesseranschlusskarte-direkt
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert ('current')"
-- dimensions: *id434
+- dimensions: *id455
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert (20121201, source)"
-- dimensions: &id435
+- dimensions: &id456
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.hang_steillagen_20121231
   sources: [ch.blw.hang_steillagen_20121231_cache_out]
   title: Hanglagen (20121231)
-- dimensions: *id435
+- dimensions: *id456
   name: ch.blw.hang_steillagen
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen ('current')
-- dimensions: *id435
+- dimensions: *id456
   name: ch.blw.hang_steillagen_20121231_source
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen (20121231, source)
-- dimensions: &id436
+- dimensions: &id457
     Time:
       default: '20100501'
       values: ['20100501']
   name: ch.blw.hang_steillagen_20100501
   sources: [ch.blw.hang_steillagen_20100501_cache_out]
   title: Hanglagen (20100501)
-- dimensions: *id436
+- dimensions: *id457
   name: ch.blw.hang_steillagen_20100501_source
   sources: [ch.blw.hang_steillagen_20100501_cache]
   title: Hanglagen (20100501, source)
-- dimensions: &id437
+- dimensions: &id458
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-futterbau_20081024
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache_out]
   title: Klimaeignung Futterbau (20081024)
-- dimensions: *id437
+- dimensions: *id458
   name: ch.blw.klimaeignung-futterbau
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau ('current')
-- dimensions: *id437
+- dimensions: *id458
   name: ch.blw.klimaeignung-futterbau_20081024_source
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau (20081024, source)
-- dimensions: &id438
+- dimensions: &id459
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-getreidebau_20081024
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache_out]
   title: Klimaeignung Getreidebau (20081024)
-- dimensions: *id438
+- dimensions: *id459
   name: ch.blw.klimaeignung-getreidebau
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau ('current')
-- dimensions: *id438
+- dimensions: *id459
   name: ch.blw.klimaeignung-getreidebau_20081024_source
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau (20081024, source)
-- dimensions: &id439
+- dimensions: &id460
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kartoffeln_20081024
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache_out]
   title: Klimaeignung Kartoffeln (20081024)
-- dimensions: *id439
+- dimensions: *id460
   name: ch.blw.klimaeignung-kartoffeln
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln ('current')
-- dimensions: *id439
+- dimensions: *id460
   name: ch.blw.klimaeignung-kartoffeln_20081024_source
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln (20081024, source)
-- dimensions: &id440
+- dimensions: &id461
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-koernermais_20081024
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache_out]
   title: "Klimaeignung K\xF6rnermais (20081024)"
-- dimensions: *id440
+- dimensions: *id461
   name: ch.blw.klimaeignung-koernermais
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais ('current')"
-- dimensions: *id440
+- dimensions: *id461
   name: ch.blw.klimaeignung-koernermais_20081024_source
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais (20081024, source)"
-- dimensions: &id441
+- dimensions: &id462
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kulturland_20081024
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache_out]
   title: Klimaeignung Kulturland (20081024)
-- dimensions: *id441
+- dimensions: *id462
   name: ch.blw.klimaeignung-kulturland
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland ('current')
-- dimensions: *id441
+- dimensions: *id462
   name: ch.blw.klimaeignung-kulturland_20081024_source
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland (20081024, source)
-- dimensions: &id442
+- dimensions: &id463
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-spezialkulturen_20081024
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache_out]
   title: Klimaeignung Spezialkulturen (20081024)
-- dimensions: *id442
+- dimensions: *id463
   name: ch.blw.klimaeignung-spezialkulturen
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen ('current')
-- dimensions: *id442
+- dimensions: *id463
   name: ch.blw.klimaeignung-spezialkulturen_20081024_source
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen (20081024, source)
-- dimensions: &id443
+- dimensions: &id464
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-typ_20081024
   sources: [ch.blw.klimaeignung-typ_20081024_cache_out]
   title: "Klimaeignung \xDCbersicht (20081024)"
-- dimensions: *id443
+- dimensions: *id464
   name: ch.blw.klimaeignung-typ
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht ('current')"
-- dimensions: *id443
+- dimensions: *id464
   name: ch.blw.klimaeignung-typ_20081024_source
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht (20081024, source)"
-- dimensions: &id444
+- dimensions: &id465
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache_out]
   title: Klimaeignung Zwischenfruchtbau (20081024)
-- dimensions: *id444
+- dimensions: *id465
   name: ch.blw.klimaeignung-zwischenfruchtbau
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau ('current')
-- dimensions: *id444
+- dimensions: *id465
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024_source
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau (20081024, source)
-- dimensions: &id445
+- dimensions: &id466
+    Time:
+      default: '20150708'
+      values: ['20150708']
+  name: ch.blw.landwirtschaftliche-zonengrenzen_20150708
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache_out]
+  title: Landwirtschaftliche Zonengrenzen (20150708)
+- dimensions: *id466
+  name: ch.blw.landwirtschaftliche-zonengrenzen
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache]
+  title: Landwirtschaftliche Zonengrenzen ('current')
+- dimensions: *id466
+  name: ch.blw.landwirtschaftliche-zonengrenzen_20150708_source
+  sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache]
+  title: Landwirtschaftliche Zonengrenzen (20150708, source)
+- dimensions: &id467
     Time:
       default: '20140418'
       values: ['20140418']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140418
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20140418)
-- dimensions: *id445
-  name: ch.blw.landwirtschaftliche-zonengrenzen
-  sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache]
-  title: Landwirtschaftliche Zonengrenzen ('current')
-- dimensions: *id445
+- dimensions: *id467
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140418_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140418_cache]
   title: Landwirtschaftliche Zonengrenzen (20140418, source)
-- dimensions: &id446
+- dimensions: &id468
     Time:
       default: '20140417'
       values: ['20140417']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140417
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20140417)
-- dimensions: *id446
+- dimensions: *id468
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140417_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140417_cache]
   title: Landwirtschaftliche Zonengrenzen (20140417, source)
-- dimensions: &id447
+- dimensions: &id469
     Time:
       default: '20140108'
       values: ['20140108']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140108
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20140108)
-- dimensions: *id447
+- dimensions: *id469
   name: ch.blw.landwirtschaftliche-zonengrenzen_20140108_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20140108_cache]
   title: Landwirtschaftliche Zonengrenzen (20140108, source)
-- dimensions: &id448
+- dimensions: &id470
     Time:
       default: '20130531'
       values: ['20130531']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20130531
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20130531)
-- dimensions: *id448
+- dimensions: *id470
   name: ch.blw.landwirtschaftliche-zonengrenzen_20130531_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20130531_cache]
   title: Landwirtschaftliche Zonengrenzen (20130531, source)
-- dimensions: &id449
+- dimensions: &id471
     Time:
       default: '20111214'
       values: ['20111214']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111214
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20111214)
-- dimensions: *id449
+- dimensions: *id471
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111214_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111214_cache]
   title: Landwirtschaftliche Zonengrenzen (20111214, source)
-- dimensions: &id450
+- dimensions: &id472
     Time:
       default: '20111010'
       values: ['20111010']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111010
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20111010)
-- dimensions: *id450
+- dimensions: *id472
   name: ch.blw.landwirtschaftliche-zonengrenzen_20111010_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20111010_cache]
   title: Landwirtschaftliche Zonengrenzen (20111010, source)
-- dimensions: &id451
+- dimensions: &id473
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.niederschlagshaushalt_20081024
   sources: [ch.blw.niederschlagshaushalt_20081024_cache_out]
   title: Niederschlagshaushalt (20081024)
-- dimensions: *id451
+- dimensions: *id473
   name: ch.blw.niederschlagshaushalt
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt ('current')
-- dimensions: *id451
+- dimensions: *id473
   name: ch.blw.niederschlagshaushalt_20081024_source
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt (20081024, source)
-- dimensions: &id452
+- dimensions: &id474
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.steil_terrassenlagen_rebbau_20121231
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache_out]
   title: "Rebfl\xE4chen in Hanglagen (20121231)"
-- dimensions: *id452
+- dimensions: *id474
   name: ch.blw.steil_terrassenlagen_rebbau
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen ('current')"
-- dimensions: *id452
+- dimensions: *id474
   name: ch.blw.steil_terrassenlagen_rebbau_20121231_source
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen (20121231, source)"
-- dimensions: &id453
+- dimensions: &id475
     Time:
       default: '20100501'
       values: ['20100501']
   name: ch.blw.steil_terrassenlagen_rebbau_20100501
   sources: [ch.blw.steil_terrassenlagen_rebbau_20100501_cache_out]
   title: "Rebfl\xE4chen in Hanglagen (20100501)"
-- dimensions: *id453
+- dimensions: *id475
   name: ch.blw.steil_terrassenlagen_rebbau_20100501_source
   sources: [ch.blw.steil_terrassenlagen_rebbau_20100501_cache]
   title: "Rebfl\xE4chen in Hanglagen (20100501, source)"
-- dimensions: &id454
+- dimensions: &id476
     Time:
       default: '20110805'
       values: ['20110805']
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache_out]
   title: GGA Fleischware (20110805)
-- dimensions: *id454
+- dimensions: *id476
   name: ch.blw.ursprungsbezeichnungen-fleisch
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware ('current')
-- dimensions: *id454
+- dimensions: *id476
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805_source
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware (20110805, source)
-- dimensions: &id455
+- dimensions: &id477
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-fleisch_20081024
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache_out]
   title: GGA Fleischware (20081024)
-- dimensions: *id455
+- dimensions: *id477
   name: ch.blw.ursprungsbezeichnungen-fleisch_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20081024_cache]
   title: GGA Fleischware (20081024, source)
-- dimensions: &id456
+- dimensions: &id478
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache_out]
   title: "GUB K\xE4se (20081024)"
-- dimensions: *id456
+- dimensions: *id478
   name: ch.blw.ursprungsbezeichnungen-kaese
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se ('current')"
-- dimensions: *id456
+- dimensions: *id478
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se (20081024, source)"
-- dimensions: &id457
+- dimensions: &id479
     Time:
       default: '20150306'
       values: ['20150306']
   name: ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306
   sources: [ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_cache_out]
-  title: ch.blw.ursprungsbezeichnungen-konditoreiwaren (20150306)
-- dimensions: *id457
+  title: GGA Konditoreiware (20150306)
+- dimensions: *id479
   name: ch.blw.ursprungsbezeichnungen-konditoreiwaren
   sources: [ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_cache]
-  title: ch.blw.ursprungsbezeichnungen-konditoreiwaren ('current')
-- dimensions: *id457
+  title: GGA Konditoreiware ('current')
+- dimensions: *id479
   name: ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_source
   sources: [ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_cache]
-  title: ch.blw.ursprungsbezeichnungen-konditoreiwaren (20150306, source)
-- dimensions: &id458
+  title: GGA Konditoreiware (20150306, source)
+- dimensions: &id480
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache_out]
   title: GUB Pflanzliche Produkte (20081024)
-- dimensions: *id458
+- dimensions: *id480
   name: ch.blw.ursprungsbezeichnungen-pflanzen
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte ('current')
-- dimensions: *id458
+- dimensions: *id480
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte (20081024, source)
-- dimensions: &id459
+- dimensions: &id481
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache_out]
   title: GUB Spirituosen (20081024)
-- dimensions: *id459
+- dimensions: *id481
   name: ch.blw.ursprungsbezeichnungen-spirituosen
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen ('current')
-- dimensions: *id459
+- dimensions: *id481
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen (20081024, source)
-- dimensions: &id460
+- dimensions: &id482
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache_out]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20120101)"
-- dimensions: *id460
+- dimensions: *id482
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz ('current')"
-- dimensions: *id460
+- dimensions: *id482
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_source
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20120101, source)"
-- dimensions: &id461
+- dimensions: &id483
     Time:
       default: '20110412'
       values: ['20110412']
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache_out]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20110412)"
-- dimensions: *id461
+- dimensions: *id483
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_source
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20110412_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20110412, source)"
-- dimensions: &id462
+- dimensions: &id484
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.kantone.cadastralwebmap-farbe_20121201
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache_out]
   title: CadastralWebMap (20121201)
-- dimensions: *id462
+- dimensions: *id484
   name: ch.kantone.cadastralwebmap-farbe
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
   title: CadastralWebMap ('current')
-- dimensions: *id462
+- dimensions: *id484
   name: ch.kantone.cadastralwebmap-farbe_20121201_source
   sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
   title: CadastralWebMap (20121201, source)
-- dimensions: &id463
+- dimensions: &id485
     Time:
       default: '20120918'
       values: ['20120918']
   name: ch.sgpk.maechtigkeit-lockergesteine_20120918
   sources: [ch.sgpk.maechtigkeit-lockergesteine_20120918_cache_out]
   title: "M\xE4chtigkeit der Lockergesteine (20120918)"
-- dimensions: *id463
+- dimensions: *id485
   name: ch.sgpk.maechtigkeit-lockergesteine
   sources: [ch.sgpk.maechtigkeit-lockergesteine_20120918_cache]
   title: "M\xE4chtigkeit der Lockergesteine ('current')"
-- dimensions: *id463
+- dimensions: *id485
   name: ch.sgpk.maechtigkeit-lockergesteine_20120918_source
   sources: [ch.sgpk.maechtigkeit-lockergesteine_20120918_cache]
   title: "M\xE4chtigkeit der Lockergesteine (20120918, source)"
-- dimensions: &id464
+- dimensions: &id486
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.dreiecksvermaschung_20061231
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache_out]
   title: LV95 Dreiecksvermaschung (20061231)
-- dimensions: *id464
+- dimensions: *id486
   name: ch.swisstopo.dreiecksvermaschung
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung ('current')
-- dimensions: *id464
+- dimensions: *id486
   name: ch.swisstopo.dreiecksvermaschung_20061231_source
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung (20061231, source)
-- dimensions: &id465
+- dimensions: &id487
     Time:
       default: '20140924'
       values: ['20140924']
   name: ch.swisstopo.fixpunkte-agnes_20140924
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache_out]
   title: AGNES (20140924)
-- dimensions: *id465
+- dimensions: *id487
   name: ch.swisstopo.fixpunkte-agnes
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES ('current')
-- dimensions: *id465
+- dimensions: *id487
   name: ch.swisstopo.fixpunkte-agnes_20140924_source
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES (20140924, source)
-- dimensions: &id466
+- dimensions: &id488
     Time:
       default: '20120622'
       values: ['20120622']
   name: ch.swisstopo.fixpunkte-agnes_20120622
   sources: [ch.swisstopo.fixpunkte-agnes_20120622_cache_out]
   title: AGNES (20120622)
-- dimensions: *id466
+- dimensions: *id488
   name: ch.swisstopo.fixpunkte-agnes_20120622_source
   sources: [ch.swisstopo.fixpunkte-agnes_20120622_cache]
   title: AGNES (20120622, source)
-- dimensions: &id467
+- dimensions: &id489
     Time:
       default: '20110509'
       values: ['20110509']
   name: ch.swisstopo.fixpunkte-agnes_20110509
   sources: [ch.swisstopo.fixpunkte-agnes_20110509_cache_out]
   title: AGNES (20110509)
-- dimensions: *id467
+- dimensions: *id489
   name: ch.swisstopo.fixpunkte-agnes_20110509_source
   sources: [ch.swisstopo.fixpunkte-agnes_20110509_cache]
   title: AGNES (20110509, source)
-- dimensions: &id468
+- dimensions: &id490
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp1_20121212
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP1 (20121212)"
-- dimensions: *id468
+- dimensions: *id490
   name: ch.swisstopo.fixpunkte-hfp1
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1 ('current')"
-- dimensions: *id468
+- dimensions: *id490
   name: ch.swisstopo.fixpunkte-hfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1 (20121212, source)"
-- dimensions: &id469
+- dimensions: &id491
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp2_20121212
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP2 (20121212)"
-- dimensions: *id469
+- dimensions: *id491
   name: ch.swisstopo.fixpunkte-hfp2
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2 ('current')"
-- dimensions: *id469
+- dimensions: *id491
   name: ch.swisstopo.fixpunkte-hfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2 (20121212, source)"
-- dimensions: &id470
+- dimensions: &id492
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp1_20121212
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache_out]
   title: Lagefixpunkte LFP1 (20121212)
-- dimensions: *id470
+- dimensions: *id492
   name: ch.swisstopo.fixpunkte-lfp1
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1 ('current')
-- dimensions: *id470
+- dimensions: *id492
   name: ch.swisstopo.fixpunkte-lfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1 (20121212, source)
-- dimensions: &id471
+- dimensions: &id493
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp2_20121212
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache_out]
   title: Lagefixpunkte LFP2 (20121212)
-- dimensions: *id471
+- dimensions: *id493
   name: ch.swisstopo.fixpunkte-lfp2
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2 ('current')
-- dimensions: *id471
+- dimensions: *id493
   name: ch.swisstopo.fixpunkte-lfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2 (20121212, source)
-- dimensions: &id472
+- dimensions: &id494
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-ch1903_20041231
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache_out]
   title: Geoidmodell in CH1903 (20041231)
-- dimensions: *id472
+- dimensions: *id494
   name: ch.swisstopo.geoidmodell-ch1903
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903 ('current')
-- dimensions: *id472
+- dimensions: *id494
   name: ch.swisstopo.geoidmodell-ch1903_20041231_source
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903 (20041231, source)
-- dimensions: &id473
+- dimensions: &id495
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-etrs89_20041231
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache_out]
   title: Geoidmodell in ETRS89 (20041231)
-- dimensions: *id473
+- dimensions: *id495
   name: ch.swisstopo.geoidmodell-etrs89
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89 ('current')
-- dimensions: *id473
+- dimensions: *id495
   name: ch.swisstopo.geoidmodell-etrs89_20041231_source
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89 (20041231, source)
-- dimensions: &id474
+- dimensions: &id496
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache_out]
   title: Letzteiszeitl. Max. (Karte) 500 (20081231)
-- dimensions: *id474
+- dimensions: *id496
   name: ch.swisstopo.geologie-eiszeit-lgm-raster
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Letzteiszeitl. Max. (Karte) 500 ('current')
-- dimensions: *id474
+- dimensions: *id496
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_source
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Letzteiszeitl. Max. (Karte) 500 (20081231, source)
-- dimensions: &id475
+- dimensions: &id497
     Time:
       default: '20140601'
       values: ['20140601']
   name: ch.swisstopo.geologie-geocover_20140601
   sources: [ch.swisstopo.geologie-geocover_20140601_cache_out]
   title: GeoCover - Vektordaten (20140601)
-- dimensions: *id475
+- dimensions: *id497
   name: ch.swisstopo.geologie-geocover
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: GeoCover - Vektordaten ('current')
-- dimensions: *id475
+- dimensions: *id497
   name: ch.swisstopo.geologie-geocover_20140601_source
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: GeoCover - Vektordaten (20140601, source)
-- dimensions: &id476
+- dimensions: &id498
     Time:
       default: '20110406'
       values: ['20110406']
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache_out]
   title: Bouguer-Anomalien 500 (20110406)
-- dimensions: *id476
+- dimensions: *id498
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache]
   title: Bouguer-Anomalien 500 ('current')
-- dimensions: *id476
+- dimensions: *id498
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_source
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache]
   title: Bouguer-Anomalien 500 (20110406, source)
-- dimensions: &id477
+- dimensions: &id499
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache_out]
   title: Bouguer-Anomalien 500 (19791231)
-- dimensions: *id477
+- dimensions: *id499
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_19791231_cache]
   title: Bouguer-Anomalien 500 (19791231, source)
-- dimensions: &id478
+- dimensions: &id500
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache_out]
   title: Isostatische Anomalien 500 (19791231)
-- dimensions: *id478
+- dimensions: *id500
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien 500 ('current')
-- dimensions: *id478
+- dimensions: *id500
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien 500 (19791231, source)
-- dimensions: &id479
+- dimensions: &id501
     Time:
       default: '20070425'
       values: ['20070425']
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache_out]
   title: Blatteinteilung GeoKarten 500 (20070425)
-- dimensions: *id479
+- dimensions: *id501
   name: ch.swisstopo.geologie-geolkarten500.metadata
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 ('current')
-- dimensions: *id479
+- dimensions: *id501
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425_source
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 (20070425, source)
-- dimensions: &id480
+- dimensions: &id502
     Time:
       default: '20080630'
       values: ['20080630']
   name: ch.swisstopo.geologie-geologische_karte_20080630
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache_out]
   title: Geologie 500 (20080630)
-- dimensions: *id480
+- dimensions: *id502
   name: ch.swisstopo.geologie-geologische_karte
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologie 500 ('current')
-- dimensions: *id480
+- dimensions: *id502
   name: ch.swisstopo.geologie-geologische_karte_20080630_source
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologie 500 (20080630, source)
-- dimensions: &id481
+- dimensions: &id503
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.geologie-geologische_karte_20051231
   sources: [ch.swisstopo.geologie-geologische_karte_20051231_cache_out]
   title: Geologie 500 (20051231)
-- dimensions: *id481
+- dimensions: *id503
   name: ch.swisstopo.geologie-geologische_karte_20051231_source
   sources: [ch.swisstopo.geologie-geologische_karte_20051231_cache]
   title: Geologie 500 (20051231, source)
-- dimensions: &id482
+- dimensions: &id504
     Time:
       default: '20131120'
       values: ['20131120']
   name: ch.swisstopo.geologie-geologischer_atlas_20131120
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache_out]
   title: Geologischer Atlas GA25 (20131120)
-- dimensions: *id482
+- dimensions: *id504
   name: ch.swisstopo.geologie-geologischer_atlas
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geologischer Atlas GA25 ('current')
-- dimensions: *id482
+- dimensions: *id504
   name: ch.swisstopo.geologie-geologischer_atlas_20131120_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geologischer Atlas GA25 (20131120, source)
-- dimensions: &id483
+- dimensions: &id505
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.swisstopo.geologie-geologischer_atlas_20120601
   sources: [ch.swisstopo.geologie-geologischer_atlas_20120601_cache_out]
   title: Geologischer Atlas GA25 (20120601)
-- dimensions: *id483
+- dimensions: *id505
   name: ch.swisstopo.geologie-geologischer_atlas_20120601_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20120601_cache]
   title: Geologischer Atlas GA25 (20120601, source)
-- dimensions: &id484
+- dimensions: &id506
     Time:
       default: '20101221'
       values: ['20101221']
   name: ch.swisstopo.geologie-geologischer_atlas_20101221
   sources: [ch.swisstopo.geologie-geologischer_atlas_20101221_cache_out]
   title: Geologischer Atlas GA25 (20101221)
-- dimensions: *id484
+- dimensions: *id506
   name: ch.swisstopo.geologie-geologischer_atlas_20101221_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20101221_cache]
   title: Geologischer Atlas GA25 (20101221, source)
-- dimensions: &id485
+- dimensions: &id507
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache_out]
   title: Aeromagnetik Mittelland/Jura 500 (19831231)
-- dimensions: *id485
+- dimensions: *id507
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Mittelland/Jura 500 ('current')
-- dimensions: *id485
+- dimensions: *id507
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Mittelland/Jura 500 (19831231, source)
-- dimensions: &id486
+- dimensions: &id508
     Time:
       default: '20120628'
       values: ['20120628']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache_out]
   title: Aeromagnetik 500 (20120628)
-- dimensions: *id486
+- dimensions: *id508
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik 500 ('current')
-- dimensions: *id486
+- dimensions: *id508
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik 500 (20120628, source)
-- dimensions: &id487
+- dimensions: &id509
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache_out]
   title: Aeromagnetik 500 (19821231)
-- dimensions: *id487
+- dimensions: *id509
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_19821231_cache]
   title: Aeromagnetik 500 (19821231, source)
-- dimensions: &id488
+- dimensions: &id510
     Time:
       default: '20011203'
       values: ['20011203']
   name: ch.swisstopo.geologie-geophysik-deklination_20011203
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache_out]
   title: Deklination 500 (20011203)
-- dimensions: *id488
+- dimensions: *id510
   name: ch.swisstopo.geologie-geophysik-deklination
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination 500 ('current')
-- dimensions: *id488
+- dimensions: *id510
   name: ch.swisstopo.geologie-geophysik-deklination_20011203_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination 500 (20011203, source)
-- dimensions: &id489
+- dimensions: &id511
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-deklination_19791231
   sources: [ch.swisstopo.geologie-geophysik-deklination_19791231_cache_out]
   title: Deklination 500 (19791231)
-- dimensions: *id489
+- dimensions: *id511
   name: ch.swisstopo.geologie-geophysik-deklination_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_19791231_cache]
   title: Deklination 500 (19791231, source)
-- dimensions: &id490
+- dimensions: &id512
     Time:
       default: '20111121'
       values: ['20111121']
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache_out]
   title: "W\xE4rmestromdichte 500 (20111121)"
-- dimensions: *id490
+- dimensions: *id512
   name: ch.swisstopo.geologie-geophysik-geothermie
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: "W\xE4rmestromdichte 500 ('current')"
-- dimensions: *id490
+- dimensions: *id512
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: "W\xE4rmestromdichte 500 (20111121, source)"
-- dimensions: &id491
+- dimensions: &id513
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.geologie-geophysik-geothermie_19821231
   sources: [ch.swisstopo.geologie-geophysik-geothermie_19821231_cache_out]
   title: "W\xE4rmestromdichte 500 (19821231)"
-- dimensions: *id491
+- dimensions: *id513
   name: ch.swisstopo.geologie-geophysik-geothermie_19821231_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_19821231_cache]
   title: "W\xE4rmestromdichte 500 (19821231, source)"
-- dimensions: &id492
+- dimensions: &id514
     Time:
       default: '20111128'
       values: ['20111128']
   name: ch.swisstopo.geologie-geophysik-inklination_20111128
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache_out]
   title: Inklination 500 (20111128)
-- dimensions: *id492
+- dimensions: *id514
   name: ch.swisstopo.geologie-geophysik-inklination
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination 500 ('current')
-- dimensions: *id492
+- dimensions: *id514
   name: ch.swisstopo.geologie-geophysik-inklination_20111128_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination 500 (20111128, source)
-- dimensions: &id493
+- dimensions: &id515
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-inklination_19791231
   sources: [ch.swisstopo.geologie-geophysik-inklination_19791231_cache_out]
   title: Inklination 500 (19791231)
-- dimensions: *id493
+- dimensions: *id515
   name: ch.swisstopo.geologie-geophysik-inklination_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_19791231_cache]
   title: Inklination 500 (19791231, source)
-- dimensions: &id494
+- dimensions: &id516
     Time:
       default: '19800101'
       values: ['19800101']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache_out]
   title: "Magnetfeldst\xE4rke 500 (19800101)"
-- dimensions: *id494
+- dimensions: *id516
   name: ch.swisstopo.geologie-geophysik-totalintensitaet
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke 500 ('current')"
-- dimensions: *id494
+- dimensions: *id516
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke 500 (19800101, source)"
-- dimensions: &id495
+- dimensions: &id517
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19791231
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache_out]
   title: "Magnetfeldst\xE4rke 500 (19791231)"
-- dimensions: *id495
+- dimensions: *id517
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19791231_cache]
   title: "Magnetfeldst\xE4rke 500 (19791231, source)"
-- dimensions: &id496
+- dimensions: &id518
     Time:
       default: '19670101'
       values: ['19670101']
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache_out]
   title: Geotechnische Karte 200 (19670101)
-- dimensions: *id496
+- dimensions: *id518
   name: ch.swisstopo.geologie-geotechnik-gk200
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnische Karte 200 ('current')
-- dimensions: *id496
+- dimensions: *id518
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnische Karte 200 (19670101, source)
-- dimensions: &id497
+- dimensions: &id519
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache_out]
   title: Entstehung der Gesteine 500 (20060304)
-- dimensions: *id497
+- dimensions: *id519
   name: ch.swisstopo.geologie-geotechnik-gk500-genese
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine 500 ('current')
-- dimensions: *id497
+- dimensions: *id519
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine 500 (20060304, source)
-- dimensions: &id498
+- dimensions: &id520
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache_out]
   title: Entstehung der Gesteine 500 (20000101)
-- dimensions: *id498
+- dimensions: *id520
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20000101_cache]
   title: Entstehung der Gesteine 500 (20000101, source)
-- dimensions: &id499
+- dimensions: &id521
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache_out]
   title: Gesteinsklassen 500 (20060304)
-- dimensions: *id499
+- dimensions: *id521
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinsklassen 500 ('current')
-- dimensions: *id499
+- dimensions: *id521
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinsklassen 500 (20060304, source)
-- dimensions: &id500
+- dimensions: &id522
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache_out]
   title: Gesteinsklassen 500 (20000101)
-- dimensions: *id500
+- dimensions: *id522
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20000101_cache]
   title: Gesteinsklassen 500 (20000101, source)
-- dimensions: &id501
+- dimensions: &id523
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache_out]
   title: Lithologie (Hauptgruppen) 500 (20060304)
-- dimensions: *id501
+- dimensions: *id523
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie (Hauptgruppen) 500 ('current')
-- dimensions: *id501
+- dimensions: *id523
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie (Hauptgruppen) 500 (20060304, source)
-- dimensions: &id502
+- dimensions: &id524
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache_out]
   title: Lithologie (Hauptgruppen) 500 (20000101)
-- dimensions: *id502
+- dimensions: *id524
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20000101_cache]
   title: Lithologie (Hauptgruppen) 500 (20000101, source)
-- dimensions: &id503
+- dimensions: &id525
     Time:
       default: '19900101'
       values: ['19900101']
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache_out]
   title: Mineralische Rohstoffe 200 (19900101)
-- dimensions: *id503
+- dimensions: *id525
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe 200 ('current')
-- dimensions: *id503
+- dimensions: *id525
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_source
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe 200 (19900101, source)
-- dimensions: &id504
+- dimensions: &id526
     Time:
       default: '20130620'
       values: ['20130620']
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache_out]
   title: Steine an hist. Bauwerken (20130620)
-- dimensions: *id504
+- dimensions: *id526
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an hist. Bauwerken ('current')
-- dimensions: *id504
+- dimensions: *id526
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_source
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an hist. Bauwerken (20130620, source)
-- dimensions: &id505
+- dimensions: &id527
     Time:
       default: '20130107'
       values: ['20130107']
   name: ch.swisstopo.geologie-geotope_20130107
   sources: [ch.swisstopo.geologie-geotope_20130107_cache_out]
   title: Schweizerische Geotope (20130107)
-- dimensions: *id505
+- dimensions: *id527
   name: ch.swisstopo.geologie-geotope
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Schweizerische Geotope ('current')
-- dimensions: *id505
+- dimensions: *id527
   name: ch.swisstopo.geologie-geotope_20130107_source
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Schweizerische Geotope (20130107, source)
-- dimensions: &id506
+- dimensions: &id528
     Time:
       default: '20110201'
       values: ['20110201']
   name: ch.swisstopo.geologie-geotope_20110201
   sources: [ch.swisstopo.geologie-geotope_20110201_cache_out]
   title: Schweizerische Geotope (20110201)
-- dimensions: *id506
+- dimensions: *id528
   name: ch.swisstopo.geologie-geotope_20110201_source
   sources: [ch.swisstopo.geologie-geotope_20110201_cache]
   title: Schweizerische Geotope (20110201, source)
-- dimensions: &id507
+- dimensions: &id529
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache_out]
   title: Gravimetrischer Atlas 100 (20021231)
-- dimensions: *id507
+- dimensions: *id529
   name: ch.swisstopo.geologie-gravimetrischer_atlas
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas 100 ('current')
-- dimensions: *id507
+- dimensions: *id529
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas 100 (20021231, source)
-- dimensions: &id508
+- dimensions: &id530
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache_out]
   title: Einteilung gravim. Atlas 100 (20021231)
-- dimensions: *id508
+- dimensions: *id530
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravim. Atlas 100 ('current')
-- dimensions: *id508
+- dimensions: *id530
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravim. Atlas 100 (20021231, source)
-- dimensions: &id509
+- dimensions: &id531
     Time:
       default: '20081103'
       values: ['20081103']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache_out]
   title: Grundwasservorkommen 500 (20081103)
-- dimensions: *id509
+- dimensions: *id531
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 ('current')
-- dimensions: *id509
+- dimensions: *id531
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 (20081103, source)
-- dimensions: &id510
+- dimensions: &id532
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache_out]
   title: Grundwasservorkommen 500 (20070101)
-- dimensions: *id510
+- dimensions: *id532
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20070101_cache]
   title: Grundwasservorkommen 500 (20070101, source)
-- dimensions: &id511
+- dimensions: &id533
     Time:
       default: '20081016'
       values: ['20081016']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache_out]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016)"
-- dimensions: *id511
+- dimensions: *id533
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 ('current')"
-- dimensions: *id511
+- dimensions: *id533
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016, source)"
-- dimensions: &id512
+- dimensions: &id534
     Time:
       default: '20070914'
       values: ['20070914']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache_out]
   title: "Grundwasservulnerabilit\xE4t 500 (20070914)"
-- dimensions: *id512
+- dimensions: *id534
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20070914_cache]
   title: "Grundwasservulnerabilit\xE4t 500 (20070914, source)"
-- dimensions: &id513
+- dimensions: &id535
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache_out]
   title: Einteilung geol. Spezialkarten (20110101)
-- dimensions: *id513
+- dimensions: *id535
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten ('current')
-- dimensions: *id513
+- dimensions: *id535
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_source
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten (20110101, source)
-- dimensions: &id514
+- dimensions: &id536
     Time:
       default: '20080522'
       values: ['20080522']
   name: ch.swisstopo.geologie-tektonische_karte_20080522
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache_out]
   title: Tektonik 500 (20080522)
-- dimensions: *id514
+- dimensions: *id536
   name: ch.swisstopo.geologie-tektonische_karte
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonik 500 ('current')
-- dimensions: *id514
+- dimensions: *id536
   name: ch.swisstopo.geologie-tektonische_karte_20080522_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonik 500 (20080522, source)
-- dimensions: &id515
+- dimensions: &id537
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.geologie-tektonische_karte_20051231
   sources: [ch.swisstopo.geologie-tektonische_karte_20051231_cache_out]
   title: Tektonik 500 (20051231)
-- dimensions: *id515
+- dimensions: *id537
   name: ch.swisstopo.geologie-tektonische_karte_20051231_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20051231_cache]
   title: Tektonik 500 (20051231, source)
-- dimensions: &id516
+- dimensions: &id538
     Time:
       default: '18650101'
       values: ['18650101']
   name: ch.swisstopo.hiks-dufour_18650101
   sources: [ch.swisstopo.hiks-dufour_18650101_cache_out]
   title: Dufourkarte Erstausgabe (18650101)
-- dimensions: *id516
+- dimensions: *id538
   name: ch.swisstopo.hiks-dufour
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe ('current')
-- dimensions: *id516
+- dimensions: *id538
   name: ch.swisstopo.hiks-dufour_18650101_source
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe (18650101, source)
-- dimensions: &id517
+- dimensions: &id539
     Time:
       default: '19260101'
       values: ['19260101']
   name: ch.swisstopo.hiks-siegfried_19260101
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache_out]
   title: Siegfriedkarte Erstausgabe (19260101)
-- dimensions: *id517
+- dimensions: *id539
   name: ch.swisstopo.hiks-siegfried
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe ('current')
-- dimensions: *id517
+- dimensions: *id539
   name: ch.swisstopo.hiks-siegfried_19260101_source
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe (19260101, source)
-- dimensions: &id518
+- dimensions: &id540
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.koordinatenaenderung_20061231
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache_out]
   title: "LV95 Koordinaten\xE4nderung (20061231)"
-- dimensions: *id518
+- dimensions: *id540
   name: ch.swisstopo.koordinatenaenderung
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung ('current')"
-- dimensions: *id518
+- dimensions: *id540
   name: ch.swisstopo.koordinatenaenderung_20061231_source
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung (20061231, source)"
-- dimensions: &id519
+- dimensions: &id541
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache_out]
   title: Luftbilder Privater (99991231)
-- dimensions: *id519
+- dimensions: *id541
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater ('current')
-- dimensions: *id519
+- dimensions: *id541
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater (99991231, source)
-- dimensions: &id520
+- dimensions: &id542
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache_out]
   title: Luftbilder Privater (20091231)
-- dimensions: *id520
+- dimensions: *id542
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache]
   title: Luftbilder Privater (20091231, source)
-- dimensions: &id521
+- dimensions: &id543
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache_out]
   title: Luftbilder Privater (20081231)
-- dimensions: *id521
+- dimensions: *id543
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache]
   title: Luftbilder Privater (20081231, source)
-- dimensions: &id522
+- dimensions: &id544
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache_out]
   title: Luftbilder Privater (20071231)
-- dimensions: *id522
+- dimensions: *id544
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache]
   title: Luftbilder Privater (20071231, source)
-- dimensions: &id523
+- dimensions: &id545
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache_out]
   title: Luftbilder Privater (20061231)
-- dimensions: *id523
+- dimensions: *id545
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache]
   title: Luftbilder Privater (20061231, source)
-- dimensions: &id524
+- dimensions: &id546
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache_out]
   title: Luftbilder Privater (20051231)
-- dimensions: *id524
+- dimensions: *id546
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache]
   title: Luftbilder Privater (20051231, source)
-- dimensions: &id525
+- dimensions: &id547
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache_out]
   title: Luftbilder Privater (20041231)
-- dimensions: *id525
+- dimensions: *id547
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache]
   title: Luftbilder Privater (20041231, source)
-- dimensions: &id526
+- dimensions: &id548
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache_out]
   title: Luftbilder Privater (20031231)
-- dimensions: *id526
+- dimensions: *id548
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache]
   title: Luftbilder Privater (20031231, source)
-- dimensions: &id527
+- dimensions: &id549
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache_out]
   title: Luftbilder Privater (20021231)
-- dimensions: *id527
+- dimensions: *id549
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache]
   title: Luftbilder Privater (20021231, source)
-- dimensions: &id528
+- dimensions: &id550
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache_out]
   title: Luftbilder Privater (20011231)
-- dimensions: *id528
+- dimensions: *id550
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache]
   title: Luftbilder Privater (20011231, source)
-- dimensions: &id529
+- dimensions: &id551
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache_out]
   title: Luftbilder Privater (20001231)
-- dimensions: *id529
+- dimensions: *id551
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache]
   title: Luftbilder Privater (20001231, source)
-- dimensions: &id530
+- dimensions: &id552
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache_out]
   title: Luftbilder Privater (19991231)
-- dimensions: *id530
+- dimensions: *id552
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache]
   title: Luftbilder Privater (19991231, source)
-- dimensions: &id531
+- dimensions: &id553
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache_out]
   title: Luftbilder Privater (19981231)
-- dimensions: *id531
+- dimensions: *id553
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache]
   title: Luftbilder Privater (19981231, source)
-- dimensions: &id532
+- dimensions: &id554
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache_out]
   title: Luftbilder Privater (19971231)
-- dimensions: *id532
+- dimensions: *id554
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache]
   title: Luftbilder Privater (19971231, source)
-- dimensions: &id533
+- dimensions: &id555
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache_out]
   title: Luftbilder Privater (19961231)
-- dimensions: *id533
+- dimensions: *id555
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache]
   title: Luftbilder Privater (19961231, source)
-- dimensions: &id534
+- dimensions: &id556
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache_out]
   title: Luftbilder Privater (19951231)
-- dimensions: *id534
+- dimensions: *id556
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache]
   title: Luftbilder Privater (19951231, source)
-- dimensions: &id535
+- dimensions: &id557
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache_out]
   title: Luftbilder Privater (19941231)
-- dimensions: *id535
+- dimensions: *id557
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache]
   title: Luftbilder Privater (19941231, source)
-- dimensions: &id536
+- dimensions: &id558
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache_out]
   title: Luftbilder Privater (19931231)
-- dimensions: *id536
+- dimensions: *id558
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache]
   title: Luftbilder Privater (19931231, source)
-- dimensions: &id537
+- dimensions: &id559
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache_out]
   title: Luftbilder Privater (19921231)
-- dimensions: *id537
+- dimensions: *id559
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache]
   title: Luftbilder Privater (19921231, source)
-- dimensions: &id538
+- dimensions: &id560
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache_out]
   title: Luftbilder Privater (19911231)
-- dimensions: *id538
+- dimensions: *id560
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache]
   title: Luftbilder Privater (19911231, source)
-- dimensions: &id539
+- dimensions: &id561
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache_out]
   title: Luftbilder Privater (19901231)
-- dimensions: *id539
+- dimensions: *id561
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache]
   title: Luftbilder Privater (19901231, source)
-- dimensions: &id540
+- dimensions: &id562
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache_out]
   title: Luftbilder Privater (19891231)
-- dimensions: *id540
+- dimensions: *id562
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache]
   title: Luftbilder Privater (19891231, source)
-- dimensions: &id541
+- dimensions: &id563
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache_out]
   title: Luftbilder Kantone (99991231)
-- dimensions: *id541
+- dimensions: *id563
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone ('current')
-- dimensions: *id541
+- dimensions: *id563
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone (99991231, source)
-- dimensions: &id542
+- dimensions: &id564
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache_out]
   title: Luftbilder Kantone (20141231)
-- dimensions: *id542
+- dimensions: *id564
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache]
   title: Luftbilder Kantone (20141231, source)
-- dimensions: &id543
+- dimensions: &id565
     Time:
       default: '20131231'
       values: ['20131231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache_out]
   title: Luftbilder Kantone (20131231)
-- dimensions: *id543
+- dimensions: *id565
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache]
   title: Luftbilder Kantone (20131231, source)
-- dimensions: &id544
+- dimensions: &id566
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache_out]
   title: Luftbilder Kantone (20121231)
-- dimensions: *id544
+- dimensions: *id566
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache]
   title: Luftbilder Kantone (20121231, source)
-- dimensions: &id545
+- dimensions: &id567
     Time:
       default: '20111231'
       values: ['20111231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache_out]
   title: Luftbilder Kantone (20111231)
-- dimensions: *id545
+- dimensions: *id567
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache]
   title: Luftbilder Kantone (20111231, source)
-- dimensions: &id546
+- dimensions: &id568
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache_out]
   title: Luftbilder Kantone (20091231)
-- dimensions: *id546
+- dimensions: *id568
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache]
   title: Luftbilder Kantone (20091231, source)
-- dimensions: &id547
+- dimensions: &id569
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache_out]
   title: Luftbilder Kantone (19841231)
-- dimensions: *id547
+- dimensions: *id569
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache]
   title: Luftbilder Kantone (19841231, source)
-- dimensions: &id548
+- dimensions: &id570
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache_out]
   title: Luftbilder Kantone (19671231)
-- dimensions: *id548
+- dimensions: *id570
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache]
   title: Luftbilder Kantone (19671231, source)
-- dimensions: &id549
+- dimensions: &id571
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache_out]
   title: Luftbilder Kantone (19661231)
-- dimensions: *id549
+- dimensions: *id571
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache]
   title: Luftbilder Kantone (19661231, source)
-- dimensions: &id550
+- dimensions: &id572
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache_out]
   title: Luftbilder Kantone (19651231)
-- dimensions: *id550
+- dimensions: *id572
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache]
   title: Luftbilder Kantone (19651231, source)
-- dimensions: &id551
+- dimensions: &id573
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache_out]
   title: Luftbilder Kantone (19641231)
-- dimensions: *id551
+- dimensions: *id573
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache]
   title: Luftbilder Kantone (19641231, source)
-- dimensions: &id552
+- dimensions: &id574
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache_out]
   title: Luftbilder Kantone (19631231)
-- dimensions: *id552
+- dimensions: *id574
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache]
   title: Luftbilder Kantone (19631231, source)
-- dimensions: &id553
+- dimensions: &id575
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache_out]
   title: Luftbilder Kantone (19621231)
-- dimensions: *id553
+- dimensions: *id575
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache]
   title: Luftbilder Kantone (19621231, source)
-- dimensions: &id554
+- dimensions: &id576
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache_out]
   title: Luftbilder swisstopo farbig (99991231)
-- dimensions: *id554
+- dimensions: *id576
   name: ch.swisstopo.lubis-luftbilder_farbe
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig ('current')
-- dimensions: *id554
+- dimensions: *id576
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig (99991231, source)
-- dimensions: &id555
+- dimensions: &id577
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache_out]
   title: Luftbilder swisstopo farbig (20101231)
-- dimensions: *id555
+- dimensions: *id577
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache]
   title: Luftbilder swisstopo farbig (20101231, source)
-- dimensions: &id556
+- dimensions: &id578
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache_out]
   title: Luftbilder swisstopo farbig (20091231)
-- dimensions: *id556
+- dimensions: *id578
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache]
   title: Luftbilder swisstopo farbig (20091231, source)
-- dimensions: &id557
+- dimensions: &id579
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache_out]
   title: Luftbilder swisstopo farbig (20081231)
-- dimensions: *id557
+- dimensions: *id579
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache]
   title: Luftbilder swisstopo farbig (20081231, source)
-- dimensions: &id558
+- dimensions: &id580
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache_out]
   title: Luftbilder swisstopo farbig (20071231)
-- dimensions: *id558
+- dimensions: *id580
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache]
   title: Luftbilder swisstopo farbig (20071231, source)
-- dimensions: &id559
+- dimensions: &id581
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache_out]
   title: Luftbilder swisstopo farbig (20061231)
-- dimensions: *id559
+- dimensions: *id581
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache]
   title: Luftbilder swisstopo farbig (20061231, source)
-- dimensions: &id560
+- dimensions: &id582
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache_out]
   title: Luftbilder swisstopo farbig (20051231)
-- dimensions: *id560
+- dimensions: *id582
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache]
   title: Luftbilder swisstopo farbig (20051231, source)
-- dimensions: &id561
+- dimensions: &id583
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache_out]
   title: Luftbilder swisstopo farbig (20041231)
-- dimensions: *id561
+- dimensions: *id583
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache]
   title: Luftbilder swisstopo farbig (20041231, source)
-- dimensions: &id562
+- dimensions: &id584
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache_out]
   title: Luftbilder swisstopo farbig (20031231)
-- dimensions: *id562
+- dimensions: *id584
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache]
   title: Luftbilder swisstopo farbig (20031231, source)
-- dimensions: &id563
+- dimensions: &id585
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache_out]
   title: Luftbilder swisstopo farbig (20021231)
-- dimensions: *id563
+- dimensions: *id585
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache]
   title: Luftbilder swisstopo farbig (20021231, source)
-- dimensions: &id564
+- dimensions: &id586
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache_out]
   title: Luftbilder swisstopo farbig (20011231)
-- dimensions: *id564
+- dimensions: *id586
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache]
   title: Luftbilder swisstopo farbig (20011231, source)
-- dimensions: &id565
+- dimensions: &id587
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache_out]
   title: Luftbilder swisstopo farbig (20001231)
-- dimensions: *id565
+- dimensions: *id587
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache]
   title: Luftbilder swisstopo farbig (20001231, source)
-- dimensions: &id566
+- dimensions: &id588
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache_out]
   title: Luftbilder swisstopo farbig (19991231)
-- dimensions: *id566
+- dimensions: *id588
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache]
   title: Luftbilder swisstopo farbig (19991231, source)
-- dimensions: &id567
+- dimensions: &id589
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache_out]
   title: Luftbilder swisstopo farbig (19981231)
-- dimensions: *id567
+- dimensions: *id589
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache]
   title: Luftbilder swisstopo farbig (19981231, source)
-- dimensions: &id568
+- dimensions: &id590
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache_out]
   title: Luftbilder swisstopo farbig (19971231)
-- dimensions: *id568
+- dimensions: *id590
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache]
   title: Luftbilder swisstopo farbig (19971231, source)
-- dimensions: &id569
+- dimensions: &id591
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache_out]
   title: Luftbilder swisstopo farbig (19961231)
-- dimensions: *id569
+- dimensions: *id591
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache]
   title: Luftbilder swisstopo farbig (19961231, source)
-- dimensions: &id570
+- dimensions: &id592
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache_out]
   title: Luftbilder swisstopo farbig (19951231)
-- dimensions: *id570
+- dimensions: *id592
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache]
   title: Luftbilder swisstopo farbig (19951231, source)
-- dimensions: &id571
+- dimensions: &id593
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache_out]
   title: Luftbilder swisstopo farbig (19941231)
-- dimensions: *id571
+- dimensions: *id593
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache]
   title: Luftbilder swisstopo farbig (19941231, source)
-- dimensions: &id572
+- dimensions: &id594
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache_out]
   title: Luftbilder swisstopo farbig (19931231)
-- dimensions: *id572
+- dimensions: *id594
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache]
   title: Luftbilder swisstopo farbig (19931231, source)
-- dimensions: &id573
+- dimensions: &id595
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache_out]
   title: Luftbilder swisstopo farbig (19921231)
-- dimensions: *id573
+- dimensions: *id595
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache]
   title: Luftbilder swisstopo farbig (19921231, source)
-- dimensions: &id574
+- dimensions: &id596
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache_out]
   title: Luftbilder swisstopo farbig (19911231)
-- dimensions: *id574
+- dimensions: *id596
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache]
   title: Luftbilder swisstopo farbig (19911231, source)
-- dimensions: &id575
+- dimensions: &id597
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache_out]
   title: Luftbilder swisstopo farbig (19901231)
-- dimensions: *id575
+- dimensions: *id597
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache]
   title: Luftbilder swisstopo farbig (19901231, source)
-- dimensions: &id576
+- dimensions: &id598
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache_out]
   title: Luftbilder swisstopo farbig (19891231)
-- dimensions: *id576
+- dimensions: *id598
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache]
   title: Luftbilder swisstopo farbig (19891231, source)
-- dimensions: &id577
+- dimensions: &id599
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache_out]
   title: Luftbilder swisstopo farbig (19881231)
-- dimensions: *id577
+- dimensions: *id599
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache]
   title: Luftbilder swisstopo farbig (19881231, source)
-- dimensions: &id578
+- dimensions: &id600
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache_out]
   title: Luftbilder swisstopo farbig (19871231)
-- dimensions: *id578
+- dimensions: *id600
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache]
   title: Luftbilder swisstopo farbig (19871231, source)
-- dimensions: &id579
+- dimensions: &id601
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache_out]
   title: Luftbilder swisstopo farbig (19861231)
-- dimensions: *id579
+- dimensions: *id601
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache]
   title: Luftbilder swisstopo farbig (19861231, source)
-- dimensions: &id580
+- dimensions: &id602
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache_out]
   title: Luftbilder swisstopo farbig (19851231)
-- dimensions: *id580
+- dimensions: *id602
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache]
   title: Luftbilder swisstopo farbig (19851231, source)
-- dimensions: &id581
+- dimensions: &id603
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache_out]
   title: Luftbilder swisstopo farbig (19841231)
-- dimensions: *id581
+- dimensions: *id603
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache]
   title: Luftbilder swisstopo farbig (19841231, source)
-- dimensions: &id582
+- dimensions: &id604
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache_out]
   title: Luftbilder swisstopo farbig (19831231)
-- dimensions: *id582
+- dimensions: *id604
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache]
   title: Luftbilder swisstopo farbig (19831231, source)
-- dimensions: &id583
+- dimensions: &id605
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache_out]
   title: Luftbilder swisstopo farbig (19821231)
-- dimensions: *id583
+- dimensions: *id605
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache]
   title: Luftbilder swisstopo farbig (19821231, source)
-- dimensions: &id584
+- dimensions: &id606
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache_out]
   title: Luftbilder swisstopo farbig (19811231)
-- dimensions: *id584
+- dimensions: *id606
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache]
   title: Luftbilder swisstopo farbig (19811231, source)
-- dimensions: &id585
+- dimensions: &id607
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache_out]
   title: Luftbilder swisstopo infrarot (99991231)
-- dimensions: *id585
+- dimensions: *id607
   name: ch.swisstopo.lubis-luftbilder_infrarot
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot ('current')
-- dimensions: *id585
+- dimensions: *id607
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot (99991231, source)
-- dimensions: &id586
+- dimensions: &id608
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache_out]
   title: Luftbilder swisstopo infrarot (20091231)
-- dimensions: *id586
+- dimensions: *id608
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache]
   title: Luftbilder swisstopo infrarot (20091231, source)
-- dimensions: &id587
+- dimensions: &id609
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache_out]
   title: Luftbilder swisstopo infrarot (20081231)
-- dimensions: *id587
+- dimensions: *id609
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache]
   title: Luftbilder swisstopo infrarot (20081231, source)
-- dimensions: &id588
+- dimensions: &id610
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache_out]
   title: Luftbilder swisstopo infrarot (20071231)
-- dimensions: *id588
+- dimensions: *id610
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache]
   title: Luftbilder swisstopo infrarot (20071231, source)
-- dimensions: &id589
+- dimensions: &id611
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache_out]
   title: Luftbilder swisstopo infrarot (20061231)
-- dimensions: *id589
+- dimensions: *id611
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache]
   title: Luftbilder swisstopo infrarot (20061231, source)
-- dimensions: &id590
+- dimensions: &id612
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache_out]
   title: Luftbilder swisstopo infrarot (20051231)
-- dimensions: *id590
+- dimensions: *id612
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache]
   title: Luftbilder swisstopo infrarot (20051231, source)
-- dimensions: &id591
+- dimensions: &id613
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache_out]
   title: Luftbilder swisstopo infrarot (20041231)
-- dimensions: *id591
+- dimensions: *id613
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache]
   title: Luftbilder swisstopo infrarot (20041231, source)
-- dimensions: &id592
+- dimensions: &id614
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache_out]
   title: Luftbilder swisstopo infrarot (20031231)
-- dimensions: *id592
+- dimensions: *id614
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache]
   title: Luftbilder swisstopo infrarot (20031231, source)
-- dimensions: &id593
+- dimensions: &id615
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache_out]
   title: Luftbilder swisstopo infrarot (20021231)
-- dimensions: *id593
+- dimensions: *id615
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache]
   title: Luftbilder swisstopo infrarot (20021231, source)
-- dimensions: &id594
+- dimensions: &id616
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache_out]
   title: Luftbilder swisstopo infrarot (20011231)
-- dimensions: *id594
+- dimensions: *id616
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache]
   title: Luftbilder swisstopo infrarot (20011231, source)
-- dimensions: &id595
+- dimensions: &id617
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache_out]
   title: Luftbilder swisstopo infrarot (20001231)
-- dimensions: *id595
+- dimensions: *id617
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache]
   title: Luftbilder swisstopo infrarot (20001231, source)
-- dimensions: &id596
+- dimensions: &id618
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache_out]
   title: Luftbilder swisstopo infrarot (19991231)
-- dimensions: *id596
+- dimensions: *id618
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache]
   title: Luftbilder swisstopo infrarot (19991231, source)
-- dimensions: &id597
+- dimensions: &id619
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache_out]
   title: Luftbilder swisstopo infrarot (19981231)
-- dimensions: *id597
+- dimensions: *id619
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache]
   title: Luftbilder swisstopo infrarot (19981231, source)
-- dimensions: &id598
+- dimensions: &id620
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache_out]
   title: Luftbilder swisstopo infrarot (19971231)
-- dimensions: *id598
+- dimensions: *id620
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache]
   title: Luftbilder swisstopo infrarot (19971231, source)
-- dimensions: &id599
+- dimensions: &id621
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache_out]
   title: Luftbilder swisstopo infrarot (19961231)
-- dimensions: *id599
+- dimensions: *id621
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache]
   title: Luftbilder swisstopo infrarot (19961231, source)
-- dimensions: &id600
+- dimensions: &id622
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache_out]
   title: Luftbilder swisstopo infrarot (19951231)
-- dimensions: *id600
+- dimensions: *id622
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache]
   title: Luftbilder swisstopo infrarot (19951231, source)
-- dimensions: &id601
+- dimensions: &id623
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache_out]
   title: Luftbilder swisstopo infrarot (19941231)
-- dimensions: *id601
+- dimensions: *id623
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache]
   title: Luftbilder swisstopo infrarot (19941231, source)
-- dimensions: &id602
+- dimensions: &id624
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache_out]
   title: Luftbilder swisstopo infrarot (19931231)
-- dimensions: *id602
+- dimensions: *id624
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache]
   title: Luftbilder swisstopo infrarot (19931231, source)
-- dimensions: &id603
+- dimensions: &id625
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache_out]
   title: Luftbilder swisstopo infrarot (19921231)
-- dimensions: *id603
+- dimensions: *id625
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache]
   title: Luftbilder swisstopo infrarot (19921231, source)
-- dimensions: &id604
+- dimensions: &id626
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache_out]
   title: Luftbilder swisstopo infrarot (19911231)
-- dimensions: *id604
+- dimensions: *id626
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache]
   title: Luftbilder swisstopo infrarot (19911231, source)
-- dimensions: &id605
+- dimensions: &id627
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache_out]
   title: Luftbilder swisstopo infrarot (19901231)
-- dimensions: *id605
+- dimensions: *id627
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache]
   title: Luftbilder swisstopo infrarot (19901231, source)
-- dimensions: &id606
+- dimensions: &id628
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache_out]
   title: Luftbilder swisstopo infrarot (19891231)
-- dimensions: *id606
+- dimensions: *id628
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache]
   title: Luftbilder swisstopo infrarot (19891231, source)
-- dimensions: &id607
+- dimensions: &id629
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache_out]
   title: Luftbilder swisstopo infrarot (19881231)
-- dimensions: *id607
+- dimensions: *id629
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache]
   title: Luftbilder swisstopo infrarot (19881231, source)
-- dimensions: &id608
+- dimensions: &id630
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache_out]
   title: Luftbilder swisstopo infrarot (19871231)
-- dimensions: *id608
+- dimensions: *id630
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache]
   title: Luftbilder swisstopo infrarot (19871231, source)
-- dimensions: &id609
+- dimensions: &id631
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache_out]
   title: Luftbilder swisstopo infrarot (19861231)
-- dimensions: *id609
+- dimensions: *id631
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache]
   title: Luftbilder swisstopo infrarot (19861231, source)
-- dimensions: &id610
+- dimensions: &id632
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache_out]
   title: Luftbilder swisstopo infrarot (19851231)
-- dimensions: *id610
+- dimensions: *id632
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache]
   title: Luftbilder swisstopo infrarot (19851231, source)
-- dimensions: &id611
+- dimensions: &id633
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache_out]
   title: Luftbilder swisstopo infrarot (19841231)
-- dimensions: *id611
+- dimensions: *id633
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache]
   title: Luftbilder swisstopo infrarot (19841231, source)
-- dimensions: &id612
+- dimensions: &id634
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache_out]
   title: Luftbilder swisstopo infrarot (19831231)
-- dimensions: *id612
+- dimensions: *id634
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache]
   title: Luftbilder swisstopo infrarot (19831231, source)
-- dimensions: &id613
+- dimensions: &id635
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache_out]
   title: Luftbilder swisstopo infrarot (19811231)
-- dimensions: *id613
+- dimensions: *id635
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache]
   title: Luftbilder swisstopo infrarot (19811231, source)
-- dimensions: &id614
+- dimensions: &id636
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache_out]
   title: Luftbilder swisstopo s/w (99991231)
-- dimensions: *id614
+- dimensions: *id636
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w ('current')
-- dimensions: *id614
+- dimensions: *id636
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w (99991231, source)
-- dimensions: &id615
+- dimensions: &id637
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache_out]
   title: Luftbilder swisstopo s/w (20101231)
-- dimensions: *id615
+- dimensions: *id637
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache]
   title: Luftbilder swisstopo s/w (20101231, source)
-- dimensions: &id616
+- dimensions: &id638
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache_out]
   title: Luftbilder swisstopo s/w (20091231)
-- dimensions: *id616
+- dimensions: *id638
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache]
   title: Luftbilder swisstopo s/w (20091231, source)
-- dimensions: &id617
+- dimensions: &id639
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache_out]
   title: Luftbilder swisstopo s/w (20081231)
-- dimensions: *id617
+- dimensions: *id639
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache]
   title: Luftbilder swisstopo s/w (20081231, source)
-- dimensions: &id618
+- dimensions: &id640
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache_out]
   title: Luftbilder swisstopo s/w (20071231)
-- dimensions: *id618
+- dimensions: *id640
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache]
   title: Luftbilder swisstopo s/w (20071231, source)
-- dimensions: &id619
+- dimensions: &id641
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache_out]
   title: Luftbilder swisstopo s/w (20061231)
-- dimensions: *id619
+- dimensions: *id641
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache]
   title: Luftbilder swisstopo s/w (20061231, source)
-- dimensions: &id620
+- dimensions: &id642
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache_out]
   title: Luftbilder swisstopo s/w (20051231)
-- dimensions: *id620
+- dimensions: *id642
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache]
   title: Luftbilder swisstopo s/w (20051231, source)
-- dimensions: &id621
+- dimensions: &id643
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache_out]
   title: Luftbilder swisstopo s/w (20041231)
-- dimensions: *id621
+- dimensions: *id643
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache]
   title: Luftbilder swisstopo s/w (20041231, source)
-- dimensions: &id622
+- dimensions: &id644
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache_out]
   title: Luftbilder swisstopo s/w (20031231)
-- dimensions: *id622
+- dimensions: *id644
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache]
   title: Luftbilder swisstopo s/w (20031231, source)
-- dimensions: &id623
+- dimensions: &id645
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache_out]
   title: Luftbilder swisstopo s/w (20021231)
-- dimensions: *id623
+- dimensions: *id645
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache]
   title: Luftbilder swisstopo s/w (20021231, source)
-- dimensions: &id624
+- dimensions: &id646
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache_out]
   title: Luftbilder swisstopo s/w (20011231)
-- dimensions: *id624
+- dimensions: *id646
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache]
   title: Luftbilder swisstopo s/w (20011231, source)
-- dimensions: &id625
+- dimensions: &id647
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache_out]
   title: Luftbilder swisstopo s/w (20001231)
-- dimensions: *id625
+- dimensions: *id647
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache]
   title: Luftbilder swisstopo s/w (20001231, source)
-- dimensions: &id626
+- dimensions: &id648
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache_out]
   title: Luftbilder swisstopo s/w (19991231)
-- dimensions: *id626
+- dimensions: *id648
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache]
   title: Luftbilder swisstopo s/w (19991231, source)
-- dimensions: &id627
+- dimensions: &id649
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache_out]
   title: Luftbilder swisstopo s/w (19981231)
-- dimensions: *id627
+- dimensions: *id649
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache]
   title: Luftbilder swisstopo s/w (19981231, source)
-- dimensions: &id628
+- dimensions: &id650
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache_out]
   title: Luftbilder swisstopo s/w (19971231)
-- dimensions: *id628
+- dimensions: *id650
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache]
   title: Luftbilder swisstopo s/w (19971231, source)
-- dimensions: &id629
+- dimensions: &id651
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache_out]
   title: Luftbilder swisstopo s/w (19961231)
-- dimensions: *id629
+- dimensions: *id651
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache]
   title: Luftbilder swisstopo s/w (19961231, source)
-- dimensions: &id630
+- dimensions: &id652
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache_out]
   title: Luftbilder swisstopo s/w (19951231)
-- dimensions: *id630
+- dimensions: *id652
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache]
   title: Luftbilder swisstopo s/w (19951231, source)
-- dimensions: &id631
+- dimensions: &id653
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache_out]
   title: Luftbilder swisstopo s/w (19941231)
-- dimensions: *id631
+- dimensions: *id653
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache]
   title: Luftbilder swisstopo s/w (19941231, source)
-- dimensions: &id632
+- dimensions: &id654
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache_out]
   title: Luftbilder swisstopo s/w (19931231)
-- dimensions: *id632
+- dimensions: *id654
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache]
   title: Luftbilder swisstopo s/w (19931231, source)
-- dimensions: &id633
+- dimensions: &id655
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache_out]
   title: Luftbilder swisstopo s/w (19921231)
-- dimensions: *id633
+- dimensions: *id655
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache]
   title: Luftbilder swisstopo s/w (19921231, source)
-- dimensions: &id634
+- dimensions: &id656
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache_out]
   title: Luftbilder swisstopo s/w (19911231)
-- dimensions: *id634
+- dimensions: *id656
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache]
   title: Luftbilder swisstopo s/w (19911231, source)
-- dimensions: &id635
+- dimensions: &id657
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache_out]
   title: Luftbilder swisstopo s/w (19901231)
-- dimensions: *id635
+- dimensions: *id657
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache]
   title: Luftbilder swisstopo s/w (19901231, source)
-- dimensions: &id636
+- dimensions: &id658
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache_out]
   title: Luftbilder swisstopo s/w (19891231)
-- dimensions: *id636
+- dimensions: *id658
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache]
   title: Luftbilder swisstopo s/w (19891231, source)
-- dimensions: &id637
+- dimensions: &id659
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache_out]
   title: Luftbilder swisstopo s/w (19881231)
-- dimensions: *id637
+- dimensions: *id659
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache]
   title: Luftbilder swisstopo s/w (19881231, source)
-- dimensions: &id638
+- dimensions: &id660
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache_out]
   title: Luftbilder swisstopo s/w (19871231)
-- dimensions: *id638
+- dimensions: *id660
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache]
   title: Luftbilder swisstopo s/w (19871231, source)
-- dimensions: &id639
+- dimensions: &id661
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache_out]
   title: Luftbilder swisstopo s/w (19861231)
-- dimensions: *id639
+- dimensions: *id661
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache]
   title: Luftbilder swisstopo s/w (19861231, source)
-- dimensions: &id640
+- dimensions: &id662
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache_out]
   title: Luftbilder swisstopo s/w (19851231)
-- dimensions: *id640
+- dimensions: *id662
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache]
   title: Luftbilder swisstopo s/w (19851231, source)
-- dimensions: &id641
+- dimensions: &id663
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache_out]
   title: Luftbilder swisstopo s/w (19841231)
-- dimensions: *id641
+- dimensions: *id663
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache]
   title: Luftbilder swisstopo s/w (19841231, source)
-- dimensions: &id642
+- dimensions: &id664
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache_out]
   title: Luftbilder swisstopo s/w (19831231)
-- dimensions: *id642
+- dimensions: *id664
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache]
   title: Luftbilder swisstopo s/w (19831231, source)
-- dimensions: &id643
+- dimensions: &id665
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache_out]
   title: Luftbilder swisstopo s/w (19821231)
-- dimensions: *id643
+- dimensions: *id665
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache]
   title: Luftbilder swisstopo s/w (19821231, source)
-- dimensions: &id644
+- dimensions: &id666
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache_out]
   title: Luftbilder swisstopo s/w (19811231)
-- dimensions: *id644
+- dimensions: *id666
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache]
   title: Luftbilder swisstopo s/w (19811231, source)
-- dimensions: &id645
+- dimensions: &id667
     Time:
       default: '19801231'
       values: ['19801231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache_out]
   title: Luftbilder swisstopo s/w (19801231)
-- dimensions: *id645
+- dimensions: *id667
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache]
   title: Luftbilder swisstopo s/w (19801231, source)
-- dimensions: &id646
+- dimensions: &id668
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache_out]
   title: Luftbilder swisstopo s/w (19791231)
-- dimensions: *id646
+- dimensions: *id668
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache]
   title: Luftbilder swisstopo s/w (19791231, source)
-- dimensions: &id647
+- dimensions: &id669
     Time:
       default: '19781231'
       values: ['19781231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache_out]
   title: Luftbilder swisstopo s/w (19781231)
-- dimensions: *id647
+- dimensions: *id669
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache]
   title: Luftbilder swisstopo s/w (19781231, source)
-- dimensions: &id648
+- dimensions: &id670
     Time:
       default: '19771231'
       values: ['19771231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache_out]
   title: Luftbilder swisstopo s/w (19771231)
-- dimensions: *id648
+- dimensions: *id670
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache]
   title: Luftbilder swisstopo s/w (19771231, source)
-- dimensions: &id649
+- dimensions: &id671
     Time:
       default: '19761231'
       values: ['19761231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache_out]
   title: Luftbilder swisstopo s/w (19761231)
-- dimensions: *id649
+- dimensions: *id671
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache]
   title: Luftbilder swisstopo s/w (19761231, source)
-- dimensions: &id650
+- dimensions: &id672
     Time:
       default: '19751231'
       values: ['19751231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache_out]
   title: Luftbilder swisstopo s/w (19751231)
-- dimensions: *id650
+- dimensions: *id672
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache]
   title: Luftbilder swisstopo s/w (19751231, source)
-- dimensions: &id651
+- dimensions: &id673
     Time:
       default: '19741231'
       values: ['19741231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache_out]
   title: Luftbilder swisstopo s/w (19741231)
-- dimensions: *id651
+- dimensions: *id673
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache]
   title: Luftbilder swisstopo s/w (19741231, source)
-- dimensions: &id652
+- dimensions: &id674
     Time:
       default: '19731231'
       values: ['19731231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache_out]
   title: Luftbilder swisstopo s/w (19731231)
-- dimensions: *id652
+- dimensions: *id674
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache]
   title: Luftbilder swisstopo s/w (19731231, source)
-- dimensions: &id653
+- dimensions: &id675
     Time:
       default: '19721231'
       values: ['19721231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache_out]
   title: Luftbilder swisstopo s/w (19721231)
-- dimensions: *id653
+- dimensions: *id675
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache]
   title: Luftbilder swisstopo s/w (19721231, source)
-- dimensions: &id654
+- dimensions: &id676
     Time:
       default: '19711231'
       values: ['19711231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache_out]
   title: Luftbilder swisstopo s/w (19711231)
-- dimensions: *id654
+- dimensions: *id676
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache]
   title: Luftbilder swisstopo s/w (19711231, source)
-- dimensions: &id655
+- dimensions: &id677
     Time:
       default: '19701231'
       values: ['19701231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache_out]
   title: Luftbilder swisstopo s/w (19701231)
-- dimensions: *id655
+- dimensions: *id677
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache]
   title: Luftbilder swisstopo s/w (19701231, source)
-- dimensions: &id656
+- dimensions: &id678
     Time:
       default: '19691231'
       values: ['19691231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache_out]
   title: Luftbilder swisstopo s/w (19691231)
-- dimensions: *id656
+- dimensions: *id678
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache]
   title: Luftbilder swisstopo s/w (19691231, source)
-- dimensions: &id657
+- dimensions: &id679
     Time:
       default: '19681231'
       values: ['19681231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache_out]
   title: Luftbilder swisstopo s/w (19681231)
-- dimensions: *id657
+- dimensions: *id679
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache]
   title: Luftbilder swisstopo s/w (19681231, source)
-- dimensions: &id658
+- dimensions: &id680
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache_out]
   title: Luftbilder swisstopo s/w (19671231)
-- dimensions: *id658
+- dimensions: *id680
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache]
   title: Luftbilder swisstopo s/w (19671231, source)
-- dimensions: &id659
+- dimensions: &id681
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache_out]
   title: Luftbilder swisstopo s/w (19661231)
-- dimensions: *id659
+- dimensions: *id681
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache]
   title: Luftbilder swisstopo s/w (19661231, source)
-- dimensions: &id660
+- dimensions: &id682
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache_out]
   title: Luftbilder swisstopo s/w (19651231)
-- dimensions: *id660
+- dimensions: *id682
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache]
   title: Luftbilder swisstopo s/w (19651231, source)
-- dimensions: &id661
+- dimensions: &id683
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache_out]
   title: Luftbilder swisstopo s/w (19641231)
-- dimensions: *id661
+- dimensions: *id683
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache]
   title: Luftbilder swisstopo s/w (19641231, source)
-- dimensions: &id662
+- dimensions: &id684
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache_out]
   title: Luftbilder swisstopo s/w (19631231)
-- dimensions: *id662
+- dimensions: *id684
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache]
   title: Luftbilder swisstopo s/w (19631231, source)
-- dimensions: &id663
+- dimensions: &id685
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache_out]
   title: Luftbilder swisstopo s/w (19621231)
-- dimensions: *id663
+- dimensions: *id685
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache]
   title: Luftbilder swisstopo s/w (19621231, source)
-- dimensions: &id664
+- dimensions: &id686
     Time:
       default: '19611231'
       values: ['19611231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache_out]
   title: Luftbilder swisstopo s/w (19611231)
-- dimensions: *id664
+- dimensions: *id686
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache]
   title: Luftbilder swisstopo s/w (19611231, source)
-- dimensions: &id665
+- dimensions: &id687
     Time:
       default: '19601231'
       values: ['19601231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache_out]
   title: Luftbilder swisstopo s/w (19601231)
-- dimensions: *id665
+- dimensions: *id687
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache]
   title: Luftbilder swisstopo s/w (19601231, source)
-- dimensions: &id666
+- dimensions: &id688
     Time:
       default: '19591231'
       values: ['19591231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache_out]
   title: Luftbilder swisstopo s/w (19591231)
-- dimensions: *id666
+- dimensions: *id688
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache]
   title: Luftbilder swisstopo s/w (19591231, source)
-- dimensions: &id667
+- dimensions: &id689
     Time:
       default: '19581231'
       values: ['19581231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache_out]
   title: Luftbilder swisstopo s/w (19581231)
-- dimensions: *id667
+- dimensions: *id689
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache]
   title: Luftbilder swisstopo s/w (19581231, source)
-- dimensions: &id668
+- dimensions: &id690
     Time:
       default: '19571231'
       values: ['19571231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache_out]
   title: Luftbilder swisstopo s/w (19571231)
-- dimensions: *id668
+- dimensions: *id690
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache]
   title: Luftbilder swisstopo s/w (19571231, source)
-- dimensions: &id669
+- dimensions: &id691
     Time:
       default: '19561231'
       values: ['19561231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache_out]
   title: Luftbilder swisstopo s/w (19561231)
-- dimensions: *id669
+- dimensions: *id691
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache]
   title: Luftbilder swisstopo s/w (19561231, source)
-- dimensions: &id670
+- dimensions: &id692
     Time:
       default: '19551231'
       values: ['19551231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache_out]
   title: Luftbilder swisstopo s/w (19551231)
-- dimensions: *id670
+- dimensions: *id692
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache]
   title: Luftbilder swisstopo s/w (19551231, source)
-- dimensions: &id671
+- dimensions: &id693
     Time:
       default: '19541231'
       values: ['19541231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache_out]
   title: Luftbilder swisstopo s/w (19541231)
-- dimensions: *id671
+- dimensions: *id693
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache]
   title: Luftbilder swisstopo s/w (19541231, source)
-- dimensions: &id672
+- dimensions: &id694
     Time:
       default: '19531231'
       values: ['19531231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache_out]
   title: Luftbilder swisstopo s/w (19531231)
-- dimensions: *id672
+- dimensions: *id694
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache]
   title: Luftbilder swisstopo s/w (19531231, source)
-- dimensions: &id673
+- dimensions: &id695
     Time:
       default: '19521231'
       values: ['19521231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache_out]
   title: Luftbilder swisstopo s/w (19521231)
-- dimensions: *id673
+- dimensions: *id695
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache]
   title: Luftbilder swisstopo s/w (19521231, source)
-- dimensions: &id674
+- dimensions: &id696
     Time:
       default: '19511231'
       values: ['19511231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache_out]
   title: Luftbilder swisstopo s/w (19511231)
-- dimensions: *id674
+- dimensions: *id696
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache]
   title: Luftbilder swisstopo s/w (19511231, source)
-- dimensions: &id675
+- dimensions: &id697
     Time:
       default: '19501231'
       values: ['19501231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache_out]
   title: Luftbilder swisstopo s/w (19501231)
-- dimensions: *id675
+- dimensions: *id697
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache]
   title: Luftbilder swisstopo s/w (19501231, source)
-- dimensions: &id676
+- dimensions: &id698
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache_out]
   title: Luftbilder swisstopo s/w (19491231)
-- dimensions: *id676
+- dimensions: *id698
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache]
   title: Luftbilder swisstopo s/w (19491231, source)
-- dimensions: &id677
+- dimensions: &id699
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache_out]
   title: Luftbilder swisstopo s/w (19481231)
-- dimensions: *id677
+- dimensions: *id699
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache]
   title: Luftbilder swisstopo s/w (19481231, source)
-- dimensions: &id678
+- dimensions: &id700
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache_out]
   title: Luftbilder swisstopo s/w (19471231)
-- dimensions: *id678
+- dimensions: *id700
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache]
   title: Luftbilder swisstopo s/w (19471231, source)
-- dimensions: &id679
+- dimensions: &id701
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache_out]
   title: Luftbilder swisstopo s/w (19461231)
-- dimensions: *id679
+- dimensions: *id701
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache]
   title: Luftbilder swisstopo s/w (19461231, source)
-- dimensions: &id680
+- dimensions: &id702
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache_out]
   title: Luftbilder swisstopo s/w (19451231)
-- dimensions: *id680
+- dimensions: *id702
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache]
   title: Luftbilder swisstopo s/w (19451231, source)
-- dimensions: &id681
+- dimensions: &id703
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache_out]
   title: Luftbilder swisstopo s/w (19441231)
-- dimensions: *id681
+- dimensions: *id703
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache]
   title: Luftbilder swisstopo s/w (19441231, source)
-- dimensions: &id682
+- dimensions: &id704
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache_out]
   title: Luftbilder swisstopo s/w (19431231)
-- dimensions: *id682
+- dimensions: *id704
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache]
   title: Luftbilder swisstopo s/w (19431231, source)
-- dimensions: &id683
+- dimensions: &id705
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache_out]
   title: Luftbilder swisstopo s/w (19421231)
-- dimensions: *id683
+- dimensions: *id705
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache]
   title: Luftbilder swisstopo s/w (19421231, source)
-- dimensions: &id684
+- dimensions: &id706
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache_out]
   title: Luftbilder swisstopo s/w (19411231)
-- dimensions: *id684
+- dimensions: *id706
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache]
   title: Luftbilder swisstopo s/w (19411231, source)
-- dimensions: &id685
+- dimensions: &id707
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache_out]
   title: Luftbilder swisstopo s/w (19401231)
-- dimensions: *id685
+- dimensions: *id707
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache]
   title: Luftbilder swisstopo s/w (19401231, source)
-- dimensions: &id686
+- dimensions: &id708
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache_out]
   title: Luftbilder swisstopo s/w (19391231)
-- dimensions: *id686
+- dimensions: *id708
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache]
   title: Luftbilder swisstopo s/w (19391231, source)
-- dimensions: &id687
+- dimensions: &id709
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache_out]
   title: Luftbilder swisstopo s/w (19381231)
-- dimensions: *id687
+- dimensions: *id709
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache]
   title: Luftbilder swisstopo s/w (19381231, source)
-- dimensions: &id688
+- dimensions: &id710
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache_out]
   title: Luftbilder swisstopo s/w (19371231)
-- dimensions: *id688
+- dimensions: *id710
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache]
   title: Luftbilder swisstopo s/w (19371231, source)
-- dimensions: &id689
+- dimensions: &id711
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache_out]
   title: Luftbilder swisstopo s/w (19361231)
-- dimensions: *id689
+- dimensions: *id711
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache]
   title: Luftbilder swisstopo s/w (19361231, source)
-- dimensions: &id690
+- dimensions: &id712
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache_out]
   title: Luftbilder swisstopo s/w (19351231)
-- dimensions: *id690
+- dimensions: *id712
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache]
   title: Luftbilder swisstopo s/w (19351231, source)
-- dimensions: &id691
+- dimensions: &id713
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache_out]
   title: Luftbilder swisstopo s/w (19341231)
-- dimensions: *id691
+- dimensions: *id713
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache]
   title: Luftbilder swisstopo s/w (19341231, source)
-- dimensions: &id692
+- dimensions: &id714
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache_out]
   title: Luftbilder swisstopo s/w (19331231)
-- dimensions: *id692
+- dimensions: *id714
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache]
   title: Luftbilder swisstopo s/w (19331231, source)
-- dimensions: &id693
+- dimensions: &id715
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache_out]
   title: Luftbilder swisstopo s/w (19321231)
-- dimensions: *id693
+- dimensions: *id715
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache]
   title: Luftbilder swisstopo s/w (19321231, source)
-- dimensions: &id694
+- dimensions: &id716
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache_out]
   title: Luftbilder swisstopo s/w (19311231)
-- dimensions: *id694
+- dimensions: *id716
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache]
   title: Luftbilder swisstopo s/w (19311231, source)
-- dimensions: &id695
+- dimensions: &id717
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache_out]
   title: Luftbilder swisstopo s/w (19301231)
-- dimensions: *id695
+- dimensions: *id717
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache]
   title: Luftbilder swisstopo s/w (19301231, source)
-- dimensions: &id696
+- dimensions: &id718
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache_out]
   title: Luftbilder swisstopo s/w (19291231)
-- dimensions: *id696
+- dimensions: *id718
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache]
   title: Luftbilder swisstopo s/w (19291231, source)
-- dimensions: &id697
+- dimensions: &id719
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache_out]
   title: Luftbilder swisstopo s/w (19281231)
-- dimensions: *id697
+- dimensions: *id719
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache]
   title: Luftbilder swisstopo s/w (19281231, source)
-- dimensions: &id698
+- dimensions: &id720
     Time:
       default: '19271231'
       values: ['19271231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache_out]
   title: Luftbilder swisstopo s/w (19271231)
-- dimensions: *id698
+- dimensions: *id720
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache]
   title: Luftbilder swisstopo s/w (19271231, source)
-- dimensions: &id699
+- dimensions: &id721
     Time:
       default: '19261231'
       values: ['19261231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache_out]
   title: Luftbilder swisstopo s/w (19261231)
-- dimensions: *id699
+- dimensions: *id721
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache]
   title: Luftbilder swisstopo s/w (19261231, source)
-- dimensions: &id700
+- dimensions: &id722
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe_20151231
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id700
+- dimensions: *id722
   name: ch.swisstopo.pixelkarte-farbe
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id700
+- dimensions: *id722
   name: ch.swisstopo.pixelkarte-farbe_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id701
+- dimensions: &id723
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe_20140520
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140520)
-- dimensions: *id701
+- dimensions: *id723
   name: ch.swisstopo.pixelkarte-farbe_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache]
   title: Landeskarte 1:25'000 | LK25 (20140520, source)
-- dimensions: &id702
+- dimensions: &id724
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe_20140106
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140106)
-- dimensions: *id702
+- dimensions: *id724
   name: ch.swisstopo.pixelkarte-farbe_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache]
   title: Landeskarte 1:25'000 | LK25 (20140106, source)
-- dimensions: &id703
+- dimensions: &id725
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe_20130903
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130903)
-- dimensions: *id703
+- dimensions: *id725
   name: ch.swisstopo.pixelkarte-farbe_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache]
   title: Landeskarte 1:25'000 | LK25 (20130903, source)
-- dimensions: &id704
+- dimensions: &id726
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe_20130213
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130213)
-- dimensions: *id704
+- dimensions: *id726
   name: ch.swisstopo.pixelkarte-farbe_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache]
   title: Landeskarte 1:25'000 | LK25 (20130213, source)
-- dimensions: &id705
+- dimensions: &id727
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe_20120809
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20120809)
-- dimensions: *id705
+- dimensions: *id727
   name: ch.swisstopo.pixelkarte-farbe_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache]
   title: Landeskarte 1:25'000 | LK25 (20120809, source)
-- dimensions: &id706
+- dimensions: &id728
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-farbe_20111206
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111206)
-- dimensions: *id706
+- dimensions: *id728
   name: ch.swisstopo.pixelkarte-farbe_20111206_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache]
   title: Landeskarte 1:25'000 | LK25 (20111206, source)
-- dimensions: &id707
+- dimensions: &id729
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe_20111027
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111027)
-- dimensions: *id707
+- dimensions: *id729
   name: ch.swisstopo.pixelkarte-farbe_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache]
   title: Landeskarte 1:25'000 | LK25 (20111027, source)
-- dimensions: &id708
+- dimensions: &id730
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-farbe_20110401
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20110401)
-- dimensions: *id708
+- dimensions: *id730
   name: ch.swisstopo.pixelkarte-farbe_20110401_source
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache]
   title: Landeskarte 1:25'000 | LK25 (20110401, source)
-- dimensions: &id709
+- dimensions: &id731
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000 (20140106)
-- dimensions: *id709
+- dimensions: *id731
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Mio. | LK1000 ('current')
-- dimensions: *id709
+- dimensions: *id731
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Mio. | LK1000 (20140106, source)
-- dimensions: &id710
+- dimensions: &id732
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000 (20120809)
-- dimensions: *id710
+- dimensions: *id732
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20120809_cache]
   title: Landeskarte 1:1 Mio. | LK1000 (20120809, source)
-- dimensions: &id711
+- dimensions: &id733
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache_out]
   title: Landeskarte 1:1 Mio. | LK1000 (20111027)
-- dimensions: *id711
+- dimensions: *id733
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20111027_cache]
   title: Landeskarte 1:1 Mio. | LK1000 (20111027, source)
-- dimensions: &id712
+- dimensions: &id734
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20151231)
-- dimensions: *id712
+- dimensions: *id734
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
   title: Landeskarte 1:100'000 | LK100 ('current')
-- dimensions: *id712
+- dimensions: *id734
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
   title: Landeskarte 1:100'000 | LK100 (20151231, source)
-- dimensions: &id713
+- dimensions: &id735
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20140106)
-- dimensions: *id713
+- dimensions: *id735
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20140106_cache]
   title: Landeskarte 1:100'000 | LK100 (20140106, source)
-- dimensions: &id714
+- dimensions: &id736
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20130903)
-- dimensions: *id714
+- dimensions: *id736
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130903_cache]
   title: Landeskarte 1:100'000 | LK100 (20130903, source)
-- dimensions: &id715
+- dimensions: &id737
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20130213)
-- dimensions: *id715
+- dimensions: *id737
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20130213_cache]
   title: Landeskarte 1:100'000 | LK100 (20130213, source)
-- dimensions: &id716
+- dimensions: &id738
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20120809)
-- dimensions: *id716
+- dimensions: *id738
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20120809_cache]
   title: Landeskarte 1:100'000 | LK100 (20120809, source)
-- dimensions: &id717
+- dimensions: &id739
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20111206)
-- dimensions: *id717
+- dimensions: *id739
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111206_cache]
   title: Landeskarte 1:100'000 | LK100 (20111206, source)
-- dimensions: &id718
+- dimensions: &id740
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20111027)
-- dimensions: *id718
+- dimensions: *id740
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20111027_cache]
   title: Landeskarte 1:100'000 | LK100 (20111027, source)
-- dimensions: &id719
+- dimensions: &id741
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache_out]
   title: Landeskarte 1:200'000 | LK200 (20151231)
-- dimensions: *id719
+- dimensions: *id741
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
   title: Landeskarte 1:200'000 | LK200 ('current')
-- dimensions: *id719
+- dimensions: *id741
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
   title: Landeskarte 1:200'000 | LK200 (20151231, source)
-- dimensions: &id720
+- dimensions: &id742
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache_out]
   title: Landeskarte 1:200'000 | LK200 (20111027)
-- dimensions: *id720
+- dimensions: *id742
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20111027_cache]
   title: Landeskarte 1:200'000 | LK200 (20111027, source)
-- dimensions: &id721
+- dimensions: &id743
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id721
+- dimensions: *id743
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id721
+- dimensions: *id743
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id722
+- dimensions: &id744
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140520)
-- dimensions: *id722
+- dimensions: *id744
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140520_cache]
   title: Landeskarte 1:25'000 | LK25 (20140520, source)
-- dimensions: &id723
+- dimensions: &id745
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140106)
-- dimensions: *id723
+- dimensions: *id745
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20140106_cache]
   title: Landeskarte 1:25'000 | LK25 (20140106, source)
-- dimensions: &id724
+- dimensions: &id746
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130903)
-- dimensions: *id724
+- dimensions: *id746
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130903_cache]
   title: Landeskarte 1:25'000 | LK25 (20130903, source)
-- dimensions: &id725
+- dimensions: &id747
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130213)
-- dimensions: *id725
+- dimensions: *id747
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20130213_cache]
   title: Landeskarte 1:25'000 | LK25 (20130213, source)
-- dimensions: &id726
+- dimensions: &id748
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20120809)
-- dimensions: *id726
+- dimensions: *id748
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20120809_cache]
   title: Landeskarte 1:25'000 | LK25 (20120809, source)
-- dimensions: &id727
+- dimensions: &id749
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111027)
-- dimensions: *id727
+- dimensions: *id749
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20111027_cache]
   title: Landeskarte 1:25'000 | LK25 (20111027, source)
-- dimensions: &id728
+- dimensions: &id750
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache_out]
   title: Landeskarte 1:500'000 | LK500 (20151231)
-- dimensions: *id728
+- dimensions: *id750
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
   title: Landeskarte 1:500'000 | LK500 ('current')
-- dimensions: *id728
+- dimensions: *id750
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
   title: Landeskarte 1:500'000 | LK500 (20151231, source)
-- dimensions: &id729
+- dimensions: &id751
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache_out]
   title: Landeskarte 1:500'000 | LK500 (20111027)
-- dimensions: *id729
+- dimensions: *id751
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20111027_cache]
   title: Landeskarte 1:500'000 | LK500 (20111027, source)
-- dimensions: &id730
+- dimensions: &id752
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20151231)
-- dimensions: *id730
+- dimensions: *id752
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
   title: Landeskarte 1:50'000 | LK50 ('current')
-- dimensions: *id730
+- dimensions: *id752
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
   title: Landeskarte 1:50'000 | LK50 (20151231, source)
-- dimensions: &id731
+- dimensions: &id753
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20140520)
-- dimensions: *id731
+- dimensions: *id753
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140520_cache]
   title: Landeskarte 1:50'000 | LK50 (20140520, source)
-- dimensions: &id732
+- dimensions: &id754
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20140106)
-- dimensions: *id732
+- dimensions: *id754
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20140106_cache]
   title: Landeskarte 1:50'000 | LK50 (20140106, source)
-- dimensions: &id733
+- dimensions: &id755
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20130903)
-- dimensions: *id733
+- dimensions: *id755
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130903_cache]
   title: Landeskarte 1:50'000 | LK50 (20130903, source)
-- dimensions: &id734
+- dimensions: &id756
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20130213)
-- dimensions: *id734
+- dimensions: *id756
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20130213_cache]
   title: Landeskarte 1:50'000 | LK50 (20130213, source)
-- dimensions: &id735
+- dimensions: &id757
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20120809)
-- dimensions: *id735
+- dimensions: *id757
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20120809_cache]
   title: Landeskarte 1:50'000 | LK50 (20120809, source)
-- dimensions: &id736
+- dimensions: &id758
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20111027)
-- dimensions: *id736
+- dimensions: *id758
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20111027_cache]
   title: Landeskarte 1:50'000 | LK50 (20111027, source)
-- dimensions: &id737
+- dimensions: &id759
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-grau_20151231
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id737
+- dimensions: *id759
   name: ch.swisstopo.pixelkarte-grau
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id737
+- dimensions: *id759
   name: ch.swisstopo.pixelkarte-grau_20151231_source
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id738
+- dimensions: &id760
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-grau_20140520
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140520)
-- dimensions: *id738
+- dimensions: *id760
   name: ch.swisstopo.pixelkarte-grau_20140520_source
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache]
   title: Landeskarte 1:25'000 | LK25 (20140520, source)
-- dimensions: &id739
+- dimensions: &id761
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-grau_20140106
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140106)
-- dimensions: *id739
+- dimensions: *id761
   name: ch.swisstopo.pixelkarte-grau_20140106_source
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache]
   title: Landeskarte 1:25'000 | LK25 (20140106, source)
-- dimensions: &id740
+- dimensions: &id762
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-grau_20130903
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130903)
-- dimensions: *id740
+- dimensions: *id762
   name: ch.swisstopo.pixelkarte-grau_20130903_source
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache]
   title: Landeskarte 1:25'000 | LK25 (20130903, source)
-- dimensions: &id741
+- dimensions: &id763
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-grau_20130213
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130213)
-- dimensions: *id741
+- dimensions: *id763
   name: ch.swisstopo.pixelkarte-grau_20130213_source
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache]
   title: Landeskarte 1:25'000 | LK25 (20130213, source)
-- dimensions: &id742
+- dimensions: &id764
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-grau_20120809
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20120809)
-- dimensions: *id742
+- dimensions: *id764
   name: ch.swisstopo.pixelkarte-grau_20120809_source
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache]
   title: Landeskarte 1:25'000 | LK25 (20120809, source)
-- dimensions: &id743
+- dimensions: &id765
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-grau_20111206
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111206)
-- dimensions: *id743
+- dimensions: *id765
   name: ch.swisstopo.pixelkarte-grau_20111206_source
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache]
   title: Landeskarte 1:25'000 | LK25 (20111206, source)
-- dimensions: &id744
+- dimensions: &id766
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-grau_20111027
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111027)
-- dimensions: *id744
+- dimensions: *id766
   name: ch.swisstopo.pixelkarte-grau_20111027_source
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache]
   title: Landeskarte 1:25'000 | LK25 (20111027, source)
-- dimensions: &id745
+- dimensions: &id767
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-grau_20110401
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20110401)
-- dimensions: *id745
+- dimensions: *id767
   name: ch.swisstopo.pixelkarte-grau_20110401_source
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache]
   title: Landeskarte 1:25'000 | LK25 (20110401, source)
-- dimensions: &id746
+- dimensions: &id768
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache_out]
   title: swissALTI3D Reliefschattierung (20150101)
-- dimensions: *id746
+- dimensions: *id768
   name: ch.swisstopo.swissalti3d-reliefschattierung
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung ('current')
-- dimensions: *id746
+- dimensions: *id768
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung (20150101, source)
-- dimensions: &id747
+- dimensions: &id769
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20140101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache_out]
   title: swissALTI3D Reliefschattierung (20140101)
-- dimensions: *id747
+- dimensions: *id769
   name: ch.swisstopo.swissalti3d-reliefschattierung_20140101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20140101_cache]
   title: swissALTI3D Reliefschattierung (20140101, source)
-- dimensions: &id748
+- dimensions: &id770
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20130101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache_out]
   title: swissALTI3D Reliefschattierung (20130101)
-- dimensions: *id748
+- dimensions: *id770
   name: ch.swisstopo.swissalti3d-reliefschattierung_20130101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20130101_cache]
   title: swissALTI3D Reliefschattierung (20130101, source)
-- dimensions: &id749
+- dimensions: &id771
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20110101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache_out]
   title: swissALTI3D Reliefschattierung (20110101)
-- dimensions: *id749
+- dimensions: *id771
   name: ch.swisstopo.swissalti3d-reliefschattierung_20110101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20110101_cache]
   title: swissALTI3D Reliefschattierung (20110101, source)
-- dimensions: &id750
+- dimensions: &id772
     Time:
       default: '20000101'
       values: ['20000101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20000101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache_out]
   title: swissALTI3D Reliefschattierung (20000101)
-- dimensions: *id750
+- dimensions: *id772
   name: ch.swisstopo.swissalti3d-reliefschattierung_20000101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20000101_cache]
   title: swissALTI3D Reliefschattierung (20000101, source)
-- dimensions: &id751
+- dimensions: &id773
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache_out]
   title: Bezirksgrenzen (20150101)
-- dimensions: *id751
+- dimensions: *id773
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen ('current')
-- dimensions: *id751
+- dimensions: *id773
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen (20150101, source)
-- dimensions: &id752
+- dimensions: &id774
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache_out]
   title: Bezirksgrenzen (20140101)
-- dimensions: *id752
+- dimensions: *id774
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20140101_cache]
   title: Bezirksgrenzen (20140101, source)
-- dimensions: &id753
+- dimensions: &id775
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache_out]
   title: Bezirksgrenzen (20130101)
-- dimensions: *id753
+- dimensions: *id775
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20130101_cache]
   title: Bezirksgrenzen (20130101, source)
-- dimensions: &id754
+- dimensions: &id776
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache_out]
   title: Bezirksgrenzen (20120101)
-- dimensions: *id754
+- dimensions: *id776
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20120101_cache]
   title: Bezirksgrenzen (20120101, source)
-- dimensions: &id755
+- dimensions: &id777
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache_out]
   title: Gemeindegrenzen (20150101)
-- dimensions: *id755
+- dimensions: *id777
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen ('current')
-- dimensions: *id755
+- dimensions: *id777
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen (20150101, source)
-- dimensions: &id756
+- dimensions: &id778
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache_out]
   title: Gemeindegrenzen (20140101)
-- dimensions: *id756
+- dimensions: *id778
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20140101_cache]
   title: Gemeindegrenzen (20140101, source)
-- dimensions: &id757
+- dimensions: &id779
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache_out]
   title: Gemeindegrenzen (20130101)
-- dimensions: *id757
+- dimensions: *id779
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20130101_cache]
   title: Gemeindegrenzen (20130101, source)
-- dimensions: &id758
+- dimensions: &id780
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache_out]
   title: Gemeindegrenzen (20120101)
-- dimensions: *id758
+- dimensions: *id780
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20120101_cache]
   title: Gemeindegrenzen (20120101, source)
-- dimensions: &id759
+- dimensions: &id781
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache_out]
   title: Kantonsgrenzen (20150101)
-- dimensions: *id759
+- dimensions: *id781
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen ('current')
-- dimensions: *id759
+- dimensions: *id781
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen (20150101, source)
-- dimensions: &id760
+- dimensions: &id782
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache_out]
   title: Kantonsgrenzen (20140101)
-- dimensions: *id760
+- dimensions: *id782
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20140101_cache]
   title: Kantonsgrenzen (20140101, source)
-- dimensions: &id761
+- dimensions: &id783
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache_out]
   title: Kantonsgrenzen (20130101)
-- dimensions: *id761
+- dimensions: *id783
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20130101_cache]
   title: Kantonsgrenzen (20130101, source)
-- dimensions: &id762
+- dimensions: &id784
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache_out]
   title: Kantonsgrenzen (20120101)
-- dimensions: *id762
+- dimensions: *id784
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20120101_cache]
   title: Kantonsgrenzen (20120101, source)
-- dimensions: &id763
+- dimensions: &id785
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache_out]
   title: Landesgrenzen (20150101)
-- dimensions: *id763
+- dimensions: *id785
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen ('current')
-- dimensions: *id763
+- dimensions: *id785
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen (20150101, source)
-- dimensions: &id764
+- dimensions: &id786
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache_out]
   title: Landesgrenzen (20140101)
-- dimensions: *id764
+- dimensions: *id786
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20140101_cache]
   title: Landesgrenzen (20140101, source)
-- dimensions: &id765
+- dimensions: &id787
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache_out]
   title: Landesgrenzen (20130101)
-- dimensions: *id765
+- dimensions: *id787
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20130101_cache]
   title: Landesgrenzen (20130101, source)
-- dimensions: &id766
+- dimensions: &id788
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache_out]
   title: Landesgrenzen (20120101)
-- dimensions: *id766
+- dimensions: *id788
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20120101_cache]
   title: Landesgrenzen (20120101, source)
-- dimensions: &id767
+- dimensions: &id789
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.swissbuildings3d_19980101
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache_out]
   title: "Vereinfachte 3D-Geb\xE4ude (19980101)"
-- dimensions: *id767
+- dimensions: *id789
   name: ch.swisstopo.swissbuildings3d
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude ('current')"
-- dimensions: *id767
+- dimensions: *id789
   name: ch.swisstopo.swissbuildings3d_19980101_source
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude (19980101, source)"
-- dimensions: &id768
+- dimensions: &id790
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.swissimage_20151231
   sources: [ch.swisstopo.swissimage_20151231_cache_out]
   title: SWISSIMAGE (20151231)
-- dimensions: *id768
+- dimensions: *id790
   name: ch.swisstopo.swissimage
   sources: [ch.swisstopo.swissimage_20151231_cache]
   title: SWISSIMAGE ('current')
-- dimensions: *id768
+- dimensions: *id790
   name: ch.swisstopo.swissimage_20151231_source
   sources: [ch.swisstopo.swissimage_20151231_cache]
   title: SWISSIMAGE (20151231, source)
-- dimensions: &id769
+- dimensions: &id791
     Time:
       default: '20140620'
       values: ['20140620']
   name: ch.swisstopo.swissimage_20140620
   sources: [ch.swisstopo.swissimage_20140620_cache_out]
   title: SWISSIMAGE (20140620)
-- dimensions: *id769
+- dimensions: *id791
   name: ch.swisstopo.swissimage_20140620_source
   sources: [ch.swisstopo.swissimage_20140620_cache]
   title: SWISSIMAGE (20140620, source)
-- dimensions: &id770
+- dimensions: &id792
     Time:
       default: '20131107'
       values: ['20131107']
   name: ch.swisstopo.swissimage_20131107
   sources: [ch.swisstopo.swissimage_20131107_cache_out]
   title: SWISSIMAGE (20131107)
-- dimensions: *id770
+- dimensions: *id792
   name: ch.swisstopo.swissimage_20131107_source
   sources: [ch.swisstopo.swissimage_20131107_cache]
   title: SWISSIMAGE (20131107, source)
-- dimensions: &id771
+- dimensions: &id793
     Time:
       default: '20130916'
       values: ['20130916']
   name: ch.swisstopo.swissimage_20130916
   sources: [ch.swisstopo.swissimage_20130916_cache_out]
   title: SWISSIMAGE (20130916)
-- dimensions: *id771
+- dimensions: *id793
   name: ch.swisstopo.swissimage_20130916_source
   sources: [ch.swisstopo.swissimage_20130916_cache]
   title: SWISSIMAGE (20130916, source)
-- dimensions: &id772
+- dimensions: &id794
     Time:
       default: '20130422'
       values: ['20130422']
   name: ch.swisstopo.swissimage_20130422
   sources: [ch.swisstopo.swissimage_20130422_cache_out]
   title: SWISSIMAGE (20130422)
-- dimensions: *id772
+- dimensions: *id794
   name: ch.swisstopo.swissimage_20130422_source
   sources: [ch.swisstopo.swissimage_20130422_cache]
   title: SWISSIMAGE (20130422, source)
-- dimensions: &id773
+- dimensions: &id795
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.swissimage_20120809
   sources: [ch.swisstopo.swissimage_20120809_cache_out]
   title: SWISSIMAGE (20120809)
-- dimensions: *id773
+- dimensions: *id795
   name: ch.swisstopo.swissimage_20120809_source
   sources: [ch.swisstopo.swissimage_20120809_cache]
   title: SWISSIMAGE (20120809, source)
-- dimensions: &id774
+- dimensions: &id796
     Time:
       default: '20120225'
       values: ['20120225']
   name: ch.swisstopo.swissimage_20120225
   sources: [ch.swisstopo.swissimage_20120225_cache_out]
   title: SWISSIMAGE (20120225)
-- dimensions: *id774
+- dimensions: *id796
   name: ch.swisstopo.swissimage_20120225_source
   sources: [ch.swisstopo.swissimage_20120225_cache]
   title: SWISSIMAGE (20120225, source)
-- dimensions: &id775
+- dimensions: &id797
     Time:
       default: '20110914'
       values: ['20110914']
   name: ch.swisstopo.swissimage_20110914
   sources: [ch.swisstopo.swissimage_20110914_cache_out]
   title: SWISSIMAGE (20110914)
-- dimensions: *id775
+- dimensions: *id797
   name: ch.swisstopo.swissimage_20110914_source
   sources: [ch.swisstopo.swissimage_20110914_cache]
   title: SWISSIMAGE (20110914, source)
-- dimensions: &id776
+- dimensions: &id798
     Time:
       default: '20110228'
       values: ['20110228']
   name: ch.swisstopo.swissimage_20110228
   sources: [ch.swisstopo.swissimage_20110228_cache_out]
   title: SWISSIMAGE (20110228)
-- dimensions: *id776
+- dimensions: *id798
   name: ch.swisstopo.swissimage_20110228_source
   sources: [ch.swisstopo.swissimage_20110228_cache]
   title: SWISSIMAGE (20110228, source)
-- dimensions: &id777
+- dimensions: &id799
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.swisstopo.swissnames3d_20150101
+  sources: [ch.swisstopo.swissnames3d_20150101_cache_out]
+  title: Geografische Namen swissNAMES3D (20150101)
+- dimensions: *id799
+  name: ch.swisstopo.swissnames3d
+  sources: [ch.swisstopo.swissnames3d_20150101_cache]
+  title: Geografische Namen swissNAMES3D ('current')
+- dimensions: *id799
+  name: ch.swisstopo.swissnames3d_20150101_source
+  sources: [ch.swisstopo.swissnames3d_20150101_cache]
+  title: Geografische Namen swissNAMES3D (20150101, source)
+- dimensions: &id800
     Time:
       default: '20150401'
       values: ['20150401']
   name: ch.swisstopo.swisstlm3d-karte-farbe_20150401
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache_out]
   title: Karte swissTLM (farbig) (20150401)
-- dimensions: *id777
+- dimensions: *id800
   name: ch.swisstopo.swisstlm3d-karte-farbe
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache]
   title: Karte swissTLM (farbig) ('current')
-- dimensions: *id777
+- dimensions: *id800
   name: ch.swisstopo.swisstlm3d-karte-farbe_20150401_source
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache]
   title: Karte swissTLM (farbig) (20150401, source)
-- dimensions: &id778
+- dimensions: &id801
     Time:
       default: '20150401'
       values: ['20150401']
   name: ch.swisstopo.swisstlm3d-karte-grau_20150401
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache_out]
   title: Karte swissTLM (grau) (20150401)
-- dimensions: *id778
+- dimensions: *id801
   name: ch.swisstopo.swisstlm3d-karte-grau
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache]
   title: Karte swissTLM (grau) ('current')
-- dimensions: *id778
+- dimensions: *id801
   name: ch.swisstopo.swisstlm3d-karte-grau_20150401_source
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache]
   title: Karte swissTLM (grau) (20150401, source)
-- dimensions: &id779
+- dimensions: &id802
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20150101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache_out]
   title: Wanderwege (20150101)
-- dimensions: *id779
+- dimensions: *id802
   name: ch.swisstopo.swisstlm3d-wanderwege
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
   title: Wanderwege ('current')
-- dimensions: *id779
+- dimensions: *id802
   name: ch.swisstopo.swisstlm3d-wanderwege_20150101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
   title: Wanderwege (20150101, source)
-- dimensions: &id780
+- dimensions: &id803
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20140101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache_out]
   title: Wanderwege (20140101)
-- dimensions: *id780
+- dimensions: *id803
   name: ch.swisstopo.swisstlm3d-wanderwege_20140101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20140101_cache]
   title: Wanderwege (20140101, source)
-- dimensions: &id781
+- dimensions: &id804
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20130101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20130101_cache_out]
   title: Wanderwege (20130101)
-- dimensions: *id781
+- dimensions: *id804
   name: ch.swisstopo.swisstlm3d-wanderwege_20130101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20130101_cache]
   title: Wanderwege (20130101, source)
-- dimensions: &id782
+- dimensions: &id805
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo.transformationsgenauigkeit_20141101
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache_out]
   title: LV95 Transformationsgenauigkeit (20141101)
-- dimensions: *id782
+- dimensions: *id805
   name: ch.swisstopo.transformationsgenauigkeit
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit ('current')
-- dimensions: *id782
+- dimensions: *id805
   name: ch.swisstopo.transformationsgenauigkeit_20141101_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit (20141101, source)
-- dimensions: &id783
+- dimensions: &id806
     Time:
       default: '20131028'
       values: ['20131028']
   name: ch.swisstopo.transformationsgenauigkeit_20131028
   sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache_out]
   title: LV95 Transformationsgenauigkeit (20131028)
-- dimensions: *id783
+- dimensions: *id806
   name: ch.swisstopo.transformationsgenauigkeit_20131028_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20131028_cache]
   title: LV95 Transformationsgenauigkeit (20131028, source)
-- dimensions: &id784
+- dimensions: &id807
     Time:
       default: '20100531'
       values: ['20100531']
   name: ch.swisstopo.transformationsgenauigkeit_20100531
   sources: [ch.swisstopo.transformationsgenauigkeit_20100531_cache_out]
   title: LV95 Transformationsgenauigkeit (20100531)
-- dimensions: *id784
+- dimensions: *id807
   name: ch.swisstopo.transformationsgenauigkeit_20100531_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20100531_cache]
   title: LV95 Transformationsgenauigkeit (20100531, source)
-- dimensions: &id785
+- dimensions: &id808
     Time:
       default: '20131101'
       values: ['20131101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache_out]
   title: PLZ und Ortschaften (20131101)
-- dimensions: *id785
+- dimensions: *id808
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften ('current')
-- dimensions: *id785
+- dimensions: *id808
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften (20131101, source)
-- dimensions: &id786
+- dimensions: &id809
     Time:
       default: '20130501'
       values: ['20130501']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache_out]
   title: PLZ und Ortschaften (20130501)
-- dimensions: *id786
+- dimensions: *id809
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20130501_cache]
   title: PLZ und Ortschaften (20130501, source)
-- dimensions: &id787
+- dimensions: &id810
     Time:
       default: '20121102'
       values: ['20121102']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache_out]
   title: PLZ und Ortschaften (20121102)
-- dimensions: *id787
+- dimensions: *id810
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20121102_cache]
   title: PLZ und Ortschaften (20121102, source)
-- dimensions: &id788
+- dimensions: &id811
     Time:
       default: '20120501'
       values: ['20120501']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache_out]
   title: PLZ und Ortschaften (20120501)
-- dimensions: *id788
+- dimensions: *id811
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20120501_cache]
   title: PLZ und Ortschaften (20120501, source)
-- dimensions: &id789
+- dimensions: &id812
     Time:
       default: '20111101'
       values: ['20111101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache_out]
   title: PLZ und Ortschaften (20111101)
-- dimensions: *id789
+- dimensions: *id812
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20111101_cache]
   title: PLZ und Ortschaften (20111101, source)
-- dimensions: &id790
+- dimensions: &id813
     Time:
       default: '20110502'
       values: ['20110502']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache_out]
   title: PLZ und Ortschaften (20110502)
-- dimensions: *id790
+- dimensions: *id813
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20110502_cache]
   title: PLZ und Ortschaften (20110502, source)
-- dimensions: &id791
+- dimensions: &id814
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache_out]
   title: Spannungsarme Gebiete (20141101)
-- dimensions: *id791
+- dimensions: *id814
   name: ch.swisstopo-vd.spannungsarme-gebiete
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete ('current')
-- dimensions: *id791
+- dimensions: *id814
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete (20141101, source)
-- dimensions: &id792
+- dimensions: &id815
     Time:
       default: '20131028'
       values: ['20131028']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20131028
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache_out]
   title: Spannungsarme Gebiete (20131028)
-- dimensions: *id792
+- dimensions: *id815
   name: ch.swisstopo-vd.spannungsarme-gebiete_20131028_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20131028_cache]
   title: Spannungsarme Gebiete (20131028, source)
-- dimensions: &id793
+- dimensions: &id816
     Time:
       default: '20121102'
       values: ['20121102']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20121102
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache_out]
   title: Spannungsarme Gebiete (20121102)
-- dimensions: *id793
+- dimensions: *id816
   name: ch.swisstopo-vd.spannungsarme-gebiete_20121102_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20121102_cache]
   title: Spannungsarme Gebiete (20121102, source)
-- dimensions: &id794
+- dimensions: &id817
     Time:
       default: '20111216'
       values: ['20111216']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20111216
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache_out]
   title: Spannungsarme Gebiete (20111216)
-- dimensions: *id794
+- dimensions: *id817
   name: ch.swisstopo-vd.spannungsarme-gebiete_20111216_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20111216_cache]
   title: Spannungsarme Gebiete (20111216, source)
-- dimensions: &id795
+- dimensions: &id818
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20150101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache_out]
   title: Schutzgebiete VECTOR200 (20150101)
-- dimensions: *id795
+- dimensions: *id818
   name: ch.swisstopo.vec200-adminboundaries-protectedarea
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache]
   title: Schutzgebiete VECTOR200 ('current')
-- dimensions: *id795
+- dimensions: *id818
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache]
   title: Schutzgebiete VECTOR200 (20150101, source)
-- dimensions: &id796
+- dimensions: &id819
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20140101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache_out]
   title: Schutzgebiete VECTOR200 (20140101)
-- dimensions: *id796
+- dimensions: *id819
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20140101_cache]
   title: Schutzgebiete VECTOR200 (20140101, source)
-- dimensions: &id797
+- dimensions: &id820
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20130101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache_out]
   title: Schutzgebiete VECTOR200 (20130101)
-- dimensions: *id797
+- dimensions: *id820
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20130101_cache]
   title: Schutzgebiete VECTOR200 (20130101, source)
-- dimensions: &id798
+- dimensions: &id821
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20100101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache_out]
   title: Schutzgebiete VECTOR200 (20100101)
-- dimensions: *id798
+- dimensions: *id821
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20100101_cache]
   title: Schutzgebiete VECTOR200 (20100101, source)
-- dimensions: &id799
+- dimensions: &id822
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-building_20150101
   sources: [ch.swisstopo.vec200-building_20150101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20150101)"
-- dimensions: *id799
+- dimensions: *id822
   name: ch.swisstopo.vec200-building
   sources: [ch.swisstopo.vec200-building_20150101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 ('current')"
-- dimensions: *id799
+- dimensions: *id822
   name: ch.swisstopo.vec200-building_20150101_source
   sources: [ch.swisstopo.vec200-building_20150101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20150101, source)"
-- dimensions: &id800
+- dimensions: &id823
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-building_20140101
   sources: [ch.swisstopo.vec200-building_20140101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20140101)"
-- dimensions: *id800
+- dimensions: *id823
   name: ch.swisstopo.vec200-building_20140101_source
   sources: [ch.swisstopo.vec200-building_20140101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20140101, source)"
-- dimensions: &id801
+- dimensions: &id824
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-building_20130101
   sources: [ch.swisstopo.vec200-building_20130101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20130101)"
-- dimensions: *id801
+- dimensions: *id824
   name: ch.swisstopo.vec200-building_20130101_source
   sources: [ch.swisstopo.vec200-building_20130101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20130101, source)"
-- dimensions: &id802
+- dimensions: &id825
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-building_20100101
   sources: [ch.swisstopo.vec200-building_20100101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20100101)"
-- dimensions: *id802
+- dimensions: *id825
   name: ch.swisstopo.vec200-building_20100101_source
   sources: [ch.swisstopo.vec200-building_20100101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20100101, source)"
-- dimensions: &id803
+- dimensions: &id826
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-hydrography_20150101
   sources: [ch.swisstopo.vec200-hydrography_20150101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20150101)"
-- dimensions: *id803
+- dimensions: *id826
   name: ch.swisstopo.vec200-hydrography
   sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
   title: "Gew\xE4ssernetz VECTOR200 ('current')"
-- dimensions: *id803
+- dimensions: *id826
   name: ch.swisstopo.vec200-hydrography_20150101_source
   sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20150101, source)"
-- dimensions: &id804
+- dimensions: &id827
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-hydrography_20140101
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20140101)"
-- dimensions: *id804
+- dimensions: *id827
   name: ch.swisstopo.vec200-hydrography_20140101_source
   sources: [ch.swisstopo.vec200-hydrography_20140101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20140101, source)"
-- dimensions: &id805
+- dimensions: &id828
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-hydrography_20130101
   sources: [ch.swisstopo.vec200-hydrography_20130101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20130101)"
-- dimensions: *id805
+- dimensions: *id828
   name: ch.swisstopo.vec200-hydrography_20130101_source
   sources: [ch.swisstopo.vec200-hydrography_20130101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20130101, source)"
-- dimensions: &id806
+- dimensions: &id829
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-hydrography_20100101
   sources: [ch.swisstopo.vec200-hydrography_20100101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20100101)"
-- dimensions: *id806
+- dimensions: *id829
   name: ch.swisstopo.vec200-hydrography_20100101_source
   sources: [ch.swisstopo.vec200-hydrography_20100101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20100101, source)"
-- dimensions: &id807
+- dimensions: &id830
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-landcover_20150101
   sources: [ch.swisstopo.vec200-landcover_20150101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20150101)
-- dimensions: *id807
+- dimensions: *id830
   name: ch.swisstopo.vec200-landcover
   sources: [ch.swisstopo.vec200-landcover_20150101_cache]
   title: Prim. Bodenbedeckung VECTOR200 ('current')
-- dimensions: *id807
+- dimensions: *id830
   name: ch.swisstopo.vec200-landcover_20150101_source
   sources: [ch.swisstopo.vec200-landcover_20150101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20150101, source)
-- dimensions: &id808
+- dimensions: &id831
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-landcover_20140101
   sources: [ch.swisstopo.vec200-landcover_20140101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20140101)
-- dimensions: *id808
+- dimensions: *id831
   name: ch.swisstopo.vec200-landcover_20140101_source
   sources: [ch.swisstopo.vec200-landcover_20140101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20140101, source)
-- dimensions: &id809
+- dimensions: &id832
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-landcover_20130101
   sources: [ch.swisstopo.vec200-landcover_20130101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20130101)
-- dimensions: *id809
+- dimensions: *id832
   name: ch.swisstopo.vec200-landcover_20130101_source
   sources: [ch.swisstopo.vec200-landcover_20130101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20130101, source)
-- dimensions: &id810
+- dimensions: &id833
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-landcover_20100101
   sources: [ch.swisstopo.vec200-landcover_20100101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20100101)
-- dimensions: *id810
+- dimensions: *id833
   name: ch.swisstopo.vec200-landcover_20100101_source
   sources: [ch.swisstopo.vec200-landcover_20100101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20100101, source)
-- dimensions: &id811
+- dimensions: &id834
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-landcover-wald_20150101
   sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache_out]
   title: "Waldfl\xE4chen (20150101)"
-- dimensions: *id811
+- dimensions: *id834
   name: ch.swisstopo.vec200-landcover-wald
   sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
   title: "Waldfl\xE4chen ('current')"
-- dimensions: *id811
+- dimensions: *id834
   name: ch.swisstopo.vec200-landcover-wald_20150101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
   title: "Waldfl\xE4chen (20150101, source)"
-- dimensions: &id812
+- dimensions: &id835
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-landcover-wald_20140101
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache_out]
   title: "Waldfl\xE4chen (20140101)"
-- dimensions: *id812
+- dimensions: *id835
   name: ch.swisstopo.vec200-landcover-wald_20140101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20140101_cache]
   title: "Waldfl\xE4chen (20140101, source)"
-- dimensions: &id813
+- dimensions: &id836
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-landcover-wald_20130101
   sources: [ch.swisstopo.vec200-landcover-wald_20130101_cache_out]
   title: "Waldfl\xE4chen (20130101)"
-- dimensions: *id813
+- dimensions: *id836
   name: ch.swisstopo.vec200-landcover-wald_20130101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20130101_cache]
   title: "Waldfl\xE4chen (20130101, source)"
-- dimensions: &id814
+- dimensions: &id837
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-miscellaneous_20150101
   sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache_out]
   title: Einzelobjekte VECTOR200 (20150101)
-- dimensions: *id814
+- dimensions: *id837
   name: ch.swisstopo.vec200-miscellaneous
   sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
   title: Einzelobjekte VECTOR200 ('current')
-- dimensions: *id814
+- dimensions: *id837
   name: ch.swisstopo.vec200-miscellaneous_20150101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
   title: Einzelobjekte VECTOR200 (20150101, source)
-- dimensions: &id815
+- dimensions: &id838
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-miscellaneous_20140101
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache_out]
   title: Einzelobjekte VECTOR200 (20140101)
-- dimensions: *id815
+- dimensions: *id838
   name: ch.swisstopo.vec200-miscellaneous_20140101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20140101_cache]
   title: Einzelobjekte VECTOR200 (20140101, source)
-- dimensions: &id816
+- dimensions: &id839
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-miscellaneous_20130101
   sources: [ch.swisstopo.vec200-miscellaneous_20130101_cache_out]
   title: Einzelobjekte VECTOR200 (20130101)
-- dimensions: *id816
+- dimensions: *id839
   name: ch.swisstopo.vec200-miscellaneous_20130101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20130101_cache]
   title: Einzelobjekte VECTOR200 (20130101, source)
-- dimensions: &id817
+- dimensions: &id840
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-miscellaneous_20100101
   sources: [ch.swisstopo.vec200-miscellaneous_20100101_cache_out]
   title: Einzelobjekte VECTOR200 (20100101)
-- dimensions: *id817
+- dimensions: *id840
   name: ch.swisstopo.vec200-miscellaneous_20100101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20100101_cache]
   title: Einzelobjekte VECTOR200 (20100101, source)
-- dimensions: &id818
+- dimensions: &id841
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20150101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20150101)"
-- dimensions: *id818
+- dimensions: *id841
   name: ch.swisstopo.vec200-miscellaneous-geodpoint
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache]
   title: "H\xF6henkoten VECTOR200 ('current')"
-- dimensions: *id818
+- dimensions: *id841
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache]
   title: "H\xF6henkoten VECTOR200 (20150101, source)"
-- dimensions: &id819
+- dimensions: &id842
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20140101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20140101)"
-- dimensions: *id819
+- dimensions: *id842
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20140101_cache]
   title: "H\xF6henkoten VECTOR200 (20140101, source)"
-- dimensions: &id820
+- dimensions: &id843
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20130101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20130101)"
-- dimensions: *id820
+- dimensions: *id843
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20130101_cache]
   title: "H\xF6henkoten VECTOR200 (20130101, source)"
-- dimensions: &id821
+- dimensions: &id844
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20100101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20100101)"
-- dimensions: *id821
+- dimensions: *id844
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20100101_cache]
   title: "H\xF6henkoten VECTOR200 (20100101, source)"
-- dimensions: &id822
+- dimensions: &id845
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-names-namedlocation_20150101
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache_out]
   title: Namen VECTOR200 (20150101)
-- dimensions: *id822
+- dimensions: *id845
   name: ch.swisstopo.vec200-names-namedlocation
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache]
   title: Namen VECTOR200 ('current')
-- dimensions: *id822
+- dimensions: *id845
   name: ch.swisstopo.vec200-names-namedlocation_20150101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache]
   title: Namen VECTOR200 (20150101, source)
-- dimensions: &id823
+- dimensions: &id846
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-names-namedlocation_20140101
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache_out]
   title: Namen VECTOR200 (20140101)
-- dimensions: *id823
+- dimensions: *id846
   name: ch.swisstopo.vec200-names-namedlocation_20140101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20140101_cache]
   title: Namen VECTOR200 (20140101, source)
-- dimensions: &id824
+- dimensions: &id847
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-names-namedlocation_20130101
   sources: [ch.swisstopo.vec200-names-namedlocation_20130101_cache_out]
   title: Namen VECTOR200 (20130101)
-- dimensions: *id824
+- dimensions: *id847
   name: ch.swisstopo.vec200-names-namedlocation_20130101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20130101_cache]
   title: Namen VECTOR200 (20130101, source)
-- dimensions: &id825
+- dimensions: &id848
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-names-namedlocation_20100101
   sources: [ch.swisstopo.vec200-names-namedlocation_20100101_cache_out]
   title: Namen VECTOR200 (20100101)
-- dimensions: *id825
+- dimensions: *id848
   name: ch.swisstopo.vec200-names-namedlocation_20100101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20100101_cache]
   title: Namen VECTOR200 (20100101, source)
-- dimensions: &id826
+- dimensions: &id849
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20150101)"
-- dimensions: *id826
+- dimensions: *id849
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 ('current')"
-- dimensions: *id826
+- dimensions: *id849
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20150101, source)"
-- dimensions: &id827
+- dimensions: &id850
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20140101)"
-- dimensions: *id827
+- dimensions: *id850
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20140101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20140101, source)"
-- dimensions: &id828
+- dimensions: &id851
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20130101)"
-- dimensions: *id828
+- dimensions: *id851
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20130101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20130101, source)"
-- dimensions: &id829
+- dimensions: &id852
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20100101)"
-- dimensions: *id829
+- dimensions: *id852
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20100101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20100101, source)"
-- dimensions: &id830
+- dimensions: &id853
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20150101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache_out]
   title: Strassennetz VECTOR200 (20150101)
-- dimensions: *id830
+- dimensions: *id853
   name: ch.swisstopo.vec200-transportation-strassennetz
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
   title: Strassennetz VECTOR200 ('current')
-- dimensions: *id830
+- dimensions: *id853
   name: ch.swisstopo.vec200-transportation-strassennetz_20150101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
   title: Strassennetz VECTOR200 (20150101, source)
-- dimensions: &id831
+- dimensions: &id854
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20140101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache_out]
   title: Strassennetz VECTOR200 (20140101)
-- dimensions: *id831
+- dimensions: *id854
   name: ch.swisstopo.vec200-transportation-strassennetz_20140101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20140101_cache]
   title: Strassennetz VECTOR200 (20140101, source)
-- dimensions: &id832
+- dimensions: &id855
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20130101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20130101_cache_out]
   title: Strassennetz VECTOR200 (20130101)
-- dimensions: *id832
+- dimensions: *id855
   name: ch.swisstopo.vec200-transportation-strassennetz_20130101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20130101_cache]
   title: Strassennetz VECTOR200 (20130101, source)
-- dimensions: &id833
+- dimensions: &id856
     Time:
       default: '20100101'
       values: ['20100101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20100101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20100101_cache_out]
   title: Strassennetz VECTOR200 (20100101)
-- dimensions: *id833
+- dimensions: *id856
   name: ch.swisstopo.vec200-transportation-strassennetz_20100101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20100101_cache]
   title: Strassennetz VECTOR200 (20100101, source)
-- dimensions: &id834
+- dimensions: &id857
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-anlagen_20090401
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache_out]
   title: Anlagen VECTOR25 (20090401)
-- dimensions: *id834
+- dimensions: *id857
   name: ch.swisstopo.vec25-anlagen
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25 ('current')
-- dimensions: *id834
+- dimensions: *id857
   name: ch.swisstopo.vec25-anlagen_20090401_source
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25 (20090401, source)
-- dimensions: &id835
+- dimensions: &id858
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-einzelobjekte_19980101
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache_out]
   title: Einzelobjekte VECTOR25 (19980101)
-- dimensions: *id835
+- dimensions: *id858
   name: ch.swisstopo.vec25-einzelobjekte
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25 ('current')
-- dimensions: *id835
+- dimensions: *id858
   name: ch.swisstopo.vec25-einzelobjekte_19980101_source
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25 (19980101, source)
-- dimensions: &id836
+- dimensions: &id859
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache_out]
   title: Eisenbahnnetz VECTOR25 (20090401)
-- dimensions: *id836
+- dimensions: *id859
   name: ch.swisstopo.vec25-eisenbahnnetz
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25 ('current')
-- dimensions: *id836
+- dimensions: *id859
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401_source
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25 (20090401, source)
-- dimensions: &id837
+- dimensions: &id860
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gebaeude_20090401
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache_out]
   title: "Geb\xE4ude VECTOR25 (20090401)"
-- dimensions: *id837
+- dimensions: *id860
   name: ch.swisstopo.vec25-gebaeude
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25 ('current')"
-- dimensions: *id837
+- dimensions: *id860
   name: ch.swisstopo.vec25-gebaeude_20090401_source
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25 (20090401, source)"
-- dimensions: &id838
+- dimensions: &id861
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gewaessernetz_20090401
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache_out]
   title: "Gew\xE4ssernetz VECTOR25 (20090401)"
-- dimensions: *id838
+- dimensions: *id861
   name: ch.swisstopo.vec25-gewaessernetz
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25 ('current')"
-- dimensions: *id838
+- dimensions: *id861
   name: ch.swisstopo.vec25-gewaessernetz_20090401_source
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25 (20090401, source)"
-- dimensions: &id839
+- dimensions: &id862
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-heckenbaeume_19980101
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache_out]
   title: "Hecken und B\xE4ume VECTOR25 (19980101)"
-- dimensions: *id839
+- dimensions: *id862
   name: ch.swisstopo.vec25-heckenbaeume
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25 ('current')"
-- dimensions: *id839
+- dimensions: *id862
   name: ch.swisstopo.vec25-heckenbaeume_19980101_source
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25 (19980101, source)"
-- dimensions: &id840
+- dimensions: &id863
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-primaerflaechen_20090401
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache_out]
   title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401)"
-- dimensions: *id840
+- dimensions: *id863
   name: ch.swisstopo.vec25-primaerflaechen
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25 ('current')"
-- dimensions: *id840
+- dimensions: *id863
   name: ch.swisstopo.vec25-primaerflaechen_20090401_source
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401, source)"
-- dimensions: &id841
+- dimensions: &id864
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-strassennetz_20090401
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache_out]
   title: Strassennetz VECTOR25 (20090401)
-- dimensions: *id841
+- dimensions: *id864
   name: ch.swisstopo.vec25-strassennetz
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25 ('current')
-- dimensions: *id841
+- dimensions: *id864
   name: ch.swisstopo.vec25-strassennetz_20090401_source
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25 (20090401, source)
-- dimensions: &id842
+- dimensions: &id865
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache_out]
   title: "\xDCbriger Verkehr VECTOR25 (20090401)"
-- dimensions: *id842
+- dimensions: *id865
   name: ch.swisstopo.vec25-uebrigerverkehr
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25 ('current')"
-- dimensions: *id842
+- dimensions: *id865
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401_source
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25 (20090401, source)"
-- dimensions: &id843
+- dimensions: &id866
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache_out]
   title: LV95 Verschiebungsvektoren TSP1 (20061231)
-- dimensions: *id843
+- dimensions: *id866
   name: ch.swisstopo.verschiebungsvektoren-tsp1
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 ('current')
-- dimensions: *id843
+- dimensions: *id866
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 (20061231, source)
-- dimensions: &id844
+- dimensions: &id867
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache_out]
   title: LV95 Verschiebungsvektoren TSP2 (20070101)
-- dimensions: *id844
+- dimensions: *id867
   name: ch.swisstopo.verschiebungsvektoren-tsp2
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 ('current')
-- dimensions: *id844
+- dimensions: *id867
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 (20070101, source)
-- dimensions: &id845
+- dimensions: &id868
+    Time:
+      default: '20131231'
+      values: ['20131231']
+  name: ch.swisstopo.zeitreihen_20131231
+  sources: [ch.swisstopo.zeitreihen_20131231_cache_out]
+  title: Zeitreise - Kartenwerke (20131231)
+- dimensions: *id868
+  name: ch.swisstopo.zeitreihen
+  sources: [ch.swisstopo.zeitreihen_20131231_cache]
+  title: Zeitreise - Kartenwerke ('current')
+- dimensions: *id868
+  name: ch.swisstopo.zeitreihen_20131231_source
+  sources: [ch.swisstopo.zeitreihen_20131231_cache]
+  title: Zeitreise - Kartenwerke (20131231, source)
+- dimensions: &id869
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.swisstopo.zeitreihen_20121231
+  sources: [ch.swisstopo.zeitreihen_20121231_cache_out]
+  title: Zeitreise - Kartenwerke (20121231)
+- dimensions: *id869
+  name: ch.swisstopo.zeitreihen_20121231_source
+  sources: [ch.swisstopo.zeitreihen_20121231_cache]
+  title: Zeitreise - Kartenwerke (20121231, source)
+- dimensions: &id870
+    Time:
+      default: '20111231'
+      values: ['20111231']
+  name: ch.swisstopo.zeitreihen_20111231
+  sources: [ch.swisstopo.zeitreihen_20111231_cache_out]
+  title: Zeitreise - Kartenwerke (20111231)
+- dimensions: *id870
+  name: ch.swisstopo.zeitreihen_20111231_source
+  sources: [ch.swisstopo.zeitreihen_20111231_cache]
+  title: Zeitreise - Kartenwerke (20111231, source)
+- dimensions: &id871
+    Time:
+      default: '20101231'
+      values: ['20101231']
+  name: ch.swisstopo.zeitreihen_20101231
+  sources: [ch.swisstopo.zeitreihen_20101231_cache_out]
+  title: Zeitreise - Kartenwerke (20101231)
+- dimensions: *id871
+  name: ch.swisstopo.zeitreihen_20101231_source
+  sources: [ch.swisstopo.zeitreihen_20101231_cache]
+  title: Zeitreise - Kartenwerke (20101231, source)
+- dimensions: &id872
+    Time:
+      default: '20091231'
+      values: ['20091231']
+  name: ch.swisstopo.zeitreihen_20091231
+  sources: [ch.swisstopo.zeitreihen_20091231_cache_out]
+  title: Zeitreise - Kartenwerke (20091231)
+- dimensions: *id872
+  name: ch.swisstopo.zeitreihen_20091231_source
+  sources: [ch.swisstopo.zeitreihen_20091231_cache]
+  title: Zeitreise - Kartenwerke (20091231, source)
+- dimensions: &id873
+    Time:
+      default: '20081231'
+      values: ['20081231']
+  name: ch.swisstopo.zeitreihen_20081231
+  sources: [ch.swisstopo.zeitreihen_20081231_cache_out]
+  title: Zeitreise - Kartenwerke (20081231)
+- dimensions: *id873
+  name: ch.swisstopo.zeitreihen_20081231_source
+  sources: [ch.swisstopo.zeitreihen_20081231_cache]
+  title: Zeitreise - Kartenwerke (20081231, source)
+- dimensions: &id874
+    Time:
+      default: '20071231'
+      values: ['20071231']
+  name: ch.swisstopo.zeitreihen_20071231
+  sources: [ch.swisstopo.zeitreihen_20071231_cache_out]
+  title: Zeitreise - Kartenwerke (20071231)
+- dimensions: *id874
+  name: ch.swisstopo.zeitreihen_20071231_source
+  sources: [ch.swisstopo.zeitreihen_20071231_cache]
+  title: Zeitreise - Kartenwerke (20071231, source)
+- dimensions: &id875
+    Time:
+      default: '20061231'
+      values: ['20061231']
+  name: ch.swisstopo.zeitreihen_20061231
+  sources: [ch.swisstopo.zeitreihen_20061231_cache_out]
+  title: Zeitreise - Kartenwerke (20061231)
+- dimensions: *id875
+  name: ch.swisstopo.zeitreihen_20061231_source
+  sources: [ch.swisstopo.zeitreihen_20061231_cache]
+  title: Zeitreise - Kartenwerke (20061231, source)
+- dimensions: &id876
+    Time:
+      default: '20051231'
+      values: ['20051231']
+  name: ch.swisstopo.zeitreihen_20051231
+  sources: [ch.swisstopo.zeitreihen_20051231_cache_out]
+  title: Zeitreise - Kartenwerke (20051231)
+- dimensions: *id876
+  name: ch.swisstopo.zeitreihen_20051231_source
+  sources: [ch.swisstopo.zeitreihen_20051231_cache]
+  title: Zeitreise - Kartenwerke (20051231, source)
+- dimensions: &id877
+    Time:
+      default: '20041231'
+      values: ['20041231']
+  name: ch.swisstopo.zeitreihen_20041231
+  sources: [ch.swisstopo.zeitreihen_20041231_cache_out]
+  title: Zeitreise - Kartenwerke (20041231)
+- dimensions: *id877
+  name: ch.swisstopo.zeitreihen_20041231_source
+  sources: [ch.swisstopo.zeitreihen_20041231_cache]
+  title: Zeitreise - Kartenwerke (20041231, source)
+- dimensions: &id878
+    Time:
+      default: '20031231'
+      values: ['20031231']
+  name: ch.swisstopo.zeitreihen_20031231
+  sources: [ch.swisstopo.zeitreihen_20031231_cache_out]
+  title: Zeitreise - Kartenwerke (20031231)
+- dimensions: *id878
+  name: ch.swisstopo.zeitreihen_20031231_source
+  sources: [ch.swisstopo.zeitreihen_20031231_cache]
+  title: Zeitreise - Kartenwerke (20031231, source)
+- dimensions: &id879
+    Time:
+      default: '20021231'
+      values: ['20021231']
+  name: ch.swisstopo.zeitreihen_20021231
+  sources: [ch.swisstopo.zeitreihen_20021231_cache_out]
+  title: Zeitreise - Kartenwerke (20021231)
+- dimensions: *id879
+  name: ch.swisstopo.zeitreihen_20021231_source
+  sources: [ch.swisstopo.zeitreihen_20021231_cache]
+  title: Zeitreise - Kartenwerke (20021231, source)
+- dimensions: &id880
+    Time:
+      default: '20011231'
+      values: ['20011231']
+  name: ch.swisstopo.zeitreihen_20011231
+  sources: [ch.swisstopo.zeitreihen_20011231_cache_out]
+  title: Zeitreise - Kartenwerke (20011231)
+- dimensions: *id880
+  name: ch.swisstopo.zeitreihen_20011231_source
+  sources: [ch.swisstopo.zeitreihen_20011231_cache]
+  title: Zeitreise - Kartenwerke (20011231, source)
+- dimensions: &id881
+    Time:
+      default: '20001231'
+      values: ['20001231']
+  name: ch.swisstopo.zeitreihen_20001231
+  sources: [ch.swisstopo.zeitreihen_20001231_cache_out]
+  title: Zeitreise - Kartenwerke (20001231)
+- dimensions: *id881
+  name: ch.swisstopo.zeitreihen_20001231_source
+  sources: [ch.swisstopo.zeitreihen_20001231_cache]
+  title: Zeitreise - Kartenwerke (20001231, source)
+- dimensions: &id882
+    Time:
+      default: '19991231'
+      values: ['19991231']
+  name: ch.swisstopo.zeitreihen_19991231
+  sources: [ch.swisstopo.zeitreihen_19991231_cache_out]
+  title: Zeitreise - Kartenwerke (19991231)
+- dimensions: *id882
+  name: ch.swisstopo.zeitreihen_19991231_source
+  sources: [ch.swisstopo.zeitreihen_19991231_cache]
+  title: Zeitreise - Kartenwerke (19991231, source)
+- dimensions: &id883
+    Time:
+      default: '19981231'
+      values: ['19981231']
+  name: ch.swisstopo.zeitreihen_19981231
+  sources: [ch.swisstopo.zeitreihen_19981231_cache_out]
+  title: Zeitreise - Kartenwerke (19981231)
+- dimensions: *id883
+  name: ch.swisstopo.zeitreihen_19981231_source
+  sources: [ch.swisstopo.zeitreihen_19981231_cache]
+  title: Zeitreise - Kartenwerke (19981231, source)
+- dimensions: &id884
+    Time:
+      default: '19971231'
+      values: ['19971231']
+  name: ch.swisstopo.zeitreihen_19971231
+  sources: [ch.swisstopo.zeitreihen_19971231_cache_out]
+  title: Zeitreise - Kartenwerke (19971231)
+- dimensions: *id884
+  name: ch.swisstopo.zeitreihen_19971231_source
+  sources: [ch.swisstopo.zeitreihen_19971231_cache]
+  title: Zeitreise - Kartenwerke (19971231, source)
+- dimensions: &id885
+    Time:
+      default: '19961231'
+      values: ['19961231']
+  name: ch.swisstopo.zeitreihen_19961231
+  sources: [ch.swisstopo.zeitreihen_19961231_cache_out]
+  title: Zeitreise - Kartenwerke (19961231)
+- dimensions: *id885
+  name: ch.swisstopo.zeitreihen_19961231_source
+  sources: [ch.swisstopo.zeitreihen_19961231_cache]
+  title: Zeitreise - Kartenwerke (19961231, source)
+- dimensions: &id886
+    Time:
+      default: '19951231'
+      values: ['19951231']
+  name: ch.swisstopo.zeitreihen_19951231
+  sources: [ch.swisstopo.zeitreihen_19951231_cache_out]
+  title: Zeitreise - Kartenwerke (19951231)
+- dimensions: *id886
+  name: ch.swisstopo.zeitreihen_19951231_source
+  sources: [ch.swisstopo.zeitreihen_19951231_cache]
+  title: Zeitreise - Kartenwerke (19951231, source)
+- dimensions: &id887
+    Time:
+      default: '19941231'
+      values: ['19941231']
+  name: ch.swisstopo.zeitreihen_19941231
+  sources: [ch.swisstopo.zeitreihen_19941231_cache_out]
+  title: Zeitreise - Kartenwerke (19941231)
+- dimensions: *id887
+  name: ch.swisstopo.zeitreihen_19941231_source
+  sources: [ch.swisstopo.zeitreihen_19941231_cache]
+  title: Zeitreise - Kartenwerke (19941231, source)
+- dimensions: &id888
+    Time:
+      default: '19931231'
+      values: ['19931231']
+  name: ch.swisstopo.zeitreihen_19931231
+  sources: [ch.swisstopo.zeitreihen_19931231_cache_out]
+  title: Zeitreise - Kartenwerke (19931231)
+- dimensions: *id888
+  name: ch.swisstopo.zeitreihen_19931231_source
+  sources: [ch.swisstopo.zeitreihen_19931231_cache]
+  title: Zeitreise - Kartenwerke (19931231, source)
+- dimensions: &id889
+    Time:
+      default: '19921231'
+      values: ['19921231']
+  name: ch.swisstopo.zeitreihen_19921231
+  sources: [ch.swisstopo.zeitreihen_19921231_cache_out]
+  title: Zeitreise - Kartenwerke (19921231)
+- dimensions: *id889
+  name: ch.swisstopo.zeitreihen_19921231_source
+  sources: [ch.swisstopo.zeitreihen_19921231_cache]
+  title: Zeitreise - Kartenwerke (19921231, source)
+- dimensions: &id890
+    Time:
+      default: '19911231'
+      values: ['19911231']
+  name: ch.swisstopo.zeitreihen_19911231
+  sources: [ch.swisstopo.zeitreihen_19911231_cache_out]
+  title: Zeitreise - Kartenwerke (19911231)
+- dimensions: *id890
+  name: ch.swisstopo.zeitreihen_19911231_source
+  sources: [ch.swisstopo.zeitreihen_19911231_cache]
+  title: Zeitreise - Kartenwerke (19911231, source)
+- dimensions: &id891
+    Time:
+      default: '19901231'
+      values: ['19901231']
+  name: ch.swisstopo.zeitreihen_19901231
+  sources: [ch.swisstopo.zeitreihen_19901231_cache_out]
+  title: Zeitreise - Kartenwerke (19901231)
+- dimensions: *id891
+  name: ch.swisstopo.zeitreihen_19901231_source
+  sources: [ch.swisstopo.zeitreihen_19901231_cache]
+  title: Zeitreise - Kartenwerke (19901231, source)
+- dimensions: &id892
+    Time:
+      default: '19891231'
+      values: ['19891231']
+  name: ch.swisstopo.zeitreihen_19891231
+  sources: [ch.swisstopo.zeitreihen_19891231_cache_out]
+  title: Zeitreise - Kartenwerke (19891231)
+- dimensions: *id892
+  name: ch.swisstopo.zeitreihen_19891231_source
+  sources: [ch.swisstopo.zeitreihen_19891231_cache]
+  title: Zeitreise - Kartenwerke (19891231, source)
+- dimensions: &id893
+    Time:
+      default: '19881231'
+      values: ['19881231']
+  name: ch.swisstopo.zeitreihen_19881231
+  sources: [ch.swisstopo.zeitreihen_19881231_cache_out]
+  title: Zeitreise - Kartenwerke (19881231)
+- dimensions: *id893
+  name: ch.swisstopo.zeitreihen_19881231_source
+  sources: [ch.swisstopo.zeitreihen_19881231_cache]
+  title: Zeitreise - Kartenwerke (19881231, source)
+- dimensions: &id894
+    Time:
+      default: '19871231'
+      values: ['19871231']
+  name: ch.swisstopo.zeitreihen_19871231
+  sources: [ch.swisstopo.zeitreihen_19871231_cache_out]
+  title: Zeitreise - Kartenwerke (19871231)
+- dimensions: *id894
+  name: ch.swisstopo.zeitreihen_19871231_source
+  sources: [ch.swisstopo.zeitreihen_19871231_cache]
+  title: Zeitreise - Kartenwerke (19871231, source)
+- dimensions: &id895
+    Time:
+      default: '19861231'
+      values: ['19861231']
+  name: ch.swisstopo.zeitreihen_19861231
+  sources: [ch.swisstopo.zeitreihen_19861231_cache_out]
+  title: Zeitreise - Kartenwerke (19861231)
+- dimensions: *id895
+  name: ch.swisstopo.zeitreihen_19861231_source
+  sources: [ch.swisstopo.zeitreihen_19861231_cache]
+  title: Zeitreise - Kartenwerke (19861231, source)
+- dimensions: &id896
+    Time:
+      default: '19851231'
+      values: ['19851231']
+  name: ch.swisstopo.zeitreihen_19851231
+  sources: [ch.swisstopo.zeitreihen_19851231_cache_out]
+  title: Zeitreise - Kartenwerke (19851231)
+- dimensions: *id896
+  name: ch.swisstopo.zeitreihen_19851231_source
+  sources: [ch.swisstopo.zeitreihen_19851231_cache]
+  title: Zeitreise - Kartenwerke (19851231, source)
+- dimensions: &id897
+    Time:
+      default: '19841231'
+      values: ['19841231']
+  name: ch.swisstopo.zeitreihen_19841231
+  sources: [ch.swisstopo.zeitreihen_19841231_cache_out]
+  title: Zeitreise - Kartenwerke (19841231)
+- dimensions: *id897
+  name: ch.swisstopo.zeitreihen_19841231_source
+  sources: [ch.swisstopo.zeitreihen_19841231_cache]
+  title: Zeitreise - Kartenwerke (19841231, source)
+- dimensions: &id898
+    Time:
+      default: '19831231'
+      values: ['19831231']
+  name: ch.swisstopo.zeitreihen_19831231
+  sources: [ch.swisstopo.zeitreihen_19831231_cache_out]
+  title: Zeitreise - Kartenwerke (19831231)
+- dimensions: *id898
+  name: ch.swisstopo.zeitreihen_19831231_source
+  sources: [ch.swisstopo.zeitreihen_19831231_cache]
+  title: Zeitreise - Kartenwerke (19831231, source)
+- dimensions: &id899
+    Time:
+      default: '19821231'
+      values: ['19821231']
+  name: ch.swisstopo.zeitreihen_19821231
+  sources: [ch.swisstopo.zeitreihen_19821231_cache_out]
+  title: Zeitreise - Kartenwerke (19821231)
+- dimensions: *id899
+  name: ch.swisstopo.zeitreihen_19821231_source
+  sources: [ch.swisstopo.zeitreihen_19821231_cache]
+  title: Zeitreise - Kartenwerke (19821231, source)
+- dimensions: &id900
+    Time:
+      default: '19811231'
+      values: ['19811231']
+  name: ch.swisstopo.zeitreihen_19811231
+  sources: [ch.swisstopo.zeitreihen_19811231_cache_out]
+  title: Zeitreise - Kartenwerke (19811231)
+- dimensions: *id900
+  name: ch.swisstopo.zeitreihen_19811231_source
+  sources: [ch.swisstopo.zeitreihen_19811231_cache]
+  title: Zeitreise - Kartenwerke (19811231, source)
+- dimensions: &id901
+    Time:
+      default: '19801231'
+      values: ['19801231']
+  name: ch.swisstopo.zeitreihen_19801231
+  sources: [ch.swisstopo.zeitreihen_19801231_cache_out]
+  title: Zeitreise - Kartenwerke (19801231)
+- dimensions: *id901
+  name: ch.swisstopo.zeitreihen_19801231_source
+  sources: [ch.swisstopo.zeitreihen_19801231_cache]
+  title: Zeitreise - Kartenwerke (19801231, source)
+- dimensions: &id902
+    Time:
+      default: '19791231'
+      values: ['19791231']
+  name: ch.swisstopo.zeitreihen_19791231
+  sources: [ch.swisstopo.zeitreihen_19791231_cache_out]
+  title: Zeitreise - Kartenwerke (19791231)
+- dimensions: *id902
+  name: ch.swisstopo.zeitreihen_19791231_source
+  sources: [ch.swisstopo.zeitreihen_19791231_cache]
+  title: Zeitreise - Kartenwerke (19791231, source)
+- dimensions: &id903
+    Time:
+      default: '19781231'
+      values: ['19781231']
+  name: ch.swisstopo.zeitreihen_19781231
+  sources: [ch.swisstopo.zeitreihen_19781231_cache_out]
+  title: Zeitreise - Kartenwerke (19781231)
+- dimensions: *id903
+  name: ch.swisstopo.zeitreihen_19781231_source
+  sources: [ch.swisstopo.zeitreihen_19781231_cache]
+  title: Zeitreise - Kartenwerke (19781231, source)
+- dimensions: &id904
+    Time:
+      default: '19771231'
+      values: ['19771231']
+  name: ch.swisstopo.zeitreihen_19771231
+  sources: [ch.swisstopo.zeitreihen_19771231_cache_out]
+  title: Zeitreise - Kartenwerke (19771231)
+- dimensions: *id904
+  name: ch.swisstopo.zeitreihen_19771231_source
+  sources: [ch.swisstopo.zeitreihen_19771231_cache]
+  title: Zeitreise - Kartenwerke (19771231, source)
+- dimensions: &id905
+    Time:
+      default: '19761231'
+      values: ['19761231']
+  name: ch.swisstopo.zeitreihen_19761231
+  sources: [ch.swisstopo.zeitreihen_19761231_cache_out]
+  title: Zeitreise - Kartenwerke (19761231)
+- dimensions: *id905
+  name: ch.swisstopo.zeitreihen_19761231_source
+  sources: [ch.swisstopo.zeitreihen_19761231_cache]
+  title: Zeitreise - Kartenwerke (19761231, source)
+- dimensions: &id906
+    Time:
+      default: '19751231'
+      values: ['19751231']
+  name: ch.swisstopo.zeitreihen_19751231
+  sources: [ch.swisstopo.zeitreihen_19751231_cache_out]
+  title: Zeitreise - Kartenwerke (19751231)
+- dimensions: *id906
+  name: ch.swisstopo.zeitreihen_19751231_source
+  sources: [ch.swisstopo.zeitreihen_19751231_cache]
+  title: Zeitreise - Kartenwerke (19751231, source)
+- dimensions: &id907
+    Time:
+      default: '19741231'
+      values: ['19741231']
+  name: ch.swisstopo.zeitreihen_19741231
+  sources: [ch.swisstopo.zeitreihen_19741231_cache_out]
+  title: Zeitreise - Kartenwerke (19741231)
+- dimensions: *id907
+  name: ch.swisstopo.zeitreihen_19741231_source
+  sources: [ch.swisstopo.zeitreihen_19741231_cache]
+  title: Zeitreise - Kartenwerke (19741231, source)
+- dimensions: &id908
+    Time:
+      default: '19731231'
+      values: ['19731231']
+  name: ch.swisstopo.zeitreihen_19731231
+  sources: [ch.swisstopo.zeitreihen_19731231_cache_out]
+  title: Zeitreise - Kartenwerke (19731231)
+- dimensions: *id908
+  name: ch.swisstopo.zeitreihen_19731231_source
+  sources: [ch.swisstopo.zeitreihen_19731231_cache]
+  title: Zeitreise - Kartenwerke (19731231, source)
+- dimensions: &id909
+    Time:
+      default: '19721231'
+      values: ['19721231']
+  name: ch.swisstopo.zeitreihen_19721231
+  sources: [ch.swisstopo.zeitreihen_19721231_cache_out]
+  title: Zeitreise - Kartenwerke (19721231)
+- dimensions: *id909
+  name: ch.swisstopo.zeitreihen_19721231_source
+  sources: [ch.swisstopo.zeitreihen_19721231_cache]
+  title: Zeitreise - Kartenwerke (19721231, source)
+- dimensions: &id910
+    Time:
+      default: '19711231'
+      values: ['19711231']
+  name: ch.swisstopo.zeitreihen_19711231
+  sources: [ch.swisstopo.zeitreihen_19711231_cache_out]
+  title: Zeitreise - Kartenwerke (19711231)
+- dimensions: *id910
+  name: ch.swisstopo.zeitreihen_19711231_source
+  sources: [ch.swisstopo.zeitreihen_19711231_cache]
+  title: Zeitreise - Kartenwerke (19711231, source)
+- dimensions: &id911
+    Time:
+      default: '19701231'
+      values: ['19701231']
+  name: ch.swisstopo.zeitreihen_19701231
+  sources: [ch.swisstopo.zeitreihen_19701231_cache_out]
+  title: Zeitreise - Kartenwerke (19701231)
+- dimensions: *id911
+  name: ch.swisstopo.zeitreihen_19701231_source
+  sources: [ch.swisstopo.zeitreihen_19701231_cache]
+  title: Zeitreise - Kartenwerke (19701231, source)
+- dimensions: &id912
+    Time:
+      default: '19691231'
+      values: ['19691231']
+  name: ch.swisstopo.zeitreihen_19691231
+  sources: [ch.swisstopo.zeitreihen_19691231_cache_out]
+  title: Zeitreise - Kartenwerke (19691231)
+- dimensions: *id912
+  name: ch.swisstopo.zeitreihen_19691231_source
+  sources: [ch.swisstopo.zeitreihen_19691231_cache]
+  title: Zeitreise - Kartenwerke (19691231, source)
+- dimensions: &id913
+    Time:
+      default: '19681231'
+      values: ['19681231']
+  name: ch.swisstopo.zeitreihen_19681231
+  sources: [ch.swisstopo.zeitreihen_19681231_cache_out]
+  title: Zeitreise - Kartenwerke (19681231)
+- dimensions: *id913
+  name: ch.swisstopo.zeitreihen_19681231_source
+  sources: [ch.swisstopo.zeitreihen_19681231_cache]
+  title: Zeitreise - Kartenwerke (19681231, source)
+- dimensions: &id914
+    Time:
+      default: '19671231'
+      values: ['19671231']
+  name: ch.swisstopo.zeitreihen_19671231
+  sources: [ch.swisstopo.zeitreihen_19671231_cache_out]
+  title: Zeitreise - Kartenwerke (19671231)
+- dimensions: *id914
+  name: ch.swisstopo.zeitreihen_19671231_source
+  sources: [ch.swisstopo.zeitreihen_19671231_cache]
+  title: Zeitreise - Kartenwerke (19671231, source)
+- dimensions: &id915
+    Time:
+      default: '19661231'
+      values: ['19661231']
+  name: ch.swisstopo.zeitreihen_19661231
+  sources: [ch.swisstopo.zeitreihen_19661231_cache_out]
+  title: Zeitreise - Kartenwerke (19661231)
+- dimensions: *id915
+  name: ch.swisstopo.zeitreihen_19661231_source
+  sources: [ch.swisstopo.zeitreihen_19661231_cache]
+  title: Zeitreise - Kartenwerke (19661231, source)
+- dimensions: &id916
+    Time:
+      default: '19651231'
+      values: ['19651231']
+  name: ch.swisstopo.zeitreihen_19651231
+  sources: [ch.swisstopo.zeitreihen_19651231_cache_out]
+  title: Zeitreise - Kartenwerke (19651231)
+- dimensions: *id916
+  name: ch.swisstopo.zeitreihen_19651231_source
+  sources: [ch.swisstopo.zeitreihen_19651231_cache]
+  title: Zeitreise - Kartenwerke (19651231, source)
+- dimensions: &id917
+    Time:
+      default: '19641231'
+      values: ['19641231']
+  name: ch.swisstopo.zeitreihen_19641231
+  sources: [ch.swisstopo.zeitreihen_19641231_cache_out]
+  title: Zeitreise - Kartenwerke (19641231)
+- dimensions: *id917
+  name: ch.swisstopo.zeitreihen_19641231_source
+  sources: [ch.swisstopo.zeitreihen_19641231_cache]
+  title: Zeitreise - Kartenwerke (19641231, source)
+- dimensions: &id918
+    Time:
+      default: '19631231'
+      values: ['19631231']
+  name: ch.swisstopo.zeitreihen_19631231
+  sources: [ch.swisstopo.zeitreihen_19631231_cache_out]
+  title: Zeitreise - Kartenwerke (19631231)
+- dimensions: *id918
+  name: ch.swisstopo.zeitreihen_19631231_source
+  sources: [ch.swisstopo.zeitreihen_19631231_cache]
+  title: Zeitreise - Kartenwerke (19631231, source)
+- dimensions: &id919
+    Time:
+      default: '19621231'
+      values: ['19621231']
+  name: ch.swisstopo.zeitreihen_19621231
+  sources: [ch.swisstopo.zeitreihen_19621231_cache_out]
+  title: Zeitreise - Kartenwerke (19621231)
+- dimensions: *id919
+  name: ch.swisstopo.zeitreihen_19621231_source
+  sources: [ch.swisstopo.zeitreihen_19621231_cache]
+  title: Zeitreise - Kartenwerke (19621231, source)
+- dimensions: &id920
+    Time:
+      default: '19611231'
+      values: ['19611231']
+  name: ch.swisstopo.zeitreihen_19611231
+  sources: [ch.swisstopo.zeitreihen_19611231_cache_out]
+  title: Zeitreise - Kartenwerke (19611231)
+- dimensions: *id920
+  name: ch.swisstopo.zeitreihen_19611231_source
+  sources: [ch.swisstopo.zeitreihen_19611231_cache]
+  title: Zeitreise - Kartenwerke (19611231, source)
+- dimensions: &id921
+    Time:
+      default: '19601231'
+      values: ['19601231']
+  name: ch.swisstopo.zeitreihen_19601231
+  sources: [ch.swisstopo.zeitreihen_19601231_cache_out]
+  title: Zeitreise - Kartenwerke (19601231)
+- dimensions: *id921
+  name: ch.swisstopo.zeitreihen_19601231_source
+  sources: [ch.swisstopo.zeitreihen_19601231_cache]
+  title: Zeitreise - Kartenwerke (19601231, source)
+- dimensions: &id922
+    Time:
+      default: '19591231'
+      values: ['19591231']
+  name: ch.swisstopo.zeitreihen_19591231
+  sources: [ch.swisstopo.zeitreihen_19591231_cache_out]
+  title: Zeitreise - Kartenwerke (19591231)
+- dimensions: *id922
+  name: ch.swisstopo.zeitreihen_19591231_source
+  sources: [ch.swisstopo.zeitreihen_19591231_cache]
+  title: Zeitreise - Kartenwerke (19591231, source)
+- dimensions: &id923
+    Time:
+      default: '19581231'
+      values: ['19581231']
+  name: ch.swisstopo.zeitreihen_19581231
+  sources: [ch.swisstopo.zeitreihen_19581231_cache_out]
+  title: Zeitreise - Kartenwerke (19581231)
+- dimensions: *id923
+  name: ch.swisstopo.zeitreihen_19581231_source
+  sources: [ch.swisstopo.zeitreihen_19581231_cache]
+  title: Zeitreise - Kartenwerke (19581231, source)
+- dimensions: &id924
+    Time:
+      default: '19571231'
+      values: ['19571231']
+  name: ch.swisstopo.zeitreihen_19571231
+  sources: [ch.swisstopo.zeitreihen_19571231_cache_out]
+  title: Zeitreise - Kartenwerke (19571231)
+- dimensions: *id924
+  name: ch.swisstopo.zeitreihen_19571231_source
+  sources: [ch.swisstopo.zeitreihen_19571231_cache]
+  title: Zeitreise - Kartenwerke (19571231, source)
+- dimensions: &id925
+    Time:
+      default: '19561231'
+      values: ['19561231']
+  name: ch.swisstopo.zeitreihen_19561231
+  sources: [ch.swisstopo.zeitreihen_19561231_cache_out]
+  title: Zeitreise - Kartenwerke (19561231)
+- dimensions: *id925
+  name: ch.swisstopo.zeitreihen_19561231_source
+  sources: [ch.swisstopo.zeitreihen_19561231_cache]
+  title: Zeitreise - Kartenwerke (19561231, source)
+- dimensions: &id926
+    Time:
+      default: '19551231'
+      values: ['19551231']
+  name: ch.swisstopo.zeitreihen_19551231
+  sources: [ch.swisstopo.zeitreihen_19551231_cache_out]
+  title: Zeitreise - Kartenwerke (19551231)
+- dimensions: *id926
+  name: ch.swisstopo.zeitreihen_19551231_source
+  sources: [ch.swisstopo.zeitreihen_19551231_cache]
+  title: Zeitreise - Kartenwerke (19551231, source)
+- dimensions: &id927
+    Time:
+      default: '19541231'
+      values: ['19541231']
+  name: ch.swisstopo.zeitreihen_19541231
+  sources: [ch.swisstopo.zeitreihen_19541231_cache_out]
+  title: Zeitreise - Kartenwerke (19541231)
+- dimensions: *id927
+  name: ch.swisstopo.zeitreihen_19541231_source
+  sources: [ch.swisstopo.zeitreihen_19541231_cache]
+  title: Zeitreise - Kartenwerke (19541231, source)
+- dimensions: &id928
+    Time:
+      default: '19531231'
+      values: ['19531231']
+  name: ch.swisstopo.zeitreihen_19531231
+  sources: [ch.swisstopo.zeitreihen_19531231_cache_out]
+  title: Zeitreise - Kartenwerke (19531231)
+- dimensions: *id928
+  name: ch.swisstopo.zeitreihen_19531231_source
+  sources: [ch.swisstopo.zeitreihen_19531231_cache]
+  title: Zeitreise - Kartenwerke (19531231, source)
+- dimensions: &id929
+    Time:
+      default: '19521231'
+      values: ['19521231']
+  name: ch.swisstopo.zeitreihen_19521231
+  sources: [ch.swisstopo.zeitreihen_19521231_cache_out]
+  title: Zeitreise - Kartenwerke (19521231)
+- dimensions: *id929
+  name: ch.swisstopo.zeitreihen_19521231_source
+  sources: [ch.swisstopo.zeitreihen_19521231_cache]
+  title: Zeitreise - Kartenwerke (19521231, source)
+- dimensions: &id930
+    Time:
+      default: '19511231'
+      values: ['19511231']
+  name: ch.swisstopo.zeitreihen_19511231
+  sources: [ch.swisstopo.zeitreihen_19511231_cache_out]
+  title: Zeitreise - Kartenwerke (19511231)
+- dimensions: *id930
+  name: ch.swisstopo.zeitreihen_19511231_source
+  sources: [ch.swisstopo.zeitreihen_19511231_cache]
+  title: Zeitreise - Kartenwerke (19511231, source)
+- dimensions: &id931
+    Time:
+      default: '19501231'
+      values: ['19501231']
+  name: ch.swisstopo.zeitreihen_19501231
+  sources: [ch.swisstopo.zeitreihen_19501231_cache_out]
+  title: Zeitreise - Kartenwerke (19501231)
+- dimensions: *id931
+  name: ch.swisstopo.zeitreihen_19501231_source
+  sources: [ch.swisstopo.zeitreihen_19501231_cache]
+  title: Zeitreise - Kartenwerke (19501231, source)
+- dimensions: &id932
+    Time:
+      default: '19491231'
+      values: ['19491231']
+  name: ch.swisstopo.zeitreihen_19491231
+  sources: [ch.swisstopo.zeitreihen_19491231_cache_out]
+  title: Zeitreise - Kartenwerke (19491231)
+- dimensions: *id932
+  name: ch.swisstopo.zeitreihen_19491231_source
+  sources: [ch.swisstopo.zeitreihen_19491231_cache]
+  title: Zeitreise - Kartenwerke (19491231, source)
+- dimensions: &id933
+    Time:
+      default: '19481231'
+      values: ['19481231']
+  name: ch.swisstopo.zeitreihen_19481231
+  sources: [ch.swisstopo.zeitreihen_19481231_cache_out]
+  title: Zeitreise - Kartenwerke (19481231)
+- dimensions: *id933
+  name: ch.swisstopo.zeitreihen_19481231_source
+  sources: [ch.swisstopo.zeitreihen_19481231_cache]
+  title: Zeitreise - Kartenwerke (19481231, source)
+- dimensions: &id934
+    Time:
+      default: '19471231'
+      values: ['19471231']
+  name: ch.swisstopo.zeitreihen_19471231
+  sources: [ch.swisstopo.zeitreihen_19471231_cache_out]
+  title: Zeitreise - Kartenwerke (19471231)
+- dimensions: *id934
+  name: ch.swisstopo.zeitreihen_19471231_source
+  sources: [ch.swisstopo.zeitreihen_19471231_cache]
+  title: Zeitreise - Kartenwerke (19471231, source)
+- dimensions: &id935
+    Time:
+      default: '19461231'
+      values: ['19461231']
+  name: ch.swisstopo.zeitreihen_19461231
+  sources: [ch.swisstopo.zeitreihen_19461231_cache_out]
+  title: Zeitreise - Kartenwerke (19461231)
+- dimensions: *id935
+  name: ch.swisstopo.zeitreihen_19461231_source
+  sources: [ch.swisstopo.zeitreihen_19461231_cache]
+  title: Zeitreise - Kartenwerke (19461231, source)
+- dimensions: &id936
+    Time:
+      default: '19451231'
+      values: ['19451231']
+  name: ch.swisstopo.zeitreihen_19451231
+  sources: [ch.swisstopo.zeitreihen_19451231_cache_out]
+  title: Zeitreise - Kartenwerke (19451231)
+- dimensions: *id936
+  name: ch.swisstopo.zeitreihen_19451231_source
+  sources: [ch.swisstopo.zeitreihen_19451231_cache]
+  title: Zeitreise - Kartenwerke (19451231, source)
+- dimensions: &id937
+    Time:
+      default: '19441231'
+      values: ['19441231']
+  name: ch.swisstopo.zeitreihen_19441231
+  sources: [ch.swisstopo.zeitreihen_19441231_cache_out]
+  title: Zeitreise - Kartenwerke (19441231)
+- dimensions: *id937
+  name: ch.swisstopo.zeitreihen_19441231_source
+  sources: [ch.swisstopo.zeitreihen_19441231_cache]
+  title: Zeitreise - Kartenwerke (19441231, source)
+- dimensions: &id938
+    Time:
+      default: '19431231'
+      values: ['19431231']
+  name: ch.swisstopo.zeitreihen_19431231
+  sources: [ch.swisstopo.zeitreihen_19431231_cache_out]
+  title: Zeitreise - Kartenwerke (19431231)
+- dimensions: *id938
+  name: ch.swisstopo.zeitreihen_19431231_source
+  sources: [ch.swisstopo.zeitreihen_19431231_cache]
+  title: Zeitreise - Kartenwerke (19431231, source)
+- dimensions: &id939
+    Time:
+      default: '19421231'
+      values: ['19421231']
+  name: ch.swisstopo.zeitreihen_19421231
+  sources: [ch.swisstopo.zeitreihen_19421231_cache_out]
+  title: Zeitreise - Kartenwerke (19421231)
+- dimensions: *id939
+  name: ch.swisstopo.zeitreihen_19421231_source
+  sources: [ch.swisstopo.zeitreihen_19421231_cache]
+  title: Zeitreise - Kartenwerke (19421231, source)
+- dimensions: &id940
+    Time:
+      default: '19411231'
+      values: ['19411231']
+  name: ch.swisstopo.zeitreihen_19411231
+  sources: [ch.swisstopo.zeitreihen_19411231_cache_out]
+  title: Zeitreise - Kartenwerke (19411231)
+- dimensions: *id940
+  name: ch.swisstopo.zeitreihen_19411231_source
+  sources: [ch.swisstopo.zeitreihen_19411231_cache]
+  title: Zeitreise - Kartenwerke (19411231, source)
+- dimensions: &id941
+    Time:
+      default: '19401231'
+      values: ['19401231']
+  name: ch.swisstopo.zeitreihen_19401231
+  sources: [ch.swisstopo.zeitreihen_19401231_cache_out]
+  title: Zeitreise - Kartenwerke (19401231)
+- dimensions: *id941
+  name: ch.swisstopo.zeitreihen_19401231_source
+  sources: [ch.swisstopo.zeitreihen_19401231_cache]
+  title: Zeitreise - Kartenwerke (19401231, source)
+- dimensions: &id942
+    Time:
+      default: '19391231'
+      values: ['19391231']
+  name: ch.swisstopo.zeitreihen_19391231
+  sources: [ch.swisstopo.zeitreihen_19391231_cache_out]
+  title: Zeitreise - Kartenwerke (19391231)
+- dimensions: *id942
+  name: ch.swisstopo.zeitreihen_19391231_source
+  sources: [ch.swisstopo.zeitreihen_19391231_cache]
+  title: Zeitreise - Kartenwerke (19391231, source)
+- dimensions: &id943
+    Time:
+      default: '19381231'
+      values: ['19381231']
+  name: ch.swisstopo.zeitreihen_19381231
+  sources: [ch.swisstopo.zeitreihen_19381231_cache_out]
+  title: Zeitreise - Kartenwerke (19381231)
+- dimensions: *id943
+  name: ch.swisstopo.zeitreihen_19381231_source
+  sources: [ch.swisstopo.zeitreihen_19381231_cache]
+  title: Zeitreise - Kartenwerke (19381231, source)
+- dimensions: &id944
+    Time:
+      default: '19371231'
+      values: ['19371231']
+  name: ch.swisstopo.zeitreihen_19371231
+  sources: [ch.swisstopo.zeitreihen_19371231_cache_out]
+  title: Zeitreise - Kartenwerke (19371231)
+- dimensions: *id944
+  name: ch.swisstopo.zeitreihen_19371231_source
+  sources: [ch.swisstopo.zeitreihen_19371231_cache]
+  title: Zeitreise - Kartenwerke (19371231, source)
+- dimensions: &id945
+    Time:
+      default: '19361231'
+      values: ['19361231']
+  name: ch.swisstopo.zeitreihen_19361231
+  sources: [ch.swisstopo.zeitreihen_19361231_cache_out]
+  title: Zeitreise - Kartenwerke (19361231)
+- dimensions: *id945
+  name: ch.swisstopo.zeitreihen_19361231_source
+  sources: [ch.swisstopo.zeitreihen_19361231_cache]
+  title: Zeitreise - Kartenwerke (19361231, source)
+- dimensions: &id946
+    Time:
+      default: '19351231'
+      values: ['19351231']
+  name: ch.swisstopo.zeitreihen_19351231
+  sources: [ch.swisstopo.zeitreihen_19351231_cache_out]
+  title: Zeitreise - Kartenwerke (19351231)
+- dimensions: *id946
+  name: ch.swisstopo.zeitreihen_19351231_source
+  sources: [ch.swisstopo.zeitreihen_19351231_cache]
+  title: Zeitreise - Kartenwerke (19351231, source)
+- dimensions: &id947
+    Time:
+      default: '19341231'
+      values: ['19341231']
+  name: ch.swisstopo.zeitreihen_19341231
+  sources: [ch.swisstopo.zeitreihen_19341231_cache_out]
+  title: Zeitreise - Kartenwerke (19341231)
+- dimensions: *id947
+  name: ch.swisstopo.zeitreihen_19341231_source
+  sources: [ch.swisstopo.zeitreihen_19341231_cache]
+  title: Zeitreise - Kartenwerke (19341231, source)
+- dimensions: &id948
+    Time:
+      default: '19331231'
+      values: ['19331231']
+  name: ch.swisstopo.zeitreihen_19331231
+  sources: [ch.swisstopo.zeitreihen_19331231_cache_out]
+  title: Zeitreise - Kartenwerke (19331231)
+- dimensions: *id948
+  name: ch.swisstopo.zeitreihen_19331231_source
+  sources: [ch.swisstopo.zeitreihen_19331231_cache]
+  title: Zeitreise - Kartenwerke (19331231, source)
+- dimensions: &id949
+    Time:
+      default: '19321231'
+      values: ['19321231']
+  name: ch.swisstopo.zeitreihen_19321231
+  sources: [ch.swisstopo.zeitreihen_19321231_cache_out]
+  title: Zeitreise - Kartenwerke (19321231)
+- dimensions: *id949
+  name: ch.swisstopo.zeitreihen_19321231_source
+  sources: [ch.swisstopo.zeitreihen_19321231_cache]
+  title: Zeitreise - Kartenwerke (19321231, source)
+- dimensions: &id950
+    Time:
+      default: '19311231'
+      values: ['19311231']
+  name: ch.swisstopo.zeitreihen_19311231
+  sources: [ch.swisstopo.zeitreihen_19311231_cache_out]
+  title: Zeitreise - Kartenwerke (19311231)
+- dimensions: *id950
+  name: ch.swisstopo.zeitreihen_19311231_source
+  sources: [ch.swisstopo.zeitreihen_19311231_cache]
+  title: Zeitreise - Kartenwerke (19311231, source)
+- dimensions: &id951
+    Time:
+      default: '19301231'
+      values: ['19301231']
+  name: ch.swisstopo.zeitreihen_19301231
+  sources: [ch.swisstopo.zeitreihen_19301231_cache_out]
+  title: Zeitreise - Kartenwerke (19301231)
+- dimensions: *id951
+  name: ch.swisstopo.zeitreihen_19301231_source
+  sources: [ch.swisstopo.zeitreihen_19301231_cache]
+  title: Zeitreise - Kartenwerke (19301231, source)
+- dimensions: &id952
+    Time:
+      default: '19291231'
+      values: ['19291231']
+  name: ch.swisstopo.zeitreihen_19291231
+  sources: [ch.swisstopo.zeitreihen_19291231_cache_out]
+  title: Zeitreise - Kartenwerke (19291231)
+- dimensions: *id952
+  name: ch.swisstopo.zeitreihen_19291231_source
+  sources: [ch.swisstopo.zeitreihen_19291231_cache]
+  title: Zeitreise - Kartenwerke (19291231, source)
+- dimensions: &id953
+    Time:
+      default: '19281231'
+      values: ['19281231']
+  name: ch.swisstopo.zeitreihen_19281231
+  sources: [ch.swisstopo.zeitreihen_19281231_cache_out]
+  title: Zeitreise - Kartenwerke (19281231)
+- dimensions: *id953
+  name: ch.swisstopo.zeitreihen_19281231_source
+  sources: [ch.swisstopo.zeitreihen_19281231_cache]
+  title: Zeitreise - Kartenwerke (19281231, source)
+- dimensions: &id954
+    Time:
+      default: '19271231'
+      values: ['19271231']
+  name: ch.swisstopo.zeitreihen_19271231
+  sources: [ch.swisstopo.zeitreihen_19271231_cache_out]
+  title: Zeitreise - Kartenwerke (19271231)
+- dimensions: *id954
+  name: ch.swisstopo.zeitreihen_19271231_source
+  sources: [ch.swisstopo.zeitreihen_19271231_cache]
+  title: Zeitreise - Kartenwerke (19271231, source)
+- dimensions: &id955
+    Time:
+      default: '19261231'
+      values: ['19261231']
+  name: ch.swisstopo.zeitreihen_19261231
+  sources: [ch.swisstopo.zeitreihen_19261231_cache_out]
+  title: Zeitreise - Kartenwerke (19261231)
+- dimensions: *id955
+  name: ch.swisstopo.zeitreihen_19261231_source
+  sources: [ch.swisstopo.zeitreihen_19261231_cache]
+  title: Zeitreise - Kartenwerke (19261231, source)
+- dimensions: &id956
+    Time:
+      default: '19251231'
+      values: ['19251231']
+  name: ch.swisstopo.zeitreihen_19251231
+  sources: [ch.swisstopo.zeitreihen_19251231_cache_out]
+  title: Zeitreise - Kartenwerke (19251231)
+- dimensions: *id956
+  name: ch.swisstopo.zeitreihen_19251231_source
+  sources: [ch.swisstopo.zeitreihen_19251231_cache]
+  title: Zeitreise - Kartenwerke (19251231, source)
+- dimensions: &id957
+    Time:
+      default: '19241231'
+      values: ['19241231']
+  name: ch.swisstopo.zeitreihen_19241231
+  sources: [ch.swisstopo.zeitreihen_19241231_cache_out]
+  title: Zeitreise - Kartenwerke (19241231)
+- dimensions: *id957
+  name: ch.swisstopo.zeitreihen_19241231_source
+  sources: [ch.swisstopo.zeitreihen_19241231_cache]
+  title: Zeitreise - Kartenwerke (19241231, source)
+- dimensions: &id958
+    Time:
+      default: '19231231'
+      values: ['19231231']
+  name: ch.swisstopo.zeitreihen_19231231
+  sources: [ch.swisstopo.zeitreihen_19231231_cache_out]
+  title: Zeitreise - Kartenwerke (19231231)
+- dimensions: *id958
+  name: ch.swisstopo.zeitreihen_19231231_source
+  sources: [ch.swisstopo.zeitreihen_19231231_cache]
+  title: Zeitreise - Kartenwerke (19231231, source)
+- dimensions: &id959
+    Time:
+      default: '19221231'
+      values: ['19221231']
+  name: ch.swisstopo.zeitreihen_19221231
+  sources: [ch.swisstopo.zeitreihen_19221231_cache_out]
+  title: Zeitreise - Kartenwerke (19221231)
+- dimensions: *id959
+  name: ch.swisstopo.zeitreihen_19221231_source
+  sources: [ch.swisstopo.zeitreihen_19221231_cache]
+  title: Zeitreise - Kartenwerke (19221231, source)
+- dimensions: &id960
+    Time:
+      default: '19211231'
+      values: ['19211231']
+  name: ch.swisstopo.zeitreihen_19211231
+  sources: [ch.swisstopo.zeitreihen_19211231_cache_out]
+  title: Zeitreise - Kartenwerke (19211231)
+- dimensions: *id960
+  name: ch.swisstopo.zeitreihen_19211231_source
+  sources: [ch.swisstopo.zeitreihen_19211231_cache]
+  title: Zeitreise - Kartenwerke (19211231, source)
+- dimensions: &id961
+    Time:
+      default: '19201231'
+      values: ['19201231']
+  name: ch.swisstopo.zeitreihen_19201231
+  sources: [ch.swisstopo.zeitreihen_19201231_cache_out]
+  title: Zeitreise - Kartenwerke (19201231)
+- dimensions: *id961
+  name: ch.swisstopo.zeitreihen_19201231_source
+  sources: [ch.swisstopo.zeitreihen_19201231_cache]
+  title: Zeitreise - Kartenwerke (19201231, source)
+- dimensions: &id962
+    Time:
+      default: '19191231'
+      values: ['19191231']
+  name: ch.swisstopo.zeitreihen_19191231
+  sources: [ch.swisstopo.zeitreihen_19191231_cache_out]
+  title: Zeitreise - Kartenwerke (19191231)
+- dimensions: *id962
+  name: ch.swisstopo.zeitreihen_19191231_source
+  sources: [ch.swisstopo.zeitreihen_19191231_cache]
+  title: Zeitreise - Kartenwerke (19191231, source)
+- dimensions: &id963
+    Time:
+      default: '19181231'
+      values: ['19181231']
+  name: ch.swisstopo.zeitreihen_19181231
+  sources: [ch.swisstopo.zeitreihen_19181231_cache_out]
+  title: Zeitreise - Kartenwerke (19181231)
+- dimensions: *id963
+  name: ch.swisstopo.zeitreihen_19181231_source
+  sources: [ch.swisstopo.zeitreihen_19181231_cache]
+  title: Zeitreise - Kartenwerke (19181231, source)
+- dimensions: &id964
+    Time:
+      default: '19171231'
+      values: ['19171231']
+  name: ch.swisstopo.zeitreihen_19171231
+  sources: [ch.swisstopo.zeitreihen_19171231_cache_out]
+  title: Zeitreise - Kartenwerke (19171231)
+- dimensions: *id964
+  name: ch.swisstopo.zeitreihen_19171231_source
+  sources: [ch.swisstopo.zeitreihen_19171231_cache]
+  title: Zeitreise - Kartenwerke (19171231, source)
+- dimensions: &id965
+    Time:
+      default: '19161231'
+      values: ['19161231']
+  name: ch.swisstopo.zeitreihen_19161231
+  sources: [ch.swisstopo.zeitreihen_19161231_cache_out]
+  title: Zeitreise - Kartenwerke (19161231)
+- dimensions: *id965
+  name: ch.swisstopo.zeitreihen_19161231_source
+  sources: [ch.swisstopo.zeitreihen_19161231_cache]
+  title: Zeitreise - Kartenwerke (19161231, source)
+- dimensions: &id966
+    Time:
+      default: '19151231'
+      values: ['19151231']
+  name: ch.swisstopo.zeitreihen_19151231
+  sources: [ch.swisstopo.zeitreihen_19151231_cache_out]
+  title: Zeitreise - Kartenwerke (19151231)
+- dimensions: *id966
+  name: ch.swisstopo.zeitreihen_19151231_source
+  sources: [ch.swisstopo.zeitreihen_19151231_cache]
+  title: Zeitreise - Kartenwerke (19151231, source)
+- dimensions: &id967
+    Time:
+      default: '19141231'
+      values: ['19141231']
+  name: ch.swisstopo.zeitreihen_19141231
+  sources: [ch.swisstopo.zeitreihen_19141231_cache_out]
+  title: Zeitreise - Kartenwerke (19141231)
+- dimensions: *id967
+  name: ch.swisstopo.zeitreihen_19141231_source
+  sources: [ch.swisstopo.zeitreihen_19141231_cache]
+  title: Zeitreise - Kartenwerke (19141231, source)
+- dimensions: &id968
+    Time:
+      default: '19131231'
+      values: ['19131231']
+  name: ch.swisstopo.zeitreihen_19131231
+  sources: [ch.swisstopo.zeitreihen_19131231_cache_out]
+  title: Zeitreise - Kartenwerke (19131231)
+- dimensions: *id968
+  name: ch.swisstopo.zeitreihen_19131231_source
+  sources: [ch.swisstopo.zeitreihen_19131231_cache]
+  title: Zeitreise - Kartenwerke (19131231, source)
+- dimensions: &id969
+    Time:
+      default: '19121231'
+      values: ['19121231']
+  name: ch.swisstopo.zeitreihen_19121231
+  sources: [ch.swisstopo.zeitreihen_19121231_cache_out]
+  title: Zeitreise - Kartenwerke (19121231)
+- dimensions: *id969
+  name: ch.swisstopo.zeitreihen_19121231_source
+  sources: [ch.swisstopo.zeitreihen_19121231_cache]
+  title: Zeitreise - Kartenwerke (19121231, source)
+- dimensions: &id970
+    Time:
+      default: '19111231'
+      values: ['19111231']
+  name: ch.swisstopo.zeitreihen_19111231
+  sources: [ch.swisstopo.zeitreihen_19111231_cache_out]
+  title: Zeitreise - Kartenwerke (19111231)
+- dimensions: *id970
+  name: ch.swisstopo.zeitreihen_19111231_source
+  sources: [ch.swisstopo.zeitreihen_19111231_cache]
+  title: Zeitreise - Kartenwerke (19111231, source)
+- dimensions: &id971
+    Time:
+      default: '19101231'
+      values: ['19101231']
+  name: ch.swisstopo.zeitreihen_19101231
+  sources: [ch.swisstopo.zeitreihen_19101231_cache_out]
+  title: Zeitreise - Kartenwerke (19101231)
+- dimensions: *id971
+  name: ch.swisstopo.zeitreihen_19101231_source
+  sources: [ch.swisstopo.zeitreihen_19101231_cache]
+  title: Zeitreise - Kartenwerke (19101231, source)
+- dimensions: &id972
+    Time:
+      default: '19091231'
+      values: ['19091231']
+  name: ch.swisstopo.zeitreihen_19091231
+  sources: [ch.swisstopo.zeitreihen_19091231_cache_out]
+  title: Zeitreise - Kartenwerke (19091231)
+- dimensions: *id972
+  name: ch.swisstopo.zeitreihen_19091231_source
+  sources: [ch.swisstopo.zeitreihen_19091231_cache]
+  title: Zeitreise - Kartenwerke (19091231, source)
+- dimensions: &id973
+    Time:
+      default: '19081231'
+      values: ['19081231']
+  name: ch.swisstopo.zeitreihen_19081231
+  sources: [ch.swisstopo.zeitreihen_19081231_cache_out]
+  title: Zeitreise - Kartenwerke (19081231)
+- dimensions: *id973
+  name: ch.swisstopo.zeitreihen_19081231_source
+  sources: [ch.swisstopo.zeitreihen_19081231_cache]
+  title: Zeitreise - Kartenwerke (19081231, source)
+- dimensions: &id974
+    Time:
+      default: '19071231'
+      values: ['19071231']
+  name: ch.swisstopo.zeitreihen_19071231
+  sources: [ch.swisstopo.zeitreihen_19071231_cache_out]
+  title: Zeitreise - Kartenwerke (19071231)
+- dimensions: *id974
+  name: ch.swisstopo.zeitreihen_19071231_source
+  sources: [ch.swisstopo.zeitreihen_19071231_cache]
+  title: Zeitreise - Kartenwerke (19071231, source)
+- dimensions: &id975
+    Time:
+      default: '19061231'
+      values: ['19061231']
+  name: ch.swisstopo.zeitreihen_19061231
+  sources: [ch.swisstopo.zeitreihen_19061231_cache_out]
+  title: Zeitreise - Kartenwerke (19061231)
+- dimensions: *id975
+  name: ch.swisstopo.zeitreihen_19061231_source
+  sources: [ch.swisstopo.zeitreihen_19061231_cache]
+  title: Zeitreise - Kartenwerke (19061231, source)
+- dimensions: &id976
+    Time:
+      default: '19051231'
+      values: ['19051231']
+  name: ch.swisstopo.zeitreihen_19051231
+  sources: [ch.swisstopo.zeitreihen_19051231_cache_out]
+  title: Zeitreise - Kartenwerke (19051231)
+- dimensions: *id976
+  name: ch.swisstopo.zeitreihen_19051231_source
+  sources: [ch.swisstopo.zeitreihen_19051231_cache]
+  title: Zeitreise - Kartenwerke (19051231, source)
+- dimensions: &id977
+    Time:
+      default: '19041231'
+      values: ['19041231']
+  name: ch.swisstopo.zeitreihen_19041231
+  sources: [ch.swisstopo.zeitreihen_19041231_cache_out]
+  title: Zeitreise - Kartenwerke (19041231)
+- dimensions: *id977
+  name: ch.swisstopo.zeitreihen_19041231_source
+  sources: [ch.swisstopo.zeitreihen_19041231_cache]
+  title: Zeitreise - Kartenwerke (19041231, source)
+- dimensions: &id978
+    Time:
+      default: '19031231'
+      values: ['19031231']
+  name: ch.swisstopo.zeitreihen_19031231
+  sources: [ch.swisstopo.zeitreihen_19031231_cache_out]
+  title: Zeitreise - Kartenwerke (19031231)
+- dimensions: *id978
+  name: ch.swisstopo.zeitreihen_19031231_source
+  sources: [ch.swisstopo.zeitreihen_19031231_cache]
+  title: Zeitreise - Kartenwerke (19031231, source)
+- dimensions: &id979
+    Time:
+      default: '19021231'
+      values: ['19021231']
+  name: ch.swisstopo.zeitreihen_19021231
+  sources: [ch.swisstopo.zeitreihen_19021231_cache_out]
+  title: Zeitreise - Kartenwerke (19021231)
+- dimensions: *id979
+  name: ch.swisstopo.zeitreihen_19021231_source
+  sources: [ch.swisstopo.zeitreihen_19021231_cache]
+  title: Zeitreise - Kartenwerke (19021231, source)
+- dimensions: &id980
+    Time:
+      default: '19011231'
+      values: ['19011231']
+  name: ch.swisstopo.zeitreihen_19011231
+  sources: [ch.swisstopo.zeitreihen_19011231_cache_out]
+  title: Zeitreise - Kartenwerke (19011231)
+- dimensions: *id980
+  name: ch.swisstopo.zeitreihen_19011231_source
+  sources: [ch.swisstopo.zeitreihen_19011231_cache]
+  title: Zeitreise - Kartenwerke (19011231, source)
+- dimensions: &id981
+    Time:
+      default: '19001231'
+      values: ['19001231']
+  name: ch.swisstopo.zeitreihen_19001231
+  sources: [ch.swisstopo.zeitreihen_19001231_cache_out]
+  title: Zeitreise - Kartenwerke (19001231)
+- dimensions: *id981
+  name: ch.swisstopo.zeitreihen_19001231_source
+  sources: [ch.swisstopo.zeitreihen_19001231_cache]
+  title: Zeitreise - Kartenwerke (19001231, source)
+- dimensions: &id982
+    Time:
+      default: '18991231'
+      values: ['18991231']
+  name: ch.swisstopo.zeitreihen_18991231
+  sources: [ch.swisstopo.zeitreihen_18991231_cache_out]
+  title: Zeitreise - Kartenwerke (18991231)
+- dimensions: *id982
+  name: ch.swisstopo.zeitreihen_18991231_source
+  sources: [ch.swisstopo.zeitreihen_18991231_cache]
+  title: Zeitreise - Kartenwerke (18991231, source)
+- dimensions: &id983
+    Time:
+      default: '18981231'
+      values: ['18981231']
+  name: ch.swisstopo.zeitreihen_18981231
+  sources: [ch.swisstopo.zeitreihen_18981231_cache_out]
+  title: Zeitreise - Kartenwerke (18981231)
+- dimensions: *id983
+  name: ch.swisstopo.zeitreihen_18981231_source
+  sources: [ch.swisstopo.zeitreihen_18981231_cache]
+  title: Zeitreise - Kartenwerke (18981231, source)
+- dimensions: &id984
+    Time:
+      default: '18971231'
+      values: ['18971231']
+  name: ch.swisstopo.zeitreihen_18971231
+  sources: [ch.swisstopo.zeitreihen_18971231_cache_out]
+  title: Zeitreise - Kartenwerke (18971231)
+- dimensions: *id984
+  name: ch.swisstopo.zeitreihen_18971231_source
+  sources: [ch.swisstopo.zeitreihen_18971231_cache]
+  title: Zeitreise - Kartenwerke (18971231, source)
+- dimensions: &id985
+    Time:
+      default: '18961231'
+      values: ['18961231']
+  name: ch.swisstopo.zeitreihen_18961231
+  sources: [ch.swisstopo.zeitreihen_18961231_cache_out]
+  title: Zeitreise - Kartenwerke (18961231)
+- dimensions: *id985
+  name: ch.swisstopo.zeitreihen_18961231_source
+  sources: [ch.swisstopo.zeitreihen_18961231_cache]
+  title: Zeitreise - Kartenwerke (18961231, source)
+- dimensions: &id986
+    Time:
+      default: '18951231'
+      values: ['18951231']
+  name: ch.swisstopo.zeitreihen_18951231
+  sources: [ch.swisstopo.zeitreihen_18951231_cache_out]
+  title: Zeitreise - Kartenwerke (18951231)
+- dimensions: *id986
+  name: ch.swisstopo.zeitreihen_18951231_source
+  sources: [ch.swisstopo.zeitreihen_18951231_cache]
+  title: Zeitreise - Kartenwerke (18951231, source)
+- dimensions: &id987
+    Time:
+      default: '18941231'
+      values: ['18941231']
+  name: ch.swisstopo.zeitreihen_18941231
+  sources: [ch.swisstopo.zeitreihen_18941231_cache_out]
+  title: Zeitreise - Kartenwerke (18941231)
+- dimensions: *id987
+  name: ch.swisstopo.zeitreihen_18941231_source
+  sources: [ch.swisstopo.zeitreihen_18941231_cache]
+  title: Zeitreise - Kartenwerke (18941231, source)
+- dimensions: &id988
+    Time:
+      default: '18931231'
+      values: ['18931231']
+  name: ch.swisstopo.zeitreihen_18931231
+  sources: [ch.swisstopo.zeitreihen_18931231_cache_out]
+  title: Zeitreise - Kartenwerke (18931231)
+- dimensions: *id988
+  name: ch.swisstopo.zeitreihen_18931231_source
+  sources: [ch.swisstopo.zeitreihen_18931231_cache]
+  title: Zeitreise - Kartenwerke (18931231, source)
+- dimensions: &id989
+    Time:
+      default: '18921231'
+      values: ['18921231']
+  name: ch.swisstopo.zeitreihen_18921231
+  sources: [ch.swisstopo.zeitreihen_18921231_cache_out]
+  title: Zeitreise - Kartenwerke (18921231)
+- dimensions: *id989
+  name: ch.swisstopo.zeitreihen_18921231_source
+  sources: [ch.swisstopo.zeitreihen_18921231_cache]
+  title: Zeitreise - Kartenwerke (18921231, source)
+- dimensions: &id990
+    Time:
+      default: '18911231'
+      values: ['18911231']
+  name: ch.swisstopo.zeitreihen_18911231
+  sources: [ch.swisstopo.zeitreihen_18911231_cache_out]
+  title: Zeitreise - Kartenwerke (18911231)
+- dimensions: *id990
+  name: ch.swisstopo.zeitreihen_18911231_source
+  sources: [ch.swisstopo.zeitreihen_18911231_cache]
+  title: Zeitreise - Kartenwerke (18911231, source)
+- dimensions: &id991
+    Time:
+      default: '18901231'
+      values: ['18901231']
+  name: ch.swisstopo.zeitreihen_18901231
+  sources: [ch.swisstopo.zeitreihen_18901231_cache_out]
+  title: Zeitreise - Kartenwerke (18901231)
+- dimensions: *id991
+  name: ch.swisstopo.zeitreihen_18901231_source
+  sources: [ch.swisstopo.zeitreihen_18901231_cache]
+  title: Zeitreise - Kartenwerke (18901231, source)
+- dimensions: &id992
+    Time:
+      default: '18891231'
+      values: ['18891231']
+  name: ch.swisstopo.zeitreihen_18891231
+  sources: [ch.swisstopo.zeitreihen_18891231_cache_out]
+  title: Zeitreise - Kartenwerke (18891231)
+- dimensions: *id992
+  name: ch.swisstopo.zeitreihen_18891231_source
+  sources: [ch.swisstopo.zeitreihen_18891231_cache]
+  title: Zeitreise - Kartenwerke (18891231, source)
+- dimensions: &id993
+    Time:
+      default: '18881231'
+      values: ['18881231']
+  name: ch.swisstopo.zeitreihen_18881231
+  sources: [ch.swisstopo.zeitreihen_18881231_cache_out]
+  title: Zeitreise - Kartenwerke (18881231)
+- dimensions: *id993
+  name: ch.swisstopo.zeitreihen_18881231_source
+  sources: [ch.swisstopo.zeitreihen_18881231_cache]
+  title: Zeitreise - Kartenwerke (18881231, source)
+- dimensions: &id994
+    Time:
+      default: '18871231'
+      values: ['18871231']
+  name: ch.swisstopo.zeitreihen_18871231
+  sources: [ch.swisstopo.zeitreihen_18871231_cache_out]
+  title: Zeitreise - Kartenwerke (18871231)
+- dimensions: *id994
+  name: ch.swisstopo.zeitreihen_18871231_source
+  sources: [ch.swisstopo.zeitreihen_18871231_cache]
+  title: Zeitreise - Kartenwerke (18871231, source)
+- dimensions: &id995
+    Time:
+      default: '18861231'
+      values: ['18861231']
+  name: ch.swisstopo.zeitreihen_18861231
+  sources: [ch.swisstopo.zeitreihen_18861231_cache_out]
+  title: Zeitreise - Kartenwerke (18861231)
+- dimensions: *id995
+  name: ch.swisstopo.zeitreihen_18861231_source
+  sources: [ch.swisstopo.zeitreihen_18861231_cache]
+  title: Zeitreise - Kartenwerke (18861231, source)
+- dimensions: &id996
+    Time:
+      default: '18851231'
+      values: ['18851231']
+  name: ch.swisstopo.zeitreihen_18851231
+  sources: [ch.swisstopo.zeitreihen_18851231_cache_out]
+  title: Zeitreise - Kartenwerke (18851231)
+- dimensions: *id996
+  name: ch.swisstopo.zeitreihen_18851231_source
+  sources: [ch.swisstopo.zeitreihen_18851231_cache]
+  title: Zeitreise - Kartenwerke (18851231, source)
+- dimensions: &id997
+    Time:
+      default: '18841231'
+      values: ['18841231']
+  name: ch.swisstopo.zeitreihen_18841231
+  sources: [ch.swisstopo.zeitreihen_18841231_cache_out]
+  title: Zeitreise - Kartenwerke (18841231)
+- dimensions: *id997
+  name: ch.swisstopo.zeitreihen_18841231_source
+  sources: [ch.swisstopo.zeitreihen_18841231_cache]
+  title: Zeitreise - Kartenwerke (18841231, source)
+- dimensions: &id998
+    Time:
+      default: '18831231'
+      values: ['18831231']
+  name: ch.swisstopo.zeitreihen_18831231
+  sources: [ch.swisstopo.zeitreihen_18831231_cache_out]
+  title: Zeitreise - Kartenwerke (18831231)
+- dimensions: *id998
+  name: ch.swisstopo.zeitreihen_18831231_source
+  sources: [ch.swisstopo.zeitreihen_18831231_cache]
+  title: Zeitreise - Kartenwerke (18831231, source)
+- dimensions: &id999
+    Time:
+      default: '18821231'
+      values: ['18821231']
+  name: ch.swisstopo.zeitreihen_18821231
+  sources: [ch.swisstopo.zeitreihen_18821231_cache_out]
+  title: Zeitreise - Kartenwerke (18821231)
+- dimensions: *id999
+  name: ch.swisstopo.zeitreihen_18821231_source
+  sources: [ch.swisstopo.zeitreihen_18821231_cache]
+  title: Zeitreise - Kartenwerke (18821231, source)
+- dimensions: &id1000
+    Time:
+      default: '18811231'
+      values: ['18811231']
+  name: ch.swisstopo.zeitreihen_18811231
+  sources: [ch.swisstopo.zeitreihen_18811231_cache_out]
+  title: Zeitreise - Kartenwerke (18811231)
+- dimensions: *id1000
+  name: ch.swisstopo.zeitreihen_18811231_source
+  sources: [ch.swisstopo.zeitreihen_18811231_cache]
+  title: Zeitreise - Kartenwerke (18811231, source)
+- dimensions: &id1001
+    Time:
+      default: '18801231'
+      values: ['18801231']
+  name: ch.swisstopo.zeitreihen_18801231
+  sources: [ch.swisstopo.zeitreihen_18801231_cache_out]
+  title: Zeitreise - Kartenwerke (18801231)
+- dimensions: *id1001
+  name: ch.swisstopo.zeitreihen_18801231_source
+  sources: [ch.swisstopo.zeitreihen_18801231_cache]
+  title: Zeitreise - Kartenwerke (18801231, source)
+- dimensions: &id1002
+    Time:
+      default: '18791231'
+      values: ['18791231']
+  name: ch.swisstopo.zeitreihen_18791231
+  sources: [ch.swisstopo.zeitreihen_18791231_cache_out]
+  title: Zeitreise - Kartenwerke (18791231)
+- dimensions: *id1002
+  name: ch.swisstopo.zeitreihen_18791231_source
+  sources: [ch.swisstopo.zeitreihen_18791231_cache]
+  title: Zeitreise - Kartenwerke (18791231, source)
+- dimensions: &id1003
+    Time:
+      default: '18781231'
+      values: ['18781231']
+  name: ch.swisstopo.zeitreihen_18781231
+  sources: [ch.swisstopo.zeitreihen_18781231_cache_out]
+  title: Zeitreise - Kartenwerke (18781231)
+- dimensions: *id1003
+  name: ch.swisstopo.zeitreihen_18781231_source
+  sources: [ch.swisstopo.zeitreihen_18781231_cache]
+  title: Zeitreise - Kartenwerke (18781231, source)
+- dimensions: &id1004
+    Time:
+      default: '18771231'
+      values: ['18771231']
+  name: ch.swisstopo.zeitreihen_18771231
+  sources: [ch.swisstopo.zeitreihen_18771231_cache_out]
+  title: Zeitreise - Kartenwerke (18771231)
+- dimensions: *id1004
+  name: ch.swisstopo.zeitreihen_18771231_source
+  sources: [ch.swisstopo.zeitreihen_18771231_cache]
+  title: Zeitreise - Kartenwerke (18771231, source)
+- dimensions: &id1005
+    Time:
+      default: '18761231'
+      values: ['18761231']
+  name: ch.swisstopo.zeitreihen_18761231
+  sources: [ch.swisstopo.zeitreihen_18761231_cache_out]
+  title: Zeitreise - Kartenwerke (18761231)
+- dimensions: *id1005
+  name: ch.swisstopo.zeitreihen_18761231_source
+  sources: [ch.swisstopo.zeitreihen_18761231_cache]
+  title: Zeitreise - Kartenwerke (18761231, source)
+- dimensions: &id1006
+    Time:
+      default: '18751231'
+      values: ['18751231']
+  name: ch.swisstopo.zeitreihen_18751231
+  sources: [ch.swisstopo.zeitreihen_18751231_cache_out]
+  title: Zeitreise - Kartenwerke (18751231)
+- dimensions: *id1006
+  name: ch.swisstopo.zeitreihen_18751231_source
+  sources: [ch.swisstopo.zeitreihen_18751231_cache]
+  title: Zeitreise - Kartenwerke (18751231, source)
+- dimensions: &id1007
+    Time:
+      default: '18741231'
+      values: ['18741231']
+  name: ch.swisstopo.zeitreihen_18741231
+  sources: [ch.swisstopo.zeitreihen_18741231_cache_out]
+  title: Zeitreise - Kartenwerke (18741231)
+- dimensions: *id1007
+  name: ch.swisstopo.zeitreihen_18741231_source
+  sources: [ch.swisstopo.zeitreihen_18741231_cache]
+  title: Zeitreise - Kartenwerke (18741231, source)
+- dimensions: &id1008
+    Time:
+      default: '18731231'
+      values: ['18731231']
+  name: ch.swisstopo.zeitreihen_18731231
+  sources: [ch.swisstopo.zeitreihen_18731231_cache_out]
+  title: Zeitreise - Kartenwerke (18731231)
+- dimensions: *id1008
+  name: ch.swisstopo.zeitreihen_18731231_source
+  sources: [ch.swisstopo.zeitreihen_18731231_cache]
+  title: Zeitreise - Kartenwerke (18731231, source)
+- dimensions: &id1009
+    Time:
+      default: '18721231'
+      values: ['18721231']
+  name: ch.swisstopo.zeitreihen_18721231
+  sources: [ch.swisstopo.zeitreihen_18721231_cache_out]
+  title: Zeitreise - Kartenwerke (18721231)
+- dimensions: *id1009
+  name: ch.swisstopo.zeitreihen_18721231_source
+  sources: [ch.swisstopo.zeitreihen_18721231_cache]
+  title: Zeitreise - Kartenwerke (18721231, source)
+- dimensions: &id1010
+    Time:
+      default: '18711231'
+      values: ['18711231']
+  name: ch.swisstopo.zeitreihen_18711231
+  sources: [ch.swisstopo.zeitreihen_18711231_cache_out]
+  title: Zeitreise - Kartenwerke (18711231)
+- dimensions: *id1010
+  name: ch.swisstopo.zeitreihen_18711231_source
+  sources: [ch.swisstopo.zeitreihen_18711231_cache]
+  title: Zeitreise - Kartenwerke (18711231, source)
+- dimensions: &id1011
+    Time:
+      default: '18701231'
+      values: ['18701231']
+  name: ch.swisstopo.zeitreihen_18701231
+  sources: [ch.swisstopo.zeitreihen_18701231_cache_out]
+  title: Zeitreise - Kartenwerke (18701231)
+- dimensions: *id1011
+  name: ch.swisstopo.zeitreihen_18701231_source
+  sources: [ch.swisstopo.zeitreihen_18701231_cache]
+  title: Zeitreise - Kartenwerke (18701231, source)
+- dimensions: &id1012
+    Time:
+      default: '18691231'
+      values: ['18691231']
+  name: ch.swisstopo.zeitreihen_18691231
+  sources: [ch.swisstopo.zeitreihen_18691231_cache_out]
+  title: Zeitreise - Kartenwerke (18691231)
+- dimensions: *id1012
+  name: ch.swisstopo.zeitreihen_18691231_source
+  sources: [ch.swisstopo.zeitreihen_18691231_cache]
+  title: Zeitreise - Kartenwerke (18691231, source)
+- dimensions: &id1013
+    Time:
+      default: '18681231'
+      values: ['18681231']
+  name: ch.swisstopo.zeitreihen_18681231
+  sources: [ch.swisstopo.zeitreihen_18681231_cache_out]
+  title: Zeitreise - Kartenwerke (18681231)
+- dimensions: *id1013
+  name: ch.swisstopo.zeitreihen_18681231_source
+  sources: [ch.swisstopo.zeitreihen_18681231_cache]
+  title: Zeitreise - Kartenwerke (18681231, source)
+- dimensions: &id1014
+    Time:
+      default: '18671231'
+      values: ['18671231']
+  name: ch.swisstopo.zeitreihen_18671231
+  sources: [ch.swisstopo.zeitreihen_18671231_cache_out]
+  title: Zeitreise - Kartenwerke (18671231)
+- dimensions: *id1014
+  name: ch.swisstopo.zeitreihen_18671231_source
+  sources: [ch.swisstopo.zeitreihen_18671231_cache]
+  title: Zeitreise - Kartenwerke (18671231, source)
+- dimensions: &id1015
+    Time:
+      default: '18661231'
+      values: ['18661231']
+  name: ch.swisstopo.zeitreihen_18661231
+  sources: [ch.swisstopo.zeitreihen_18661231_cache_out]
+  title: Zeitreise - Kartenwerke (18661231)
+- dimensions: *id1015
+  name: ch.swisstopo.zeitreihen_18661231_source
+  sources: [ch.swisstopo.zeitreihen_18661231_cache]
+  title: Zeitreise - Kartenwerke (18661231, source)
+- dimensions: &id1016
+    Time:
+      default: '18651231'
+      values: ['18651231']
+  name: ch.swisstopo.zeitreihen_18651231
+  sources: [ch.swisstopo.zeitreihen_18651231_cache_out]
+  title: Zeitreise - Kartenwerke (18651231)
+- dimensions: *id1016
+  name: ch.swisstopo.zeitreihen_18651231_source
+  sources: [ch.swisstopo.zeitreihen_18651231_cache]
+  title: Zeitreise - Kartenwerke (18651231, source)
+- dimensions: &id1017
+    Time:
+      default: '18641231'
+      values: ['18641231']
+  name: ch.swisstopo.zeitreihen_18641231
+  sources: [ch.swisstopo.zeitreihen_18641231_cache_out]
+  title: Zeitreise - Kartenwerke (18641231)
+- dimensions: *id1017
+  name: ch.swisstopo.zeitreihen_18641231_source
+  sources: [ch.swisstopo.zeitreihen_18641231_cache]
+  title: Zeitreise - Kartenwerke (18641231, source)
+- dimensions: &id1018
+    Time:
+      default: '18631231'
+      values: ['18631231']
+  name: ch.swisstopo.zeitreihen_18631231
+  sources: [ch.swisstopo.zeitreihen_18631231_cache_out]
+  title: Zeitreise - Kartenwerke (18631231)
+- dimensions: *id1018
+  name: ch.swisstopo.zeitreihen_18631231_source
+  sources: [ch.swisstopo.zeitreihen_18631231_cache]
+  title: Zeitreise - Kartenwerke (18631231, source)
+- dimensions: &id1019
+    Time:
+      default: '18621231'
+      values: ['18621231']
+  name: ch.swisstopo.zeitreihen_18621231
+  sources: [ch.swisstopo.zeitreihen_18621231_cache_out]
+  title: Zeitreise - Kartenwerke (18621231)
+- dimensions: *id1019
+  name: ch.swisstopo.zeitreihen_18621231_source
+  sources: [ch.swisstopo.zeitreihen_18621231_cache]
+  title: Zeitreise - Kartenwerke (18621231, source)
+- dimensions: &id1020
+    Time:
+      default: '18611231'
+      values: ['18611231']
+  name: ch.swisstopo.zeitreihen_18611231
+  sources: [ch.swisstopo.zeitreihen_18611231_cache_out]
+  title: Zeitreise - Kartenwerke (18611231)
+- dimensions: *id1020
+  name: ch.swisstopo.zeitreihen_18611231_source
+  sources: [ch.swisstopo.zeitreihen_18611231_cache]
+  title: Zeitreise - Kartenwerke (18611231, source)
+- dimensions: &id1021
+    Time:
+      default: '18601231'
+      values: ['18601231']
+  name: ch.swisstopo.zeitreihen_18601231
+  sources: [ch.swisstopo.zeitreihen_18601231_cache_out]
+  title: Zeitreise - Kartenwerke (18601231)
+- dimensions: *id1021
+  name: ch.swisstopo.zeitreihen_18601231_source
+  sources: [ch.swisstopo.zeitreihen_18601231_cache]
+  title: Zeitreise - Kartenwerke (18601231, source)
+- dimensions: &id1022
+    Time:
+      default: '18591231'
+      values: ['18591231']
+  name: ch.swisstopo.zeitreihen_18591231
+  sources: [ch.swisstopo.zeitreihen_18591231_cache_out]
+  title: Zeitreise - Kartenwerke (18591231)
+- dimensions: *id1022
+  name: ch.swisstopo.zeitreihen_18591231_source
+  sources: [ch.swisstopo.zeitreihen_18591231_cache]
+  title: Zeitreise - Kartenwerke (18591231, source)
+- dimensions: &id1023
+    Time:
+      default: '18581231'
+      values: ['18581231']
+  name: ch.swisstopo.zeitreihen_18581231
+  sources: [ch.swisstopo.zeitreihen_18581231_cache_out]
+  title: Zeitreise - Kartenwerke (18581231)
+- dimensions: *id1023
+  name: ch.swisstopo.zeitreihen_18581231_source
+  sources: [ch.swisstopo.zeitreihen_18581231_cache]
+  title: Zeitreise - Kartenwerke (18581231, source)
+- dimensions: &id1024
+    Time:
+      default: '18571231'
+      values: ['18571231']
+  name: ch.swisstopo.zeitreihen_18571231
+  sources: [ch.swisstopo.zeitreihen_18571231_cache_out]
+  title: Zeitreise - Kartenwerke (18571231)
+- dimensions: *id1024
+  name: ch.swisstopo.zeitreihen_18571231_source
+  sources: [ch.swisstopo.zeitreihen_18571231_cache]
+  title: Zeitreise - Kartenwerke (18571231, source)
+- dimensions: &id1025
+    Time:
+      default: '18561231'
+      values: ['18561231']
+  name: ch.swisstopo.zeitreihen_18561231
+  sources: [ch.swisstopo.zeitreihen_18561231_cache_out]
+  title: Zeitreise - Kartenwerke (18561231)
+- dimensions: *id1025
+  name: ch.swisstopo.zeitreihen_18561231_source
+  sources: [ch.swisstopo.zeitreihen_18561231_cache]
+  title: Zeitreise - Kartenwerke (18561231, source)
+- dimensions: &id1026
+    Time:
+      default: '18551231'
+      values: ['18551231']
+  name: ch.swisstopo.zeitreihen_18551231
+  sources: [ch.swisstopo.zeitreihen_18551231_cache_out]
+  title: Zeitreise - Kartenwerke (18551231)
+- dimensions: *id1026
+  name: ch.swisstopo.zeitreihen_18551231_source
+  sources: [ch.swisstopo.zeitreihen_18551231_cache]
+  title: Zeitreise - Kartenwerke (18551231, source)
+- dimensions: &id1027
+    Time:
+      default: '18541231'
+      values: ['18541231']
+  name: ch.swisstopo.zeitreihen_18541231
+  sources: [ch.swisstopo.zeitreihen_18541231_cache_out]
+  title: Zeitreise - Kartenwerke (18541231)
+- dimensions: *id1027
+  name: ch.swisstopo.zeitreihen_18541231_source
+  sources: [ch.swisstopo.zeitreihen_18541231_cache]
+  title: Zeitreise - Kartenwerke (18541231, source)
+- dimensions: &id1028
+    Time:
+      default: '18531231'
+      values: ['18531231']
+  name: ch.swisstopo.zeitreihen_18531231
+  sources: [ch.swisstopo.zeitreihen_18531231_cache_out]
+  title: Zeitreise - Kartenwerke (18531231)
+- dimensions: *id1028
+  name: ch.swisstopo.zeitreihen_18531231_source
+  sources: [ch.swisstopo.zeitreihen_18531231_cache]
+  title: Zeitreise - Kartenwerke (18531231, source)
+- dimensions: &id1029
+    Time:
+      default: '18521231'
+      values: ['18521231']
+  name: ch.swisstopo.zeitreihen_18521231
+  sources: [ch.swisstopo.zeitreihen_18521231_cache_out]
+  title: Zeitreise - Kartenwerke (18521231)
+- dimensions: *id1029
+  name: ch.swisstopo.zeitreihen_18521231_source
+  sources: [ch.swisstopo.zeitreihen_18521231_cache]
+  title: Zeitreise - Kartenwerke (18521231, source)
+- dimensions: &id1030
+    Time:
+      default: '18511231'
+      values: ['18511231']
+  name: ch.swisstopo.zeitreihen_18511231
+  sources: [ch.swisstopo.zeitreihen_18511231_cache_out]
+  title: Zeitreise - Kartenwerke (18511231)
+- dimensions: *id1030
+  name: ch.swisstopo.zeitreihen_18511231_source
+  sources: [ch.swisstopo.zeitreihen_18511231_cache]
+  title: Zeitreise - Kartenwerke (18511231, source)
+- dimensions: &id1031
+    Time:
+      default: '18501231'
+      values: ['18501231']
+  name: ch.swisstopo.zeitreihen_18501231
+  sources: [ch.swisstopo.zeitreihen_18501231_cache_out]
+  title: Zeitreise - Kartenwerke (18501231)
+- dimensions: *id1031
+  name: ch.swisstopo.zeitreihen_18501231_source
+  sources: [ch.swisstopo.zeitreihen_18501231_cache]
+  title: Zeitreise - Kartenwerke (18501231, source)
+- dimensions: &id1032
+    Time:
+      default: '18491231'
+      values: ['18491231']
+  name: ch.swisstopo.zeitreihen_18491231
+  sources: [ch.swisstopo.zeitreihen_18491231_cache_out]
+  title: Zeitreise - Kartenwerke (18491231)
+- dimensions: *id1032
+  name: ch.swisstopo.zeitreihen_18491231_source
+  sources: [ch.swisstopo.zeitreihen_18491231_cache]
+  title: Zeitreise - Kartenwerke (18491231, source)
+- dimensions: &id1033
+    Time:
+      default: '18481231'
+      values: ['18481231']
+  name: ch.swisstopo.zeitreihen_18481231
+  sources: [ch.swisstopo.zeitreihen_18481231_cache_out]
+  title: Zeitreise - Kartenwerke (18481231)
+- dimensions: *id1033
+  name: ch.swisstopo.zeitreihen_18481231_source
+  sources: [ch.swisstopo.zeitreihen_18481231_cache]
+  title: Zeitreise - Kartenwerke (18481231, source)
+- dimensions: &id1034
+    Time:
+      default: '18471231'
+      values: ['18471231']
+  name: ch.swisstopo.zeitreihen_18471231
+  sources: [ch.swisstopo.zeitreihen_18471231_cache_out]
+  title: Zeitreise - Kartenwerke (18471231)
+- dimensions: *id1034
+  name: ch.swisstopo.zeitreihen_18471231_source
+  sources: [ch.swisstopo.zeitreihen_18471231_cache]
+  title: Zeitreise - Kartenwerke (18471231, source)
+- dimensions: &id1035
+    Time:
+      default: '18461231'
+      values: ['18461231']
+  name: ch.swisstopo.zeitreihen_18461231
+  sources: [ch.swisstopo.zeitreihen_18461231_cache_out]
+  title: Zeitreise - Kartenwerke (18461231)
+- dimensions: *id1035
+  name: ch.swisstopo.zeitreihen_18461231_source
+  sources: [ch.swisstopo.zeitreihen_18461231_cache]
+  title: Zeitreise - Kartenwerke (18461231, source)
+- dimensions: &id1036
+    Time:
+      default: '18451231'
+      values: ['18451231']
+  name: ch.swisstopo.zeitreihen_18451231
+  sources: [ch.swisstopo.zeitreihen_18451231_cache_out]
+  title: Zeitreise - Kartenwerke (18451231)
+- dimensions: *id1036
+  name: ch.swisstopo.zeitreihen_18451231_source
+  sources: [ch.swisstopo.zeitreihen_18451231_cache]
+  title: Zeitreise - Kartenwerke (18451231, source)
+- dimensions: &id1037
+    Time:
+      default: '18441231'
+      values: ['18441231']
+  name: ch.swisstopo.zeitreihen_18441231
+  sources: [ch.swisstopo.zeitreihen_18441231_cache_out]
+  title: Zeitreise - Kartenwerke (18441231)
+- dimensions: *id1037
+  name: ch.swisstopo.zeitreihen_18441231_source
+  sources: [ch.swisstopo.zeitreihen_18441231_cache]
+  title: Zeitreise - Kartenwerke (18441231, source)
+- dimensions: &id1038
     Time:
       default: '20110501'
       values: ['20110501']
   name: ch.vbs.territorialregionen_20110501
   sources: [ch.vbs.territorialregionen_20110501_cache_out]
   title: Territorialregionen (20110501)
-- dimensions: *id845
+- dimensions: *id1038
   name: ch.vbs.territorialregionen
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen ('current')
-- dimensions: *id845
+- dimensions: *id1038
   name: ch.vbs.territorialregionen_20110501_source
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen (20110501, source)
@@ -18521,6 +22922,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-vogelreservate/default/20090617/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bafu.bundesinventare-vogelreservate_20150622_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bafu.bundesinventare-vogelreservate/default/20150622/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bafu.fauna-steinbockkolonien_20020114_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20045,6 +24458,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anbieter-eigenes_festnetz/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.anbieter-eigenes_festnetz_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anbieter-eigenes_festnetz/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.anschlussart-glasfaser_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20129,6 +24554,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anschlussart-glasfaser/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.anschlussart-glasfaser_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anschlussart-glasfaser/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.anschlussart-koaxialkabel_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20213,6 +24650,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anschlussart-koaxialkabel/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.anschlussart-koaxialkabel_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anschlussart-koaxialkabel/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.anschlussart-kupferdraht_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20297,6 +24746,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anschlussart-kupferdraht/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.anschlussart-kupferdraht_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.anschlussart-kupferdraht/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.downlink100_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20381,6 +24842,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink100/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.downlink100_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink100/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.downlink10_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20465,6 +24938,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink10/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.downlink10_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink10/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.downlink1_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20549,6 +25034,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink1/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.downlink1_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink1/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.downlink20_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20633,6 +25130,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink20/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.downlink20_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink20/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.downlink2_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20717,6 +25226,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink2/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.downlink2_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink2/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.downlink50_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20801,6 +25322,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink50/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.downlink50_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.downlink50/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.uplink100_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20885,6 +25418,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink100/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.uplink100_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink100/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.uplink10_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -20969,6 +25514,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink10/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.uplink10_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink10/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.uplink1_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -21053,6 +25610,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink1/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.uplink1_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink1/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.uplink20_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -21137,6 +25706,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink20/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.uplink20_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink20/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.uplink2_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -21221,6 +25802,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink2/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.uplink2_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink2/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.uplink50_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -21305,6 +25898,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink50/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.uplink50_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.uplink50/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.verfuegbarkeit-hdtv_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -21389,6 +25994,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.verfuegbarkeit-hdtv/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.verfuegbarkeit-hdtv_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.verfuegbarkeit-hdtv/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.verfuegbarkeit-tv_20121222_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -21473,6 +26090,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.verfuegbarkeit-tv/default/20141120/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.bakom.verfuegbarkeit-tv_20150521_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.bakom.verfuegbarkeit-tv/default/20150521/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.bakom.versorgungsgebiet-tv_20070704_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -22265,6 +26894,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.blw.landwirtschaftliche-zonengrenzen/default/20140418/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.blw.landwirtschaftliche-zonengrenzen_20150708_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.blw.landwirtschaftliche-zonengrenzen/default/20150708/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.blw.niederschlagshaushalt_20081024_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -26302,6 +30943,18 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20151231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissnames3d_20150101_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swissnames3d/default/20150101/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.swisstopo.swisstlm3d-karte-farbe_20150401_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]
@@ -26998,6 +31651,2046 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.verschiebungsvektoren-tsp2/default/20070101/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18441231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18441231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18451231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18451231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18461231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18461231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18471231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18471231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18481231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18481231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18491231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18491231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18501231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18501231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18511231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18511231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18521231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18521231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18531231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18531231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18541231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18541231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18551231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18551231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18561231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18561231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18571231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18571231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18581231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18581231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18591231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18591231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18601231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18601231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18611231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18611231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18621231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18621231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18631231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18631231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18641231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18641231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18651231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18651231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18661231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18661231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18671231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18671231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18681231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18681231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18691231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18691231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18701231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18701231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18711231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18711231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18721231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18721231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18731231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18731231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18741231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18741231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18751231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18751231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18761231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18761231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18771231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18771231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18781231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18781231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18791231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18791231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18801231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18801231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18811231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18811231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18821231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18821231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18831231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18831231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18841231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18841231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18851231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18851231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18861231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18861231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18871231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18871231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18881231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18881231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18891231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18891231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18901231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18901231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18911231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18911231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18921231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18921231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18931231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18931231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18941231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18941231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18951231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18951231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18961231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18961231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18971231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18971231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18981231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18981231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_18991231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/18991231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19001231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19001231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19011231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19011231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19021231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19021231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19031231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19031231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19041231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19041231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19051231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19051231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19061231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19061231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19071231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19071231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19081231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19081231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19091231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19091231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19101231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19101231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19111231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19111231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19121231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19131231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19131231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19141231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19141231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19151231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19151231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19161231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19161231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19171231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19171231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19181231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19181231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19191231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19191231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19201231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19201231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19211231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19211231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19221231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19221231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19231231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19231231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19241231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19241231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19251231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19251231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19261231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19261231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19271231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19271231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19281231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19281231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19291231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19291231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19301231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19301231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19311231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19311231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19321231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19321231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19331231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19331231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19341231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19341231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19351231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19351231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19361231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19361231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19371231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19371231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19381231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19381231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19391231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19391231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19401231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19401231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19411231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19411231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19421231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19421231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19431231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19431231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19441231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19441231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19451231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19451231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19461231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19461231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19471231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19471231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19481231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19481231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19491231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19491231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19501231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19501231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19511231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19511231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19521231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19521231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19531231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19531231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19541231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19541231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19551231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19551231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19561231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19561231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19571231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19571231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19581231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19581231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19591231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19591231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19601231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19601231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19611231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19611231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19621231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19621231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19631231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19631231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19641231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19641231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19651231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19651231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19661231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19661231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19671231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19671231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19681231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19681231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19691231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19691231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19701231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19701231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19711231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19711231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19721231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19721231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19731231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19731231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19741231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19741231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19751231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19751231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19761231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19761231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19771231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19771231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19781231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19781231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19791231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19791231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19801231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19801231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19811231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19811231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19821231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19821231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19831231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19831231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19841231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19841231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19851231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19851231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19861231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19861231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19871231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19871231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19881231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19881231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19891231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19891231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19901231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19901231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19911231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19911231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19921231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19921231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19931231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19931231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19941231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19941231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19951231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19951231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19961231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19961231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19971231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19971231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19981231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19981231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_19991231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/19991231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20001231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20001231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20011231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20011231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20021231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20021231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20031231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20031231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20041231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20041231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20051231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20051231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20061231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20061231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20071231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20071231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20081231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20081231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20091231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20091231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20101231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20101231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20111231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20111231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20121231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20121231/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.zeitreihen_20131231_source:
+    coverage:
+      bbox: [420000, 30000, 900000, 350000]
+      bbox_srs: EPSG:21781
+    grid: swisstopo-pixelkarte
+    http:
+      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
+    on_error:
+      204: {cache: true, response: transparent}
+    transparent: true
+    type: tile
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.zeitreihen/default/20131231/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.vbs.territorialregionen_20110501_source:
     coverage:
       bbox: [420000, 30000, 900000, 350000]

--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -110,7 +110,10 @@ for idx, layersConfig in enumerate(getLayersConfigs()):
             timestamps = layersConfig.timestamp.split(',')
             total_timestamps += len(timestamps)
             current_timestamp = timestamps[0]
-            image_format = layersConfig.arr_all_formats.split(',')[0]
+            if bod_layer_id == 'ch.swisstopo.zeitreihen':
+                image_format = 'png'
+            else:
+                image_format = layersConfig.arr_all_formats.split(',')[0]
             server_layer_name = bod_layer_id
 
             current_timestamps[bod_layer_id] = current_timestamp


### PR DESCRIPTION
 ...but using png instead of pngjpeg (as in map.geo.admin.ch), as this custom image format is not well supported amongs desktop GIS.

See in Redmine  [BGDI Datenhaltung - Datenintegration #4835]

[GetCapabilities](http://mf-chsdi3.dev.bgdi.ch/mom_wmts_zeitreiehen/1.0.0/WMTSCapabilities.xml)

[Beispiel](http://mf-chsdi3.dev.bgdi.ch/mom_wmts_zeitreiehen/examples/ol3_lv95_all.html?layer=ch.swisstopo.zeitreihen&timestamp=19051231&format=png&base_url=http://mf-chsdi3.dev.bgdi.ch/mom_wmts_zeitreiehen)

ArcGis (10.2.2) use and display only png source, while QGis (2.8.1) display both sources, but actually only `.png`is used.