### PR TITLE
No getfeatureinfo requests are allowed in mapproxy

### DIFF
--- a/apache/mapproxy.conf.in
+++ b/apache/mapproxy.conf.in
@@ -46,3 +46,8 @@ WSGIScriptAliasMatch ^${apache_entry_path}/mapproxy ${buildout:directory}/buildo
     Header unset ETag
     Header unset Age
 </LocationMatch>
+
+# No GetFeatureInfo request is allowed for WMS service
+RewriteCond %{QUERY_STRING} SERVICE=WMS [NC]
+RewriteCond %{QUERY_STRING} REQUEST=GetFeatureInfo [NC]
+RewriteRule ^${apache_entry_path}/mapproxy/service - [F]


### PR DESCRIPTION

This request is forbbiden:

http://mf-chsdi3.dev.bgdi.ch/fix_1600/mapproxy/service?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetFeatureInfo&SRS=EPSG%3A4326&WIDTH=768&HEIGHT=496&BBOX=6.990654807967476%2C46.033800893281246%2C7.023613792342768%2C46.04857638750783&INFO_FORMAT=text%2Fhtml&X=316.45&Y=183.55&BUFFER=15&QUERY_LAYERS=SWISS-PIXELKARTE&LAYERS=ch.swisstopo.pixelkarte-farbe

Hopefully fixes https://github.com/geoadmin/mf-chsdi3/issues/1600