### PR TITLE
[WIP] Don't return a geometry for features that are too big

### DIFF
--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -83,19 +83,20 @@ class TestMapServiceView(TestsBase):
 
     def test_identify_valid(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96', 'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status='*')
-        self.assertTrue(resp.status_code in (200, 509))
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
 
     def test_identify_valid_topic_all(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96', 'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status='*')
-        self.assertTrue(resp.status_code in (200, 509))
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
 
     def test_identify_valid_with_callback(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96', 'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all',
                   'callback': 'cb'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status='*')
-        self.assertTrue(resp.status_code in (200, 509))
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        self.assertTrue(resp.content_type == 'text/javascript')
+        resp.mustcontain('cb({')
 
     def test_identify_with_geojson(self):
         params = {'geometry': '600000,200000,631000,210000', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96', 'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1',
@@ -323,7 +324,14 @@ class TestMapServiceView(TestsBase):
         resp.mustcontain('cb({')
 
     def test_feature_toobig(self):
-        self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.geologie-geocover/910652', params={'geometryFormat': 'geojson'}, status=509)
+        resp = self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.geologie-geocover/910652', params={'geometryFormat': 'geojson'}, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertTrue('geometry' not in resp.json['feature'])
+
+    def test_feature_big_but_good(self):
+        resp = self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.geologie-geocover/1080284', params={'geometryFormat': 'geojson'}, status=200)
+        self.assertTrue(resp.content_type == 'application/json')
+        self.assertTrue('geometry' in resp.json['feature'])
 
     def test_htmlpopup_valid(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362/htmlPopup', status=200)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -496,9 +496,15 @@ def _format_search_text(columnType, searchText):
         raise exc.HTTPBadRequest('Find operations cannot be performed on geometry columns')
 
 
+def has_long_geometry(feature):
+    if len(getattr(feature, feature.geometry_column_to_return().name).data) > 1000000:
+        return True
+    return False
+
+
 def _process_feature(feature, params):
     # TODO find a way to use translate directly in the model
-    if params.returnGeometry:
+    if params.returnGeometry and not has_long_geometry(feature):
         f = feature.__geo_interface__
         # Filter out this layer individually, disregarding of the global returnGeometry
         # setting


### PR DESCRIPTION
This is an alternative/addition to https://github.com/geoadmin/mf-chsdi3/pull/1621

In #1621, we return a `413` (requested feature is too big) whenever we do a request that contains one result that contains a feature which wbk string is longer than 1M characters. This protects our backends against very long requests.

The approach in #1621 has the downside that for some requests, the identify will also ignore features that are well withing the limit, or features from other layers that are also within the limits (We can combine serveral layers for one single `identify` request).

This PR tries to address the downside of the above by, in all cases, return a valid result (`200`) but to remove (and not parse) the geometry of features hitting the specified limits. 

There's a downside to this as well: the clients need to adapt their code to handle features with no geometry. This has not been verified in mf-geoadmin3 yet.