### PR TITLE
Use helper and webdav host from settings

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -96,6 +96,8 @@ host = mf-chsdi3.bgdi.admin.ch
 server_port = 6543
 # Geodata staging
 geodata_staging = prod
+# WebDav host
+webdav_host = https://dav0.bgdi.admin.ch
 # the Unix user under which the modwsgi daemon processes are executed,
 # can be overriden in development-specific buildout config files
 modwsgi_user = www-data

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+import requests
 from osgeo import osr, ogr
 from pyramid.threadlocal import get_current_registry
 from pyramid.i18n import get_locale_name
@@ -44,6 +45,11 @@ def make_api_url(request, agnostic=False):
         return ''.join(('//', host))
     else:
         return ''.join((request.scheme, '://', host))
+
+
+def resource_exists(path):
+    r = requests.head(path)
+    return r.status_code == requests.codes.ok
 
 
 def check_url(url, config):

--- a/chsdi/templates/htmlpopup/energiestaedte_2000watt_areale.mako
+++ b/chsdi/templates/htmlpopup/energiestaedte_2000watt_areale.mako
@@ -184,11 +184,11 @@ Das Label für 2000-Watt-Areale zeichnet Siedlungsgebiete aus, die einen nachhal
 %endif
   </tr>
   % if lang=='fr' :
-<tr><img class="image" src="//dav0.bgdi.admin.ch/bfe_pub/images_energiestaedte-2000watt-aufdemweg/Sub-Logo_2000Watt_f.png" alt=""/></tr>
+<tr><img class="image" src="${request.registry.settings['webdav_host']}/bfe_pub/images_energiestaedte-2000watt-aufdemweg/Sub-Logo_2000Watt_f.png" alt=""/></tr>
   % elif lang=='it' :
-<tr><img class="image" src="//dav0.bgdi.admin.ch/bfe_pub/images_energiestaedte-2000watt-aufdemweg/Sub-Logo_2000Watt_i.png" alt=""/></tr>
+<tr><img class="image" src="${request.registry.settings['webdav_host']}/bfe_pub/images_energiestaedte-2000watt-aufdemweg/Sub-Logo_2000Watt_i.png" alt=""/></tr>
   % else :
-<tr><img class="image" src="//dav0.bgdi.admin.ch/bfe_pub/images_energiestaedte-2000watt-aufdemweg/Sub-Logo_2000Watt_d.png" alt=""/></tr>
+<tr><img class="image" src="${request.registry.settings['webdav_host']}/bfe_pub/images_energiestaedte-2000watt-aufdemweg/Sub-Logo_2000Watt_d.png" alt=""/></tr>
   % endif
 </table>
 </%def>

--- a/chsdi/templates/htmlpopup/fliessgewaesser_typ.mako
+++ b/chsdi/templates/htmlpopup/fliessgewaesser_typ.mako
@@ -11,51 +11,40 @@
 <tr><td class="cell-left">${_('ch.bafu.typisierung-fliessgewaesser.gefaelle')}</td>         <td>${c['attributes']['gefaelle'] or '-'}</td></tr>
 <tr><td class="cell-left">${_('ch.bafu.typisierung-fliessgewaesser.geo')}</td>              <td>${c['attributes']['geo'] or '-'}</td></tr>
 <%
-    from urllib2 import urlopen
-    url_pdf = "https://dav0.bgdi.admin.ch/bafu/"+c['attributes']['url_portraits']
-    response = None
-    try:
-        response = urlopen(url_pdf)
-        pdf = True
-    except:
-        pdf = False
-    finally:
-        if response:
-            response.close()
+    from chsdi.lib.helpers import resource_exists
+    pdf = None
+    if c['attributes']['url_portraits'] is not None:
+        webDavHost = request.registry.settings['webdav_host']
+        url_pdf = webDavHost + '/bafu/' + c['attributes']['url_portraits']
+        pdf = resource_exists(url_pdf)
 %>
+<tr>
+  <td class="cell-left">${_('ch.bafu.typisierung-fliessgewaesser.url_portraits')}</td>
+  <td>
 % if pdf:
-<tr><td class="cell-left">${_('ch.bafu.typisierung-fliessgewaesser.url_portraits')}</td>    <td><a href="${url_pdf}" target="_blank">${c['attributes']['url_portraits'] or '-'}</a></td></tr>
+    <a href="${url_pdf}" target="_blank">${c['attributes']['url_portraits']}</a></td>
 % else:
-<tr><td class="cell-left">${_('ch.bafu.typisierung-fliessgewaesser.url_portraits')}</td>    <td>-</td></tr>
+    -
 % endif
+</td>
+</tr>
 </%def>
 
 <%def name="extended_info(c, lang)">
 <%
+    from chsdi.lib.helpers import resource_exists
     lang = 'fr' if lang in ('fr', 'it') else 'de'
     url_uebersicht = 'url_uebersicht_%s' % lang
+    webDavHost = request.registry.settings['webdav_host']
+    pdf = None
+    pdf_legend = None
 
-    from urllib2 import urlopen
-    url_pdf = "https://dav0.bgdi.admin.ch/bafu/"+c['attributes']['url_portraits']
-    url_legend_pdf = "https://dav0.bgdi.admin.ch/bafu/"+c['attributes'][url_uebersicht]
-    response = None
-    try:
-        response = urlopen(url_pdf)
-        pdf = True
-    except:
-        pdf = False
-    finally:
-        if response:
-            response.close()
-    response = None
-    try:
-        response = urlopen(url_legend_pdf)
-        legend_pdf = True
-    except:
-        legend_pdf = False
-    finally:
-        if response:
-            response.close()
+    if c['attributes']['url_portraits'] is not None:
+        url_pdf = webDavHost + '/bafu/' + c['attributes']['url_portraits']
+        pdf = resource_exists(url_pdf)
+    if c['attributes'][url_uebersicht] is not None:
+        url_legend_pdf = webDavHost + '/bafu/' +c['attributes'][url_uebersicht]
+        pdf_legend = resource_exists(url_legend_pdf)
 %>
 
 <table class="table-with-border kernkraftwerke-extended">
@@ -112,7 +101,7 @@
 <tr>
 <th class="cell-left">${_('ch.bafu.typisierung-fliessgewaesser.url_uebersicht')}</th>
 % if legend_pdf:
-<td><a href="https://dav0.bgdi.admin.ch/bafu/${c['attributes'][url_uebersicht] or '-'}" target="_blank">${c['attributes'][url_uebersicht] or '-'}</a></td>
+<td><a href="${url_pdf_legend}" target="_blank">${c['attributes'][url_uebersicht] or '-'}</a></td>
 % else:
 <td>-</td>
 % endif

--- a/chsdi/templates/htmlpopup/geotechnik_gk200.mako
+++ b/chsdi/templates/htmlpopup/geotechnik_gk200.mako
@@ -2,13 +2,14 @@
 
 <%def name="table_body(c,lang)">
 <%
-    PDF_Link = 'https://dav0.bgdi.admin.ch/kogis_web/downloads/geologie/geotechnik/' + c['attributes']['file_name'] + '_' + lang + '.pdf'
+    webDavHost = request.registry.settings['webdav_host']
+    url_pdf = webDavHost + '/kogis_web/downloads/geologie/geotechnik/' + c['attributes']['file_name'] + '_' + lang + '.pdf'
 %>
     <tr><td colspan="3">&nbsp;</tr>
     <tr>
       <td>${_('Legend')}</td>
       <td width="20">&nbsp;</td>
-      <td><a href="${PDF_Link}" target="_blank">${_('tt_geotechnik_gk200')}</a></td>
+      <td><a href="${url_pdf}" target="_blank">${_('tt_geotechnik_gk200')}</a></td>
     </tr>
     <tr><td colspan="3">&nbsp;</tr>
 </%def>

--- a/chsdi/templates/htmlpopup/geotechnik_mineralische_rohstoffe200.mako
+++ b/chsdi/templates/htmlpopup/geotechnik_mineralische_rohstoffe200.mako
@@ -2,13 +2,14 @@
 
 <%def name="table_body(c,lang)">
 <%
-    PDF_Link = 'https://dav0.bgdi.admin.ch/kogis_web/downloads/geologie/geotechnik/' + c['attributes']['legend'] 
+    webDavHost = request.registry.settings['webdav_host']
+    url_pdf = webDavHost + '/kogis_web/downloads/geologie/geotechnik/' + c['attributes']['legend']
 %>
     <tr><td colspan="3">&nbsp;</tr>
     <tr>
       <td>${_('Legend')}</td>
       <td width="20">&nbsp;</td>
-      <td><a href="${PDF_Link}" target="_blank">${_('tt_geotechnik_gk200')}</a> - ${c['attributes']['area_name'] or '-'}</td>
+      <td><a href="${url_pdf}" target="_blank">${_('tt_geotechnik_gk200')}</a> - ${c['attributes']['area_name'] or '-'}</td>
     </tr>
     <tr><td colspan="3">&nbsp;</tr>
 </%def>

--- a/chsdi/templates/htmlpopup/geotope.mako
+++ b/chsdi/templates/htmlpopup/geotope.mako
@@ -3,5 +3,9 @@
 <%def name="table_body(c,lang)">
 <tr><td class="cell-left">${_('name')}</td><td>${c['attributes']['nom'] or '-'}</td></tr>
 <tr><td class="cell-left">${_('nummer')}</td><td>${c['attributes']['nummer'] or '-'}</td></tr>
-<tr><td class="cell-left">${_('link2dok')}</td>    <td><a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/geologie/geotope/geotope-CH_${c['attributes']['fix_id']}.pdf" target="_blank">Link</a></td></tr>
+<%
+    webDavHost = request.registry.settings['webdav_host']
+    url_pdf = webDavHost + '/kogis_web/downloads/geologie/geotope/geotope-CH_' + c['attributes']['fix_id'] + '.pdf'
+%>
+<tr><td class="cell-left">${_('link2dok')}</td>    <td><a href="${url_pdf}" target="_blank">Link</a></td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/geschiebemessnetz.mako
+++ b/chsdi/templates/htmlpopup/geschiebemessnetz.mako
@@ -11,10 +11,14 @@
 <tr><td class="cell-left">${_('ch.bafu.feststoffe-geschiebemessnetz.station')}</td><td>${c['attributes']['station'] or '-'}</td></tr>
 <tr><td class="cell-left">${_('ch.bafu.feststoffe-geschiebemessnetz.institut')}</td><td>${c['attributes']['institut'] or '-'}</td></tr>
 <tr><td class="cell-left">${_('ch.bafu.feststoffe-geschiebemessnetz.amt')}</td><td>${c['attributes']['amt'] or '-'}</td></tr>
+<%
+    webDavHost = request.registry.settings['webdav_host']
+    url_pdf = webDavHost + '/kogis_web/downloads/bafu/geschiebemessnetz/' + c['attributes']['pdf_file']
+%>
 <tr><td class="cell-left">${_('link')}</td>
     <td>
     % if c['attributes']['pdf_file']:
-      <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/bafu/geschiebemessnetz/${c['attributes']['pdf_file']}" target="_blank">${_('link')}</a>
+      <a href="${url_pdf}" target="_blank">${_('link')}</a>
     % else:
       -
     % endif
@@ -151,10 +155,18 @@
 <td>${c['attributes']['emailadresse2'] or '-'}</td>
 </tr>
 <tr>
+<%
+    from chsdi.lib.helpers import resource_exists
+    pdf = None
+    if c['attributes']['pdf_file'] is not None:
+        webDavHost = request.registry.settings['webdav_host']
+        url_pdf = webDavHost + '/kogis_web/downloads/bafu/geschiebemessnetz/' + c['attributes']['pdf_file']
+        pdf = resource_exists(url_pdf)
+%>
 <th class="cell-left">${_('link')}</th>
 <td>
     % if c['attributes']['pdf_file']:
-      <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/bafu/geschiebemessnetz/${c['attributes']['pdf_file']}" target="_blank">${_('link')}</a>
+      <a href="${url_pdf}" target="_blank">${_('link')}</a>
     % else:
       -
     % endif

--- a/chsdi/templates/htmlpopup/isos.mako
+++ b/chsdi/templates/htmlpopup/isos.mako
@@ -16,16 +16,24 @@
     <tr><td class="cell-left">${_('fassung')}</td>                    <td>${c['attributes']['fassungsjahr'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('band_1_2')}</td>                   <td>${c['attributes']['band_1'] or '-'} | ${c['attributes']['band_2'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('publikationsjahr_1_2')}</td>       <td>${c['attributes']['publikationsjahr_1'] or '-'} | ${c['attributes']['publikationsjahr_2'] or '-'}</td></tr>
+<%
+    webDavHost = request.registry.settings['webdav_host']
+    if c['attributes']['pdf_dokument_1'] is not None:
+        url_pdf = webDavHost + '/isos/' + c['attributes']['pdf_dokument_1'] + '.pdf'
+    if c['attributes']['pdf_dokument_2'] is not None:
+        url_pdf2 = webDavHost + '/isos/' + c['attributes']['pdf_dokument_2'] + '.pdf'
+%>
+
     <tr>
       <td class="cell-left">${_('pdf_dokument_1_2')}</td>
       <td>
         % if c['attributes']['pdf_dokument_1']:
-            <a href="https://dav0.bgdi.admin.ch/isos/${c['attributes']['pdf_dokument_1']|trim,quoting}.pdf" target="_blank">${c['attributes']['pdf_dokument_1']}.pdf</a> |
+            <a href="${url_pdf}" target="_blank">${c['attributes']['pdf_dokument_1']}.pdf</a> |
         % else:
             - | 
         % endif
         % if c['attributes']['pdf_dokument_2']:
-            &nbsp;<a href="https://dav0.bgdi.admin.ch/isos/${c['attributes']['pdf_dokument_2']|trim,quoting}.pdf" target="_blank">${c['attributes']['pdf_dokument_2']}.pdf</a>
+            &nbsp;<a href="${url_pdf2}" target="_blank">${c['attributes']['pdf_dokument_2']}.pdf</a>
         % else:
             &nbsp;-
         % endif

--- a/chsdi/templates/htmlpopup/ivs_nat.mako
+++ b/chsdi/templates/htmlpopup/ivs_nat.mako
@@ -32,52 +32,48 @@
     <tr><td class="cell-left">${_('ivs_documentation')}</td>
 <%
     from urllib2 import urlopen
-    PDF_Full = c['attributes']['ivs_sortsla']
-    PDF_Level_1 =  PDF_Full[0:6] + '0000'
-    PDF_Level_1_Name = PDF_Full[0:2]+ ' ' + str(int(PDF_Full[2:6]))
-    PDF_Level_2_exist = PDF_Full[6:8]
-    PDF_Level_2 = PDF_Full[0:8] + '00'
-    PDF_Level_2_Name = PDF_Level_1_Name + '.' +  str(int(PDF_Full[6:8]))
-    PDF_Level_3_exist = PDF_Full[8:10] 
-    PDF_Level_3 = PDF_Full 
-    PDF_Level_3_Name = PDF_Level_2_Name + '.' + str(int(PDF_Full[8:10]))
-    url = "http://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/"+c['attributes']['ivs_sortsla']+".pdf"
-    response = None
-    try:
-        response = urlopen(url)
-        pdf = True
-    except:
-        pdf = False
-    finally:
-        if response:
-            response.close()
+    from chsdi.lib.helpers import resource_exists
+    webDavHost = request.registry.settings['webdav_host']
+    pdf = None
+    if c['attributes']['ivs_sortsla'] is not None:
+        PDF_Full = c['attributes']['ivs_sortsla']
+        PDF_Level_1 =  PDF_Full[0:6] + '0000'
+        PDF_Level_1_Name = PDF_Full[0:2]+ ' ' + str(int(PDF_Full[2:6]))
+        PDF_Level_2_exist = PDF_Full[6:8]
+        PDF_Level_2 = PDF_Full[0:8] + '00'
+        PDF_Level_2_Name = PDF_Level_1_Name + '.' +  str(int(PDF_Full[6:8]))
+        PDF_Level_3_exist = PDF_Full[8:10] 
+        PDF_Level_3 = PDF_Full 
+        PDF_Level_3_Name = PDF_Level_2_Name + '.' + str(int(PDF_Full[8:10]))
+        url = webDavHost + "/kogis_web/downloads/ivs/beschr/de/" + c['attributes']['ivs_sortsla'] + ".pdf"
+        pdf = resource_exists(url)
 %>
 
 % if pdf: 
     <td>
-    % if lang =='fr':
-        ${_('ivs_nat_strecke')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
+    % if lang =='fr': 
+        ${_('ivs_nat_strecke')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
       % if PDF_Level_2_exist <> '00':
-        ${_('ivs_nat_linienfuehrung')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
+        ${_('ivs_nat_linienfuehrung')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
       % endif
       % if PDF_Level_3_exist <> '00':
-        ${_('ivs_nat_abschnitt')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
+        ${_('ivs_nat_abschnitt')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
       % endif
     % elif lang == 'it':
-      ${_('ivs_nat_strecke')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/it/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
+      ${_('ivs_nat_strecke')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/it/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
       % if PDF_Level_2_exist <> '00':
-        ${_('ivs_nat_linienfuehrung')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/it/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
+        ${_('ivs_nat_linienfuehrung')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/it/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
       % endif
       % if PDF_Level_3_exist <> '00':
-        ${_('ivs_nat_abschnitt')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/it/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
+        ${_('ivs_nat_abschnitt')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/it/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
       % endif
     % else:
-      ${_('ivs_nat_strecke')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
+      ${_('ivs_nat_strecke')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/de/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
       % if PDF_Level_2_exist <> '00':
-        ${_('ivs_nat_linienfuehrung')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
+        ${_('ivs_nat_linienfuehrung')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/de/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
       % endif
       % if PDF_Level_3_exist <> '00':
-        ${_('ivs_nat_abschnitt')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
+        ${_('ivs_nat_abschnitt')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/de/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
       % endif
     % endif
     </td></tr>

--- a/chsdi/templates/htmlpopup/kantone.ivs-reg_loc.mako
+++ b/chsdi/templates/htmlpopup/kantone.ivs-reg_loc.mako
@@ -25,54 +25,48 @@
     <tr><td class="cell-left">${_('ivs_documentation')}</td>
 <%
     from urllib2 import urlopen
-    PDF_Full = c['attributes']['ivs_sortsla']
-    PDF_Level_1 =  PDF_Full[0:6] + '0000'
-    PDF_Level_1_Name = PDF_Full[0:2]+ ' ' + str(int(PDF_Full[2:6]))
-    PDF_Level_2_exist = PDF_Full[6:8]
-    PDF_Level_2 = PDF_Full[0:8] + '00'
-    PDF_Level_2_Name = PDF_Level_1_Name + '.' +  str(int(PDF_Full[6:8]))
-    PDF_Level_3_exist = PDF_Full[8:10] 
-    PDF_Level_3 = PDF_Full 
-    PDF_Level_3_Name = PDF_Level_2_Name + '.' + str(int(PDF_Full[8:10]))
-    url = "http://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/"+c['attributes']['ivs_sortsla']+".pdf"
-    response = None
-    try:
-        response = urlopen(url)
-        pdf = True
-    except:
-        pdf = False
-        ivs_kanton = c['attributes']['ivs_kanton'].replace(' ','').lower()
-        default_pdf_link = "http://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/Kantonshefte/"+ivs_kanton+"_kantonsheft.pdf"
-    finally:
-        if response:
-            response.close()
+    from chsdi.lib.helpers import resource_exists
+    webDavHost = request.registry.settings['webdav_host']
+    pdf = None
+    if c['attributes']['ivs_sortsla'] is not None: 
+        PDF_Full = c['attributes']['ivs_sortsla']
+        PDF_Level_1 =  PDF_Full[0:6] + '0000'
+        PDF_Level_1_Name = PDF_Full[0:2]+ ' ' + str(int(PDF_Full[2:6]))
+        PDF_Level_2_exist = PDF_Full[6:8]
+        PDF_Level_2 = PDF_Full[0:8] + '00'
+        PDF_Level_2_Name = PDF_Level_1_Name + '.' +  str(int(PDF_Full[6:8]))
+        PDF_Level_3_exist = PDF_Full[8:10] 
+        PDF_Level_3 = PDF_Full 
+        PDF_Level_3_Name = PDF_Level_2_Name + '.' + str(int(PDF_Full[8:10]))
+        url = webDavHost +  "/kogis_web/downloads/ivs/beschr/de/"+c['attributes']['ivs_sortsla']+".pdf"
+        pdf = resource_exists(url)
 %>
 
     % if pdf: 
     <td>
         % if lang =='fr':
-            ${_('ivs_nat_strecke')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
+            ${_('ivs_nat_strecke')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
             % if PDF_Level_2_exist <> '00':
-                ${_('ivs_nat_linienfuehrung')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
+                ${_('ivs_nat_linienfuehrung')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
             % endif
             % if PDF_Level_3_exist <> '00':
-                ${_('ivs_nat_abschnitt')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
+                ${_('ivs_nat_abschnitt')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/fr/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
             % endif
         % elif lang == 'it':
-            ${_('ivs_nat_strecke')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/it/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
+            ${_('ivs_nat_strecke')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/it/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
             % if PDF_Level_2_exist <> '00':
-                ${_('ivs_nat_linienfuehrung')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/it/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
+                ${_('ivs_nat_linienfuehrung')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/it/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
             % endif
             % if PDF_Level_3_exist <> '00':
-                ${_('ivs_nat_abschnitt')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/it/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
+                ${_('ivs_nat_abschnitt')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/it/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
             % endif
         % else:
-            ${_('ivs_nat_strecke')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
+            ${_('ivs_nat_strecke')}: <a href="/kogis_web/downloads/ivs/beschr/de/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
             % if PDF_Level_2_exist <> '00':
-                ${_('ivs_nat_linienfuehrung')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
+                ${_('ivs_nat_linienfuehrung')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/de/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
             % endif
             % if PDF_Level_3_exist <> '00':
-                ${_('ivs_nat_abschnitt')}: <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/ivs/beschr/de/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
+                ${_('ivs_nat_abschnitt')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/de/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
             % endif
         % endif
     % else:

--- a/chsdi/templates/htmlpopup/kgs.mako
+++ b/chsdi/templates/htmlpopup/kgs.mako
@@ -17,7 +17,8 @@
         objarts = c['attributes']['objektart'].split(',')
         import csv
         from urllib2 import urlopen
-        csv_url = 'http://dav0.bgdi.admin.ch/kogis_web/downloads/kgs/bilder/meta.txt'
+        webDavHost = request.registry.settings['webdav_host']
+        csv_url = webDavHost + '/kogis_web/downloads/kgs/bilder/meta.txt'
         csv_file = None
         try:
             csv_file = urlopen(csv_url)
@@ -87,7 +88,7 @@
             <th class="cell-left">${_('Feature tooltip')}:</th>
             <td>
 	        % for pdf in c['attributes']['pdf_list'].split('##'):
-                <a href="http://dav0.bgdi.admin.ch/kogis_web/downloads/kgs/matrizen/${pdf}" target="_blank">${pdf}</a><br />
+                <a href="${webDavHost}/kogis_web/downloads/kgs/matrizen/${pdf}" target="_blank">${pdf}</a><br />
 	        % endfor
             </td>
 	    </tr>
@@ -124,8 +125,8 @@
             <div class="thumbnail-container">
             %for pic in pic_list:
                 <div class="thumbnail">
-                    <a href="http://dav0.bgdi.admin.ch/kogis_web/downloads/kgs/bilder/kgs_${pic[0]}_${pic[1]}.jpg">
-                        <img class="image" src="http://dav0.bgdi.admin.ch/kogis_web/downloads/kgs/bilder/kgs_${pic[0]}_${pic[1]}.jpg" />
+                    <a href="${webDavHost}/kogis_web/downloads/kgs/bilder/kgs_${pic[0]}_${pic[1]}.jpg">
+                        <img class="image" src="${webDavHost}/kogis_web/downloads/kgs/bilder/kgs_${pic[0]}_${pic[1]}.jpg" />
                     </a>
                     <div>${pic[3] or ''} - ${pic[2] or ''}</div>
                 </div>

--- a/chsdi/templates/htmlpopup/wildtierkorridor.mako
+++ b/chsdi/templates/htmlpopup/wildtierkorridor.mako
@@ -5,13 +5,17 @@
 <%
     lang = 'fr' if lang in ('fr', 'it') else 'dt'
     zusta = 'zusta_%s' % lang
+
+    if c['attributes']['nr'] is not None:
+        webDavHost = request.registry.settings['webdav_host']
+        url_pdf = webDavHost + '/kogis_web/downloads/bafu/' + c['attributes']['nr'] + '.pdf'
 %>
 
     <tr><td class="cell-left">${_('tt_ch.bafu.fauna-wildtierkorridor_national_nr')}</td>       <td>${c['attributes']['nr'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_ch.bafu.fauna-wildtierkorridor_national_zustand')}</td>  <td>${c['attributes'][zusta] or '-'}</td></tr>
     <tr><td class="cell-left">${_('pdf')}</td>                                         <td>
     % if c['attributes']['nr']:
-      <a href="https://dav0.bgdi.admin.ch/kogis_web/downloads/bafu/${c['attributes']['nr']}.pdf" target="_blank">${_('link')}</a>
+      <a href="${url_pdf}" target="_blank">${_('link')}</a>
     % else:
       -
     % endif

--- a/production.ini.in
+++ b/production.ini.in
@@ -42,6 +42,7 @@ sphinxhost = ${sphinxhost}
 wmshost = ${wmshost}
 mapproxyhost = ${mapproxyhost}
 geoadminhost = ${geoadminhost}
+webdav_host = ${webdav_host}
 api_url = ${api_url}
 install_directory = ${buildout:directory}
 host = ${host}


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-chsdi3/issues/1613

This PR adds a new variable in settings:
webdav_host

We also use a helper function to determine if a resource exists or not. (We request only the header)

In general I find it really annoying that we need to check for the existence of a resource on webdav. If a link exists in DB we should have it on webDav or we don't put the link in the DB to start with.

I am not changing that everywhere for now as we have ton of references.

@AFoletti @daguer @ltclm @pfanguin @alcapat 

Anyone motivated to change that in all templates?

Simply do:
git grep dav0.bgdi.admin.ch

and follow what has been done in this PR. (using helper function and variable from settings)