### PR TITLE
Add 'tooltip' and 'queryableAttributes' to layersConfig

### DIFF
--- a/chsdi/models/__init__.py
+++ b/chsdi/models/__init__.py
@@ -58,3 +58,15 @@ def models_from_name(name):
         return models
     else:
         return None
+
+
+def get_models_attributes_keys(models, lang, attributeOnly):
+    allAttributes = []
+    for model in models:
+        attributes = []
+        if hasattr(model, '__queryable_attributes__'):
+            attributes = model.get_queryable_attributes_keys(lang)
+        elif not attributeOnly:
+            attributes = model().getAttributesKeys()
+        allAttributes = allAttributes + attributes
+    return list(set(allAttributes))

--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -4,7 +4,7 @@ from sqlalchemy import Column, Text, Integer, Boolean
 from sqlalchemy.dialects import postgresql
 
 from chsdi.lib.helpers import make_agnostic
-from chsdi.models import bases, models_from_name
+from chsdi.models import bases, models_from_name, get_models_attributes_keys
 
 Base = bases['bod']
 
@@ -129,12 +129,7 @@ class LayersConfig(Base):
         # adding __queryable_attributes__ if they have them
         models = models_from_name(self.layerBodId)
         if models is not None:
-            queryable_attributes = []
-            for model in models:
-                if hasattr(model, '__queryable_attributes__'):
-                    queryable_attributes.extend(model.get_queryable_attributes_keys(params.lang))
-
-            queryable_attributes = list(set(queryable_attributes))
+            queryable_attributes = get_models_attributes_keys(models, params.lang, True)
             if len(queryable_attributes) > 0:
                 config['queryableAttributes'] = queryable_attributes
 

--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -4,7 +4,7 @@ from sqlalchemy import Column, Text, Integer, Boolean
 from sqlalchemy.dialects import postgresql
 
 from chsdi.lib.helpers import make_agnostic
-from chsdi.models import bases
+from chsdi.models import bases, models_from_name
 
 Base = bases['bod']
 
@@ -64,9 +64,10 @@ class LayersConfig(Base):
     minResolution = Column('minresolution', postgresql.DOUBLE_PRECISION)
     maxResolution = Column('maxresolution', postgresql.DOUBLE_PRECISION)
     parentLayerId = Column('parentlayerid', Text)
-    queryable = Column('queryable', Boolean)
     searchable = Column('searchable', Boolean)
+    queryable = Column('queryable', Boolean)
     selectbyrectangle = Column('selectbyrectangle', Boolean)
+    tooltip = Column('tooltip', Boolean)
     serverLayerName = Column('server_layername', Text)
     singleTile = Column('singletile', Boolean)
     subLayersIds = Column('sublayersids', postgresql.ARRAY(Text))
@@ -124,6 +125,18 @@ class LayersConfig(Base):
         # sublayers don't have attributions
         if 'attribution' in config:
             config['attributionUrl'] = translate(self.__dict__['attribution'] + '.url')
+
+        # adding __queryable_attributes__ if they have them
+        models = models_from_name(self.layerBodId)
+        if models is not None:
+            queryable_attributes = []
+            for model in models:
+                if hasattr(model, '__queryable_attributes__'):
+                    queryable_attributes.extend(model.get_queryable_attributes_keys(params.lang))
+
+            queryable_attributes = list(set(queryable_attributes))
+            if len(queryable_attributes) > 0:
+                config['queryableAttributes'] = queryable_attributes
 
         return {self.layerBodId: config}
 

--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -421,6 +421,15 @@ class TestMapServiceView(TestsBase):
     def test_layersconfig_wrong_map(self):
         self.testapp.get('/rest/services/foo/MapServer/layersConfig', status=400)
 
+    def test_layersconfig_queryable_attributes(self):
+        resp = self.testapp.get('/rest/services/all/MapServer/layersConfig', status=200)
+        self.failUnless(resp.content_type == 'application/json')
+        jsonData = resp.json
+        self.failUnless('ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp' in jsonData)
+        layer = jsonData['ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp']
+        self.failUnless('queryableAttributes' in layer)
+        self.failUnless(len(layer['queryableAttributes']) > 0)
+
     def test_layer_attributes(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln', status=200)
         self.assertTrue(resp.content_type == 'application/json')

--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -423,12 +423,16 @@ class TestMapServiceView(TestsBase):
 
     def test_layersconfig_queryable_attributes(self):
         resp = self.testapp.get('/rest/services/all/MapServer/layersConfig', status=200)
-        self.failUnless(resp.content_type == 'application/json')
+        self.assertTrue(resp.content_type == 'application/json')
         jsonData = resp.json
-        self.failUnless('ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp' in jsonData)
+        self.assertTrue('ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp' in jsonData)
         layer = jsonData['ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp']
-        self.failUnless('queryableAttributes' in layer)
-        self.failUnless(len(layer['queryableAttributes']) > 0)
+        self.assertTrue('queryableAttributes' in layer)
+        self.assertTrue(len(layer['queryableAttributes']) > 0)
+        # Should not have
+        self.assertTrue('ch.swisstopo.vec200-transportation-oeffentliche-verkehr' in jsonData)
+        layer = jsonData['ch.swisstopo.vec200-transportation-oeffentliche-verkehr']
+        self.assertTrue('queryableAttributes' not in layer)
 
     def test_layer_attributes(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln', status=200)

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -12,7 +12,7 @@ import pyramid.httpexceptions as exc
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from chsdi.lib.validation.mapservice import MapServiceValidation
-from chsdi.models import models_from_name
+from chsdi.models import models_from_name, get_models_attributes_keys
 from chsdi.models.bod import LayersConfig, get_bod_model, computeHeader
 from chsdi.lib.filters import full_text_search, filter_by_geodata_staging, filter_by_map_name
 
@@ -109,19 +109,6 @@ def _find_type(model, colProp):
         return model.get_column_by_property_name(colProp).type
 
 
-def _get_models_attributes_keys(models, lang):
-    allAttributes = []
-    for model in models:
-        if hasattr(model, '__queryable_attributes__'):
-            attributes = model.get_queryable_attributes_keys(lang)
-        else:
-            # Maybe this should be removed since only searchable layers
-            # have attributes that can be queried
-            attributes = model().getAttributesKeys()
-        allAttributes = allAttributes + attributes
-    return list(set(allAttributes))
-
-
 # Could be moved in features.py as it accesses vector models
 @view_config(route_name='featureAttributes', renderer='jsonp')
 def feature_attributes(request):
@@ -135,7 +122,7 @@ def feature_attributes(request):
         raise exc.HTTPBadRequest('No Vector Table was found for %s' % layerId)
 
     # Take into account all models and remove duplicated keys
-    attributes = _get_models_attributes_keys(models, params.lang)
+    attributes = get_models_attributes_keys(models, params.lang, False)
     trackAttributesNames = []
     fields = []
 


### PR DESCRIPTION
This is the result of the discussion in https://github.com/geoadmin/mf-chsdi3/pull/1096

Long term goal is to get rid of `queryable` and `selectbyrectangle` attribute in LayersConfig and in the bod. In the future, we will have

`tooltip`: layer has a tooltip. Thus can be used in front-end for left mousclick or selection by rectangle
`queryableAttributes`: if the layer can be used in the query tool, it will have an array of attributes that can be queried. If not, it will not contain this property
`searchable`: [existing] layers can be search view search tool (and will have a sphinx index)

This is the first step by adding `tooltip` and `queryableAttributes` where appropriate. Client side code will be adapted as well to reflect these changes.