### PR TITLE
KML admin interface

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -121,12 +121,11 @@ RewriteCond %{HTTP:X-Forwarded-Proto} !https
 RewriteRule ^${apache_entry_path}/admin         https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
 
 <LocationMatch ^${apache_entry_path}/admin/kml>
-AuthType Basic
-AuthName "Your IWI credential"
-# Optional line:
-AuthBasicProvider file
-AuthUserFile "/var/www/vhosts/mf-chsdi3/private/htpasswd"
-AuthGroupFile "/var/www/vhosts/mf-chsdi3/private/htgroup"
-Require group iwi-team bgdi-team
-
+    AuthType Basic
+    AuthName "Your IWI credential"
+    # Optional line:
+    AuthBasicProvider file
+    AuthUserFile "/var/www/vhosts/mf-chsdi3/private/htpasswd"
+    AuthGroupFile "/var/www/vhosts/mf-chsdi3/private/htgroup"
+    Require group iwi-team bgdi-team
 </LocationMatch>

--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -115,3 +115,18 @@ AliasMatch ^${apache_entry_path}/kml/(map\.geo\.admin\.ch_KML_\d+\.kml)$ ${print
 
 # Zadara downloads
 AliasMatch ^${apache_entry_path}/downloads/ch.(.*)$ ${vars:zadara_dir}ch.$1
+
+# KML admin
+RewriteCond %{HTTP:X-Forwarded-Proto} !https
+RewriteRule ^${apache_entry_path}/admin         https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
+
+<LocationMatch ^${apache_entry_path}/admin/kml>
+AuthType Basic
+AuthName "Your IWI credential"
+# Optional line:
+AuthBasicProvider file
+AuthUserFile "/var/www/vhosts/mf-chsdi3/private/htpasswd"
+AuthGroupFile "/var/www/vhosts/mf-chsdi3/private/htgroup"
+Require group iwi-team bgdi-team
+
+</LocationMatch>

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -89,6 +89,7 @@ def main(global_config, **settings):
     config.add_route('downloadkml', '/downloadkml')
     config.add_route('files_collection', '/files')
     config.add_route('files', '/files/{id}')
+    config.add_route('adminkml', '/admin/kml')
 
     # Some views for specific routes
     config.add_view(route_name='dev', renderer='chsdi:templates/index.mako')

--- a/chsdi/templates/adminkml.mako
+++ b/chsdi/templates/adminkml.mako
@@ -1,0 +1,125 @@
+<html>
+  <head>
+   <script src="//api3.geo.admin.ch/loader.js?lang=en" type="text/javascript"></script>
+   <style>
+      body {
+        margin: 0 auto;
+        position: absolute;
+        top: 0;
+        font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+      }
+      
+      #header {
+        margin-top: 0;
+        margin-left:40px;
+        height: 150px;
+        position: relative;
+        max-width: 1670px;
+        min-width: 1000px;
+        background-color: rgba(200,200,200,1);
+        padding: 5px 10px 10px 10px;
+        text-align: center;
+        border-bottom: 4px solid red;
+      }
+
+      #header h2 {
+       font-weight: normal;
+      }
+      
+      #link {
+        font-weight: bold;
+      }
+      
+      #link p {
+        display: inline-block;
+        padding-left: 10px;
+        margin: 0;
+      }
+  
+      #content {
+        max-width: 1800px;
+        width: 100%;
+        margin-right: 0;
+        float: left;
+        min-height: 1200px;
+        margin-top: 40px;
+        margin-left: 40px;
+      }
+
+       .map {
+        height: 400px;
+        width: 100%;
+      }
+
+      #api:first-child {
+        background-color: #E3F6CE;
+      }
+      
+      #api:first-child::after {
+        content: 'Last created';
+        color: #01DF01;
+        font-weight: bold;
+        display: inline-block;
+        margin: 5px 0 5px 10px; 
+      }
+
+      #api {
+        float: left;
+        height: 465;
+        width: 550;
+        margin: 0 10px 20px 0;
+      }
+    </style>
+  </head>
+  <body>
+<%
+files = pageargs['files']
+bucket = pageargs['bucket']
+%>
+    <div id="header">
+      <h1>Administration for kml storage</h1>
+      <h2><i>Displaying of the last 50 files created - Number of kml file: ${count}</i></h2>
+    </div>
+
+    <div id="content">
+% for idx, file in enumerate(files):
+      <div id="api">
+        <div id="map-${idx}" class="map"></div><br>
+        <div id="link"><p><a target="_blank" href='https://map.geo.admin.ch/?X=182898.59&Y=662367.14&zoom=0&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=&adminId=${file[1]}'>Edit link on map.geo.admin.ch</a></p><p>Created on : ${file[2]}</p></div>
+      </div>
+
+  <script type="text/javascript">
+      var layer = ga.layer.create('ch.swisstopo.pixelkarte-farbe');
+ 
+      var source${idx} = new ol.source.Vector({
+          url: '//${bucket}/files/${file[0]}',
+          format : new ol.format.KML({
+            projection: 'EPSG:21781'
+          })
+      });
+
+      var vector${idx} = new ol.layer.Vector({
+        source: source${idx}
+      });
+
+      var map${idx} = new ga.Map({
+        target: 'map-${idx}',
+        layers: [layer],
+        view: new ol.View({
+        })
+      });
+    
+      source${idx}.on('change', function(event) {
+  
+        var extent = source${idx}.getExtent();
+        map${idx}.getView().fitExtent(extent, map${idx}.getSize());
+      }); 
+ 
+      map${idx}.addLayer(vector${idx});
+  </script>
+
+%endfor
+
+    </div> 
+  </body>
+</html>

--- a/chsdi/templates/adminkml.mako
+++ b/chsdi/templates/adminkml.mako
@@ -75,6 +75,7 @@
 <%
 files = pageargs['files']
 bucket = pageargs['bucket']
+host = pageargs['host']
 %>
     <div id="header">
       <h1>Administration for kml storage</h1>
@@ -85,7 +86,7 @@ bucket = pageargs['bucket']
 % for idx, file in enumerate(files):
       <div id="api">
         <div id="map-${idx}" class="map"></div><br>
-        <div id="link"><p><a target="_blank" href='https://mf-geoadmin3.dev.bgdi.ch/?X=182898.59&Y=662367.14&zoom=0&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=&adminId=${file[1]}'>Edit link on map.geo.admin.ch</a></p><p>Created on : ${file[2]}</p></div>
+        <div id="link"><p><a target="_blank" href='https://${host}/?X=182898.59&Y=662367.14&zoom=0&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=&adminId=${file[1]}'>Edit link on map.geo.admin.ch</a></p><p>Created on : ${file[2]}</p></div>
       </div>
 
   <script type="text/javascript">

--- a/chsdi/templates/adminkml.mako
+++ b/chsdi/templates/adminkml.mako
@@ -85,7 +85,7 @@ bucket = pageargs['bucket']
 % for idx, file in enumerate(files):
       <div id="api">
         <div id="map-${idx}" class="map"></div><br>
-        <div id="link"><p><a target="_blank" href='https://map.geo.admin.ch/?X=182898.59&Y=662367.14&zoom=0&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=&adminId=${file[1]}'>Edit link on map.geo.admin.ch</a></p><p>Created on : ${file[2]}</p></div>
+        <div id="link"><p><a target="_blank" href='https://mf-geoadmin3.dev.bgdi.ch/?X=182898.59&Y=662367.14&zoom=0&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=&adminId=${file[1]}'>Edit link on map.geo.admin.ch</a></p><p>Created on : ${file[2]}</p></div>
       </div>
 
   <script type="text/javascript">

--- a/chsdi/tests/integration/test_file_storage.py
+++ b/chsdi/tests/integration/test_file_storage.py
@@ -14,7 +14,7 @@ VALID_KML = '''<?xml version="1.0" encoding="UTF-8"?>
     <description>Attached to the ground. Intelligently places itself
        at the height of the underlying terrain.</description>
     <Point>
-      <coordinates>-122.0822035425683,37.42228990140251,0</coordinates>
+      <coordinates>7.0,46.0,0</coordinates>
     </Point>
   </Placemark>
 </kml>'''

--- a/chsdi/views/admin.py
+++ b/chsdi/views/admin.py
@@ -10,7 +10,7 @@ from chsdi.models.clientdata_dynamodb import get_dynamodb_table
 def admin_kml(self):
     bucket_name = self.registry.settings.get('geoadmin_file_storage_bucket')
     files = kml_load(bucket_name=bucket_name)
-    kmls = {'files': files, 'count': len(files), 'bucket': self.registry.settings.get('api_url')}
+    kmls = {'files': files, 'count': len(files), 'bucket': self.registry.settings.get('api_url'), 'host': self.registry.settings.get('geoadminhost')}
     response = render_to_response(
         'chsdi:templates/adminkml.mako',
         kmls)

--- a/chsdi/views/admin.py
+++ b/chsdi/views/admin.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import datetime
+from pyramid.view import view_config
+from pyramid.renderers import render_to_response
+from chsdi.models.clientdata_dynamodb import get_dynamodb_table
+
+
+@view_config(route_name='adminkml', renderer='json')
+def admin_kml(self):
+    bucket_name = self.registry.settings.get('geoadmin_file_storage_bucket')
+    files = kml_load(bucket_name=bucket_name)
+    kmls = {'files': files, 'count': len(files), 'bucket': self.registry.settings.get('api_url')}
+    response = render_to_response(
+        'chsdi:templates/adminkml.mako',
+        kmls)
+    response.content_type = 'text/html'
+    return response
+
+
+def kml_load(bucket_name='public.geo.admin.ch'):
+    now = datetime.datetime.now()
+    date = now.strftime('%Y-%m-%d')
+    table = get_dynamodb_table(table_name='geoadmin-file-storage')
+    fileid = []
+    results = table.query_2(bucket__eq=bucket_name, timestamp__beginswith=date, index='bucketTimestampIndex', limit=50, reverse=True)
+    for f in results:
+        fileid.append((f['fileId'], f['adminId'], f['timestamp']))
+    return fileid


### PR DESCRIPTION

Using a custom `bucketTimestampIndex`index to `query` instead of `scan`. The service is also adding a new `bucket`attribute, because dynamodb may only filter on _RangeIndex_ (in this case `timestamp`).

```
{
    u 'Table': {
        u 'GlobalSecondaryIndexes': [{
            u 'IndexSizeBytes': 6489026, u 'IndexName': u 'fileIdIndex', u 'Projection': {
                u 'ProjectionType': u 'ALL'
            }, u 'IndexStatus': u 'ACTIVE', u 'ProvisionedThroughput': {
                u 'NumberOfDecreasesToday': 0, u 'WriteCapacityUnits': 4, u 'LastIncreaseDateTime': 1437681114.25, u 'ReadCapacityUnits': 2, u 'LastDecreaseDateTime': 1437688256.433
            }, u 'KeySchema': [{
                u 'KeyType': u 'HASH', u 'AttributeName': u 'fileId'
            }, {
                u 'KeyType': u 'RANGE', u 'AttributeName': u 'timestamp'
            }], u 'IndexArn': u 'arn:aws:dynamodb:eu-west-1:443130343732:table/geoadmin-file-storage/index/fileIdIndex', u 'ItemCount': 63158
        }, {
            u 'IndexSizeBytes': 4939136, u 'IndexName': u 'bucketTimestampIndex', u 'Projection': {
                u 'ProjectionType': u 'ALL'
            }, u 'IndexStatus': u 'ACTIVE', u 'ProvisionedThroughput': {
                u 'NumberOfDecreasesToday': 0, u 'WriteCapacityUnits': 4, u 'ReadCapacityUnits': 2, u 'LastDecreaseDateTime': 1437688295.868
            }, u 'KeySchema': [{
                u 'KeyType': u 'HASH', u 'AttributeName': u 'bucket'
            }, {
                u 'KeyType': u 'RANGE', u 'AttributeName': u 'timestamp'
            }], u 'IndexArn': u 'arn:aws:dynamodb:eu-west-1:443130343732:table/geoadmin-file-storage/index/bucketTimestampIndex', u 'ItemCount': 44924
        }], u 'AttributeDefinitions': [{
            u 'AttributeName': u 'adminId', u 'AttributeType': u 'S'
        }, {
            u 'AttributeName': u 'bucket', u 'AttributeType': u 'S'
        }, {
            u 'AttributeName': u 'fileId', u 'AttributeType': u 'S'
        }, {
            u 'AttributeName': u 'timestamp', u 'AttributeType': u 'S'
        }], u 'TableArn': u 'arn:aws:dynamodb:eu-west-1:443130343732:table/geoadmin-file-storage', u 'ProvisionedThroughput': {
            u 'NumberOfDecreasesToday': 0, u 'WriteCapacityUnits': 5, u 'LastIncreaseDateTime': 1437693125.438, u 'ReadCapacityUnits': 10, u 'LastDecreaseDateTime': 1437693132.669
        }, u 'TableSizeBytes': 6489026, u 'TableName': u 'geoadmin-file-storage', u 'TableStatus': u 'ACTIVE', u 'KeySchema': [{
            u 'KeyType': u 'HASH', u 'AttributeName': u 'adminId'
        }], u 'ItemCount': 63158, u 'CreationDateTime': 1431459708.399
    }
}
```


Files `htpasswd` and `htgroup`are managed by `Puppet`