### PR TITLE
Switch API to OL 3.6

### DIFF
--- a/chsdi/templates/loader.js
+++ b/chsdi/templates/loader.js
@@ -18,7 +18,7 @@ ${layersconfig|n}
 % if mode == 'preview' or mode == 'previewdebug':
 document.write('<link rel="stylesheet" type="text/css" href="' + "${h.versioned(request.static_url('chsdi:static/css/ga.css'))}" + '" />');
 % else:
-document.write('<link rel="stylesheet" type="text/css" href="' + "${h.versioned(request.static_url('chsdi:static/css/old-ga.css'))}" + '" />');
+document.write('<link rel="stylesheet" type="text/css" href="' + "${h.versioned(request.static_url('chsdi:static/css/ga.css'))}" + '" />');
 % endif
 document.write('<scr' + 'ipt type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/proj4js/2.2.1/proj4.js"></scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/EPSG21781.js'))}" + '"></scr' + 'ipt>');
@@ -29,13 +29,13 @@ document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(requ
 % elif mode == 'previewdebug':
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/ga-debug.js'))}" + '"></scr' + 'ipt>');
 % elif mode == 'debug':
-document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/old-ga-debug.js'))}" + '"></scr' + 'ipt>');
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/ga-debug.js'))}" + '"></scr' + 'ipt>');
 % elif mode == 'waf':
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/old-ga-waf.js'))}" + '"></scr' + 'ipt>');
 % elif mode == 'wafint':
 document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/old-ga-wafint.js'))}" + '"></scr' + 'ipt>');
 % else:
-document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/old-ga.js'))}" + '"></scr' + 'ipt>');
+document.write('<scr' + 'ipt type="text/javascript" src="' + "${h.versioned(request.static_url('chsdi:static/js/ga.js'))}" + '"></scr' + 'ipt>');
 % endif
 })();
 


### PR DESCRIPTION
The old `preview`mode is now the default `one`


The folliwng PR have to be merged

- [x] Adapt examples  https://github.com/geoadmin/mf-chsdi3/pull/1507
- [x] Storymaps https://github.com/geoadmin/web-storymaps/pull/196
- [x] Swissguesser (nothing to do :-))
- [x] Various CMS example