### PR TITLE
Using owslib getrecords2 instead of deprecated getrecords

### DIFF
--- a/ows_checker/_checker.py
+++ b/ows_checker/_checker.py
@@ -4724,7 +4724,7 @@ class OWSCheck(object):
         try:
             from owslib.csw import CatalogueServiceWeb
             csw = CatalogueServiceWeb(self.base_url)
-            csw.getrecords()
+            csw.getrecords2()
             records = csw.records.copy()
             for rid in records.keys():
                 csw.getrecordbyid(id=[rid])


### PR DESCRIPTION


fix #1610 