### PR TITLE
Handle exception when query has wrong type for id

### DIFF
--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -286,6 +286,9 @@ class TestMapServiceView(TestsBase):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/0', status=404)
         resp.mustcontain('No feature with id')
 
+        resp = self.testapp.get('/rest/services/api/MapServer/ch.bafu.bundesinventare-bln/htmlPopup', status=404)
+        resp.mustcontain('No feature with id')
+
     def test_feature_valid(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362', status=200)
         self.failUnless(resp.content_type == 'application/json')

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -8,7 +8,7 @@ from pyramid.response import Response
 import pyramid.httpexceptions as exc
 
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
-from sqlalchemy.exc import InternalError
+from sqlalchemy.exc import InternalError, DataError
 from sqlalchemy.sql.expression import cast, func
 from sqlalchemy import Text, Integer, Boolean, Numeric, Date
 from sqlalchemy import text
@@ -304,7 +304,7 @@ def _get_features(params, extended=False):
             query = query.filter(model.id == featureId)
             try:
                 feature = query.one()
-            except NoResultFound:
+            except (NoResultFound, DataError):
                 feature = None
             except MultipleResultsFound:
                 raise exc.HTTPInternalServerError('Multiple features found for the same id %s' % featureId)


### PR DESCRIPTION
This is a fix for https://github.com/geoadmin/mf-chsdi3/issues/1611

We handle the `DataError` exception now that can be thrown when there is a type mismatch between the given ID and the type of the ID field in the db.