### PR TITLE
Assure that NaN parameters are parsed correctly

### DIFF
--- a/chsdi/esrigeojsonencoder.py
+++ b/chsdi/esrigeojsonencoder.py
@@ -13,6 +13,8 @@ from papyrus.geo_interface import GeoInterface
 from geojson.crs import Named
 from functools import reduce
 
+from chsdi.lib.helpers import float_raise_nan
+
 
 class EsriGeoJSONEncoder(GeoJSONEncoder):
 
@@ -145,7 +147,8 @@ class EsriSimple():
         if isinstance(ob, list):
             coords = ob
         else:
-            coords = [float(x.strip()) for x in ob.split(',')]
+            coords = [float_raise_nan(x.strip()) for x in ob.split(',')]
+
         wkid = 21781
         if len(coords) == 2:
             x, y = coords
@@ -216,7 +219,9 @@ def loads(obj):
 
     except:
         return json.loads(obj,
-                          object_hook=EsriGeoJSON.to_instance)
+                          object_hook=EsriGeoJSON.to_instance,
+                          parse_constant=float_raise_nan
+                          )
     else:
         raise ValueError("%r is not a recognized esri geometry type", obj)
 

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+import math
 import requests
 from osgeo import osr, ogr
 from pyramid.threadlocal import get_current_registry
@@ -238,3 +239,11 @@ def transformCoordinate(wkt, srid_from, srid_to):
     geom.AssignSpatialReference(srid_in)
     geom.TransformTo(srid_out)
     return geom
+
+
+# float('NaN') does not raise an Exception. This function does.
+def float_raise_nan(val):
+    ret = float(val)
+    if math.isnan(ret):
+        raise ValueError('nan is not considered valid float')
+    return ret

--- a/chsdi/lib/validation/height.py
+++ b/chsdi/lib/validation/height.py
@@ -2,6 +2,8 @@
 
 from pyramid.httpexceptions import HTTPBadRequest
 
+from chsdi.lib.helpers import float_raise_nan
+
 
 class HeightValidation(object):
 
@@ -27,7 +29,7 @@ class HeightValidation(object):
         if value is None:
             raise HTTPBadRequest("Missing parameter 'easting'/'lon'")
         try:
-            self._lon = float(value)
+            self._lon = float_raise_nan(value)
         except ValueError:
             raise HTTPBadRequest("Please provide numerical values for the parameter 'easting'/'lon'")
 
@@ -36,7 +38,7 @@ class HeightValidation(object):
         if value is None:
             raise HTTPBadRequest("Missing parameter 'norhting'/'lat'")
         try:
-            self._lat = float(value)
+            self._lat = float_raise_nan(value)
         except ValueError:
             raise HTTPBadRequest("Please provide numerical values for the parameter 'northing'/'lat'")
 

--- a/chsdi/lib/validation/mapservice.py
+++ b/chsdi/lib/validation/mapservice.py
@@ -4,6 +4,7 @@
 from shapely.geometry import asShape
 from pyramid.httpexceptions import HTTPBadRequest
 
+from chsdi.lib.helpers import float_raise_nan
 from chsdi.lib.validation import MapNameValidation
 from chsdi.esrigeojsonencoder import loads
 
@@ -143,7 +144,7 @@ class MapServiceValidation(MapNameValidation):
         if len(value) != 3:
             raise HTTPBadRequest('Please provide the parameter imageDisplay in a comma separated list of 3 arguments (width,height,dpi)')
         try:
-            self._imageDisplay = map(float, value)
+            self._imageDisplay = map(float_raise_nan, value)
         except ValueError:
             raise HTTPBadRequest('Please provide numerical values for the parameter imageDisplay')
 
@@ -167,7 +168,7 @@ class MapServiceValidation(MapNameValidation):
         elif value is None and self._where is None:
             raise HTTPBadRequest('Please provide the parameter tolerance (Required)')
         try:
-            self._tolerance = float(value)
+            self._tolerance = float_raise_nan(value)
         except ValueError:
             raise HTTPBadRequest('Please provide an integer value for the pixel tolerance')
 

--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -2,6 +2,7 @@
 
 from pyramid.httpexceptions import HTTPBadRequest
 
+from chsdi.lib.helpers import float_raise_nan
 from chsdi.lib.validation import MapNameValidation
 
 MAX_SPHINX_INDEX_LENGTH = 63
@@ -95,7 +96,7 @@ class SearchValidation(MapNameValidation):
             if len(values) != 4:
                 raise HTTPBadRequest("Please provide 4 coordinates in a comma separated list")
             try:
-                values = map(float, values)
+                values = map(float_raise_nan, values)
             except ValueError:
                 raise HTTPBadRequest("Please provide numerical values for the parameter bbox")
             # Swiss extent

--- a/chsdi/tests/integration/test_height.py
+++ b/chsdi/tests/integration/test_height.py
@@ -14,6 +14,12 @@ class TestHeightView(TestsBase):
         self.assertTrue(resp.content_type == 'application/json')
         self.assertTrue(resp.json['height'] == '560.2')
 
+    def test_height_nan(self):
+        resp = self.testapp.get('/rest/services/height', params={'easting': 'NaN', 'northing': '200000.1'}, headers=self.headers, status=400)
+        resp.mustcontain('Please provide numerical values for the parameter \'easting\'/\'lon\'')
+        resp = self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': 'NaN'}, headers=self.headers, status=400)
+        resp.mustcontain('Please provide numerical values for the parameter \'northing\'/\'lat\'')
+
     def test_height_no_header(self):
         self.testapp.get('/rest/services/height', params={'easting': '600000', 'northing': '200000'}, status=403)
 

--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -74,6 +74,27 @@ class TestMapServiceView(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         self.assertTrue(resp.content_type == 'application/json')
 
+    def test_identify_nan_error(self):
+        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}', 'geometryType': 'esriGeometryPolygon', 'imageDisplay': '500,600,96',
+                  'mapExtent': 'NaN,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bafu.bundesinventare-bln'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp.mustcontain('Please provide numerical values for the parameter mapExtent')
+        params = {'geometryType': 'esriGeometryPoint', 'geometry': '600000,NaN,549402,148103.5', 'imageDisplay': '500,600,96', 'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
+        resp.mustcontain('Please provide a valid geometry')
+        params = {'geometry': '{"rings":[[[NaN,NaN],[NaN,NaN],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}', 'geometryType': 'esriGeometryPolygon', 'imageDisplay': '500,600,96',
+                  'mapExtent': '600000,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bafu.bundesinventare-bln'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp.mustcontain('Please provide a valid geometry')
+        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}', 'geometryType': 'esriGeometryPolygon', 'imageDisplay': '500,NaN,96',
+                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bafu.bundesinventare-bln'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp.mustcontain('Please provide numerical values for the parameter imageDisplay')
+        params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}', 'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
+                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': 'NaN', 'layers': 'all:ch.bazl.sachplan-infrastruktur-luftfahrt_kraft'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp.mustcontain('Please provide an integer value for the pixel tolerance')
+
     def test_identify_zero_tolerance_and_scale(self):
         params = {'geometry': '681999,251083,682146,251190', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryEnvelope',
                   'imageDisplay': '1920,452,96', 'layers': 'all:ch.bazl.sachplan-infrastruktur-luftfahrt_kraft',

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -249,3 +249,7 @@ class TestSearchServiceView(TestsBase):
         self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 11 words, should NOT work', 'type': 'locations', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=400)
         self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 11 words, should NOT work', 'type': 'layers', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=400)
         self.testapp.get('/rest/services/all/SearchServer', params={'searchText': 'this is a text with exactly 11 words, should NOT work', 'type': 'featuresearch', 'bbox': '551306.5625,167918.328125,551754.125,168514.625'}, status=400)
+
+    def test_bbox_nan(self):
+        resp = self.testapp.get('/rest/services/inspire/SearchServer', params={'searchText': 'rue des berges', 'type': 'locations', 'bbox': '551306.5625,NaN,551754.125,168514.625'}, status=400)
+        resp.mustcontain('Please provide numerical values for the parameter bbox')


### PR DESCRIPTION
This fixes https://github.com/geoadmin/mf-chsdi3/issues/1630

It also adresses other cases where a client transferes `NaN` instead of valid numbers. In case of complex geometries, this even avoids segfaulting the application.

We treat any `NaN` in the request that should be parsed to a float as invalid.