### PR TITLE
Use assertion in non-TestCase unit tests

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -126,7 +126,7 @@ mapproxy_wsgi_options=processes=4 threads=32
 #zadara
 zadara_dir=/var/local/cartoweb/downloads/
 #http proxy
-http_proxy=http://ec2-54-93-109-29.eu-central-1.compute.amazonaws.com:80
+http_proxy=http://ec2-52-28-118-239.eu-central-1.compute.amazonaws.com:80
 # shortener
 shortener.allowed_hosts = 
 shortener.allowed_domains = admin.ch, swisstopo.ch, bgdi.ch

--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -26,8 +26,6 @@ deploy_target = dev
 wsgi_threads=15
 #mapproxy wsgi options (this is pretty a default value)
 mapproxy_wsgi_options=threads=15 
-# http proxy
-http_proxy=http://ec2-54-93-109-29.eu-central-1.compute.amazonaws.com:80
 # bucket for public file storage
 geoadmin_file_storage_bucket=public.dev.bgdi.ch
 

--- a/buildout_int.cfg
+++ b/buildout_int.cfg
@@ -19,8 +19,6 @@ mapproxyhost = mf-chsdi3.int.bgdi.ch
 geodata_staging= prod
 # deploy target
 deploy_target = int
-# http proxy
-http_proxy=http://ec2-54-93-109-29.eu-central-1.compute.amazonaws.com:80
 # bucket for public file storage
 geoadmin_file_storage_bucket=public.int.bgdi.ch
 

--- a/buildout_ltmom.cfg
+++ b/buildout_ltmom.cfg
@@ -7,8 +7,6 @@ api_url = //mf-chsdi3.dev.bgdi.ch/ltmom
 host = mf-chsdi3.dev.bgdi.ch
 geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltmom
 server_port = 9001
-# http proxy
-http_proxy=http://ec2-54-93-109-29.eu-central-1.compute.amazonaws.com:80
 
 
 [modwsgi]

--- a/buildout_prod.cfg
+++ b/buildout_prod.cfg
@@ -19,8 +19,6 @@ mapproxyhost = wmts10.geo.admin.ch
 robots_file = robots_prod.txt
 # deploy target
 deploy_target = prod
-# http proxy
-http_proxy=http://ec2-54-93-109-29.eu-central-1.compute.amazonaws.com:80
 # bucket for public file storage
 geoadmin_file_storage_bucket=public.geo.admin.ch
 

--- a/chsdi/tests/mapproxy/test_wmtscapabilities_auth.py
+++ b/chsdi/tests/mapproxy/test_wmtscapabilities_auth.py
@@ -1,44 +1,52 @@
 #-*- coding: utf-8 -*-
 
 import requests
+from chsdi.tests.integration import TestsBase
 from chsdi.tests.mapproxy import MapProxyTestsBase
 
 
-class TestWmtsGetTileAuth(MapProxyTestsBase):
+class TestWmtsGetTileAuth(TestsBase):
 
     def setUp(self):
         super(TestWmtsGetTileAuth, self).setUp()
+        self.mp = MapProxyTestsBase()
+        self.mp.setUp()
         self.paths = ['/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20130903/3857/7/67/45.jpeg',
                       '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/2056/17/5/6.jpeg',
                       '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20130903/4258/10/6/4.jpeg',
                       '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20151231/4326/21/132/180.jpeg']
 
+    def tearDown(self):
+        self.mp.tearDown()
+        super(TestWmtsGetTileAuth, self).tearDown()
+
     def check_status_code(self, url, referer, code):
         headers = None
         if referer:
             headers = {'Referer': referer}
-            resp = requests.get(url, params={'_id': self.hash()}, headers=headers)
+            resp = requests.get(url, params={'_id': self.mp.hash()}, headers=headers)
         else:
-            resp = requests.get(url, params={'_id': self.hash()})
-        self.failUnless(resp.status_code == code, 'Called Url: ' + url + ' [referer: ' + str(referer) + '] with return code: ' + str(resp.status_code))
+            resp = requests.get(url, params={'_id': self.mp.hash()})
+
+        assert (resp.status_code == code), 'Called Url: ' + url + ' [referer: ' + str(referer) + '] with return code: ' + str(resp.status_code)
 
     def test_bad_referer_get_capabilties(self):
-        self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.BAD_REFERER, 403)
+        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.mp.BAD_REFERER, 403)
 
     def test_bad_referer_get_tile(self):
         for path in self.paths:
-            self.check_status_code(self.mapproxy_url + path, self.BAD_REFERER, 403)
+            self.check_status_code(self.mp.mapproxy_url + path, self.mp.BAD_REFERER, 403)
 
     def test_no_referer_get_capabilties(self):
-        self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', None, 403)
+        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', None, 403)
 
     def test_no_referer_get_tile(self):
         for path in self.paths:
-            self.check_status_code(self.mapproxy_url + path, None, 403)
+            self.check_status_code(self.mp.mapproxy_url + path, None, 403)
 
     def test_good_referer_get_capabilties(self):
-        self.check_status_code(self.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.GOOD_REFERER, 200)
+        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.mp.GOOD_REFERER, 200)
 
     def test_good_referer_get_tile(self):
         for path in self.paths:
-            self.check_status_code(self.mapproxy_url + path, self.GOOD_REFERER, 200)
+            self.check_status_code(self.mp.mapproxy_url + path, self.mp.GOOD_REFERER, 200)

--- a/chsdi/tests/mapproxy/test_wmtsgettile.py
+++ b/chsdi/tests/mapproxy/test_wmtsgettile.py
@@ -1,9 +1,10 @@
 #-*- coding: utf-8 -*-
 
-from chsdi.tests.mapproxy import MapProxyTestsBase
-
 import requests
 import random
+from nose.tools import with_setup
+
+from chsdi.tests.mapproxy import MapProxyTestsBase
 
 # Official URLS we support
 WMTS_URLS = [
@@ -33,7 +34,7 @@ HEADER_RESULTS = [{
     'Header': {'User-Agent': 'WMTS Unit Tester v0.0.1', 'Referer': 'http://unittest.geo.admin.ch'}
 }, {
     'Results': [403],
-    'Header': {'User-Agent': 'WMTS Unit Tester v0.0.1'}
+    'Header': {'User-Agent': 'WMTS Unit Tester v0.0.1', 'Referer': None}
 }, {
     'Results': [403],
     'Header': {'User-Agent': 'WMTS Unit Tester v0.0.1', 'Referer': 'http://foonogood.ch'}
@@ -45,10 +46,10 @@ def get_header():
     return HEADER_RESULTS[random.randint(0, len(HEADER_RESULTS) - 1)]
 
 
-class TestWmtsGetTile(MapProxyTestsBase):
+class TileChecker(MapProxyTestsBase):
 
     def __init__(self):
-        super(TestWmtsGetTile, self).setUp()
+        super(TileChecker, self).setUp()
         self.session = requests.Session()
         self.session.mount("http://", requests.adapters.HTTPAdapter(max_retries=5))
 
@@ -62,30 +63,9 @@ class TestWmtsGetTile(MapProxyTestsBase):
         self.session.headers.update(h['Header'])
         resp = self.session.get(url)
         checkcode = resp.status_code in h['Results']
+        assert checkcode, url
 
-        assert(checkcode)
-
-    def test_epsg21781(self):
-        for params in self.get_tiles():
-            yield self.check_status_code, params[0]
-
-    def test_epsg3857(self):
-        for params in self.get_tiles(epsg=3857):
-            yield self.check_status_code, params[0]
-
-    def test_epsg2056(self):
-        for params in self.get_tiles(epsg=2056):
-            yield self.check_status_code, params[0]
-
-    def test_epsg4326(self):
-        for params in self.get_tiles(epsg=4326):
-            yield self.check_status_code, params[0]
-
-    def test_epsg4258(self):
-        for params in self.get_tiles(epsg=4258):
-            yield self.check_status_code, params[0]
-
-    def get_tiles(self, epsg=21781):
+    def itiles(self, epsg=21781):
         from urlparse import urlparse, urlunparse
         import xml.etree.ElementTree as etree
 
@@ -96,7 +76,6 @@ class TestWmtsGetTile(MapProxyTestsBase):
                  4326: [(15, 2, 2)],
                  4258: [(15, 2, 2)]
                  }
-        param_list = []
 
         if epsg in tiles.keys():
             capabilities_name = "WMTSCapabilities.EPSG.%d.xml" % epsg if epsg != 21781 else "WMTSCapabilities.xml"
@@ -125,7 +104,46 @@ class TestWmtsGetTile(MapProxyTestsBase):
                                 pth2 = pth.replace('{TileCol}', str(col)).replace('{TileRow}', str(row)).replace('{TileMatrix}', str(zoom)).replace('{Time}', str(t))
                             except:
                                 print 'Cannot replace in template %s' % pth
-                            url = urlunparse((tpl_parsed.scheme, tpl_parsed.netloc, pth2, '', '', ''))
-                            param_list.append((url,))
+                            yield urlunparse((tpl_parsed.scheme, tpl_parsed.netloc, pth2, '', '', ''))
 
-        return param_list
+
+tc = None
+
+
+def setup():
+    global tc
+    tc = TileChecker()
+
+
+def teardown():
+    tc.tearDown()
+
+
+@with_setup(setup, teardown)
+def test_epsg21781():
+    for tile in tc.itiles():
+        yield tc.check_status_code, tile
+
+
+@with_setup(setup, teardown)
+def test_epsg3857():
+    for tile in tc.itiles(epsg=3857):
+        yield tc.check_status_code, tile
+
+
+@with_setup(setup, teardown)
+def test_epsg2056():
+    for tile in tc.itiles(epsg=2056):
+        yield tc.check_status_code, tile
+
+
+@with_setup(setup, teardown)
+def test_epsg4326():
+    for tile in tc.itiles(epsg=4326):
+        yield tc.check_status_code, tile
+
+
+@with_setup(setup, teardown)
+def test_epsg4258():
+    for tile in tc.itiles(epsg=4258):
+        yield tc.check_status_code, tile


### PR DESCRIPTION
failUnless does not exist on this class because it's not based on TestCase. We don't want to base this class on TestCase because we want to use generators. So we need assert instead.

This PR also uses the new puppet managed http_proxy.

@procrastinatio Please review.