### PR TITLE
CRS:84 to WMS config for 3D

### DIFF
--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -3319,18 +3319,6 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
-  ch.swisstopo.geologie-eiszeit-lgm_20110318_cache:
-    disable_storage: true
-    format: image/png
-    grids: [swisstopo-pixelkarte]
-    sources: [ch.swisstopo.geologie-eiszeit-lgm_20110318_source]
-  ch.swisstopo.geologie-eiszeit-lgm_20110318_cache_out:
-    disable_storage: true
-    format: image/png
-    grids: [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
-    meta_buffer: 0
-    meta_size: [1, 1]
-    sources: [ch.swisstopo.geologie-eiszeit-lgm_20110318_cache]
   ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache:
     disable_storage: true
     format: image/png
@@ -6227,32 +6215,32 @@ caches:
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.swissimage_20120225_cache]
-  "ch.swisstopo.swissimage_20120809\t_cache":
+  ch.swisstopo.swissimage_20120809_cache:
     disable_storage: true
     format: image/jpeg
     grids: [swisstopo-swissimage]
-    sources: ["ch.swisstopo.swissimage_20120809\t_source"]
-  "ch.swisstopo.swissimage_20120809\t_cache_out":
+    sources: [ch.swisstopo.swissimage_20120809_source]
+  ch.swisstopo.swissimage_20120809_cache_out:
     disable_storage: true
     format: image/jpeg
     grids: *id006
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
-    sources: ["ch.swisstopo.swissimage_20120809\t_cache"]
-  "ch.swisstopo.swissimage_20130422\t_cache":
+    sources: [ch.swisstopo.swissimage_20120809_cache]
+  ch.swisstopo.swissimage_20130422_cache:
     disable_storage: true
     format: image/jpeg
     grids: [swisstopo-swissimage]
-    sources: ["ch.swisstopo.swissimage_20130422\t_source"]
-  "ch.swisstopo.swissimage_20130422\t_cache_out":
+    sources: [ch.swisstopo.swissimage_20130422_source]
+  ch.swisstopo.swissimage_20130422_cache_out:
     disable_storage: true
     format: image/jpeg
     grids: *id006
     image: {resampling_method: bilinear}
     meta_buffer: 0
     meta_size: [1, 1]
-    sources: ["ch.swisstopo.swissimage_20130422\t_cache"]
+    sources: [ch.swisstopo.swissimage_20130422_cache]
   ch.swisstopo.swissimage_20130916_cache:
     disable_storage: true
     format: image/jpeg
@@ -12873,5324 +12861,5309 @@ layers:
   title: Geoidmodell in ETRS89 (20041231, source)
 - dimensions: &id281
     Time:
-      default: '20110318'
-      values: ['20110318']
-  name: ch.swisstopo.geologie-eiszeit-lgm_20110318
-  sources: [ch.swisstopo.geologie-eiszeit-lgm_20110318_cache_out]
-  title: ch.swisstopo.geologie-eiszeit-lgm (20110318)
-- dimensions: *id281
-  name: ch.swisstopo.geologie-eiszeit-lgm
-  sources: [ch.swisstopo.geologie-eiszeit-lgm_20110318_cache]
-  title: ch.swisstopo.geologie-eiszeit-lgm ('current')
-- dimensions: *id281
-  name: ch.swisstopo.geologie-eiszeit-lgm_20110318_source
-  sources: [ch.swisstopo.geologie-eiszeit-lgm_20110318_cache]
-  title: ch.swisstopo.geologie-eiszeit-lgm (20110318, source)
-- dimensions: &id282
-    Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache_out]
   title: Eiszeitliches Maximum 500 (20081231)
-- dimensions: *id282
+- dimensions: *id281
   name: ch.swisstopo.geologie-eiszeit-lgm-raster
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Eiszeitliches Maximum 500 ('current')
-- dimensions: *id282
+- dimensions: *id281
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_source
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Eiszeitliches Maximum 500 (20081231, source)
-- dimensions: &id283
+- dimensions: &id282
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.geologie-generalkarte-ggk200_19641231
   sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache_out]
   title: Geologische Generalkarte (19641231)
-- dimensions: *id283
+- dimensions: *id282
   name: ch.swisstopo.geologie-generalkarte-ggk200
   sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache]
   title: Geologische Generalkarte ('current')
-- dimensions: *id283
+- dimensions: *id282
   name: ch.swisstopo.geologie-generalkarte-ggk200_19641231_source
   sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache]
   title: Geologische Generalkarte (19641231, source)
-- dimensions: &id284
+- dimensions: &id283
     Time:
       default: '20140601'
       values: ['20140601']
   name: ch.swisstopo.geologie-geocover_20140601
   sources: [ch.swisstopo.geologie-geocover_20140601_cache_out]
   title: "GeoCover - Geol. Vektordatens\xE4tze (20140601)"
-- dimensions: *id284
+- dimensions: *id283
   name: ch.swisstopo.geologie-geocover
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: "GeoCover - Geol. Vektordatens\xE4tze ('current')"
-- dimensions: *id284
+- dimensions: *id283
   name: ch.swisstopo.geologie-geocover_20140601_source
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: "GeoCover - Geol. Vektordatens\xE4tze (20140601, source)"
-- dimensions: &id285
+- dimensions: &id284
     Time:
       default: '20110406'
       values: ['20110406']
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache_out]
   title: Bouguer-Anomalien 500 (20110406)
-- dimensions: *id285
+- dimensions: *id284
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache]
   title: Bouguer-Anomalien 500 ('current')
-- dimensions: *id285
+- dimensions: *id284
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_source
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache]
   title: Bouguer-Anomalien 500 (20110406, source)
-- dimensions: &id286
+- dimensions: &id285
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache_out]
   title: Isostatische Anomalien (19791231)
-- dimensions: *id286
+- dimensions: *id285
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien ('current')
-- dimensions: *id286
+- dimensions: *id285
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien (19791231, source)
-- dimensions: &id287
+- dimensions: &id286
     Time:
       default: '20070425'
       values: ['20070425']
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache_out]
   title: Blatteinteilung GeoKarten 500 (20070425)
-- dimensions: *id287
+- dimensions: *id286
   name: ch.swisstopo.geologie-geolkarten500.metadata
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 ('current')
-- dimensions: *id287
+- dimensions: *id286
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425_source
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 (20070425, source)
-- dimensions: &id288
+- dimensions: &id287
     Time:
       default: '20080630'
       values: ['20080630']
   name: ch.swisstopo.geologie-geologische_karte_20080630
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache_out]
   title: Geologische Karte 500 (20080630)
-- dimensions: *id288
+- dimensions: *id287
   name: ch.swisstopo.geologie-geologische_karte
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologische Karte 500 ('current')
-- dimensions: *id288
+- dimensions: *id287
   name: ch.swisstopo.geologie-geologische_karte_20080630_source
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologische Karte 500 (20080630, source)
-- dimensions: &id289
+- dimensions: &id288
     Time:
       default: '20131120'
       values: ['20131120']
   name: ch.swisstopo.geologie-geologischer_atlas_20131120
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache_out]
   title: Geol. Atlas der Schweiz 1:25000 (20131120)
-- dimensions: *id289
+- dimensions: *id288
   name: ch.swisstopo.geologie-geologischer_atlas
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geol. Atlas der Schweiz 1:25000 ('current')
-- dimensions: *id289
+- dimensions: *id288
   name: ch.swisstopo.geologie-geologischer_atlas_20131120_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geol. Atlas der Schweiz 1:25000 (20131120, source)
-- dimensions: &id290
+- dimensions: &id289
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache_out]
   title: Aeromagnetik Voralpen/Jura (19831231)
-- dimensions: *id290
+- dimensions: *id289
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Voralpen/Jura ('current')
-- dimensions: *id290
+- dimensions: *id289
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Voralpen/Jura (19831231, source)
-- dimensions: &id291
+- dimensions: &id290
     Time:
       default: '20120628'
       values: ['20120628']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache_out]
   title: Aeromagnetik (20120628)
-- dimensions: *id291
+- dimensions: *id290
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik ('current')
-- dimensions: *id291
+- dimensions: *id290
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik (20120628, source)
-- dimensions: &id292
+- dimensions: &id291
     Time:
       default: '20011203'
       values: ['20011203']
   name: ch.swisstopo.geologie-geophysik-deklination_20011203
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache_out]
   title: Deklination (20011203)
-- dimensions: *id292
+- dimensions: *id291
   name: ch.swisstopo.geologie-geophysik-deklination
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination ('current')
-- dimensions: *id292
+- dimensions: *id291
   name: ch.swisstopo.geologie-geophysik-deklination_20011203_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination (20011203, source)
-- dimensions: &id293
+- dimensions: &id292
     Time:
       default: '20111121'
       values: ['20111121']
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache_out]
   title: Geothermie (20111121)
-- dimensions: *id293
+- dimensions: *id292
   name: ch.swisstopo.geologie-geophysik-geothermie
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: Geothermie ('current')
-- dimensions: *id293
+- dimensions: *id292
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: Geothermie (20111121, source)
-- dimensions: &id294
+- dimensions: &id293
     Time:
       default: '20111128'
       values: ['20111128']
   name: ch.swisstopo.geologie-geophysik-inklination_20111128
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache_out]
   title: Inklination (20111128)
-- dimensions: *id294
+- dimensions: *id293
   name: ch.swisstopo.geologie-geophysik-inklination
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination ('current')
-- dimensions: *id294
+- dimensions: *id293
   name: ch.swisstopo.geologie-geophysik-inklination_20111128_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination (20111128, source)
-- dimensions: &id295
+- dimensions: &id294
     Time:
       default: '19800101'
       values: ['19800101']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache_out]
   title: "Magnetfeldst\xE4rke (19800101)"
-- dimensions: *id295
+- dimensions: *id294
   name: ch.swisstopo.geologie-geophysik-totalintensitaet
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke ('current')"
-- dimensions: *id295
+- dimensions: *id294
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke (19800101, source)"
-- dimensions: &id296
+- dimensions: &id295
     Time:
       default: '19670101'
       values: ['19670101']
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache_out]
   title: Geotechnik und Gesteine (19670101)
-- dimensions: *id296
+- dimensions: *id295
   name: ch.swisstopo.geologie-geotechnik-gk200
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnik und Gesteine ('current')
-- dimensions: *id296
+- dimensions: *id295
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnik und Gesteine (19670101, source)
-- dimensions: &id297
+- dimensions: &id296
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache_out]
   title: Entstehung der Gesteine (20060304)
-- dimensions: *id297
+- dimensions: *id296
   name: ch.swisstopo.geologie-geotechnik-gk500-genese
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine ('current')
-- dimensions: *id297
+- dimensions: *id296
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine (20060304, source)
-- dimensions: &id298
+- dimensions: &id297
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache_out]
   title: Gesteinklassierung (20060304)
-- dimensions: *id298
+- dimensions: *id297
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinklassierung ('current')
-- dimensions: *id298
+- dimensions: *id297
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinklassierung (20060304, source)
-- dimensions: &id299
+- dimensions: &id298
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache_out]
   title: Lithologie-Hauptgruppen (20060304)
-- dimensions: *id299
+- dimensions: *id298
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie-Hauptgruppen ('current')
-- dimensions: *id299
+- dimensions: *id298
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie-Hauptgruppen (20060304, source)
-- dimensions: &id300
+- dimensions: &id299
     Time:
       default: '19900101'
       values: ['19900101']
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache_out]
   title: Mineralische Rohstoffe (19900101)
-- dimensions: *id300
+- dimensions: *id299
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe ('current')
-- dimensions: *id300
+- dimensions: *id299
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_source
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe (19900101, source)
-- dimensions: &id301
+- dimensions: &id300
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache_out]
   title: "Steinbr\xFCche 1915 (20060304)"
-- dimensions: *id301
+- dimensions: *id300
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache]
   title: "Steinbr\xFCche 1915 ('current')"
-- dimensions: *id301
+- dimensions: *id300
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache]
   title: "Steinbr\xFCche 1915 (20060304, source)"
-- dimensions: &id302
+- dimensions: &id301
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache_out]
   title: "Steinbr\xFCche 1965 (20060304)"
-- dimensions: *id302
+- dimensions: *id301
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache]
   title: "Steinbr\xFCche 1965 ('current')"
-- dimensions: *id302
+- dimensions: *id301
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache]
   title: "Steinbr\xFCche 1965 (20060304, source)"
-- dimensions: &id303
+- dimensions: &id302
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache_out]
   title: "Steinbr\xFCche 1980 (20060304)"
-- dimensions: *id303
+- dimensions: *id302
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache]
   title: "Steinbr\xFCche 1980 ('current')"
-- dimensions: *id303
+- dimensions: *id302
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache]
   title: "Steinbr\xFCche 1980 (20060304, source)"
-- dimensions: &id304
+- dimensions: &id303
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache_out]
   title: "Steinbr\xFCche 1995 (20060304)"
-- dimensions: *id304
+- dimensions: *id303
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache]
   title: "Steinbr\xFCche 1995 ('current')"
-- dimensions: *id304
+- dimensions: *id303
   name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache]
   title: "Steinbr\xFCche 1995 (20060304, source)"
-- dimensions: &id305
+- dimensions: &id304
     Time:
       default: '20130620'
       values: ['20130620']
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache_out]
   title: Steine an historischen Bauwerken (20130620)
-- dimensions: *id305
+- dimensions: *id304
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an historischen Bauwerken ('current')
-- dimensions: *id305
+- dimensions: *id304
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_source
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an historischen Bauwerken (20130620, source)
-- dimensions: &id306
+- dimensions: &id305
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304
   sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache_out]
   title: Bindemittelindustrie 1965 (20060304)
-- dimensions: *id306
+- dimensions: *id305
   name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965
   sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache]
   title: Bindemittelindustrie 1965 ('current')
-- dimensions: *id306
+- dimensions: *id305
   name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache]
   title: Bindemittelindustrie 1965 (20060304, source)
-- dimensions: &id307
+- dimensions: &id306
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304
   sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache_out]
   title: Bindemittelindustrie 1995 (20060304)
-- dimensions: *id307
+- dimensions: *id306
   name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995
   sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache]
   title: Bindemittelindustrie 1995 ('current')
-- dimensions: *id307
+- dimensions: *id306
   name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache]
   title: Bindemittelindustrie 1995 (20060304, source)
-- dimensions: &id308
+- dimensions: &id307
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache_out]
   title: Ziegeleien 1907 (20060304)
-- dimensions: *id308
+- dimensions: *id307
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache]
   title: Ziegeleien 1907 ('current')
-- dimensions: *id308
+- dimensions: *id307
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache]
   title: Ziegeleien 1907 (20060304, source)
-- dimensions: &id309
+- dimensions: &id308
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache_out]
   title: Ziegeleien 1965 (20060304)
-- dimensions: *id309
+- dimensions: *id308
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache]
   title: Ziegeleien 1965 ('current')
-- dimensions: *id309
+- dimensions: *id308
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache]
   title: Ziegeleien 1965 (20060304, source)
-- dimensions: &id310
+- dimensions: &id309
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache_out]
   title: Ziegeleien 1995 (20060304)
-- dimensions: *id310
+- dimensions: *id309
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache]
   title: Ziegeleien 1995 ('current')
-- dimensions: *id310
+- dimensions: *id309
   name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache]
   title: Ziegeleien 1995 (20060304, source)
-- dimensions: &id311
+- dimensions: &id310
     Time:
       default: '20130107'
       values: ['20130107']
   name: ch.swisstopo.geologie-geotope_20130107
   sources: [ch.swisstopo.geologie-geotope_20130107_cache_out]
   title: Geotope der Schweiz (20130107)
-- dimensions: *id311
+- dimensions: *id310
   name: ch.swisstopo.geologie-geotope
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Geotope der Schweiz ('current')
-- dimensions: *id311
+- dimensions: *id310
   name: ch.swisstopo.geologie-geotope_20130107_source
   sources: [ch.swisstopo.geologie-geotope_20130107_cache]
   title: Geotope der Schweiz (20130107, source)
-- dimensions: &id312
+- dimensions: &id311
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache_out]
   title: Gravimetrischer Atlas 1:100000 (20021231)
-- dimensions: *id312
+- dimensions: *id311
   name: ch.swisstopo.geologie-gravimetrischer_atlas
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas 1:100000 ('current')
-- dimensions: *id312
+- dimensions: *id311
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas 1:100000 (20021231, source)
-- dimensions: &id313
+- dimensions: &id312
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache_out]
   title: Einteilung gravimetrischer Atlas (20021231)
-- dimensions: *id313
+- dimensions: *id312
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravimetrischer Atlas ('current')
-- dimensions: *id313
+- dimensions: *id312
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravimetrischer Atlas (20021231, source)
-- dimensions: &id314
+- dimensions: &id313
     Time:
       default: '20081103'
       values: ['20081103']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache_out]
   title: Grundwasservorkommen 500 (20081103)
-- dimensions: *id314
+- dimensions: *id313
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 ('current')
-- dimensions: *id314
+- dimensions: *id313
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 (20081103, source)
-- dimensions: &id315
+- dimensions: &id314
     Time:
       default: '20081016'
       values: ['20081016']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache_out]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016)"
-- dimensions: *id315
+- dimensions: *id314
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 ('current')"
-- dimensions: *id315
+- dimensions: *id314
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016, source)"
-- dimensions: &id316
+- dimensions: &id315
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304
   sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache_out]
   title: Industrieminerale (20060304)
-- dimensions: *id316
+- dimensions: *id315
   name: ch.swisstopo.geologie-rohstoffe-industrieminerale
   sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache]
   title: Industrieminerale ('current')
-- dimensions: *id316
+- dimensions: *id315
   name: ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_source
   sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache]
   title: Industrieminerale (20060304, source)
-- dimensions: &id317
+- dimensions: &id316
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304
   sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache_out]
   title: Mineralische Energierohstoffe (20060304)
-- dimensions: *id317
+- dimensions: *id316
   name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas
   sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache]
   title: Mineralische Energierohstoffe ('current')
-- dimensions: *id317
+- dimensions: *id316
   name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_source
   sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache]
   title: Mineralische Energierohstoffe (20060304, source)
-- dimensions: &id318
+- dimensions: &id317
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-rohstoffe-vererzungen_20060304
   sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache_out]
   title: Vererzungen (20060304)
-- dimensions: *id318
+- dimensions: *id317
   name: ch.swisstopo.geologie-rohstoffe-vererzungen
   sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache]
   title: Vererzungen ('current')
-- dimensions: *id318
+- dimensions: *id317
   name: ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_source
   sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache]
   title: Vererzungen (20060304, source)
-- dimensions: &id319
+- dimensions: &id318
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache_out]
   title: Einteilung geol. Spezialkarten (20110101)
-- dimensions: *id319
+- dimensions: *id318
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten ('current')
-- dimensions: *id319
+- dimensions: *id318
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_source
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten (20110101, source)
-- dimensions: &id320
+- dimensions: &id319
     Time:
       default: '20080522'
       values: ['20080522']
   name: ch.swisstopo.geologie-tektonische_karte_20080522
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache_out]
   title: Tektonische Karte 500 (20080522)
-- dimensions: *id320
+- dimensions: *id319
   name: ch.swisstopo.geologie-tektonische_karte
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonische Karte 500 ('current')
-- dimensions: *id320
+- dimensions: *id319
   name: ch.swisstopo.geologie-tektonische_karte_20080522_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonische Karte 500 (20080522, source)
-- dimensions: &id321
+- dimensions: &id320
     Time:
       default: '20130101'
       values: ['20130101']
   name: ch.swisstopo.hangneigung-ueber_30_20130101
   sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache_out]
   title: "Hangneigungen ab 30\xB0 (20130101)"
-- dimensions: *id321
+- dimensions: *id320
   name: ch.swisstopo.hangneigung-ueber_30
   sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache]
   title: "Hangneigungen ab 30\xB0 ('current')"
-- dimensions: *id321
+- dimensions: *id320
   name: ch.swisstopo.hangneigung-ueber_30_20130101_source
   sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache]
   title: "Hangneigungen ab 30\xB0 (20130101, source)"
-- dimensions: &id322
+- dimensions: &id321
     Time:
       default: '18650101'
       values: ['18650101']
   name: ch.swisstopo.hiks-dufour_18650101
   sources: [ch.swisstopo.hiks-dufour_18650101_cache_out]
   title: Dufourkarte Erstausgabe (18650101)
-- dimensions: *id322
+- dimensions: *id321
   name: ch.swisstopo.hiks-dufour
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe ('current')
-- dimensions: *id322
+- dimensions: *id321
   name: ch.swisstopo.hiks-dufour_18650101_source
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe (18650101, source)
-- dimensions: &id323
+- dimensions: &id322
     Time:
       default: '19260101'
       values: ['19260101']
   name: ch.swisstopo.hiks-siegfried_19260101
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache_out]
   title: Siegfriedkarte Erstausgabe (19260101)
-- dimensions: *id323
+- dimensions: *id322
   name: ch.swisstopo.hiks-siegfried
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe ('current')
-- dimensions: *id323
+- dimensions: *id322
   name: ch.swisstopo.hiks-siegfried_19260101_source
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe (19260101, source)
-- dimensions: &id324
+- dimensions: &id323
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.koordinatenaenderung_20061231
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache_out]
   title: "LV95 Koordinaten\xE4nderung (20061231)"
-- dimensions: *id324
+- dimensions: *id323
   name: ch.swisstopo.koordinatenaenderung
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung ('current')"
-- dimensions: *id324
+- dimensions: *id323
   name: ch.swisstopo.koordinatenaenderung_20061231_source
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung (20061231, source)"
-- dimensions: &id325
+- dimensions: &id324
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache_out]
   title: Luftbilder Privater (99991231)
-- dimensions: *id325
+- dimensions: *id324
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater ('current')
-- dimensions: *id325
+- dimensions: *id324
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater (99991231, source)
-- dimensions: &id326
+- dimensions: &id325
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache_out]
   title: Luftbilder Privater (20091231)
-- dimensions: *id326
+- dimensions: *id325
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache]
   title: Luftbilder Privater (20091231, source)
-- dimensions: &id327
+- dimensions: &id326
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache_out]
   title: Luftbilder Privater (20081231)
-- dimensions: *id327
+- dimensions: *id326
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache]
   title: Luftbilder Privater (20081231, source)
-- dimensions: &id328
+- dimensions: &id327
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache_out]
   title: Luftbilder Privater (20071231)
-- dimensions: *id328
+- dimensions: *id327
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache]
   title: Luftbilder Privater (20071231, source)
-- dimensions: &id329
+- dimensions: &id328
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache_out]
   title: Luftbilder Privater (20061231)
-- dimensions: *id329
+- dimensions: *id328
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache]
   title: Luftbilder Privater (20061231, source)
-- dimensions: &id330
+- dimensions: &id329
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache_out]
   title: Luftbilder Privater (20051231)
-- dimensions: *id330
+- dimensions: *id329
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache]
   title: Luftbilder Privater (20051231, source)
-- dimensions: &id331
+- dimensions: &id330
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache_out]
   title: Luftbilder Privater (20041231)
-- dimensions: *id331
+- dimensions: *id330
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache]
   title: Luftbilder Privater (20041231, source)
-- dimensions: &id332
+- dimensions: &id331
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache_out]
   title: Luftbilder Privater (20031231)
-- dimensions: *id332
+- dimensions: *id331
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache]
   title: Luftbilder Privater (20031231, source)
-- dimensions: &id333
+- dimensions: &id332
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache_out]
   title: Luftbilder Privater (20021231)
-- dimensions: *id333
+- dimensions: *id332
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache]
   title: Luftbilder Privater (20021231, source)
-- dimensions: &id334
+- dimensions: &id333
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache_out]
   title: Luftbilder Privater (20011231)
-- dimensions: *id334
+- dimensions: *id333
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache]
   title: Luftbilder Privater (20011231, source)
-- dimensions: &id335
+- dimensions: &id334
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache_out]
   title: Luftbilder Privater (20001231)
-- dimensions: *id335
+- dimensions: *id334
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache]
   title: Luftbilder Privater (20001231, source)
-- dimensions: &id336
+- dimensions: &id335
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache_out]
   title: Luftbilder Privater (19991231)
-- dimensions: *id336
+- dimensions: *id335
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache]
   title: Luftbilder Privater (19991231, source)
-- dimensions: &id337
+- dimensions: &id336
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache_out]
   title: Luftbilder Privater (19981231)
-- dimensions: *id337
+- dimensions: *id336
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache]
   title: Luftbilder Privater (19981231, source)
-- dimensions: &id338
+- dimensions: &id337
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache_out]
   title: Luftbilder Privater (19971231)
-- dimensions: *id338
+- dimensions: *id337
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache]
   title: Luftbilder Privater (19971231, source)
-- dimensions: &id339
+- dimensions: &id338
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache_out]
   title: Luftbilder Privater (19961231)
-- dimensions: *id339
+- dimensions: *id338
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache]
   title: Luftbilder Privater (19961231, source)
-- dimensions: &id340
+- dimensions: &id339
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache_out]
   title: Luftbilder Privater (19951231)
-- dimensions: *id340
+- dimensions: *id339
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache]
   title: Luftbilder Privater (19951231, source)
-- dimensions: &id341
+- dimensions: &id340
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache_out]
   title: Luftbilder Privater (19941231)
-- dimensions: *id341
+- dimensions: *id340
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache]
   title: Luftbilder Privater (19941231, source)
-- dimensions: &id342
+- dimensions: &id341
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache_out]
   title: Luftbilder Privater (19931231)
-- dimensions: *id342
+- dimensions: *id341
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache]
   title: Luftbilder Privater (19931231, source)
-- dimensions: &id343
+- dimensions: &id342
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache_out]
   title: Luftbilder Privater (19921231)
-- dimensions: *id343
+- dimensions: *id342
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache]
   title: Luftbilder Privater (19921231, source)
-- dimensions: &id344
+- dimensions: &id343
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache_out]
   title: Luftbilder Privater (19911231)
-- dimensions: *id344
+- dimensions: *id343
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache]
   title: Luftbilder Privater (19911231, source)
-- dimensions: &id345
+- dimensions: &id344
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache_out]
   title: Luftbilder Privater (19901231)
-- dimensions: *id345
+- dimensions: *id344
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache]
   title: Luftbilder Privater (19901231, source)
-- dimensions: &id346
+- dimensions: &id345
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache_out]
   title: Luftbilder Privater (19891231)
-- dimensions: *id346
+- dimensions: *id345
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache]
   title: Luftbilder Privater (19891231, source)
-- dimensions: &id347
+- dimensions: &id346
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache_out]
   title: Luftbilder Kantone (99991231)
-- dimensions: *id347
+- dimensions: *id346
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone ('current')
-- dimensions: *id347
+- dimensions: *id346
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone (99991231, source)
-- dimensions: &id348
+- dimensions: &id347
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache_out]
   title: Luftbilder Kantone (20141231)
-- dimensions: *id348
+- dimensions: *id347
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache]
   title: Luftbilder Kantone (20141231, source)
-- dimensions: &id349
+- dimensions: &id348
     Time:
       default: '20131231'
       values: ['20131231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache_out]
   title: Luftbilder Kantone (20131231)
-- dimensions: *id349
+- dimensions: *id348
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache]
   title: Luftbilder Kantone (20131231, source)
-- dimensions: &id350
+- dimensions: &id349
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache_out]
   title: Luftbilder Kantone (20121231)
-- dimensions: *id350
+- dimensions: *id349
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache]
   title: Luftbilder Kantone (20121231, source)
-- dimensions: &id351
+- dimensions: &id350
     Time:
       default: '20111231'
       values: ['20111231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache_out]
   title: Luftbilder Kantone (20111231)
-- dimensions: *id351
+- dimensions: *id350
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache]
   title: Luftbilder Kantone (20111231, source)
-- dimensions: &id352
+- dimensions: &id351
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache_out]
   title: Luftbilder Kantone (20091231)
-- dimensions: *id352
+- dimensions: *id351
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache]
   title: Luftbilder Kantone (20091231, source)
-- dimensions: &id353
+- dimensions: &id352
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache_out]
   title: Luftbilder Kantone (19841231)
-- dimensions: *id353
+- dimensions: *id352
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache]
   title: Luftbilder Kantone (19841231, source)
-- dimensions: &id354
+- dimensions: &id353
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache_out]
   title: Luftbilder Kantone (19671231)
-- dimensions: *id354
+- dimensions: *id353
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache]
   title: Luftbilder Kantone (19671231, source)
-- dimensions: &id355
+- dimensions: &id354
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache_out]
   title: Luftbilder Kantone (19661231)
-- dimensions: *id355
+- dimensions: *id354
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache]
   title: Luftbilder Kantone (19661231, source)
-- dimensions: &id356
+- dimensions: &id355
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache_out]
   title: Luftbilder Kantone (19651231)
-- dimensions: *id356
+- dimensions: *id355
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache]
   title: Luftbilder Kantone (19651231, source)
-- dimensions: &id357
+- dimensions: &id356
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache_out]
   title: Luftbilder Kantone (19641231)
-- dimensions: *id357
+- dimensions: *id356
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache]
   title: Luftbilder Kantone (19641231, source)
-- dimensions: &id358
+- dimensions: &id357
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache_out]
   title: Luftbilder Kantone (19631231)
-- dimensions: *id358
+- dimensions: *id357
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache]
   title: Luftbilder Kantone (19631231, source)
-- dimensions: &id359
+- dimensions: &id358
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache_out]
   title: Luftbilder Kantone (19621231)
-- dimensions: *id359
+- dimensions: *id358
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache]
   title: Luftbilder Kantone (19621231, source)
-- dimensions: &id360
+- dimensions: &id359
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache_out]
   title: Luftbilder swisstopo farbig (99991231)
-- dimensions: *id360
+- dimensions: *id359
   name: ch.swisstopo.lubis-luftbilder_farbe
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig ('current')
-- dimensions: *id360
+- dimensions: *id359
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig (99991231, source)
-- dimensions: &id361
+- dimensions: &id360
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache_out]
   title: Luftbilder swisstopo farbig (20101231)
-- dimensions: *id361
+- dimensions: *id360
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache]
   title: Luftbilder swisstopo farbig (20101231, source)
-- dimensions: &id362
+- dimensions: &id361
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache_out]
   title: Luftbilder swisstopo farbig (20091231)
-- dimensions: *id362
+- dimensions: *id361
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache]
   title: Luftbilder swisstopo farbig (20091231, source)
-- dimensions: &id363
+- dimensions: &id362
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache_out]
   title: Luftbilder swisstopo farbig (20081231)
-- dimensions: *id363
+- dimensions: *id362
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache]
   title: Luftbilder swisstopo farbig (20081231, source)
-- dimensions: &id364
+- dimensions: &id363
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache_out]
   title: Luftbilder swisstopo farbig (20071231)
-- dimensions: *id364
+- dimensions: *id363
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache]
   title: Luftbilder swisstopo farbig (20071231, source)
-- dimensions: &id365
+- dimensions: &id364
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache_out]
   title: Luftbilder swisstopo farbig (20061231)
-- dimensions: *id365
+- dimensions: *id364
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache]
   title: Luftbilder swisstopo farbig (20061231, source)
-- dimensions: &id366
+- dimensions: &id365
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache_out]
   title: Luftbilder swisstopo farbig (20051231)
-- dimensions: *id366
+- dimensions: *id365
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache]
   title: Luftbilder swisstopo farbig (20051231, source)
-- dimensions: &id367
+- dimensions: &id366
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache_out]
   title: Luftbilder swisstopo farbig (20041231)
-- dimensions: *id367
+- dimensions: *id366
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache]
   title: Luftbilder swisstopo farbig (20041231, source)
-- dimensions: &id368
+- dimensions: &id367
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache_out]
   title: Luftbilder swisstopo farbig (20031231)
-- dimensions: *id368
+- dimensions: *id367
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache]
   title: Luftbilder swisstopo farbig (20031231, source)
-- dimensions: &id369
+- dimensions: &id368
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache_out]
   title: Luftbilder swisstopo farbig (20021231)
-- dimensions: *id369
+- dimensions: *id368
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache]
   title: Luftbilder swisstopo farbig (20021231, source)
-- dimensions: &id370
+- dimensions: &id369
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache_out]
   title: Luftbilder swisstopo farbig (20011231)
-- dimensions: *id370
+- dimensions: *id369
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache]
   title: Luftbilder swisstopo farbig (20011231, source)
-- dimensions: &id371
+- dimensions: &id370
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache_out]
   title: Luftbilder swisstopo farbig (20001231)
-- dimensions: *id371
+- dimensions: *id370
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache]
   title: Luftbilder swisstopo farbig (20001231, source)
-- dimensions: &id372
+- dimensions: &id371
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache_out]
   title: Luftbilder swisstopo farbig (19991231)
-- dimensions: *id372
+- dimensions: *id371
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache]
   title: Luftbilder swisstopo farbig (19991231, source)
-- dimensions: &id373
+- dimensions: &id372
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache_out]
   title: Luftbilder swisstopo farbig (19981231)
-- dimensions: *id373
+- dimensions: *id372
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache]
   title: Luftbilder swisstopo farbig (19981231, source)
-- dimensions: &id374
+- dimensions: &id373
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache_out]
   title: Luftbilder swisstopo farbig (19971231)
-- dimensions: *id374
+- dimensions: *id373
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache]
   title: Luftbilder swisstopo farbig (19971231, source)
-- dimensions: &id375
+- dimensions: &id374
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache_out]
   title: Luftbilder swisstopo farbig (19961231)
-- dimensions: *id375
+- dimensions: *id374
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache]
   title: Luftbilder swisstopo farbig (19961231, source)
-- dimensions: &id376
+- dimensions: &id375
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache_out]
   title: Luftbilder swisstopo farbig (19951231)
-- dimensions: *id376
+- dimensions: *id375
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache]
   title: Luftbilder swisstopo farbig (19951231, source)
-- dimensions: &id377
+- dimensions: &id376
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache_out]
   title: Luftbilder swisstopo farbig (19941231)
-- dimensions: *id377
+- dimensions: *id376
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache]
   title: Luftbilder swisstopo farbig (19941231, source)
-- dimensions: &id378
+- dimensions: &id377
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache_out]
   title: Luftbilder swisstopo farbig (19931231)
-- dimensions: *id378
+- dimensions: *id377
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache]
   title: Luftbilder swisstopo farbig (19931231, source)
-- dimensions: &id379
+- dimensions: &id378
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache_out]
   title: Luftbilder swisstopo farbig (19921231)
-- dimensions: *id379
+- dimensions: *id378
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache]
   title: Luftbilder swisstopo farbig (19921231, source)
-- dimensions: &id380
+- dimensions: &id379
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache_out]
   title: Luftbilder swisstopo farbig (19911231)
-- dimensions: *id380
+- dimensions: *id379
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache]
   title: Luftbilder swisstopo farbig (19911231, source)
-- dimensions: &id381
+- dimensions: &id380
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache_out]
   title: Luftbilder swisstopo farbig (19901231)
-- dimensions: *id381
+- dimensions: *id380
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache]
   title: Luftbilder swisstopo farbig (19901231, source)
-- dimensions: &id382
+- dimensions: &id381
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache_out]
   title: Luftbilder swisstopo farbig (19891231)
-- dimensions: *id382
+- dimensions: *id381
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache]
   title: Luftbilder swisstopo farbig (19891231, source)
-- dimensions: &id383
+- dimensions: &id382
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache_out]
   title: Luftbilder swisstopo farbig (19881231)
-- dimensions: *id383
+- dimensions: *id382
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache]
   title: Luftbilder swisstopo farbig (19881231, source)
-- dimensions: &id384
+- dimensions: &id383
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache_out]
   title: Luftbilder swisstopo farbig (19871231)
-- dimensions: *id384
+- dimensions: *id383
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache]
   title: Luftbilder swisstopo farbig (19871231, source)
-- dimensions: &id385
+- dimensions: &id384
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache_out]
   title: Luftbilder swisstopo farbig (19861231)
-- dimensions: *id385
+- dimensions: *id384
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache]
   title: Luftbilder swisstopo farbig (19861231, source)
-- dimensions: &id386
+- dimensions: &id385
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache_out]
   title: Luftbilder swisstopo farbig (19851231)
-- dimensions: *id386
+- dimensions: *id385
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache]
   title: Luftbilder swisstopo farbig (19851231, source)
-- dimensions: &id387
+- dimensions: &id386
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache_out]
   title: Luftbilder swisstopo farbig (19841231)
-- dimensions: *id387
+- dimensions: *id386
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache]
   title: Luftbilder swisstopo farbig (19841231, source)
-- dimensions: &id388
+- dimensions: &id387
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache_out]
   title: Luftbilder swisstopo farbig (19831231)
-- dimensions: *id388
+- dimensions: *id387
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache]
   title: Luftbilder swisstopo farbig (19831231, source)
-- dimensions: &id389
+- dimensions: &id388
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache_out]
   title: Luftbilder swisstopo farbig (19821231)
-- dimensions: *id389
+- dimensions: *id388
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache]
   title: Luftbilder swisstopo farbig (19821231, source)
-- dimensions: &id390
+- dimensions: &id389
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache_out]
   title: Luftbilder swisstopo farbig (19811231)
-- dimensions: *id390
+- dimensions: *id389
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache]
   title: Luftbilder swisstopo farbig (19811231, source)
-- dimensions: &id391
+- dimensions: &id390
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache_out]
   title: Luftbilder swisstopo infrarot (99991231)
-- dimensions: *id391
+- dimensions: *id390
   name: ch.swisstopo.lubis-luftbilder_infrarot
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot ('current')
-- dimensions: *id391
+- dimensions: *id390
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot (99991231, source)
-- dimensions: &id392
+- dimensions: &id391
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache_out]
   title: Luftbilder swisstopo infrarot (20091231)
-- dimensions: *id392
+- dimensions: *id391
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache]
   title: Luftbilder swisstopo infrarot (20091231, source)
-- dimensions: &id393
+- dimensions: &id392
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache_out]
   title: Luftbilder swisstopo infrarot (20081231)
-- dimensions: *id393
+- dimensions: *id392
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache]
   title: Luftbilder swisstopo infrarot (20081231, source)
-- dimensions: &id394
+- dimensions: &id393
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache_out]
   title: Luftbilder swisstopo infrarot (20071231)
-- dimensions: *id394
+- dimensions: *id393
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache]
   title: Luftbilder swisstopo infrarot (20071231, source)
-- dimensions: &id395
+- dimensions: &id394
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache_out]
   title: Luftbilder swisstopo infrarot (20061231)
-- dimensions: *id395
+- dimensions: *id394
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache]
   title: Luftbilder swisstopo infrarot (20061231, source)
-- dimensions: &id396
+- dimensions: &id395
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache_out]
   title: Luftbilder swisstopo infrarot (20051231)
-- dimensions: *id396
+- dimensions: *id395
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache]
   title: Luftbilder swisstopo infrarot (20051231, source)
-- dimensions: &id397
+- dimensions: &id396
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache_out]
   title: Luftbilder swisstopo infrarot (20041231)
-- dimensions: *id397
+- dimensions: *id396
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache]
   title: Luftbilder swisstopo infrarot (20041231, source)
-- dimensions: &id398
+- dimensions: &id397
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache_out]
   title: Luftbilder swisstopo infrarot (20031231)
-- dimensions: *id398
+- dimensions: *id397
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache]
   title: Luftbilder swisstopo infrarot (20031231, source)
-- dimensions: &id399
+- dimensions: &id398
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache_out]
   title: Luftbilder swisstopo infrarot (20021231)
-- dimensions: *id399
+- dimensions: *id398
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache]
   title: Luftbilder swisstopo infrarot (20021231, source)
-- dimensions: &id400
+- dimensions: &id399
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache_out]
   title: Luftbilder swisstopo infrarot (20011231)
-- dimensions: *id400
+- dimensions: *id399
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache]
   title: Luftbilder swisstopo infrarot (20011231, source)
-- dimensions: &id401
+- dimensions: &id400
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache_out]
   title: Luftbilder swisstopo infrarot (20001231)
-- dimensions: *id401
+- dimensions: *id400
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache]
   title: Luftbilder swisstopo infrarot (20001231, source)
-- dimensions: &id402
+- dimensions: &id401
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache_out]
   title: Luftbilder swisstopo infrarot (19991231)
-- dimensions: *id402
+- dimensions: *id401
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache]
   title: Luftbilder swisstopo infrarot (19991231, source)
-- dimensions: &id403
+- dimensions: &id402
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache_out]
   title: Luftbilder swisstopo infrarot (19981231)
-- dimensions: *id403
+- dimensions: *id402
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache]
   title: Luftbilder swisstopo infrarot (19981231, source)
-- dimensions: &id404
+- dimensions: &id403
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache_out]
   title: Luftbilder swisstopo infrarot (19971231)
-- dimensions: *id404
+- dimensions: *id403
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache]
   title: Luftbilder swisstopo infrarot (19971231, source)
-- dimensions: &id405
+- dimensions: &id404
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache_out]
   title: Luftbilder swisstopo infrarot (19961231)
-- dimensions: *id405
+- dimensions: *id404
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache]
   title: Luftbilder swisstopo infrarot (19961231, source)
-- dimensions: &id406
+- dimensions: &id405
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache_out]
   title: Luftbilder swisstopo infrarot (19951231)
-- dimensions: *id406
+- dimensions: *id405
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache]
   title: Luftbilder swisstopo infrarot (19951231, source)
-- dimensions: &id407
+- dimensions: &id406
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache_out]
   title: Luftbilder swisstopo infrarot (19941231)
-- dimensions: *id407
+- dimensions: *id406
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache]
   title: Luftbilder swisstopo infrarot (19941231, source)
-- dimensions: &id408
+- dimensions: &id407
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache_out]
   title: Luftbilder swisstopo infrarot (19931231)
-- dimensions: *id408
+- dimensions: *id407
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache]
   title: Luftbilder swisstopo infrarot (19931231, source)
-- dimensions: &id409
+- dimensions: &id408
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache_out]
   title: Luftbilder swisstopo infrarot (19921231)
-- dimensions: *id409
+- dimensions: *id408
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache]
   title: Luftbilder swisstopo infrarot (19921231, source)
-- dimensions: &id410
+- dimensions: &id409
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache_out]
   title: Luftbilder swisstopo infrarot (19911231)
-- dimensions: *id410
+- dimensions: *id409
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache]
   title: Luftbilder swisstopo infrarot (19911231, source)
-- dimensions: &id411
+- dimensions: &id410
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache_out]
   title: Luftbilder swisstopo infrarot (19901231)
-- dimensions: *id411
+- dimensions: *id410
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache]
   title: Luftbilder swisstopo infrarot (19901231, source)
-- dimensions: &id412
+- dimensions: &id411
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache_out]
   title: Luftbilder swisstopo infrarot (19891231)
-- dimensions: *id412
+- dimensions: *id411
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache]
   title: Luftbilder swisstopo infrarot (19891231, source)
-- dimensions: &id413
+- dimensions: &id412
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache_out]
   title: Luftbilder swisstopo infrarot (19881231)
-- dimensions: *id413
+- dimensions: *id412
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache]
   title: Luftbilder swisstopo infrarot (19881231, source)
-- dimensions: &id414
+- dimensions: &id413
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache_out]
   title: Luftbilder swisstopo infrarot (19871231)
-- dimensions: *id414
+- dimensions: *id413
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache]
   title: Luftbilder swisstopo infrarot (19871231, source)
-- dimensions: &id415
+- dimensions: &id414
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache_out]
   title: Luftbilder swisstopo infrarot (19861231)
-- dimensions: *id415
+- dimensions: *id414
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache]
   title: Luftbilder swisstopo infrarot (19861231, source)
-- dimensions: &id416
+- dimensions: &id415
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache_out]
   title: Luftbilder swisstopo infrarot (19851231)
-- dimensions: *id416
+- dimensions: *id415
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache]
   title: Luftbilder swisstopo infrarot (19851231, source)
-- dimensions: &id417
+- dimensions: &id416
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache_out]
   title: Luftbilder swisstopo infrarot (19841231)
-- dimensions: *id417
+- dimensions: *id416
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache]
   title: Luftbilder swisstopo infrarot (19841231, source)
-- dimensions: &id418
+- dimensions: &id417
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache_out]
   title: Luftbilder swisstopo infrarot (19831231)
-- dimensions: *id418
+- dimensions: *id417
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache]
   title: Luftbilder swisstopo infrarot (19831231, source)
-- dimensions: &id419
+- dimensions: &id418
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache_out]
   title: Luftbilder swisstopo infrarot (19811231)
-- dimensions: *id419
+- dimensions: *id418
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache]
   title: Luftbilder swisstopo infrarot (19811231, source)
-- dimensions: &id420
+- dimensions: &id419
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache_out]
   title: Luftbilder swisstopo s/w (99991231)
-- dimensions: *id420
+- dimensions: *id419
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w ('current')
-- dimensions: *id420
+- dimensions: *id419
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w (99991231, source)
-- dimensions: &id421
+- dimensions: &id420
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache_out]
   title: Luftbilder swisstopo s/w (20101231)
-- dimensions: *id421
+- dimensions: *id420
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache]
   title: Luftbilder swisstopo s/w (20101231, source)
-- dimensions: &id422
+- dimensions: &id421
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache_out]
   title: Luftbilder swisstopo s/w (20091231)
-- dimensions: *id422
+- dimensions: *id421
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache]
   title: Luftbilder swisstopo s/w (20091231, source)
-- dimensions: &id423
+- dimensions: &id422
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache_out]
   title: Luftbilder swisstopo s/w (20081231)
-- dimensions: *id423
+- dimensions: *id422
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache]
   title: Luftbilder swisstopo s/w (20081231, source)
-- dimensions: &id424
+- dimensions: &id423
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache_out]
   title: Luftbilder swisstopo s/w (20071231)
-- dimensions: *id424
+- dimensions: *id423
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache]
   title: Luftbilder swisstopo s/w (20071231, source)
-- dimensions: &id425
+- dimensions: &id424
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache_out]
   title: Luftbilder swisstopo s/w (20061231)
-- dimensions: *id425
+- dimensions: *id424
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache]
   title: Luftbilder swisstopo s/w (20061231, source)
-- dimensions: &id426
+- dimensions: &id425
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache_out]
   title: Luftbilder swisstopo s/w (20051231)
-- dimensions: *id426
+- dimensions: *id425
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache]
   title: Luftbilder swisstopo s/w (20051231, source)
-- dimensions: &id427
+- dimensions: &id426
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache_out]
   title: Luftbilder swisstopo s/w (20041231)
-- dimensions: *id427
+- dimensions: *id426
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache]
   title: Luftbilder swisstopo s/w (20041231, source)
-- dimensions: &id428
+- dimensions: &id427
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache_out]
   title: Luftbilder swisstopo s/w (20031231)
-- dimensions: *id428
+- dimensions: *id427
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache]
   title: Luftbilder swisstopo s/w (20031231, source)
-- dimensions: &id429
+- dimensions: &id428
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache_out]
   title: Luftbilder swisstopo s/w (20021231)
-- dimensions: *id429
+- dimensions: *id428
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache]
   title: Luftbilder swisstopo s/w (20021231, source)
-- dimensions: &id430
+- dimensions: &id429
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache_out]
   title: Luftbilder swisstopo s/w (20011231)
-- dimensions: *id430
+- dimensions: *id429
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache]
   title: Luftbilder swisstopo s/w (20011231, source)
-- dimensions: &id431
+- dimensions: &id430
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache_out]
   title: Luftbilder swisstopo s/w (20001231)
-- dimensions: *id431
+- dimensions: *id430
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache]
   title: Luftbilder swisstopo s/w (20001231, source)
-- dimensions: &id432
+- dimensions: &id431
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache_out]
   title: Luftbilder swisstopo s/w (19991231)
-- dimensions: *id432
+- dimensions: *id431
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache]
   title: Luftbilder swisstopo s/w (19991231, source)
-- dimensions: &id433
+- dimensions: &id432
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache_out]
   title: Luftbilder swisstopo s/w (19981231)
-- dimensions: *id433
+- dimensions: *id432
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache]
   title: Luftbilder swisstopo s/w (19981231, source)
-- dimensions: &id434
+- dimensions: &id433
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache_out]
   title: Luftbilder swisstopo s/w (19971231)
-- dimensions: *id434
+- dimensions: *id433
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache]
   title: Luftbilder swisstopo s/w (19971231, source)
-- dimensions: &id435
+- dimensions: &id434
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache_out]
   title: Luftbilder swisstopo s/w (19961231)
-- dimensions: *id435
+- dimensions: *id434
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache]
   title: Luftbilder swisstopo s/w (19961231, source)
-- dimensions: &id436
+- dimensions: &id435
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache_out]
   title: Luftbilder swisstopo s/w (19951231)
-- dimensions: *id436
+- dimensions: *id435
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache]
   title: Luftbilder swisstopo s/w (19951231, source)
-- dimensions: &id437
+- dimensions: &id436
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache_out]
   title: Luftbilder swisstopo s/w (19941231)
-- dimensions: *id437
+- dimensions: *id436
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache]
   title: Luftbilder swisstopo s/w (19941231, source)
-- dimensions: &id438
+- dimensions: &id437
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache_out]
   title: Luftbilder swisstopo s/w (19931231)
-- dimensions: *id438
+- dimensions: *id437
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache]
   title: Luftbilder swisstopo s/w (19931231, source)
-- dimensions: &id439
+- dimensions: &id438
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache_out]
   title: Luftbilder swisstopo s/w (19921231)
-- dimensions: *id439
+- dimensions: *id438
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache]
   title: Luftbilder swisstopo s/w (19921231, source)
-- dimensions: &id440
+- dimensions: &id439
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache_out]
   title: Luftbilder swisstopo s/w (19911231)
-- dimensions: *id440
+- dimensions: *id439
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache]
   title: Luftbilder swisstopo s/w (19911231, source)
-- dimensions: &id441
+- dimensions: &id440
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache_out]
   title: Luftbilder swisstopo s/w (19901231)
-- dimensions: *id441
+- dimensions: *id440
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache]
   title: Luftbilder swisstopo s/w (19901231, source)
-- dimensions: &id442
+- dimensions: &id441
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache_out]
   title: Luftbilder swisstopo s/w (19891231)
-- dimensions: *id442
+- dimensions: *id441
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache]
   title: Luftbilder swisstopo s/w (19891231, source)
-- dimensions: &id443
+- dimensions: &id442
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache_out]
   title: Luftbilder swisstopo s/w (19881231)
-- dimensions: *id443
+- dimensions: *id442
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache]
   title: Luftbilder swisstopo s/w (19881231, source)
-- dimensions: &id444
+- dimensions: &id443
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache_out]
   title: Luftbilder swisstopo s/w (19871231)
-- dimensions: *id444
+- dimensions: *id443
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache]
   title: Luftbilder swisstopo s/w (19871231, source)
-- dimensions: &id445
+- dimensions: &id444
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache_out]
   title: Luftbilder swisstopo s/w (19861231)
-- dimensions: *id445
+- dimensions: *id444
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache]
   title: Luftbilder swisstopo s/w (19861231, source)
-- dimensions: &id446
+- dimensions: &id445
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache_out]
   title: Luftbilder swisstopo s/w (19851231)
-- dimensions: *id446
+- dimensions: *id445
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache]
   title: Luftbilder swisstopo s/w (19851231, source)
-- dimensions: &id447
+- dimensions: &id446
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache_out]
   title: Luftbilder swisstopo s/w (19841231)
-- dimensions: *id447
+- dimensions: *id446
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache]
   title: Luftbilder swisstopo s/w (19841231, source)
-- dimensions: &id448
+- dimensions: &id447
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache_out]
   title: Luftbilder swisstopo s/w (19831231)
-- dimensions: *id448
+- dimensions: *id447
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache]
   title: Luftbilder swisstopo s/w (19831231, source)
-- dimensions: &id449
+- dimensions: &id448
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache_out]
   title: Luftbilder swisstopo s/w (19821231)
-- dimensions: *id449
+- dimensions: *id448
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache]
   title: Luftbilder swisstopo s/w (19821231, source)
-- dimensions: &id450
+- dimensions: &id449
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache_out]
   title: Luftbilder swisstopo s/w (19811231)
-- dimensions: *id450
+- dimensions: *id449
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache]
   title: Luftbilder swisstopo s/w (19811231, source)
-- dimensions: &id451
+- dimensions: &id450
     Time:
       default: '19801231'
       values: ['19801231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache_out]
   title: Luftbilder swisstopo s/w (19801231)
-- dimensions: *id451
+- dimensions: *id450
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache]
   title: Luftbilder swisstopo s/w (19801231, source)
-- dimensions: &id452
+- dimensions: &id451
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache_out]
   title: Luftbilder swisstopo s/w (19791231)
-- dimensions: *id452
+- dimensions: *id451
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache]
   title: Luftbilder swisstopo s/w (19791231, source)
-- dimensions: &id453
+- dimensions: &id452
     Time:
       default: '19781231'
       values: ['19781231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache_out]
   title: Luftbilder swisstopo s/w (19781231)
-- dimensions: *id453
+- dimensions: *id452
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache]
   title: Luftbilder swisstopo s/w (19781231, source)
-- dimensions: &id454
+- dimensions: &id453
     Time:
       default: '19771231'
       values: ['19771231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache_out]
   title: Luftbilder swisstopo s/w (19771231)
-- dimensions: *id454
+- dimensions: *id453
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache]
   title: Luftbilder swisstopo s/w (19771231, source)
-- dimensions: &id455
+- dimensions: &id454
     Time:
       default: '19761231'
       values: ['19761231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache_out]
   title: Luftbilder swisstopo s/w (19761231)
-- dimensions: *id455
+- dimensions: *id454
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache]
   title: Luftbilder swisstopo s/w (19761231, source)
-- dimensions: &id456
+- dimensions: &id455
     Time:
       default: '19751231'
       values: ['19751231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache_out]
   title: Luftbilder swisstopo s/w (19751231)
-- dimensions: *id456
+- dimensions: *id455
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache]
   title: Luftbilder swisstopo s/w (19751231, source)
-- dimensions: &id457
+- dimensions: &id456
     Time:
       default: '19741231'
       values: ['19741231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache_out]
   title: Luftbilder swisstopo s/w (19741231)
-- dimensions: *id457
+- dimensions: *id456
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache]
   title: Luftbilder swisstopo s/w (19741231, source)
-- dimensions: &id458
+- dimensions: &id457
     Time:
       default: '19731231'
       values: ['19731231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache_out]
   title: Luftbilder swisstopo s/w (19731231)
-- dimensions: *id458
+- dimensions: *id457
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache]
   title: Luftbilder swisstopo s/w (19731231, source)
-- dimensions: &id459
+- dimensions: &id458
     Time:
       default: '19721231'
       values: ['19721231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache_out]
   title: Luftbilder swisstopo s/w (19721231)
-- dimensions: *id459
+- dimensions: *id458
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache]
   title: Luftbilder swisstopo s/w (19721231, source)
-- dimensions: &id460
+- dimensions: &id459
     Time:
       default: '19711231'
       values: ['19711231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache_out]
   title: Luftbilder swisstopo s/w (19711231)
-- dimensions: *id460
+- dimensions: *id459
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache]
   title: Luftbilder swisstopo s/w (19711231, source)
-- dimensions: &id461
+- dimensions: &id460
     Time:
       default: '19701231'
       values: ['19701231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache_out]
   title: Luftbilder swisstopo s/w (19701231)
-- dimensions: *id461
+- dimensions: *id460
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache]
   title: Luftbilder swisstopo s/w (19701231, source)
-- dimensions: &id462
+- dimensions: &id461
     Time:
       default: '19691231'
       values: ['19691231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache_out]
   title: Luftbilder swisstopo s/w (19691231)
-- dimensions: *id462
+- dimensions: *id461
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache]
   title: Luftbilder swisstopo s/w (19691231, source)
-- dimensions: &id463
+- dimensions: &id462
     Time:
       default: '19681231'
       values: ['19681231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache_out]
   title: Luftbilder swisstopo s/w (19681231)
-- dimensions: *id463
+- dimensions: *id462
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache]
   title: Luftbilder swisstopo s/w (19681231, source)
-- dimensions: &id464
+- dimensions: &id463
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache_out]
   title: Luftbilder swisstopo s/w (19671231)
-- dimensions: *id464
+- dimensions: *id463
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache]
   title: Luftbilder swisstopo s/w (19671231, source)
-- dimensions: &id465
+- dimensions: &id464
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache_out]
   title: Luftbilder swisstopo s/w (19661231)
-- dimensions: *id465
+- dimensions: *id464
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache]
   title: Luftbilder swisstopo s/w (19661231, source)
-- dimensions: &id466
+- dimensions: &id465
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache_out]
   title: Luftbilder swisstopo s/w (19651231)
-- dimensions: *id466
+- dimensions: *id465
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache]
   title: Luftbilder swisstopo s/w (19651231, source)
-- dimensions: &id467
+- dimensions: &id466
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache_out]
   title: Luftbilder swisstopo s/w (19641231)
-- dimensions: *id467
+- dimensions: *id466
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache]
   title: Luftbilder swisstopo s/w (19641231, source)
-- dimensions: &id468
+- dimensions: &id467
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache_out]
   title: Luftbilder swisstopo s/w (19631231)
-- dimensions: *id468
+- dimensions: *id467
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache]
   title: Luftbilder swisstopo s/w (19631231, source)
-- dimensions: &id469
+- dimensions: &id468
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache_out]
   title: Luftbilder swisstopo s/w (19621231)
-- dimensions: *id469
+- dimensions: *id468
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache]
   title: Luftbilder swisstopo s/w (19621231, source)
-- dimensions: &id470
+- dimensions: &id469
     Time:
       default: '19611231'
       values: ['19611231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache_out]
   title: Luftbilder swisstopo s/w (19611231)
-- dimensions: *id470
+- dimensions: *id469
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache]
   title: Luftbilder swisstopo s/w (19611231, source)
-- dimensions: &id471
+- dimensions: &id470
     Time:
       default: '19601231'
       values: ['19601231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache_out]
   title: Luftbilder swisstopo s/w (19601231)
-- dimensions: *id471
+- dimensions: *id470
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache]
   title: Luftbilder swisstopo s/w (19601231, source)
-- dimensions: &id472
+- dimensions: &id471
     Time:
       default: '19591231'
       values: ['19591231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache_out]
   title: Luftbilder swisstopo s/w (19591231)
-- dimensions: *id472
+- dimensions: *id471
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache]
   title: Luftbilder swisstopo s/w (19591231, source)
-- dimensions: &id473
+- dimensions: &id472
     Time:
       default: '19581231'
       values: ['19581231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache_out]
   title: Luftbilder swisstopo s/w (19581231)
-- dimensions: *id473
+- dimensions: *id472
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache]
   title: Luftbilder swisstopo s/w (19581231, source)
-- dimensions: &id474
+- dimensions: &id473
     Time:
       default: '19571231'
       values: ['19571231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache_out]
   title: Luftbilder swisstopo s/w (19571231)
-- dimensions: *id474
+- dimensions: *id473
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache]
   title: Luftbilder swisstopo s/w (19571231, source)
-- dimensions: &id475
+- dimensions: &id474
     Time:
       default: '19561231'
       values: ['19561231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache_out]
   title: Luftbilder swisstopo s/w (19561231)
-- dimensions: *id475
+- dimensions: *id474
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache]
   title: Luftbilder swisstopo s/w (19561231, source)
-- dimensions: &id476
+- dimensions: &id475
     Time:
       default: '19551231'
       values: ['19551231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache_out]
   title: Luftbilder swisstopo s/w (19551231)
-- dimensions: *id476
+- dimensions: *id475
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache]
   title: Luftbilder swisstopo s/w (19551231, source)
-- dimensions: &id477
+- dimensions: &id476
     Time:
       default: '19541231'
       values: ['19541231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache_out]
   title: Luftbilder swisstopo s/w (19541231)
-- dimensions: *id477
+- dimensions: *id476
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache]
   title: Luftbilder swisstopo s/w (19541231, source)
-- dimensions: &id478
+- dimensions: &id477
     Time:
       default: '19531231'
       values: ['19531231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache_out]
   title: Luftbilder swisstopo s/w (19531231)
-- dimensions: *id478
+- dimensions: *id477
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache]
   title: Luftbilder swisstopo s/w (19531231, source)
-- dimensions: &id479
+- dimensions: &id478
     Time:
       default: '19521231'
       values: ['19521231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache_out]
   title: Luftbilder swisstopo s/w (19521231)
-- dimensions: *id479
+- dimensions: *id478
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache]
   title: Luftbilder swisstopo s/w (19521231, source)
-- dimensions: &id480
+- dimensions: &id479
     Time:
       default: '19511231'
       values: ['19511231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache_out]
   title: Luftbilder swisstopo s/w (19511231)
-- dimensions: *id480
+- dimensions: *id479
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache]
   title: Luftbilder swisstopo s/w (19511231, source)
-- dimensions: &id481
+- dimensions: &id480
     Time:
       default: '19501231'
       values: ['19501231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache_out]
   title: Luftbilder swisstopo s/w (19501231)
-- dimensions: *id481
+- dimensions: *id480
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache]
   title: Luftbilder swisstopo s/w (19501231, source)
-- dimensions: &id482
+- dimensions: &id481
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache_out]
   title: Luftbilder swisstopo s/w (19491231)
-- dimensions: *id482
+- dimensions: *id481
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache]
   title: Luftbilder swisstopo s/w (19491231, source)
-- dimensions: &id483
+- dimensions: &id482
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache_out]
   title: Luftbilder swisstopo s/w (19481231)
-- dimensions: *id483
+- dimensions: *id482
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache]
   title: Luftbilder swisstopo s/w (19481231, source)
-- dimensions: &id484
+- dimensions: &id483
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache_out]
   title: Luftbilder swisstopo s/w (19471231)
-- dimensions: *id484
+- dimensions: *id483
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache]
   title: Luftbilder swisstopo s/w (19471231, source)
-- dimensions: &id485
+- dimensions: &id484
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache_out]
   title: Luftbilder swisstopo s/w (19461231)
-- dimensions: *id485
+- dimensions: *id484
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache]
   title: Luftbilder swisstopo s/w (19461231, source)
-- dimensions: &id486
+- dimensions: &id485
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache_out]
   title: Luftbilder swisstopo s/w (19451231)
-- dimensions: *id486
+- dimensions: *id485
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache]
   title: Luftbilder swisstopo s/w (19451231, source)
-- dimensions: &id487
+- dimensions: &id486
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache_out]
   title: Luftbilder swisstopo s/w (19441231)
-- dimensions: *id487
+- dimensions: *id486
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache]
   title: Luftbilder swisstopo s/w (19441231, source)
-- dimensions: &id488
+- dimensions: &id487
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache_out]
   title: Luftbilder swisstopo s/w (19431231)
-- dimensions: *id488
+- dimensions: *id487
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache]
   title: Luftbilder swisstopo s/w (19431231, source)
-- dimensions: &id489
+- dimensions: &id488
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache_out]
   title: Luftbilder swisstopo s/w (19421231)
-- dimensions: *id489
+- dimensions: *id488
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache]
   title: Luftbilder swisstopo s/w (19421231, source)
-- dimensions: &id490
+- dimensions: &id489
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache_out]
   title: Luftbilder swisstopo s/w (19411231)
-- dimensions: *id490
+- dimensions: *id489
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache]
   title: Luftbilder swisstopo s/w (19411231, source)
-- dimensions: &id491
+- dimensions: &id490
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache_out]
   title: Luftbilder swisstopo s/w (19401231)
-- dimensions: *id491
+- dimensions: *id490
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache]
   title: Luftbilder swisstopo s/w (19401231, source)
-- dimensions: &id492
+- dimensions: &id491
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache_out]
   title: Luftbilder swisstopo s/w (19391231)
-- dimensions: *id492
+- dimensions: *id491
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache]
   title: Luftbilder swisstopo s/w (19391231, source)
-- dimensions: &id493
+- dimensions: &id492
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache_out]
   title: Luftbilder swisstopo s/w (19381231)
-- dimensions: *id493
+- dimensions: *id492
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache]
   title: Luftbilder swisstopo s/w (19381231, source)
-- dimensions: &id494
+- dimensions: &id493
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache_out]
   title: Luftbilder swisstopo s/w (19371231)
-- dimensions: *id494
+- dimensions: *id493
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache]
   title: Luftbilder swisstopo s/w (19371231, source)
-- dimensions: &id495
+- dimensions: &id494
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache_out]
   title: Luftbilder swisstopo s/w (19361231)
-- dimensions: *id495
+- dimensions: *id494
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache]
   title: Luftbilder swisstopo s/w (19361231, source)
-- dimensions: &id496
+- dimensions: &id495
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache_out]
   title: Luftbilder swisstopo s/w (19351231)
-- dimensions: *id496
+- dimensions: *id495
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache]
   title: Luftbilder swisstopo s/w (19351231, source)
-- dimensions: &id497
+- dimensions: &id496
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache_out]
   title: Luftbilder swisstopo s/w (19341231)
-- dimensions: *id497
+- dimensions: *id496
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache]
   title: Luftbilder swisstopo s/w (19341231, source)
-- dimensions: &id498
+- dimensions: &id497
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache_out]
   title: Luftbilder swisstopo s/w (19331231)
-- dimensions: *id498
+- dimensions: *id497
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache]
   title: Luftbilder swisstopo s/w (19331231, source)
-- dimensions: &id499
+- dimensions: &id498
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache_out]
   title: Luftbilder swisstopo s/w (19321231)
-- dimensions: *id499
+- dimensions: *id498
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache]
   title: Luftbilder swisstopo s/w (19321231, source)
-- dimensions: &id500
+- dimensions: &id499
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache_out]
   title: Luftbilder swisstopo s/w (19311231)
-- dimensions: *id500
+- dimensions: *id499
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache]
   title: Luftbilder swisstopo s/w (19311231, source)
-- dimensions: &id501
+- dimensions: &id500
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache_out]
   title: Luftbilder swisstopo s/w (19301231)
-- dimensions: *id501
+- dimensions: *id500
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache]
   title: Luftbilder swisstopo s/w (19301231, source)
-- dimensions: &id502
+- dimensions: &id501
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache_out]
   title: Luftbilder swisstopo s/w (19291231)
-- dimensions: *id502
+- dimensions: *id501
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache]
   title: Luftbilder swisstopo s/w (19291231, source)
-- dimensions: &id503
+- dimensions: &id502
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache_out]
   title: Luftbilder swisstopo s/w (19281231)
-- dimensions: *id503
+- dimensions: *id502
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache]
   title: Luftbilder swisstopo s/w (19281231, source)
-- dimensions: &id504
+- dimensions: &id503
     Time:
       default: '19271231'
       values: ['19271231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache_out]
   title: Luftbilder swisstopo s/w (19271231)
-- dimensions: *id504
+- dimensions: *id503
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache]
   title: Luftbilder swisstopo s/w (19271231, source)
-- dimensions: &id505
+- dimensions: &id504
     Time:
       default: '19261231'
       values: ['19261231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache_out]
   title: Luftbilder swisstopo s/w (19261231)
-- dimensions: *id505
+- dimensions: *id504
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache]
   title: Luftbilder swisstopo s/w (19261231, source)
-- dimensions: &id506
+- dimensions: &id505
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe_20151231
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id506
+- dimensions: *id505
   name: ch.swisstopo.pixelkarte-farbe
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id506
+- dimensions: *id505
   name: ch.swisstopo.pixelkarte-farbe_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id507
+- dimensions: &id506
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache_out]
   title: Landeskarte 1:1 Million | LK1000 (20140106)
-- dimensions: *id507
+- dimensions: *id506
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Million | LK1000 ('current')
-- dimensions: *id507
+- dimensions: *id506
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Million | LK1000 (20140106, source)
-- dimensions: &id508
+- dimensions: &id507
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache_out]
   title: Landeskarte 1:100'000 | LK100 (20151231)
-- dimensions: *id508
+- dimensions: *id507
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
   title: Landeskarte 1:100'000 | LK100 ('current')
-- dimensions: *id508
+- dimensions: *id507
   name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
   title: Landeskarte 1:100'000 | LK100 (20151231, source)
-- dimensions: &id509
+- dimensions: &id508
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache_out]
   title: Landeskarte 1:200'000 | LK200 (20151231)
-- dimensions: *id509
+- dimensions: *id508
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
   title: Landeskarte 1:200'000 | LK200 ('current')
-- dimensions: *id509
+- dimensions: *id508
   name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
   title: Landeskarte 1:200'000 | LK200 (20151231, source)
-- dimensions: &id510
+- dimensions: &id509
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id510
+- dimensions: *id509
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id510
+- dimensions: *id509
   name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id511
+- dimensions: &id510
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache_out]
   title: Landeskarte 1:500'000 | LK500 (20151231)
-- dimensions: *id511
+- dimensions: *id510
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
   title: Landeskarte 1:500'000 | LK500 ('current')
-- dimensions: *id511
+- dimensions: *id510
   name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
   title: Landeskarte 1:500'000 | LK500 (20151231, source)
-- dimensions: &id512
+- dimensions: &id511
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache_out]
   title: Landeskarte 1:50'000 | LK50 (20151231)
-- dimensions: *id512
+- dimensions: *id511
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
   title: Landeskarte 1:50'000 | LK50 ('current')
-- dimensions: *id512
+- dimensions: *id511
   name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
   title: Landeskarte 1:50'000 | LK50 (20151231, source)
-- dimensions: &id513
+- dimensions: &id512
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-grau_20151231
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id513
+- dimensions: *id512
   name: ch.swisstopo.pixelkarte-grau
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id513
+- dimensions: *id512
   name: ch.swisstopo.pixelkarte-grau_20151231_source
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id514
+- dimensions: &id513
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache_out]
   title: swissALTI3D Reliefschattierung (20150101)
-- dimensions: *id514
+- dimensions: *id513
   name: ch.swisstopo.swissalti3d-reliefschattierung
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung ('current')
-- dimensions: *id514
+- dimensions: *id513
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung (20150101, source)
-- dimensions: &id515
+- dimensions: &id514
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache_out]
   title: Bezirksgrenzen (20150101)
-- dimensions: *id515
+- dimensions: *id514
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen ('current')
-- dimensions: *id515
+- dimensions: *id514
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen (20150101, source)
-- dimensions: &id516
+- dimensions: &id515
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache_out]
   title: Gemeindegrenzen (20150101)
-- dimensions: *id516
+- dimensions: *id515
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen ('current')
-- dimensions: *id516
+- dimensions: *id515
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen (20150101, source)
-- dimensions: &id517
+- dimensions: &id516
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache_out]
   title: Kantonsgrenzen (20150101)
-- dimensions: *id517
+- dimensions: *id516
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen ('current')
-- dimensions: *id517
+- dimensions: *id516
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen (20150101, source)
-- dimensions: &id518
+- dimensions: &id517
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache_out]
   title: Landesgrenzen (20150101)
-- dimensions: *id518
+- dimensions: *id517
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen ('current')
-- dimensions: *id518
+- dimensions: *id517
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen (20150101, source)
-- dimensions: &id519
+- dimensions: &id518
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.swissbuildings3d_19980101
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache_out]
   title: "Vereinfachte 3D-Geb\xE4ude (19980101)"
-- dimensions: *id519
+- dimensions: *id518
   name: ch.swisstopo.swissbuildings3d
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude ('current')"
-- dimensions: *id519
+- dimensions: *id518
   name: ch.swisstopo.swissbuildings3d_19980101_source
   sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
   title: "Vereinfachte 3D-Geb\xE4ude (19980101, source)"
-- dimensions: &id520
+- dimensions: &id519
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.swissimage_20151231
   sources: [ch.swisstopo.swissimage_20151231_cache_out]
   title: SWISSIMAGE (20151231)
-- dimensions: *id520
+- dimensions: *id519
   name: ch.swisstopo.swissimage
   sources: [ch.swisstopo.swissimage_20151231_cache]
   title: SWISSIMAGE ('current')
-- dimensions: *id520
+- dimensions: *id519
   name: ch.swisstopo.swissimage_20151231_source
   sources: [ch.swisstopo.swissimage_20151231_cache]
   title: SWISSIMAGE (20151231, source)
-- dimensions: &id521
+- dimensions: &id520
     Time:
       default: '20140620'
       values: ['20140620']
   name: ch.swisstopo.swissimage_20140620
   sources: [ch.swisstopo.swissimage_20140620_cache_out]
   title: SWISSIMAGE (20140620)
-- dimensions: *id521
+- dimensions: *id520
   name: ch.swisstopo.swissimage_20140620_source
   sources: [ch.swisstopo.swissimage_20140620_cache]
   title: SWISSIMAGE (20140620, source)
-- dimensions: &id522
+- dimensions: &id521
     Time:
       default: '20131107'
       values: ['20131107']
   name: ch.swisstopo.swissimage_20131107
   sources: [ch.swisstopo.swissimage_20131107_cache_out]
   title: SWISSIMAGE (20131107)
-- dimensions: *id522
+- dimensions: *id521
   name: ch.swisstopo.swissimage_20131107_source
   sources: [ch.swisstopo.swissimage_20131107_cache]
   title: SWISSIMAGE (20131107, source)
-- dimensions: &id523
+- dimensions: &id522
     Time:
       default: '20130916'
       values: ['20130916']
   name: ch.swisstopo.swissimage_20130916
   sources: [ch.swisstopo.swissimage_20130916_cache_out]
   title: SWISSIMAGE (20130916)
-- dimensions: *id523
+- dimensions: *id522
   name: ch.swisstopo.swissimage_20130916_source
   sources: [ch.swisstopo.swissimage_20130916_cache]
   title: SWISSIMAGE (20130916, source)
+- dimensions: &id523
+    Time:
+      default: '20130422'
+      values: ['20130422']
+  name: ch.swisstopo.swissimage_20130422
+  sources: [ch.swisstopo.swissimage_20130422_cache_out]
+  title: SWISSIMAGE (20130422)
+- dimensions: *id523
+  name: ch.swisstopo.swissimage_20130422_source
+  sources: [ch.swisstopo.swissimage_20130422_cache]
+  title: SWISSIMAGE (20130422, source)
 - dimensions: &id524
     Time:
-      default: "20130422\t"
-      values: ["20130422\t"]
-  name: "ch.swisstopo.swissimage_20130422\t"
-  sources: ["ch.swisstopo.swissimage_20130422\t_cache_out"]
-  title: "SWISSIMAGE (20130422\t)"
+      default: '20120809'
+      values: ['20120809']
+  name: ch.swisstopo.swissimage_20120809
+  sources: [ch.swisstopo.swissimage_20120809_cache_out]
+  title: SWISSIMAGE (20120809)
 - dimensions: *id524
-  name: "ch.swisstopo.swissimage_20130422\t_source"
-  sources: ["ch.swisstopo.swissimage_20130422\t_cache"]
-  title: "SWISSIMAGE (20130422\t, source)"
+  name: ch.swisstopo.swissimage_20120809_source
+  sources: [ch.swisstopo.swissimage_20120809_cache]
+  title: SWISSIMAGE (20120809, source)
 - dimensions: &id525
-    Time:
-      default: "20120809\t"
-      values: ["20120809\t"]
-  name: "ch.swisstopo.swissimage_20120809\t"
-  sources: ["ch.swisstopo.swissimage_20120809\t_cache_out"]
-  title: "SWISSIMAGE (20120809\t)"
-- dimensions: *id525
-  name: "ch.swisstopo.swissimage_20120809\t_source"
-  sources: ["ch.swisstopo.swissimage_20120809\t_cache"]
-  title: "SWISSIMAGE (20120809\t, source)"
-- dimensions: &id526
     Time:
       default: '20120225'
       values: ['20120225']
   name: ch.swisstopo.swissimage_20120225
   sources: [ch.swisstopo.swissimage_20120225_cache_out]
   title: SWISSIMAGE (20120225)
-- dimensions: *id526
+- dimensions: *id525
   name: ch.swisstopo.swissimage_20120225_source
   sources: [ch.swisstopo.swissimage_20120225_cache]
   title: SWISSIMAGE (20120225, source)
-- dimensions: &id527
+- dimensions: &id526
     Time:
       default: '20110914'
       values: ['20110914']
   name: ch.swisstopo.swissimage_20110914
   sources: [ch.swisstopo.swissimage_20110914_cache_out]
   title: SWISSIMAGE (20110914)
-- dimensions: *id527
+- dimensions: *id526
   name: ch.swisstopo.swissimage_20110914_source
   sources: [ch.swisstopo.swissimage_20110914_cache]
   title: SWISSIMAGE (20110914, source)
-- dimensions: &id528
+- dimensions: &id527
     Time:
       default: '20110228'
       values: ['20110228']
   name: ch.swisstopo.swissimage_20110228
   sources: [ch.swisstopo.swissimage_20110228_cache_out]
   title: SWISSIMAGE (20110228)
-- dimensions: *id528
+- dimensions: *id527
   name: ch.swisstopo.swissimage_20110228_source
   sources: [ch.swisstopo.swissimage_20110228_cache]
   title: SWISSIMAGE (20110228, source)
-- dimensions: &id529
+- dimensions: &id528
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.swissimage-product_20151231
   sources: [ch.swisstopo.swissimage-product_20151231_cache_out]
   title: SWISSIMAGE (20151231)
-- dimensions: *id529
+- dimensions: *id528
   name: ch.swisstopo.swissimage-product
   sources: [ch.swisstopo.swissimage-product_20151231_cache]
   title: SWISSIMAGE ('current')
-- dimensions: *id529
+- dimensions: *id528
   name: ch.swisstopo.swissimage-product_20151231_source
   sources: [ch.swisstopo.swissimage-product_20151231_cache]
   title: SWISSIMAGE (20151231, source)
-- dimensions: &id530
+- dimensions: &id529
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissnames3d_20150101
   sources: [ch.swisstopo.swissnames3d_20150101_cache_out]
   title: Geografische Namen swissNAMES3D (20150101)
-- dimensions: *id530
+- dimensions: *id529
   name: ch.swisstopo.swissnames3d
   sources: [ch.swisstopo.swissnames3d_20150101_cache]
   title: Geografische Namen swissNAMES3D ('current')
-- dimensions: *id530
+- dimensions: *id529
   name: ch.swisstopo.swissnames3d_20150101_source
   sources: [ch.swisstopo.swissnames3d_20150101_cache]
   title: Geografische Namen swissNAMES3D (20150101, source)
-- dimensions: &id531
+- dimensions: &id530
     Time:
       default: '20150401'
       values: ['20150401']
   name: ch.swisstopo.swisstlm3d-karte-farbe_20150401
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache_out]
   title: Karte swissTLM (farbig) (20150401)
-- dimensions: *id531
+- dimensions: *id530
   name: ch.swisstopo.swisstlm3d-karte-farbe
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache]
   title: Karte swissTLM (farbig) ('current')
-- dimensions: *id531
+- dimensions: *id530
   name: ch.swisstopo.swisstlm3d-karte-farbe_20150401_source
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache]
   title: Karte swissTLM (farbig) (20150401, source)
-- dimensions: &id532
+- dimensions: &id531
     Time:
       default: '20150401'
       values: ['20150401']
   name: ch.swisstopo.swisstlm3d-karte-grau_20150401
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache_out]
   title: Karte swissTLM (grau) (20150401)
-- dimensions: *id532
+- dimensions: *id531
   name: ch.swisstopo.swisstlm3d-karte-grau
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache]
   title: Karte swissTLM (grau) ('current')
-- dimensions: *id532
+- dimensions: *id531
   name: ch.swisstopo.swisstlm3d-karte-grau_20150401_source
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache]
   title: Karte swissTLM (grau) (20150401, source)
-- dimensions: &id533
+- dimensions: &id532
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20150101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache_out]
   title: Wanderwege (20150101)
-- dimensions: *id533
+- dimensions: *id532
   name: ch.swisstopo.swisstlm3d-wanderwege
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
   title: Wanderwege ('current')
-- dimensions: *id533
+- dimensions: *id532
   name: ch.swisstopo.swisstlm3d-wanderwege_20150101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
   title: Wanderwege (20150101, source)
-- dimensions: &id534
+- dimensions: &id533
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo.transformationsgenauigkeit_20141101
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache_out]
   title: LV95 Transformationsgenauigkeit (20141101)
-- dimensions: *id534
+- dimensions: *id533
   name: ch.swisstopo.transformationsgenauigkeit
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit ('current')
-- dimensions: *id534
+- dimensions: *id533
   name: ch.swisstopo.transformationsgenauigkeit_20141101_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit (20141101, source)
-- dimensions: &id535
+- dimensions: &id534
     Time:
       default: '20140703'
       values: ['20140703']
   name: ch.swisstopo.treasurehunt_20140703
   sources: [ch.swisstopo.treasurehunt_20140703_cache_out]
   title: Schatzkarte (20140703)
-- dimensions: *id535
+- dimensions: *id534
   name: ch.swisstopo.treasurehunt
   sources: [ch.swisstopo.treasurehunt_20140703_cache]
   title: Schatzkarte ('current')
-- dimensions: *id535
+- dimensions: *id534
   name: ch.swisstopo.treasurehunt_20140703_source
   sources: [ch.swisstopo.treasurehunt_20140703_cache]
   title: Schatzkarte (20140703, source)
-- dimensions: &id536
+- dimensions: &id535
     Time:
       default: '20131101'
       values: ['20131101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache_out]
   title: PLZ und Ortschaften (20131101)
-- dimensions: *id536
+- dimensions: *id535
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften ('current')
-- dimensions: *id536
+- dimensions: *id535
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften (20131101, source)
-- dimensions: &id537
+- dimensions: &id536
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache_out]
   title: Spannungsarme Gebiete (20141101)
-- dimensions: *id537
+- dimensions: *id536
   name: ch.swisstopo-vd.spannungsarme-gebiete
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete ('current')
-- dimensions: *id537
+- dimensions: *id536
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete (20141101, source)
-- dimensions: &id538
+- dimensions: &id537
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20150101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache_out]
   title: Schutzgebiete VECTOR200 (20150101)
-- dimensions: *id538
+- dimensions: *id537
   name: ch.swisstopo.vec200-adminboundaries-protectedarea
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache]
   title: Schutzgebiete VECTOR200 ('current')
-- dimensions: *id538
+- dimensions: *id537
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache]
   title: Schutzgebiete VECTOR200 (20150101, source)
-- dimensions: &id539
+- dimensions: &id538
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-building_20150101
   sources: [ch.swisstopo.vec200-building_20150101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20150101)"
-- dimensions: *id539
+- dimensions: *id538
   name: ch.swisstopo.vec200-building
   sources: [ch.swisstopo.vec200-building_20150101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 ('current')"
-- dimensions: *id539
+- dimensions: *id538
   name: ch.swisstopo.vec200-building_20150101_source
   sources: [ch.swisstopo.vec200-building_20150101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20150101, source)"
-- dimensions: &id540
+- dimensions: &id539
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-hydrography_20150101
   sources: [ch.swisstopo.vec200-hydrography_20150101_cache_out]
   title: "Gew\xE4ssernetz VECTOR200 (20150101)"
-- dimensions: *id540
+- dimensions: *id539
   name: ch.swisstopo.vec200-hydrography
   sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
   title: "Gew\xE4ssernetz VECTOR200 ('current')"
-- dimensions: *id540
+- dimensions: *id539
   name: ch.swisstopo.vec200-hydrography_20150101_source
   sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
   title: "Gew\xE4ssernetz VECTOR200 (20150101, source)"
-- dimensions: &id541
+- dimensions: &id540
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-landcover_20150101
   sources: [ch.swisstopo.vec200-landcover_20150101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20150101)
-- dimensions: *id541
+- dimensions: *id540
   name: ch.swisstopo.vec200-landcover
   sources: [ch.swisstopo.vec200-landcover_20150101_cache]
   title: Prim. Bodenbedeckung VECTOR200 ('current')
-- dimensions: *id541
+- dimensions: *id540
   name: ch.swisstopo.vec200-landcover_20150101_source
   sources: [ch.swisstopo.vec200-landcover_20150101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20150101, source)
-- dimensions: &id542
+- dimensions: &id541
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-landcover-wald_20150101
   sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache_out]
   title: "Waldfl\xE4chen (20150101)"
-- dimensions: *id542
+- dimensions: *id541
   name: ch.swisstopo.vec200-landcover-wald
   sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
   title: "Waldfl\xE4chen ('current')"
-- dimensions: *id542
+- dimensions: *id541
   name: ch.swisstopo.vec200-landcover-wald_20150101_source
   sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
   title: "Waldfl\xE4chen (20150101, source)"
-- dimensions: &id543
+- dimensions: &id542
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-miscellaneous_20150101
   sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache_out]
   title: Einzelobjekte VECTOR200 (20150101)
-- dimensions: *id543
+- dimensions: *id542
   name: ch.swisstopo.vec200-miscellaneous
   sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
   title: Einzelobjekte VECTOR200 ('current')
-- dimensions: *id543
+- dimensions: *id542
   name: ch.swisstopo.vec200-miscellaneous_20150101_source
   sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
   title: Einzelobjekte VECTOR200 (20150101, source)
-- dimensions: &id544
+- dimensions: &id543
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20150101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20150101)"
-- dimensions: *id544
+- dimensions: *id543
   name: ch.swisstopo.vec200-miscellaneous-geodpoint
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache]
   title: "H\xF6henkoten VECTOR200 ('current')"
-- dimensions: *id544
+- dimensions: *id543
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache]
   title: "H\xF6henkoten VECTOR200 (20150101, source)"
-- dimensions: &id545
+- dimensions: &id544
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-names-namedlocation_20150101
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache_out]
   title: Namen VECTOR200 (20150101)
-- dimensions: *id545
+- dimensions: *id544
   name: ch.swisstopo.vec200-names-namedlocation
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache]
   title: Namen VECTOR200 ('current')
-- dimensions: *id545
+- dimensions: *id544
   name: ch.swisstopo.vec200-names-namedlocation_20150101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache]
   title: Namen VECTOR200 (20150101, source)
-- dimensions: &id546
+- dimensions: &id545
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache_out]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20150101)"
-- dimensions: *id546
+- dimensions: *id545
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 ('current')"
-- dimensions: *id546
+- dimensions: *id545
   name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_source
   sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
   title: "\xD6ffentlicher Verkehr VECTOR200 (20150101, source)"
-- dimensions: &id547
+- dimensions: &id546
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-transportation-strassennetz_20150101
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache_out]
   title: Strassennetz VECTOR200 (20150101)
-- dimensions: *id547
+- dimensions: *id546
   name: ch.swisstopo.vec200-transportation-strassennetz
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
   title: Strassennetz VECTOR200 ('current')
-- dimensions: *id547
+- dimensions: *id546
   name: ch.swisstopo.vec200-transportation-strassennetz_20150101_source
   sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
   title: Strassennetz VECTOR200 (20150101, source)
-- dimensions: &id548
+- dimensions: &id547
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-anlagen_20090401
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache_out]
   title: Anlagen VECTOR25 (20090401)
-- dimensions: *id548
+- dimensions: *id547
   name: ch.swisstopo.vec25-anlagen
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25 ('current')
-- dimensions: *id548
+- dimensions: *id547
   name: ch.swisstopo.vec25-anlagen_20090401_source
   sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
   title: Anlagen VECTOR25 (20090401, source)
-- dimensions: &id549
+- dimensions: &id548
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-einzelobjekte_19980101
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache_out]
   title: Einzelobjekte VECTOR25 (19980101)
-- dimensions: *id549
+- dimensions: *id548
   name: ch.swisstopo.vec25-einzelobjekte
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25 ('current')
-- dimensions: *id549
+- dimensions: *id548
   name: ch.swisstopo.vec25-einzelobjekte_19980101_source
   sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
   title: Einzelobjekte VECTOR25 (19980101, source)
-- dimensions: &id550
+- dimensions: &id549
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache_out]
   title: Eisenbahnnetz VECTOR25 (20090401)
-- dimensions: *id550
+- dimensions: *id549
   name: ch.swisstopo.vec25-eisenbahnnetz
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25 ('current')
-- dimensions: *id550
+- dimensions: *id549
   name: ch.swisstopo.vec25-eisenbahnnetz_20090401_source
   sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
   title: Eisenbahnnetz VECTOR25 (20090401, source)
-- dimensions: &id551
+- dimensions: &id550
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gebaeude_20090401
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache_out]
   title: "Geb\xE4ude VECTOR25 (20090401)"
-- dimensions: *id551
+- dimensions: *id550
   name: ch.swisstopo.vec25-gebaeude
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25 ('current')"
-- dimensions: *id551
+- dimensions: *id550
   name: ch.swisstopo.vec25-gebaeude_20090401_source
   sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
   title: "Geb\xE4ude VECTOR25 (20090401, source)"
-- dimensions: &id552
+- dimensions: &id551
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-gewaessernetz_20090401
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache_out]
   title: "Gew\xE4ssernetz VECTOR25 (20090401)"
-- dimensions: *id552
+- dimensions: *id551
   name: ch.swisstopo.vec25-gewaessernetz
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25 ('current')"
-- dimensions: *id552
+- dimensions: *id551
   name: ch.swisstopo.vec25-gewaessernetz_20090401_source
   sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
   title: "Gew\xE4ssernetz VECTOR25 (20090401, source)"
-- dimensions: &id553
+- dimensions: &id552
     Time:
       default: '19980101'
       values: ['19980101']
   name: ch.swisstopo.vec25-heckenbaeume_19980101
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache_out]
   title: "Hecken und B\xE4ume VECTOR25 (19980101)"
-- dimensions: *id553
+- dimensions: *id552
   name: ch.swisstopo.vec25-heckenbaeume
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25 ('current')"
-- dimensions: *id553
+- dimensions: *id552
   name: ch.swisstopo.vec25-heckenbaeume_19980101_source
   sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
   title: "Hecken und B\xE4ume VECTOR25 (19980101, source)"
-- dimensions: &id554
+- dimensions: &id553
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-primaerflaechen_20090401
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache_out]
   title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401)"
-- dimensions: *id554
+- dimensions: *id553
   name: ch.swisstopo.vec25-primaerflaechen
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25 ('current')"
-- dimensions: *id554
+- dimensions: *id553
   name: ch.swisstopo.vec25-primaerflaechen_20090401_source
   sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
   title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401, source)"
-- dimensions: &id555
+- dimensions: &id554
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-strassennetz_20090401
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache_out]
   title: Strassennetz VECTOR25 (20090401)
-- dimensions: *id555
+- dimensions: *id554
   name: ch.swisstopo.vec25-strassennetz
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25 ('current')
-- dimensions: *id555
+- dimensions: *id554
   name: ch.swisstopo.vec25-strassennetz_20090401_source
   sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
   title: Strassennetz VECTOR25 (20090401, source)
-- dimensions: &id556
+- dimensions: &id555
     Time:
       default: '20090401'
       values: ['20090401']
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache_out]
   title: "\xDCbriger Verkehr VECTOR25 (20090401)"
-- dimensions: *id556
+- dimensions: *id555
   name: ch.swisstopo.vec25-uebrigerverkehr
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25 ('current')"
-- dimensions: *id556
+- dimensions: *id555
   name: ch.swisstopo.vec25-uebrigerverkehr_20090401_source
   sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
   title: "\xDCbriger Verkehr VECTOR25 (20090401, source)"
-- dimensions: &id557
+- dimensions: &id556
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache_out]
   title: LV95 Verschiebungsvektoren TSP1 (20061231)
-- dimensions: *id557
+- dimensions: *id556
   name: ch.swisstopo.verschiebungsvektoren-tsp1
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 ('current')
-- dimensions: *id557
+- dimensions: *id556
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 (20061231, source)
-- dimensions: &id558
+- dimensions: &id557
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache_out]
   title: LV95 Verschiebungsvektoren TSP2 (20070101)
-- dimensions: *id558
+- dimensions: *id557
   name: ch.swisstopo.verschiebungsvektoren-tsp2
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 ('current')
-- dimensions: *id558
+- dimensions: *id557
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 (20070101, source)
-- dimensions: &id559
+- dimensions: &id558
     Time:
       default: '20131231'
       values: ['20131231']
   name: ch.swisstopo.zeitreihen_20131231
   sources: [ch.swisstopo.zeitreihen_20131231_cache_out]
   title: Zeitreise - Kartenwerke (20131231)
-- dimensions: *id559
+- dimensions: *id558
   name: ch.swisstopo.zeitreihen
   sources: [ch.swisstopo.zeitreihen_20131231_cache]
   title: Zeitreise - Kartenwerke ('current')
-- dimensions: *id559
+- dimensions: *id558
   name: ch.swisstopo.zeitreihen_20131231_source
   sources: [ch.swisstopo.zeitreihen_20131231_cache]
   title: Zeitreise - Kartenwerke (20131231, source)
-- dimensions: &id560
+- dimensions: &id559
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.swisstopo.zeitreihen_20121231
   sources: [ch.swisstopo.zeitreihen_20121231_cache_out]
   title: Zeitreise - Kartenwerke (20121231)
-- dimensions: *id560
+- dimensions: *id559
   name: ch.swisstopo.zeitreihen_20121231_source
   sources: [ch.swisstopo.zeitreihen_20121231_cache]
   title: Zeitreise - Kartenwerke (20121231, source)
-- dimensions: &id561
+- dimensions: &id560
     Time:
       default: '20111231'
       values: ['20111231']
   name: ch.swisstopo.zeitreihen_20111231
   sources: [ch.swisstopo.zeitreihen_20111231_cache_out]
   title: Zeitreise - Kartenwerke (20111231)
-- dimensions: *id561
+- dimensions: *id560
   name: ch.swisstopo.zeitreihen_20111231_source
   sources: [ch.swisstopo.zeitreihen_20111231_cache]
   title: Zeitreise - Kartenwerke (20111231, source)
-- dimensions: &id562
+- dimensions: &id561
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.zeitreihen_20101231
   sources: [ch.swisstopo.zeitreihen_20101231_cache_out]
   title: Zeitreise - Kartenwerke (20101231)
-- dimensions: *id562
+- dimensions: *id561
   name: ch.swisstopo.zeitreihen_20101231_source
   sources: [ch.swisstopo.zeitreihen_20101231_cache]
   title: Zeitreise - Kartenwerke (20101231, source)
-- dimensions: &id563
+- dimensions: &id562
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.zeitreihen_20091231
   sources: [ch.swisstopo.zeitreihen_20091231_cache_out]
   title: Zeitreise - Kartenwerke (20091231)
-- dimensions: *id563
+- dimensions: *id562
   name: ch.swisstopo.zeitreihen_20091231_source
   sources: [ch.swisstopo.zeitreihen_20091231_cache]
   title: Zeitreise - Kartenwerke (20091231, source)
-- dimensions: &id564
+- dimensions: &id563
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.zeitreihen_20081231
   sources: [ch.swisstopo.zeitreihen_20081231_cache_out]
   title: Zeitreise - Kartenwerke (20081231)
-- dimensions: *id564
+- dimensions: *id563
   name: ch.swisstopo.zeitreihen_20081231_source
   sources: [ch.swisstopo.zeitreihen_20081231_cache]
   title: Zeitreise - Kartenwerke (20081231, source)
-- dimensions: &id565
+- dimensions: &id564
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.zeitreihen_20071231
   sources: [ch.swisstopo.zeitreihen_20071231_cache_out]
   title: Zeitreise - Kartenwerke (20071231)
-- dimensions: *id565
+- dimensions: *id564
   name: ch.swisstopo.zeitreihen_20071231_source
   sources: [ch.swisstopo.zeitreihen_20071231_cache]
   title: Zeitreise - Kartenwerke (20071231, source)
-- dimensions: &id566
+- dimensions: &id565
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.zeitreihen_20061231
   sources: [ch.swisstopo.zeitreihen_20061231_cache_out]
   title: Zeitreise - Kartenwerke (20061231)
-- dimensions: *id566
+- dimensions: *id565
   name: ch.swisstopo.zeitreihen_20061231_source
   sources: [ch.swisstopo.zeitreihen_20061231_cache]
   title: Zeitreise - Kartenwerke (20061231, source)
-- dimensions: &id567
+- dimensions: &id566
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.zeitreihen_20051231
   sources: [ch.swisstopo.zeitreihen_20051231_cache_out]
   title: Zeitreise - Kartenwerke (20051231)
-- dimensions: *id567
+- dimensions: *id566
   name: ch.swisstopo.zeitreihen_20051231_source
   sources: [ch.swisstopo.zeitreihen_20051231_cache]
   title: Zeitreise - Kartenwerke (20051231, source)
-- dimensions: &id568
+- dimensions: &id567
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.zeitreihen_20041231
   sources: [ch.swisstopo.zeitreihen_20041231_cache_out]
   title: Zeitreise - Kartenwerke (20041231)
-- dimensions: *id568
+- dimensions: *id567
   name: ch.swisstopo.zeitreihen_20041231_source
   sources: [ch.swisstopo.zeitreihen_20041231_cache]
   title: Zeitreise - Kartenwerke (20041231, source)
-- dimensions: &id569
+- dimensions: &id568
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.zeitreihen_20031231
   sources: [ch.swisstopo.zeitreihen_20031231_cache_out]
   title: Zeitreise - Kartenwerke (20031231)
-- dimensions: *id569
+- dimensions: *id568
   name: ch.swisstopo.zeitreihen_20031231_source
   sources: [ch.swisstopo.zeitreihen_20031231_cache]
   title: Zeitreise - Kartenwerke (20031231, source)
-- dimensions: &id570
+- dimensions: &id569
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.zeitreihen_20021231
   sources: [ch.swisstopo.zeitreihen_20021231_cache_out]
   title: Zeitreise - Kartenwerke (20021231)
-- dimensions: *id570
+- dimensions: *id569
   name: ch.swisstopo.zeitreihen_20021231_source
   sources: [ch.swisstopo.zeitreihen_20021231_cache]
   title: Zeitreise - Kartenwerke (20021231, source)
-- dimensions: &id571
+- dimensions: &id570
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.zeitreihen_20011231
   sources: [ch.swisstopo.zeitreihen_20011231_cache_out]
   title: Zeitreise - Kartenwerke (20011231)
-- dimensions: *id571
+- dimensions: *id570
   name: ch.swisstopo.zeitreihen_20011231_source
   sources: [ch.swisstopo.zeitreihen_20011231_cache]
   title: Zeitreise - Kartenwerke (20011231, source)
-- dimensions: &id572
+- dimensions: &id571
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.zeitreihen_20001231
   sources: [ch.swisstopo.zeitreihen_20001231_cache_out]
   title: Zeitreise - Kartenwerke (20001231)
-- dimensions: *id572
+- dimensions: *id571
   name: ch.swisstopo.zeitreihen_20001231_source
   sources: [ch.swisstopo.zeitreihen_20001231_cache]
   title: Zeitreise - Kartenwerke (20001231, source)
-- dimensions: &id573
+- dimensions: &id572
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.zeitreihen_19991231
   sources: [ch.swisstopo.zeitreihen_19991231_cache_out]
   title: Zeitreise - Kartenwerke (19991231)
-- dimensions: *id573
+- dimensions: *id572
   name: ch.swisstopo.zeitreihen_19991231_source
   sources: [ch.swisstopo.zeitreihen_19991231_cache]
   title: Zeitreise - Kartenwerke (19991231, source)
-- dimensions: &id574
+- dimensions: &id573
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.zeitreihen_19981231
   sources: [ch.swisstopo.zeitreihen_19981231_cache_out]
   title: Zeitreise - Kartenwerke (19981231)
-- dimensions: *id574
+- dimensions: *id573
   name: ch.swisstopo.zeitreihen_19981231_source
   sources: [ch.swisstopo.zeitreihen_19981231_cache]
   title: Zeitreise - Kartenwerke (19981231, source)
-- dimensions: &id575
+- dimensions: &id574
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.zeitreihen_19971231
   sources: [ch.swisstopo.zeitreihen_19971231_cache_out]
   title: Zeitreise - Kartenwerke (19971231)
-- dimensions: *id575
+- dimensions: *id574
   name: ch.swisstopo.zeitreihen_19971231_source
   sources: [ch.swisstopo.zeitreihen_19971231_cache]
   title: Zeitreise - Kartenwerke (19971231, source)
-- dimensions: &id576
+- dimensions: &id575
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.zeitreihen_19961231
   sources: [ch.swisstopo.zeitreihen_19961231_cache_out]
   title: Zeitreise - Kartenwerke (19961231)
-- dimensions: *id576
+- dimensions: *id575
   name: ch.swisstopo.zeitreihen_19961231_source
   sources: [ch.swisstopo.zeitreihen_19961231_cache]
   title: Zeitreise - Kartenwerke (19961231, source)
-- dimensions: &id577
+- dimensions: &id576
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.zeitreihen_19951231
   sources: [ch.swisstopo.zeitreihen_19951231_cache_out]
   title: Zeitreise - Kartenwerke (19951231)
-- dimensions: *id577
+- dimensions: *id576
   name: ch.swisstopo.zeitreihen_19951231_source
   sources: [ch.swisstopo.zeitreihen_19951231_cache]
   title: Zeitreise - Kartenwerke (19951231, source)
-- dimensions: &id578
+- dimensions: &id577
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.zeitreihen_19941231
   sources: [ch.swisstopo.zeitreihen_19941231_cache_out]
   title: Zeitreise - Kartenwerke (19941231)
-- dimensions: *id578
+- dimensions: *id577
   name: ch.swisstopo.zeitreihen_19941231_source
   sources: [ch.swisstopo.zeitreihen_19941231_cache]
   title: Zeitreise - Kartenwerke (19941231, source)
-- dimensions: &id579
+- dimensions: &id578
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.zeitreihen_19931231
   sources: [ch.swisstopo.zeitreihen_19931231_cache_out]
   title: Zeitreise - Kartenwerke (19931231)
-- dimensions: *id579
+- dimensions: *id578
   name: ch.swisstopo.zeitreihen_19931231_source
   sources: [ch.swisstopo.zeitreihen_19931231_cache]
   title: Zeitreise - Kartenwerke (19931231, source)
-- dimensions: &id580
+- dimensions: &id579
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.zeitreihen_19921231
   sources: [ch.swisstopo.zeitreihen_19921231_cache_out]
   title: Zeitreise - Kartenwerke (19921231)
-- dimensions: *id580
+- dimensions: *id579
   name: ch.swisstopo.zeitreihen_19921231_source
   sources: [ch.swisstopo.zeitreihen_19921231_cache]
   title: Zeitreise - Kartenwerke (19921231, source)
-- dimensions: &id581
+- dimensions: &id580
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.zeitreihen_19911231
   sources: [ch.swisstopo.zeitreihen_19911231_cache_out]
   title: Zeitreise - Kartenwerke (19911231)
-- dimensions: *id581
+- dimensions: *id580
   name: ch.swisstopo.zeitreihen_19911231_source
   sources: [ch.swisstopo.zeitreihen_19911231_cache]
   title: Zeitreise - Kartenwerke (19911231, source)
-- dimensions: &id582
+- dimensions: &id581
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.zeitreihen_19901231
   sources: [ch.swisstopo.zeitreihen_19901231_cache_out]
   title: Zeitreise - Kartenwerke (19901231)
-- dimensions: *id582
+- dimensions: *id581
   name: ch.swisstopo.zeitreihen_19901231_source
   sources: [ch.swisstopo.zeitreihen_19901231_cache]
   title: Zeitreise - Kartenwerke (19901231, source)
-- dimensions: &id583
+- dimensions: &id582
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.zeitreihen_19891231
   sources: [ch.swisstopo.zeitreihen_19891231_cache_out]
   title: Zeitreise - Kartenwerke (19891231)
-- dimensions: *id583
+- dimensions: *id582
   name: ch.swisstopo.zeitreihen_19891231_source
   sources: [ch.swisstopo.zeitreihen_19891231_cache]
   title: Zeitreise - Kartenwerke (19891231, source)
-- dimensions: &id584
+- dimensions: &id583
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.zeitreihen_19881231
   sources: [ch.swisstopo.zeitreihen_19881231_cache_out]
   title: Zeitreise - Kartenwerke (19881231)
-- dimensions: *id584
+- dimensions: *id583
   name: ch.swisstopo.zeitreihen_19881231_source
   sources: [ch.swisstopo.zeitreihen_19881231_cache]
   title: Zeitreise - Kartenwerke (19881231, source)
-- dimensions: &id585
+- dimensions: &id584
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.zeitreihen_19871231
   sources: [ch.swisstopo.zeitreihen_19871231_cache_out]
   title: Zeitreise - Kartenwerke (19871231)
-- dimensions: *id585
+- dimensions: *id584
   name: ch.swisstopo.zeitreihen_19871231_source
   sources: [ch.swisstopo.zeitreihen_19871231_cache]
   title: Zeitreise - Kartenwerke (19871231, source)
-- dimensions: &id586
+- dimensions: &id585
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.zeitreihen_19861231
   sources: [ch.swisstopo.zeitreihen_19861231_cache_out]
   title: Zeitreise - Kartenwerke (19861231)
-- dimensions: *id586
+- dimensions: *id585
   name: ch.swisstopo.zeitreihen_19861231_source
   sources: [ch.swisstopo.zeitreihen_19861231_cache]
   title: Zeitreise - Kartenwerke (19861231, source)
-- dimensions: &id587
+- dimensions: &id586
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.zeitreihen_19851231
   sources: [ch.swisstopo.zeitreihen_19851231_cache_out]
   title: Zeitreise - Kartenwerke (19851231)
-- dimensions: *id587
+- dimensions: *id586
   name: ch.swisstopo.zeitreihen_19851231_source
   sources: [ch.swisstopo.zeitreihen_19851231_cache]
   title: Zeitreise - Kartenwerke (19851231, source)
-- dimensions: &id588
+- dimensions: &id587
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.zeitreihen_19841231
   sources: [ch.swisstopo.zeitreihen_19841231_cache_out]
   title: Zeitreise - Kartenwerke (19841231)
-- dimensions: *id588
+- dimensions: *id587
   name: ch.swisstopo.zeitreihen_19841231_source
   sources: [ch.swisstopo.zeitreihen_19841231_cache]
   title: Zeitreise - Kartenwerke (19841231, source)
-- dimensions: &id589
+- dimensions: &id588
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.zeitreihen_19831231
   sources: [ch.swisstopo.zeitreihen_19831231_cache_out]
   title: Zeitreise - Kartenwerke (19831231)
-- dimensions: *id589
+- dimensions: *id588
   name: ch.swisstopo.zeitreihen_19831231_source
   sources: [ch.swisstopo.zeitreihen_19831231_cache]
   title: Zeitreise - Kartenwerke (19831231, source)
-- dimensions: &id590
+- dimensions: &id589
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.zeitreihen_19821231
   sources: [ch.swisstopo.zeitreihen_19821231_cache_out]
   title: Zeitreise - Kartenwerke (19821231)
-- dimensions: *id590
+- dimensions: *id589
   name: ch.swisstopo.zeitreihen_19821231_source
   sources: [ch.swisstopo.zeitreihen_19821231_cache]
   title: Zeitreise - Kartenwerke (19821231, source)
-- dimensions: &id591
+- dimensions: &id590
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.zeitreihen_19811231
   sources: [ch.swisstopo.zeitreihen_19811231_cache_out]
   title: Zeitreise - Kartenwerke (19811231)
-- dimensions: *id591
+- dimensions: *id590
   name: ch.swisstopo.zeitreihen_19811231_source
   sources: [ch.swisstopo.zeitreihen_19811231_cache]
   title: Zeitreise - Kartenwerke (19811231, source)
-- dimensions: &id592
+- dimensions: &id591
     Time:
       default: '19801231'
       values: ['19801231']
   name: ch.swisstopo.zeitreihen_19801231
   sources: [ch.swisstopo.zeitreihen_19801231_cache_out]
   title: Zeitreise - Kartenwerke (19801231)
-- dimensions: *id592
+- dimensions: *id591
   name: ch.swisstopo.zeitreihen_19801231_source
   sources: [ch.swisstopo.zeitreihen_19801231_cache]
   title: Zeitreise - Kartenwerke (19801231, source)
-- dimensions: &id593
+- dimensions: &id592
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.zeitreihen_19791231
   sources: [ch.swisstopo.zeitreihen_19791231_cache_out]
   title: Zeitreise - Kartenwerke (19791231)
-- dimensions: *id593
+- dimensions: *id592
   name: ch.swisstopo.zeitreihen_19791231_source
   sources: [ch.swisstopo.zeitreihen_19791231_cache]
   title: Zeitreise - Kartenwerke (19791231, source)
-- dimensions: &id594
+- dimensions: &id593
     Time:
       default: '19781231'
       values: ['19781231']
   name: ch.swisstopo.zeitreihen_19781231
   sources: [ch.swisstopo.zeitreihen_19781231_cache_out]
   title: Zeitreise - Kartenwerke (19781231)
-- dimensions: *id594
+- dimensions: *id593
   name: ch.swisstopo.zeitreihen_19781231_source
   sources: [ch.swisstopo.zeitreihen_19781231_cache]
   title: Zeitreise - Kartenwerke (19781231, source)
-- dimensions: &id595
+- dimensions: &id594
     Time:
       default: '19771231'
       values: ['19771231']
   name: ch.swisstopo.zeitreihen_19771231
   sources: [ch.swisstopo.zeitreihen_19771231_cache_out]
   title: Zeitreise - Kartenwerke (19771231)
-- dimensions: *id595
+- dimensions: *id594
   name: ch.swisstopo.zeitreihen_19771231_source
   sources: [ch.swisstopo.zeitreihen_19771231_cache]
   title: Zeitreise - Kartenwerke (19771231, source)
-- dimensions: &id596
+- dimensions: &id595
     Time:
       default: '19761231'
       values: ['19761231']
   name: ch.swisstopo.zeitreihen_19761231
   sources: [ch.swisstopo.zeitreihen_19761231_cache_out]
   title: Zeitreise - Kartenwerke (19761231)
-- dimensions: *id596
+- dimensions: *id595
   name: ch.swisstopo.zeitreihen_19761231_source
   sources: [ch.swisstopo.zeitreihen_19761231_cache]
   title: Zeitreise - Kartenwerke (19761231, source)
-- dimensions: &id597
+- dimensions: &id596
     Time:
       default: '19751231'
       values: ['19751231']
   name: ch.swisstopo.zeitreihen_19751231
   sources: [ch.swisstopo.zeitreihen_19751231_cache_out]
   title: Zeitreise - Kartenwerke (19751231)
-- dimensions: *id597
+- dimensions: *id596
   name: ch.swisstopo.zeitreihen_19751231_source
   sources: [ch.swisstopo.zeitreihen_19751231_cache]
   title: Zeitreise - Kartenwerke (19751231, source)
-- dimensions: &id598
+- dimensions: &id597
     Time:
       default: '19741231'
       values: ['19741231']
   name: ch.swisstopo.zeitreihen_19741231
   sources: [ch.swisstopo.zeitreihen_19741231_cache_out]
   title: Zeitreise - Kartenwerke (19741231)
-- dimensions: *id598
+- dimensions: *id597
   name: ch.swisstopo.zeitreihen_19741231_source
   sources: [ch.swisstopo.zeitreihen_19741231_cache]
   title: Zeitreise - Kartenwerke (19741231, source)
-- dimensions: &id599
+- dimensions: &id598
     Time:
       default: '19731231'
       values: ['19731231']
   name: ch.swisstopo.zeitreihen_19731231
   sources: [ch.swisstopo.zeitreihen_19731231_cache_out]
   title: Zeitreise - Kartenwerke (19731231)
-- dimensions: *id599
+- dimensions: *id598
   name: ch.swisstopo.zeitreihen_19731231_source
   sources: [ch.swisstopo.zeitreihen_19731231_cache]
   title: Zeitreise - Kartenwerke (19731231, source)
-- dimensions: &id600
+- dimensions: &id599
     Time:
       default: '19721231'
       values: ['19721231']
   name: ch.swisstopo.zeitreihen_19721231
   sources: [ch.swisstopo.zeitreihen_19721231_cache_out]
   title: Zeitreise - Kartenwerke (19721231)
-- dimensions: *id600
+- dimensions: *id599
   name: ch.swisstopo.zeitreihen_19721231_source
   sources: [ch.swisstopo.zeitreihen_19721231_cache]
   title: Zeitreise - Kartenwerke (19721231, source)
-- dimensions: &id601
+- dimensions: &id600
     Time:
       default: '19711231'
       values: ['19711231']
   name: ch.swisstopo.zeitreihen_19711231
   sources: [ch.swisstopo.zeitreihen_19711231_cache_out]
   title: Zeitreise - Kartenwerke (19711231)
-- dimensions: *id601
+- dimensions: *id600
   name: ch.swisstopo.zeitreihen_19711231_source
   sources: [ch.swisstopo.zeitreihen_19711231_cache]
   title: Zeitreise - Kartenwerke (19711231, source)
-- dimensions: &id602
+- dimensions: &id601
     Time:
       default: '19701231'
       values: ['19701231']
   name: ch.swisstopo.zeitreihen_19701231
   sources: [ch.swisstopo.zeitreihen_19701231_cache_out]
   title: Zeitreise - Kartenwerke (19701231)
-- dimensions: *id602
+- dimensions: *id601
   name: ch.swisstopo.zeitreihen_19701231_source
   sources: [ch.swisstopo.zeitreihen_19701231_cache]
   title: Zeitreise - Kartenwerke (19701231, source)
-- dimensions: &id603
+- dimensions: &id602
     Time:
       default: '19691231'
       values: ['19691231']
   name: ch.swisstopo.zeitreihen_19691231
   sources: [ch.swisstopo.zeitreihen_19691231_cache_out]
   title: Zeitreise - Kartenwerke (19691231)
-- dimensions: *id603
+- dimensions: *id602
   name: ch.swisstopo.zeitreihen_19691231_source
   sources: [ch.swisstopo.zeitreihen_19691231_cache]
   title: Zeitreise - Kartenwerke (19691231, source)
-- dimensions: &id604
+- dimensions: &id603
     Time:
       default: '19681231'
       values: ['19681231']
   name: ch.swisstopo.zeitreihen_19681231
   sources: [ch.swisstopo.zeitreihen_19681231_cache_out]
   title: Zeitreise - Kartenwerke (19681231)
-- dimensions: *id604
+- dimensions: *id603
   name: ch.swisstopo.zeitreihen_19681231_source
   sources: [ch.swisstopo.zeitreihen_19681231_cache]
   title: Zeitreise - Kartenwerke (19681231, source)
-- dimensions: &id605
+- dimensions: &id604
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.zeitreihen_19671231
   sources: [ch.swisstopo.zeitreihen_19671231_cache_out]
   title: Zeitreise - Kartenwerke (19671231)
-- dimensions: *id605
+- dimensions: *id604
   name: ch.swisstopo.zeitreihen_19671231_source
   sources: [ch.swisstopo.zeitreihen_19671231_cache]
   title: Zeitreise - Kartenwerke (19671231, source)
-- dimensions: &id606
+- dimensions: &id605
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.zeitreihen_19661231
   sources: [ch.swisstopo.zeitreihen_19661231_cache_out]
   title: Zeitreise - Kartenwerke (19661231)
-- dimensions: *id606
+- dimensions: *id605
   name: ch.swisstopo.zeitreihen_19661231_source
   sources: [ch.swisstopo.zeitreihen_19661231_cache]
   title: Zeitreise - Kartenwerke (19661231, source)
-- dimensions: &id607
+- dimensions: &id606
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.zeitreihen_19651231
   sources: [ch.swisstopo.zeitreihen_19651231_cache_out]
   title: Zeitreise - Kartenwerke (19651231)
-- dimensions: *id607
+- dimensions: *id606
   name: ch.swisstopo.zeitreihen_19651231_source
   sources: [ch.swisstopo.zeitreihen_19651231_cache]
   title: Zeitreise - Kartenwerke (19651231, source)
-- dimensions: &id608
+- dimensions: &id607
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.zeitreihen_19641231
   sources: [ch.swisstopo.zeitreihen_19641231_cache_out]
   title: Zeitreise - Kartenwerke (19641231)
-- dimensions: *id608
+- dimensions: *id607
   name: ch.swisstopo.zeitreihen_19641231_source
   sources: [ch.swisstopo.zeitreihen_19641231_cache]
   title: Zeitreise - Kartenwerke (19641231, source)
-- dimensions: &id609
+- dimensions: &id608
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.zeitreihen_19631231
   sources: [ch.swisstopo.zeitreihen_19631231_cache_out]
   title: Zeitreise - Kartenwerke (19631231)
-- dimensions: *id609
+- dimensions: *id608
   name: ch.swisstopo.zeitreihen_19631231_source
   sources: [ch.swisstopo.zeitreihen_19631231_cache]
   title: Zeitreise - Kartenwerke (19631231, source)
-- dimensions: &id610
+- dimensions: &id609
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.zeitreihen_19621231
   sources: [ch.swisstopo.zeitreihen_19621231_cache_out]
   title: Zeitreise - Kartenwerke (19621231)
-- dimensions: *id610
+- dimensions: *id609
   name: ch.swisstopo.zeitreihen_19621231_source
   sources: [ch.swisstopo.zeitreihen_19621231_cache]
   title: Zeitreise - Kartenwerke (19621231, source)
-- dimensions: &id611
+- dimensions: &id610
     Time:
       default: '19611231'
       values: ['19611231']
   name: ch.swisstopo.zeitreihen_19611231
   sources: [ch.swisstopo.zeitreihen_19611231_cache_out]
   title: Zeitreise - Kartenwerke (19611231)
-- dimensions: *id611
+- dimensions: *id610
   name: ch.swisstopo.zeitreihen_19611231_source
   sources: [ch.swisstopo.zeitreihen_19611231_cache]
   title: Zeitreise - Kartenwerke (19611231, source)
-- dimensions: &id612
+- dimensions: &id611
     Time:
       default: '19601231'
       values: ['19601231']
   name: ch.swisstopo.zeitreihen_19601231
   sources: [ch.swisstopo.zeitreihen_19601231_cache_out]
   title: Zeitreise - Kartenwerke (19601231)
-- dimensions: *id612
+- dimensions: *id611
   name: ch.swisstopo.zeitreihen_19601231_source
   sources: [ch.swisstopo.zeitreihen_19601231_cache]
   title: Zeitreise - Kartenwerke (19601231, source)
-- dimensions: &id613
+- dimensions: &id612
     Time:
       default: '19591231'
       values: ['19591231']
   name: ch.swisstopo.zeitreihen_19591231
   sources: [ch.swisstopo.zeitreihen_19591231_cache_out]
   title: Zeitreise - Kartenwerke (19591231)
-- dimensions: *id613
+- dimensions: *id612
   name: ch.swisstopo.zeitreihen_19591231_source
   sources: [ch.swisstopo.zeitreihen_19591231_cache]
   title: Zeitreise - Kartenwerke (19591231, source)
-- dimensions: &id614
+- dimensions: &id613
     Time:
       default: '19581231'
       values: ['19581231']
   name: ch.swisstopo.zeitreihen_19581231
   sources: [ch.swisstopo.zeitreihen_19581231_cache_out]
   title: Zeitreise - Kartenwerke (19581231)
-- dimensions: *id614
+- dimensions: *id613
   name: ch.swisstopo.zeitreihen_19581231_source
   sources: [ch.swisstopo.zeitreihen_19581231_cache]
   title: Zeitreise - Kartenwerke (19581231, source)
-- dimensions: &id615
+- dimensions: &id614
     Time:
       default: '19571231'
       values: ['19571231']
   name: ch.swisstopo.zeitreihen_19571231
   sources: [ch.swisstopo.zeitreihen_19571231_cache_out]
   title: Zeitreise - Kartenwerke (19571231)
-- dimensions: *id615
+- dimensions: *id614
   name: ch.swisstopo.zeitreihen_19571231_source
   sources: [ch.swisstopo.zeitreihen_19571231_cache]
   title: Zeitreise - Kartenwerke (19571231, source)
-- dimensions: &id616
+- dimensions: &id615
     Time:
       default: '19561231'
       values: ['19561231']
   name: ch.swisstopo.zeitreihen_19561231
   sources: [ch.swisstopo.zeitreihen_19561231_cache_out]
   title: Zeitreise - Kartenwerke (19561231)
-- dimensions: *id616
+- dimensions: *id615
   name: ch.swisstopo.zeitreihen_19561231_source
   sources: [ch.swisstopo.zeitreihen_19561231_cache]
   title: Zeitreise - Kartenwerke (19561231, source)
-- dimensions: &id617
+- dimensions: &id616
     Time:
       default: '19551231'
       values: ['19551231']
   name: ch.swisstopo.zeitreihen_19551231
   sources: [ch.swisstopo.zeitreihen_19551231_cache_out]
   title: Zeitreise - Kartenwerke (19551231)
-- dimensions: *id617
+- dimensions: *id616
   name: ch.swisstopo.zeitreihen_19551231_source
   sources: [ch.swisstopo.zeitreihen_19551231_cache]
   title: Zeitreise - Kartenwerke (19551231, source)
-- dimensions: &id618
+- dimensions: &id617
     Time:
       default: '19541231'
       values: ['19541231']
   name: ch.swisstopo.zeitreihen_19541231
   sources: [ch.swisstopo.zeitreihen_19541231_cache_out]
   title: Zeitreise - Kartenwerke (19541231)
-- dimensions: *id618
+- dimensions: *id617
   name: ch.swisstopo.zeitreihen_19541231_source
   sources: [ch.swisstopo.zeitreihen_19541231_cache]
   title: Zeitreise - Kartenwerke (19541231, source)
-- dimensions: &id619
+- dimensions: &id618
     Time:
       default: '19531231'
       values: ['19531231']
   name: ch.swisstopo.zeitreihen_19531231
   sources: [ch.swisstopo.zeitreihen_19531231_cache_out]
   title: Zeitreise - Kartenwerke (19531231)
-- dimensions: *id619
+- dimensions: *id618
   name: ch.swisstopo.zeitreihen_19531231_source
   sources: [ch.swisstopo.zeitreihen_19531231_cache]
   title: Zeitreise - Kartenwerke (19531231, source)
-- dimensions: &id620
+- dimensions: &id619
     Time:
       default: '19521231'
       values: ['19521231']
   name: ch.swisstopo.zeitreihen_19521231
   sources: [ch.swisstopo.zeitreihen_19521231_cache_out]
   title: Zeitreise - Kartenwerke (19521231)
-- dimensions: *id620
+- dimensions: *id619
   name: ch.swisstopo.zeitreihen_19521231_source
   sources: [ch.swisstopo.zeitreihen_19521231_cache]
   title: Zeitreise - Kartenwerke (19521231, source)
-- dimensions: &id621
+- dimensions: &id620
     Time:
       default: '19511231'
       values: ['19511231']
   name: ch.swisstopo.zeitreihen_19511231
   sources: [ch.swisstopo.zeitreihen_19511231_cache_out]
   title: Zeitreise - Kartenwerke (19511231)
-- dimensions: *id621
+- dimensions: *id620
   name: ch.swisstopo.zeitreihen_19511231_source
   sources: [ch.swisstopo.zeitreihen_19511231_cache]
   title: Zeitreise - Kartenwerke (19511231, source)
-- dimensions: &id622
+- dimensions: &id621
     Time:
       default: '19501231'
       values: ['19501231']
   name: ch.swisstopo.zeitreihen_19501231
   sources: [ch.swisstopo.zeitreihen_19501231_cache_out]
   title: Zeitreise - Kartenwerke (19501231)
-- dimensions: *id622
+- dimensions: *id621
   name: ch.swisstopo.zeitreihen_19501231_source
   sources: [ch.swisstopo.zeitreihen_19501231_cache]
   title: Zeitreise - Kartenwerke (19501231, source)
-- dimensions: &id623
+- dimensions: &id622
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.zeitreihen_19491231
   sources: [ch.swisstopo.zeitreihen_19491231_cache_out]
   title: Zeitreise - Kartenwerke (19491231)
-- dimensions: *id623
+- dimensions: *id622
   name: ch.swisstopo.zeitreihen_19491231_source
   sources: [ch.swisstopo.zeitreihen_19491231_cache]
   title: Zeitreise - Kartenwerke (19491231, source)
-- dimensions: &id624
+- dimensions: &id623
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.zeitreihen_19481231
   sources: [ch.swisstopo.zeitreihen_19481231_cache_out]
   title: Zeitreise - Kartenwerke (19481231)
-- dimensions: *id624
+- dimensions: *id623
   name: ch.swisstopo.zeitreihen_19481231_source
   sources: [ch.swisstopo.zeitreihen_19481231_cache]
   title: Zeitreise - Kartenwerke (19481231, source)
-- dimensions: &id625
+- dimensions: &id624
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.zeitreihen_19471231
   sources: [ch.swisstopo.zeitreihen_19471231_cache_out]
   title: Zeitreise - Kartenwerke (19471231)
-- dimensions: *id625
+- dimensions: *id624
   name: ch.swisstopo.zeitreihen_19471231_source
   sources: [ch.swisstopo.zeitreihen_19471231_cache]
   title: Zeitreise - Kartenwerke (19471231, source)
-- dimensions: &id626
+- dimensions: &id625
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.zeitreihen_19461231
   sources: [ch.swisstopo.zeitreihen_19461231_cache_out]
   title: Zeitreise - Kartenwerke (19461231)
-- dimensions: *id626
+- dimensions: *id625
   name: ch.swisstopo.zeitreihen_19461231_source
   sources: [ch.swisstopo.zeitreihen_19461231_cache]
   title: Zeitreise - Kartenwerke (19461231, source)
-- dimensions: &id627
+- dimensions: &id626
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.zeitreihen_19451231
   sources: [ch.swisstopo.zeitreihen_19451231_cache_out]
   title: Zeitreise - Kartenwerke (19451231)
-- dimensions: *id627
+- dimensions: *id626
   name: ch.swisstopo.zeitreihen_19451231_source
   sources: [ch.swisstopo.zeitreihen_19451231_cache]
   title: Zeitreise - Kartenwerke (19451231, source)
-- dimensions: &id628
+- dimensions: &id627
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.zeitreihen_19441231
   sources: [ch.swisstopo.zeitreihen_19441231_cache_out]
   title: Zeitreise - Kartenwerke (19441231)
-- dimensions: *id628
+- dimensions: *id627
   name: ch.swisstopo.zeitreihen_19441231_source
   sources: [ch.swisstopo.zeitreihen_19441231_cache]
   title: Zeitreise - Kartenwerke (19441231, source)
-- dimensions: &id629
+- dimensions: &id628
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.zeitreihen_19431231
   sources: [ch.swisstopo.zeitreihen_19431231_cache_out]
   title: Zeitreise - Kartenwerke (19431231)
-- dimensions: *id629
+- dimensions: *id628
   name: ch.swisstopo.zeitreihen_19431231_source
   sources: [ch.swisstopo.zeitreihen_19431231_cache]
   title: Zeitreise - Kartenwerke (19431231, source)
-- dimensions: &id630
+- dimensions: &id629
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.zeitreihen_19421231
   sources: [ch.swisstopo.zeitreihen_19421231_cache_out]
   title: Zeitreise - Kartenwerke (19421231)
-- dimensions: *id630
+- dimensions: *id629
   name: ch.swisstopo.zeitreihen_19421231_source
   sources: [ch.swisstopo.zeitreihen_19421231_cache]
   title: Zeitreise - Kartenwerke (19421231, source)
-- dimensions: &id631
+- dimensions: &id630
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.zeitreihen_19411231
   sources: [ch.swisstopo.zeitreihen_19411231_cache_out]
   title: Zeitreise - Kartenwerke (19411231)
-- dimensions: *id631
+- dimensions: *id630
   name: ch.swisstopo.zeitreihen_19411231_source
   sources: [ch.swisstopo.zeitreihen_19411231_cache]
   title: Zeitreise - Kartenwerke (19411231, source)
-- dimensions: &id632
+- dimensions: &id631
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.zeitreihen_19401231
   sources: [ch.swisstopo.zeitreihen_19401231_cache_out]
   title: Zeitreise - Kartenwerke (19401231)
-- dimensions: *id632
+- dimensions: *id631
   name: ch.swisstopo.zeitreihen_19401231_source
   sources: [ch.swisstopo.zeitreihen_19401231_cache]
   title: Zeitreise - Kartenwerke (19401231, source)
-- dimensions: &id633
+- dimensions: &id632
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.zeitreihen_19391231
   sources: [ch.swisstopo.zeitreihen_19391231_cache_out]
   title: Zeitreise - Kartenwerke (19391231)
-- dimensions: *id633
+- dimensions: *id632
   name: ch.swisstopo.zeitreihen_19391231_source
   sources: [ch.swisstopo.zeitreihen_19391231_cache]
   title: Zeitreise - Kartenwerke (19391231, source)
-- dimensions: &id634
+- dimensions: &id633
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.zeitreihen_19381231
   sources: [ch.swisstopo.zeitreihen_19381231_cache_out]
   title: Zeitreise - Kartenwerke (19381231)
-- dimensions: *id634
+- dimensions: *id633
   name: ch.swisstopo.zeitreihen_19381231_source
   sources: [ch.swisstopo.zeitreihen_19381231_cache]
   title: Zeitreise - Kartenwerke (19381231, source)
-- dimensions: &id635
+- dimensions: &id634
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.zeitreihen_19371231
   sources: [ch.swisstopo.zeitreihen_19371231_cache_out]
   title: Zeitreise - Kartenwerke (19371231)
-- dimensions: *id635
+- dimensions: *id634
   name: ch.swisstopo.zeitreihen_19371231_source
   sources: [ch.swisstopo.zeitreihen_19371231_cache]
   title: Zeitreise - Kartenwerke (19371231, source)
-- dimensions: &id636
+- dimensions: &id635
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.zeitreihen_19361231
   sources: [ch.swisstopo.zeitreihen_19361231_cache_out]
   title: Zeitreise - Kartenwerke (19361231)
-- dimensions: *id636
+- dimensions: *id635
   name: ch.swisstopo.zeitreihen_19361231_source
   sources: [ch.swisstopo.zeitreihen_19361231_cache]
   title: Zeitreise - Kartenwerke (19361231, source)
-- dimensions: &id637
+- dimensions: &id636
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.zeitreihen_19351231
   sources: [ch.swisstopo.zeitreihen_19351231_cache_out]
   title: Zeitreise - Kartenwerke (19351231)
-- dimensions: *id637
+- dimensions: *id636
   name: ch.swisstopo.zeitreihen_19351231_source
   sources: [ch.swisstopo.zeitreihen_19351231_cache]
   title: Zeitreise - Kartenwerke (19351231, source)
-- dimensions: &id638
+- dimensions: &id637
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.zeitreihen_19341231
   sources: [ch.swisstopo.zeitreihen_19341231_cache_out]
   title: Zeitreise - Kartenwerke (19341231)
-- dimensions: *id638
+- dimensions: *id637
   name: ch.swisstopo.zeitreihen_19341231_source
   sources: [ch.swisstopo.zeitreihen_19341231_cache]
   title: Zeitreise - Kartenwerke (19341231, source)
-- dimensions: &id639
+- dimensions: &id638
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.zeitreihen_19331231
   sources: [ch.swisstopo.zeitreihen_19331231_cache_out]
   title: Zeitreise - Kartenwerke (19331231)
-- dimensions: *id639
+- dimensions: *id638
   name: ch.swisstopo.zeitreihen_19331231_source
   sources: [ch.swisstopo.zeitreihen_19331231_cache]
   title: Zeitreise - Kartenwerke (19331231, source)
-- dimensions: &id640
+- dimensions: &id639
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.zeitreihen_19321231
   sources: [ch.swisstopo.zeitreihen_19321231_cache_out]
   title: Zeitreise - Kartenwerke (19321231)
-- dimensions: *id640
+- dimensions: *id639
   name: ch.swisstopo.zeitreihen_19321231_source
   sources: [ch.swisstopo.zeitreihen_19321231_cache]
   title: Zeitreise - Kartenwerke (19321231, source)
-- dimensions: &id641
+- dimensions: &id640
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.zeitreihen_19311231
   sources: [ch.swisstopo.zeitreihen_19311231_cache_out]
   title: Zeitreise - Kartenwerke (19311231)
-- dimensions: *id641
+- dimensions: *id640
   name: ch.swisstopo.zeitreihen_19311231_source
   sources: [ch.swisstopo.zeitreihen_19311231_cache]
   title: Zeitreise - Kartenwerke (19311231, source)
-- dimensions: &id642
+- dimensions: &id641
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.zeitreihen_19301231
   sources: [ch.swisstopo.zeitreihen_19301231_cache_out]
   title: Zeitreise - Kartenwerke (19301231)
-- dimensions: *id642
+- dimensions: *id641
   name: ch.swisstopo.zeitreihen_19301231_source
   sources: [ch.swisstopo.zeitreihen_19301231_cache]
   title: Zeitreise - Kartenwerke (19301231, source)
-- dimensions: &id643
+- dimensions: &id642
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.zeitreihen_19291231
   sources: [ch.swisstopo.zeitreihen_19291231_cache_out]
   title: Zeitreise - Kartenwerke (19291231)
-- dimensions: *id643
+- dimensions: *id642
   name: ch.swisstopo.zeitreihen_19291231_source
   sources: [ch.swisstopo.zeitreihen_19291231_cache]
   title: Zeitreise - Kartenwerke (19291231, source)
-- dimensions: &id644
+- dimensions: &id643
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.zeitreihen_19281231
   sources: [ch.swisstopo.zeitreihen_19281231_cache_out]
   title: Zeitreise - Kartenwerke (19281231)
-- dimensions: *id644
+- dimensions: *id643
   name: ch.swisstopo.zeitreihen_19281231_source
   sources: [ch.swisstopo.zeitreihen_19281231_cache]
   title: Zeitreise - Kartenwerke (19281231, source)
-- dimensions: &id645
+- dimensions: &id644
     Time:
       default: '19271231'
       values: ['19271231']
   name: ch.swisstopo.zeitreihen_19271231
   sources: [ch.swisstopo.zeitreihen_19271231_cache_out]
   title: Zeitreise - Kartenwerke (19271231)
-- dimensions: *id645
+- dimensions: *id644
   name: ch.swisstopo.zeitreihen_19271231_source
   sources: [ch.swisstopo.zeitreihen_19271231_cache]
   title: Zeitreise - Kartenwerke (19271231, source)
-- dimensions: &id646
+- dimensions: &id645
     Time:
       default: '19261231'
       values: ['19261231']
   name: ch.swisstopo.zeitreihen_19261231
   sources: [ch.swisstopo.zeitreihen_19261231_cache_out]
   title: Zeitreise - Kartenwerke (19261231)
-- dimensions: *id646
+- dimensions: *id645
   name: ch.swisstopo.zeitreihen_19261231_source
   sources: [ch.swisstopo.zeitreihen_19261231_cache]
   title: Zeitreise - Kartenwerke (19261231, source)
-- dimensions: &id647
+- dimensions: &id646
     Time:
       default: '19251231'
       values: ['19251231']
   name: ch.swisstopo.zeitreihen_19251231
   sources: [ch.swisstopo.zeitreihen_19251231_cache_out]
   title: Zeitreise - Kartenwerke (19251231)
-- dimensions: *id647
+- dimensions: *id646
   name: ch.swisstopo.zeitreihen_19251231_source
   sources: [ch.swisstopo.zeitreihen_19251231_cache]
   title: Zeitreise - Kartenwerke (19251231, source)
-- dimensions: &id648
+- dimensions: &id647
     Time:
       default: '19241231'
       values: ['19241231']
   name: ch.swisstopo.zeitreihen_19241231
   sources: [ch.swisstopo.zeitreihen_19241231_cache_out]
   title: Zeitreise - Kartenwerke (19241231)
-- dimensions: *id648
+- dimensions: *id647
   name: ch.swisstopo.zeitreihen_19241231_source
   sources: [ch.swisstopo.zeitreihen_19241231_cache]
   title: Zeitreise - Kartenwerke (19241231, source)
-- dimensions: &id649
+- dimensions: &id648
     Time:
       default: '19231231'
       values: ['19231231']
   name: ch.swisstopo.zeitreihen_19231231
   sources: [ch.swisstopo.zeitreihen_19231231_cache_out]
   title: Zeitreise - Kartenwerke (19231231)
-- dimensions: *id649
+- dimensions: *id648
   name: ch.swisstopo.zeitreihen_19231231_source
   sources: [ch.swisstopo.zeitreihen_19231231_cache]
   title: Zeitreise - Kartenwerke (19231231, source)
-- dimensions: &id650
+- dimensions: &id649
     Time:
       default: '19221231'
       values: ['19221231']
   name: ch.swisstopo.zeitreihen_19221231
   sources: [ch.swisstopo.zeitreihen_19221231_cache_out]
   title: Zeitreise - Kartenwerke (19221231)
-- dimensions: *id650
+- dimensions: *id649
   name: ch.swisstopo.zeitreihen_19221231_source
   sources: [ch.swisstopo.zeitreihen_19221231_cache]
   title: Zeitreise - Kartenwerke (19221231, source)
-- dimensions: &id651
+- dimensions: &id650
     Time:
       default: '19211231'
       values: ['19211231']
   name: ch.swisstopo.zeitreihen_19211231
   sources: [ch.swisstopo.zeitreihen_19211231_cache_out]
   title: Zeitreise - Kartenwerke (19211231)
-- dimensions: *id651
+- dimensions: *id650
   name: ch.swisstopo.zeitreihen_19211231_source
   sources: [ch.swisstopo.zeitreihen_19211231_cache]
   title: Zeitreise - Kartenwerke (19211231, source)
-- dimensions: &id652
+- dimensions: &id651
     Time:
       default: '19201231'
       values: ['19201231']
   name: ch.swisstopo.zeitreihen_19201231
   sources: [ch.swisstopo.zeitreihen_19201231_cache_out]
   title: Zeitreise - Kartenwerke (19201231)
-- dimensions: *id652
+- dimensions: *id651
   name: ch.swisstopo.zeitreihen_19201231_source
   sources: [ch.swisstopo.zeitreihen_19201231_cache]
   title: Zeitreise - Kartenwerke (19201231, source)
-- dimensions: &id653
+- dimensions: &id652
     Time:
       default: '19191231'
       values: ['19191231']
   name: ch.swisstopo.zeitreihen_19191231
   sources: [ch.swisstopo.zeitreihen_19191231_cache_out]
   title: Zeitreise - Kartenwerke (19191231)
-- dimensions: *id653
+- dimensions: *id652
   name: ch.swisstopo.zeitreihen_19191231_source
   sources: [ch.swisstopo.zeitreihen_19191231_cache]
   title: Zeitreise - Kartenwerke (19191231, source)
-- dimensions: &id654
+- dimensions: &id653
     Time:
       default: '19181231'
       values: ['19181231']
   name: ch.swisstopo.zeitreihen_19181231
   sources: [ch.swisstopo.zeitreihen_19181231_cache_out]
   title: Zeitreise - Kartenwerke (19181231)
-- dimensions: *id654
+- dimensions: *id653
   name: ch.swisstopo.zeitreihen_19181231_source
   sources: [ch.swisstopo.zeitreihen_19181231_cache]
   title: Zeitreise - Kartenwerke (19181231, source)
-- dimensions: &id655
+- dimensions: &id654
     Time:
       default: '19171231'
       values: ['19171231']
   name: ch.swisstopo.zeitreihen_19171231
   sources: [ch.swisstopo.zeitreihen_19171231_cache_out]
   title: Zeitreise - Kartenwerke (19171231)
-- dimensions: *id655
+- dimensions: *id654
   name: ch.swisstopo.zeitreihen_19171231_source
   sources: [ch.swisstopo.zeitreihen_19171231_cache]
   title: Zeitreise - Kartenwerke (19171231, source)
-- dimensions: &id656
+- dimensions: &id655
     Time:
       default: '19161231'
       values: ['19161231']
   name: ch.swisstopo.zeitreihen_19161231
   sources: [ch.swisstopo.zeitreihen_19161231_cache_out]
   title: Zeitreise - Kartenwerke (19161231)
-- dimensions: *id656
+- dimensions: *id655
   name: ch.swisstopo.zeitreihen_19161231_source
   sources: [ch.swisstopo.zeitreihen_19161231_cache]
   title: Zeitreise - Kartenwerke (19161231, source)
-- dimensions: &id657
+- dimensions: &id656
     Time:
       default: '19151231'
       values: ['19151231']
   name: ch.swisstopo.zeitreihen_19151231
   sources: [ch.swisstopo.zeitreihen_19151231_cache_out]
   title: Zeitreise - Kartenwerke (19151231)
-- dimensions: *id657
+- dimensions: *id656
   name: ch.swisstopo.zeitreihen_19151231_source
   sources: [ch.swisstopo.zeitreihen_19151231_cache]
   title: Zeitreise - Kartenwerke (19151231, source)
-- dimensions: &id658
+- dimensions: &id657
     Time:
       default: '19141231'
       values: ['19141231']
   name: ch.swisstopo.zeitreihen_19141231
   sources: [ch.swisstopo.zeitreihen_19141231_cache_out]
   title: Zeitreise - Kartenwerke (19141231)
-- dimensions: *id658
+- dimensions: *id657
   name: ch.swisstopo.zeitreihen_19141231_source
   sources: [ch.swisstopo.zeitreihen_19141231_cache]
   title: Zeitreise - Kartenwerke (19141231, source)
-- dimensions: &id659
+- dimensions: &id658
     Time:
       default: '19131231'
       values: ['19131231']
   name: ch.swisstopo.zeitreihen_19131231
   sources: [ch.swisstopo.zeitreihen_19131231_cache_out]
   title: Zeitreise - Kartenwerke (19131231)
-- dimensions: *id659
+- dimensions: *id658
   name: ch.swisstopo.zeitreihen_19131231_source
   sources: [ch.swisstopo.zeitreihen_19131231_cache]
   title: Zeitreise - Kartenwerke (19131231, source)
-- dimensions: &id660
+- dimensions: &id659
     Time:
       default: '19121231'
       values: ['19121231']
   name: ch.swisstopo.zeitreihen_19121231
   sources: [ch.swisstopo.zeitreihen_19121231_cache_out]
   title: Zeitreise - Kartenwerke (19121231)
-- dimensions: *id660
+- dimensions: *id659
   name: ch.swisstopo.zeitreihen_19121231_source
   sources: [ch.swisstopo.zeitreihen_19121231_cache]
   title: Zeitreise - Kartenwerke (19121231, source)
-- dimensions: &id661
+- dimensions: &id660
     Time:
       default: '19111231'
       values: ['19111231']
   name: ch.swisstopo.zeitreihen_19111231
   sources: [ch.swisstopo.zeitreihen_19111231_cache_out]
   title: Zeitreise - Kartenwerke (19111231)
-- dimensions: *id661
+- dimensions: *id660
   name: ch.swisstopo.zeitreihen_19111231_source
   sources: [ch.swisstopo.zeitreihen_19111231_cache]
   title: Zeitreise - Kartenwerke (19111231, source)
-- dimensions: &id662
+- dimensions: &id661
     Time:
       default: '19101231'
       values: ['19101231']
   name: ch.swisstopo.zeitreihen_19101231
   sources: [ch.swisstopo.zeitreihen_19101231_cache_out]
   title: Zeitreise - Kartenwerke (19101231)
-- dimensions: *id662
+- dimensions: *id661
   name: ch.swisstopo.zeitreihen_19101231_source
   sources: [ch.swisstopo.zeitreihen_19101231_cache]
   title: Zeitreise - Kartenwerke (19101231, source)
-- dimensions: &id663
+- dimensions: &id662
     Time:
       default: '19091231'
       values: ['19091231']
   name: ch.swisstopo.zeitreihen_19091231
   sources: [ch.swisstopo.zeitreihen_19091231_cache_out]
   title: Zeitreise - Kartenwerke (19091231)
-- dimensions: *id663
+- dimensions: *id662
   name: ch.swisstopo.zeitreihen_19091231_source
   sources: [ch.swisstopo.zeitreihen_19091231_cache]
   title: Zeitreise - Kartenwerke (19091231, source)
-- dimensions: &id664
+- dimensions: &id663
     Time:
       default: '19081231'
       values: ['19081231']
   name: ch.swisstopo.zeitreihen_19081231
   sources: [ch.swisstopo.zeitreihen_19081231_cache_out]
   title: Zeitreise - Kartenwerke (19081231)
-- dimensions: *id664
+- dimensions: *id663
   name: ch.swisstopo.zeitreihen_19081231_source
   sources: [ch.swisstopo.zeitreihen_19081231_cache]
   title: Zeitreise - Kartenwerke (19081231, source)
-- dimensions: &id665
+- dimensions: &id664
     Time:
       default: '19071231'
       values: ['19071231']
   name: ch.swisstopo.zeitreihen_19071231
   sources: [ch.swisstopo.zeitreihen_19071231_cache_out]
   title: Zeitreise - Kartenwerke (19071231)
-- dimensions: *id665
+- dimensions: *id664
   name: ch.swisstopo.zeitreihen_19071231_source
   sources: [ch.swisstopo.zeitreihen_19071231_cache]
   title: Zeitreise - Kartenwerke (19071231, source)
-- dimensions: &id666
+- dimensions: &id665
     Time:
       default: '19061231'
       values: ['19061231']
   name: ch.swisstopo.zeitreihen_19061231
   sources: [ch.swisstopo.zeitreihen_19061231_cache_out]
   title: Zeitreise - Kartenwerke (19061231)
-- dimensions: *id666
+- dimensions: *id665
   name: ch.swisstopo.zeitreihen_19061231_source
   sources: [ch.swisstopo.zeitreihen_19061231_cache]
   title: Zeitreise - Kartenwerke (19061231, source)
-- dimensions: &id667
+- dimensions: &id666
     Time:
       default: '19051231'
       values: ['19051231']
   name: ch.swisstopo.zeitreihen_19051231
   sources: [ch.swisstopo.zeitreihen_19051231_cache_out]
   title: Zeitreise - Kartenwerke (19051231)
-- dimensions: *id667
+- dimensions: *id666
   name: ch.swisstopo.zeitreihen_19051231_source
   sources: [ch.swisstopo.zeitreihen_19051231_cache]
   title: Zeitreise - Kartenwerke (19051231, source)
-- dimensions: &id668
+- dimensions: &id667
     Time:
       default: '19041231'
       values: ['19041231']
   name: ch.swisstopo.zeitreihen_19041231
   sources: [ch.swisstopo.zeitreihen_19041231_cache_out]
   title: Zeitreise - Kartenwerke (19041231)
-- dimensions: *id668
+- dimensions: *id667
   name: ch.swisstopo.zeitreihen_19041231_source
   sources: [ch.swisstopo.zeitreihen_19041231_cache]
   title: Zeitreise - Kartenwerke (19041231, source)
-- dimensions: &id669
+- dimensions: &id668
     Time:
       default: '19031231'
       values: ['19031231']
   name: ch.swisstopo.zeitreihen_19031231
   sources: [ch.swisstopo.zeitreihen_19031231_cache_out]
   title: Zeitreise - Kartenwerke (19031231)
-- dimensions: *id669
+- dimensions: *id668
   name: ch.swisstopo.zeitreihen_19031231_source
   sources: [ch.swisstopo.zeitreihen_19031231_cache]
   title: Zeitreise - Kartenwerke (19031231, source)
-- dimensions: &id670
+- dimensions: &id669
     Time:
       default: '19021231'
       values: ['19021231']
   name: ch.swisstopo.zeitreihen_19021231
   sources: [ch.swisstopo.zeitreihen_19021231_cache_out]
   title: Zeitreise - Kartenwerke (19021231)
-- dimensions: *id670
+- dimensions: *id669
   name: ch.swisstopo.zeitreihen_19021231_source
   sources: [ch.swisstopo.zeitreihen_19021231_cache]
   title: Zeitreise - Kartenwerke (19021231, source)
-- dimensions: &id671
+- dimensions: &id670
     Time:
       default: '19011231'
       values: ['19011231']
   name: ch.swisstopo.zeitreihen_19011231
   sources: [ch.swisstopo.zeitreihen_19011231_cache_out]
   title: Zeitreise - Kartenwerke (19011231)
-- dimensions: *id671
+- dimensions: *id670
   name: ch.swisstopo.zeitreihen_19011231_source
   sources: [ch.swisstopo.zeitreihen_19011231_cache]
   title: Zeitreise - Kartenwerke (19011231, source)
-- dimensions: &id672
+- dimensions: &id671
     Time:
       default: '19001231'
       values: ['19001231']
   name: ch.swisstopo.zeitreihen_19001231
   sources: [ch.swisstopo.zeitreihen_19001231_cache_out]
   title: Zeitreise - Kartenwerke (19001231)
-- dimensions: *id672
+- dimensions: *id671
   name: ch.swisstopo.zeitreihen_19001231_source
   sources: [ch.swisstopo.zeitreihen_19001231_cache]
   title: Zeitreise - Kartenwerke (19001231, source)
-- dimensions: &id673
+- dimensions: &id672
     Time:
       default: '18991231'
       values: ['18991231']
   name: ch.swisstopo.zeitreihen_18991231
   sources: [ch.swisstopo.zeitreihen_18991231_cache_out]
   title: Zeitreise - Kartenwerke (18991231)
-- dimensions: *id673
+- dimensions: *id672
   name: ch.swisstopo.zeitreihen_18991231_source
   sources: [ch.swisstopo.zeitreihen_18991231_cache]
   title: Zeitreise - Kartenwerke (18991231, source)
-- dimensions: &id674
+- dimensions: &id673
     Time:
       default: '18981231'
       values: ['18981231']
   name: ch.swisstopo.zeitreihen_18981231
   sources: [ch.swisstopo.zeitreihen_18981231_cache_out]
   title: Zeitreise - Kartenwerke (18981231)
-- dimensions: *id674
+- dimensions: *id673
   name: ch.swisstopo.zeitreihen_18981231_source
   sources: [ch.swisstopo.zeitreihen_18981231_cache]
   title: Zeitreise - Kartenwerke (18981231, source)
-- dimensions: &id675
+- dimensions: &id674
     Time:
       default: '18971231'
       values: ['18971231']
   name: ch.swisstopo.zeitreihen_18971231
   sources: [ch.swisstopo.zeitreihen_18971231_cache_out]
   title: Zeitreise - Kartenwerke (18971231)
-- dimensions: *id675
+- dimensions: *id674
   name: ch.swisstopo.zeitreihen_18971231_source
   sources: [ch.swisstopo.zeitreihen_18971231_cache]
   title: Zeitreise - Kartenwerke (18971231, source)
-- dimensions: &id676
+- dimensions: &id675
     Time:
       default: '18961231'
       values: ['18961231']
   name: ch.swisstopo.zeitreihen_18961231
   sources: [ch.swisstopo.zeitreihen_18961231_cache_out]
   title: Zeitreise - Kartenwerke (18961231)
-- dimensions: *id676
+- dimensions: *id675
   name: ch.swisstopo.zeitreihen_18961231_source
   sources: [ch.swisstopo.zeitreihen_18961231_cache]
   title: Zeitreise - Kartenwerke (18961231, source)
-- dimensions: &id677
+- dimensions: &id676
     Time:
       default: '18951231'
       values: ['18951231']
   name: ch.swisstopo.zeitreihen_18951231
   sources: [ch.swisstopo.zeitreihen_18951231_cache_out]
   title: Zeitreise - Kartenwerke (18951231)
-- dimensions: *id677
+- dimensions: *id676
   name: ch.swisstopo.zeitreihen_18951231_source
   sources: [ch.swisstopo.zeitreihen_18951231_cache]
   title: Zeitreise - Kartenwerke (18951231, source)
-- dimensions: &id678
+- dimensions: &id677
     Time:
       default: '18941231'
       values: ['18941231']
   name: ch.swisstopo.zeitreihen_18941231
   sources: [ch.swisstopo.zeitreihen_18941231_cache_out]
   title: Zeitreise - Kartenwerke (18941231)
-- dimensions: *id678
+- dimensions: *id677
   name: ch.swisstopo.zeitreihen_18941231_source
   sources: [ch.swisstopo.zeitreihen_18941231_cache]
   title: Zeitreise - Kartenwerke (18941231, source)
-- dimensions: &id679
+- dimensions: &id678
     Time:
       default: '18931231'
       values: ['18931231']
   name: ch.swisstopo.zeitreihen_18931231
   sources: [ch.swisstopo.zeitreihen_18931231_cache_out]
   title: Zeitreise - Kartenwerke (18931231)
-- dimensions: *id679
+- dimensions: *id678
   name: ch.swisstopo.zeitreihen_18931231_source
   sources: [ch.swisstopo.zeitreihen_18931231_cache]
   title: Zeitreise - Kartenwerke (18931231, source)
-- dimensions: &id680
+- dimensions: &id679
     Time:
       default: '18921231'
       values: ['18921231']
   name: ch.swisstopo.zeitreihen_18921231
   sources: [ch.swisstopo.zeitreihen_18921231_cache_out]
   title: Zeitreise - Kartenwerke (18921231)
-- dimensions: *id680
+- dimensions: *id679
   name: ch.swisstopo.zeitreihen_18921231_source
   sources: [ch.swisstopo.zeitreihen_18921231_cache]
   title: Zeitreise - Kartenwerke (18921231, source)
-- dimensions: &id681
+- dimensions: &id680
     Time:
       default: '18911231'
       values: ['18911231']
   name: ch.swisstopo.zeitreihen_18911231
   sources: [ch.swisstopo.zeitreihen_18911231_cache_out]
   title: Zeitreise - Kartenwerke (18911231)
-- dimensions: *id681
+- dimensions: *id680
   name: ch.swisstopo.zeitreihen_18911231_source
   sources: [ch.swisstopo.zeitreihen_18911231_cache]
   title: Zeitreise - Kartenwerke (18911231, source)
-- dimensions: &id682
+- dimensions: &id681
     Time:
       default: '18901231'
       values: ['18901231']
   name: ch.swisstopo.zeitreihen_18901231
   sources: [ch.swisstopo.zeitreihen_18901231_cache_out]
   title: Zeitreise - Kartenwerke (18901231)
-- dimensions: *id682
+- dimensions: *id681
   name: ch.swisstopo.zeitreihen_18901231_source
   sources: [ch.swisstopo.zeitreihen_18901231_cache]
   title: Zeitreise - Kartenwerke (18901231, source)
-- dimensions: &id683
+- dimensions: &id682
     Time:
       default: '18891231'
       values: ['18891231']
   name: ch.swisstopo.zeitreihen_18891231
   sources: [ch.swisstopo.zeitreihen_18891231_cache_out]
   title: Zeitreise - Kartenwerke (18891231)
-- dimensions: *id683
+- dimensions: *id682
   name: ch.swisstopo.zeitreihen_18891231_source
   sources: [ch.swisstopo.zeitreihen_18891231_cache]
   title: Zeitreise - Kartenwerke (18891231, source)
-- dimensions: &id684
+- dimensions: &id683
     Time:
       default: '18881231'
       values: ['18881231']
   name: ch.swisstopo.zeitreihen_18881231
   sources: [ch.swisstopo.zeitreihen_18881231_cache_out]
   title: Zeitreise - Kartenwerke (18881231)
-- dimensions: *id684
+- dimensions: *id683
   name: ch.swisstopo.zeitreihen_18881231_source
   sources: [ch.swisstopo.zeitreihen_18881231_cache]
   title: Zeitreise - Kartenwerke (18881231, source)
-- dimensions: &id685
+- dimensions: &id684
     Time:
       default: '18871231'
       values: ['18871231']
   name: ch.swisstopo.zeitreihen_18871231
   sources: [ch.swisstopo.zeitreihen_18871231_cache_out]
   title: Zeitreise - Kartenwerke (18871231)
-- dimensions: *id685
+- dimensions: *id684
   name: ch.swisstopo.zeitreihen_18871231_source
   sources: [ch.swisstopo.zeitreihen_18871231_cache]
   title: Zeitreise - Kartenwerke (18871231, source)
-- dimensions: &id686
+- dimensions: &id685
     Time:
       default: '18861231'
       values: ['18861231']
   name: ch.swisstopo.zeitreihen_18861231
   sources: [ch.swisstopo.zeitreihen_18861231_cache_out]
   title: Zeitreise - Kartenwerke (18861231)
-- dimensions: *id686
+- dimensions: *id685
   name: ch.swisstopo.zeitreihen_18861231_source
   sources: [ch.swisstopo.zeitreihen_18861231_cache]
   title: Zeitreise - Kartenwerke (18861231, source)
-- dimensions: &id687
+- dimensions: &id686
     Time:
       default: '18851231'
       values: ['18851231']
   name: ch.swisstopo.zeitreihen_18851231
   sources: [ch.swisstopo.zeitreihen_18851231_cache_out]
   title: Zeitreise - Kartenwerke (18851231)
-- dimensions: *id687
+- dimensions: *id686
   name: ch.swisstopo.zeitreihen_18851231_source
   sources: [ch.swisstopo.zeitreihen_18851231_cache]
   title: Zeitreise - Kartenwerke (18851231, source)
-- dimensions: &id688
+- dimensions: &id687
     Time:
       default: '18841231'
       values: ['18841231']
   name: ch.swisstopo.zeitreihen_18841231
   sources: [ch.swisstopo.zeitreihen_18841231_cache_out]
   title: Zeitreise - Kartenwerke (18841231)
-- dimensions: *id688
+- dimensions: *id687
   name: ch.swisstopo.zeitreihen_18841231_source
   sources: [ch.swisstopo.zeitreihen_18841231_cache]
   title: Zeitreise - Kartenwerke (18841231, source)
-- dimensions: &id689
+- dimensions: &id688
     Time:
       default: '18831231'
       values: ['18831231']
   name: ch.swisstopo.zeitreihen_18831231
   sources: [ch.swisstopo.zeitreihen_18831231_cache_out]
   title: Zeitreise - Kartenwerke (18831231)
-- dimensions: *id689
+- dimensions: *id688
   name: ch.swisstopo.zeitreihen_18831231_source
   sources: [ch.swisstopo.zeitreihen_18831231_cache]
   title: Zeitreise - Kartenwerke (18831231, source)
-- dimensions: &id690
+- dimensions: &id689
     Time:
       default: '18821231'
       values: ['18821231']
   name: ch.swisstopo.zeitreihen_18821231
   sources: [ch.swisstopo.zeitreihen_18821231_cache_out]
   title: Zeitreise - Kartenwerke (18821231)
-- dimensions: *id690
+- dimensions: *id689
   name: ch.swisstopo.zeitreihen_18821231_source
   sources: [ch.swisstopo.zeitreihen_18821231_cache]
   title: Zeitreise - Kartenwerke (18821231, source)
-- dimensions: &id691
+- dimensions: &id690
     Time:
       default: '18811231'
       values: ['18811231']
   name: ch.swisstopo.zeitreihen_18811231
   sources: [ch.swisstopo.zeitreihen_18811231_cache_out]
   title: Zeitreise - Kartenwerke (18811231)
-- dimensions: *id691
+- dimensions: *id690
   name: ch.swisstopo.zeitreihen_18811231_source
   sources: [ch.swisstopo.zeitreihen_18811231_cache]
   title: Zeitreise - Kartenwerke (18811231, source)
-- dimensions: &id692
+- dimensions: &id691
     Time:
       default: '18801231'
       values: ['18801231']
   name: ch.swisstopo.zeitreihen_18801231
   sources: [ch.swisstopo.zeitreihen_18801231_cache_out]
   title: Zeitreise - Kartenwerke (18801231)
-- dimensions: *id692
+- dimensions: *id691
   name: ch.swisstopo.zeitreihen_18801231_source
   sources: [ch.swisstopo.zeitreihen_18801231_cache]
   title: Zeitreise - Kartenwerke (18801231, source)
-- dimensions: &id693
+- dimensions: &id692
     Time:
       default: '18791231'
       values: ['18791231']
   name: ch.swisstopo.zeitreihen_18791231
   sources: [ch.swisstopo.zeitreihen_18791231_cache_out]
   title: Zeitreise - Kartenwerke (18791231)
-- dimensions: *id693
+- dimensions: *id692
   name: ch.swisstopo.zeitreihen_18791231_source
   sources: [ch.swisstopo.zeitreihen_18791231_cache]
   title: Zeitreise - Kartenwerke (18791231, source)
-- dimensions: &id694
+- dimensions: &id693
     Time:
       default: '18781231'
       values: ['18781231']
   name: ch.swisstopo.zeitreihen_18781231
   sources: [ch.swisstopo.zeitreihen_18781231_cache_out]
   title: Zeitreise - Kartenwerke (18781231)
-- dimensions: *id694
+- dimensions: *id693
   name: ch.swisstopo.zeitreihen_18781231_source
   sources: [ch.swisstopo.zeitreihen_18781231_cache]
   title: Zeitreise - Kartenwerke (18781231, source)
-- dimensions: &id695
+- dimensions: &id694
     Time:
       default: '18771231'
       values: ['18771231']
   name: ch.swisstopo.zeitreihen_18771231
   sources: [ch.swisstopo.zeitreihen_18771231_cache_out]
   title: Zeitreise - Kartenwerke (18771231)
-- dimensions: *id695
+- dimensions: *id694
   name: ch.swisstopo.zeitreihen_18771231_source
   sources: [ch.swisstopo.zeitreihen_18771231_cache]
   title: Zeitreise - Kartenwerke (18771231, source)
-- dimensions: &id696
+- dimensions: &id695
     Time:
       default: '18761231'
       values: ['18761231']
   name: ch.swisstopo.zeitreihen_18761231
   sources: [ch.swisstopo.zeitreihen_18761231_cache_out]
   title: Zeitreise - Kartenwerke (18761231)
-- dimensions: *id696
+- dimensions: *id695
   name: ch.swisstopo.zeitreihen_18761231_source
   sources: [ch.swisstopo.zeitreihen_18761231_cache]
   title: Zeitreise - Kartenwerke (18761231, source)
-- dimensions: &id697
+- dimensions: &id696
     Time:
       default: '18751231'
       values: ['18751231']
   name: ch.swisstopo.zeitreihen_18751231
   sources: [ch.swisstopo.zeitreihen_18751231_cache_out]
   title: Zeitreise - Kartenwerke (18751231)
-- dimensions: *id697
+- dimensions: *id696
   name: ch.swisstopo.zeitreihen_18751231_source
   sources: [ch.swisstopo.zeitreihen_18751231_cache]
   title: Zeitreise - Kartenwerke (18751231, source)
-- dimensions: &id698
+- dimensions: &id697
     Time:
       default: '18741231'
       values: ['18741231']
   name: ch.swisstopo.zeitreihen_18741231
   sources: [ch.swisstopo.zeitreihen_18741231_cache_out]
   title: Zeitreise - Kartenwerke (18741231)
-- dimensions: *id698
+- dimensions: *id697
   name: ch.swisstopo.zeitreihen_18741231_source
   sources: [ch.swisstopo.zeitreihen_18741231_cache]
   title: Zeitreise - Kartenwerke (18741231, source)
-- dimensions: &id699
+- dimensions: &id698
     Time:
       default: '18731231'
       values: ['18731231']
   name: ch.swisstopo.zeitreihen_18731231
   sources: [ch.swisstopo.zeitreihen_18731231_cache_out]
   title: Zeitreise - Kartenwerke (18731231)
-- dimensions: *id699
+- dimensions: *id698
   name: ch.swisstopo.zeitreihen_18731231_source
   sources: [ch.swisstopo.zeitreihen_18731231_cache]
   title: Zeitreise - Kartenwerke (18731231, source)
-- dimensions: &id700
+- dimensions: &id699
     Time:
       default: '18721231'
       values: ['18721231']
   name: ch.swisstopo.zeitreihen_18721231
   sources: [ch.swisstopo.zeitreihen_18721231_cache_out]
   title: Zeitreise - Kartenwerke (18721231)
-- dimensions: *id700
+- dimensions: *id699
   name: ch.swisstopo.zeitreihen_18721231_source
   sources: [ch.swisstopo.zeitreihen_18721231_cache]
   title: Zeitreise - Kartenwerke (18721231, source)
-- dimensions: &id701
+- dimensions: &id700
     Time:
       default: '18711231'
       values: ['18711231']
   name: ch.swisstopo.zeitreihen_18711231
   sources: [ch.swisstopo.zeitreihen_18711231_cache_out]
   title: Zeitreise - Kartenwerke (18711231)
-- dimensions: *id701
+- dimensions: *id700
   name: ch.swisstopo.zeitreihen_18711231_source
   sources: [ch.swisstopo.zeitreihen_18711231_cache]
   title: Zeitreise - Kartenwerke (18711231, source)
-- dimensions: &id702
+- dimensions: &id701
     Time:
       default: '18701231'
       values: ['18701231']
   name: ch.swisstopo.zeitreihen_18701231
   sources: [ch.swisstopo.zeitreihen_18701231_cache_out]
   title: Zeitreise - Kartenwerke (18701231)
-- dimensions: *id702
+- dimensions: *id701
   name: ch.swisstopo.zeitreihen_18701231_source
   sources: [ch.swisstopo.zeitreihen_18701231_cache]
   title: Zeitreise - Kartenwerke (18701231, source)
-- dimensions: &id703
+- dimensions: &id702
     Time:
       default: '18691231'
       values: ['18691231']
   name: ch.swisstopo.zeitreihen_18691231
   sources: [ch.swisstopo.zeitreihen_18691231_cache_out]
   title: Zeitreise - Kartenwerke (18691231)
-- dimensions: *id703
+- dimensions: *id702
   name: ch.swisstopo.zeitreihen_18691231_source
   sources: [ch.swisstopo.zeitreihen_18691231_cache]
   title: Zeitreise - Kartenwerke (18691231, source)
-- dimensions: &id704
+- dimensions: &id703
     Time:
       default: '18681231'
       values: ['18681231']
   name: ch.swisstopo.zeitreihen_18681231
   sources: [ch.swisstopo.zeitreihen_18681231_cache_out]
   title: Zeitreise - Kartenwerke (18681231)
-- dimensions: *id704
+- dimensions: *id703
   name: ch.swisstopo.zeitreihen_18681231_source
   sources: [ch.swisstopo.zeitreihen_18681231_cache]
   title: Zeitreise - Kartenwerke (18681231, source)
-- dimensions: &id705
+- dimensions: &id704
     Time:
       default: '18671231'
       values: ['18671231']
   name: ch.swisstopo.zeitreihen_18671231
   sources: [ch.swisstopo.zeitreihen_18671231_cache_out]
   title: Zeitreise - Kartenwerke (18671231)
-- dimensions: *id705
+- dimensions: *id704
   name: ch.swisstopo.zeitreihen_18671231_source
   sources: [ch.swisstopo.zeitreihen_18671231_cache]
   title: Zeitreise - Kartenwerke (18671231, source)
-- dimensions: &id706
+- dimensions: &id705
     Time:
       default: '18661231'
       values: ['18661231']
   name: ch.swisstopo.zeitreihen_18661231
   sources: [ch.swisstopo.zeitreihen_18661231_cache_out]
   title: Zeitreise - Kartenwerke (18661231)
-- dimensions: *id706
+- dimensions: *id705
   name: ch.swisstopo.zeitreihen_18661231_source
   sources: [ch.swisstopo.zeitreihen_18661231_cache]
   title: Zeitreise - Kartenwerke (18661231, source)
-- dimensions: &id707
+- dimensions: &id706
     Time:
       default: '18651231'
       values: ['18651231']
   name: ch.swisstopo.zeitreihen_18651231
   sources: [ch.swisstopo.zeitreihen_18651231_cache_out]
   title: Zeitreise - Kartenwerke (18651231)
-- dimensions: *id707
+- dimensions: *id706
   name: ch.swisstopo.zeitreihen_18651231_source
   sources: [ch.swisstopo.zeitreihen_18651231_cache]
   title: Zeitreise - Kartenwerke (18651231, source)
-- dimensions: &id708
+- dimensions: &id707
     Time:
       default: '18641231'
       values: ['18641231']
   name: ch.swisstopo.zeitreihen_18641231
   sources: [ch.swisstopo.zeitreihen_18641231_cache_out]
   title: Zeitreise - Kartenwerke (18641231)
-- dimensions: *id708
+- dimensions: *id707
   name: ch.swisstopo.zeitreihen_18641231_source
   sources: [ch.swisstopo.zeitreihen_18641231_cache]
   title: Zeitreise - Kartenwerke (18641231, source)
-- dimensions: &id709
+- dimensions: &id708
     Time:
       default: '18631231'
       values: ['18631231']
   name: ch.swisstopo.zeitreihen_18631231
   sources: [ch.swisstopo.zeitreihen_18631231_cache_out]
   title: Zeitreise - Kartenwerke (18631231)
-- dimensions: *id709
+- dimensions: *id708
   name: ch.swisstopo.zeitreihen_18631231_source
   sources: [ch.swisstopo.zeitreihen_18631231_cache]
   title: Zeitreise - Kartenwerke (18631231, source)
-- dimensions: &id710
+- dimensions: &id709
     Time:
       default: '18621231'
       values: ['18621231']
   name: ch.swisstopo.zeitreihen_18621231
   sources: [ch.swisstopo.zeitreihen_18621231_cache_out]
   title: Zeitreise - Kartenwerke (18621231)
-- dimensions: *id710
+- dimensions: *id709
   name: ch.swisstopo.zeitreihen_18621231_source
   sources: [ch.swisstopo.zeitreihen_18621231_cache]
   title: Zeitreise - Kartenwerke (18621231, source)
-- dimensions: &id711
+- dimensions: &id710
     Time:
       default: '18611231'
       values: ['18611231']
   name: ch.swisstopo.zeitreihen_18611231
   sources: [ch.swisstopo.zeitreihen_18611231_cache_out]
   title: Zeitreise - Kartenwerke (18611231)
-- dimensions: *id711
+- dimensions: *id710
   name: ch.swisstopo.zeitreihen_18611231_source
   sources: [ch.swisstopo.zeitreihen_18611231_cache]
   title: Zeitreise - Kartenwerke (18611231, source)
-- dimensions: &id712
+- dimensions: &id711
     Time:
       default: '18601231'
       values: ['18601231']
   name: ch.swisstopo.zeitreihen_18601231
   sources: [ch.swisstopo.zeitreihen_18601231_cache_out]
   title: Zeitreise - Kartenwerke (18601231)
-- dimensions: *id712
+- dimensions: *id711
   name: ch.swisstopo.zeitreihen_18601231_source
   sources: [ch.swisstopo.zeitreihen_18601231_cache]
   title: Zeitreise - Kartenwerke (18601231, source)
-- dimensions: &id713
+- dimensions: &id712
     Time:
       default: '18591231'
       values: ['18591231']
   name: ch.swisstopo.zeitreihen_18591231
   sources: [ch.swisstopo.zeitreihen_18591231_cache_out]
   title: Zeitreise - Kartenwerke (18591231)
-- dimensions: *id713
+- dimensions: *id712
   name: ch.swisstopo.zeitreihen_18591231_source
   sources: [ch.swisstopo.zeitreihen_18591231_cache]
   title: Zeitreise - Kartenwerke (18591231, source)
-- dimensions: &id714
+- dimensions: &id713
     Time:
       default: '18581231'
       values: ['18581231']
   name: ch.swisstopo.zeitreihen_18581231
   sources: [ch.swisstopo.zeitreihen_18581231_cache_out]
   title: Zeitreise - Kartenwerke (18581231)
-- dimensions: *id714
+- dimensions: *id713
   name: ch.swisstopo.zeitreihen_18581231_source
   sources: [ch.swisstopo.zeitreihen_18581231_cache]
   title: Zeitreise - Kartenwerke (18581231, source)
-- dimensions: &id715
+- dimensions: &id714
     Time:
       default: '18571231'
       values: ['18571231']
   name: ch.swisstopo.zeitreihen_18571231
   sources: [ch.swisstopo.zeitreihen_18571231_cache_out]
   title: Zeitreise - Kartenwerke (18571231)
-- dimensions: *id715
+- dimensions: *id714
   name: ch.swisstopo.zeitreihen_18571231_source
   sources: [ch.swisstopo.zeitreihen_18571231_cache]
   title: Zeitreise - Kartenwerke (18571231, source)
-- dimensions: &id716
+- dimensions: &id715
     Time:
       default: '18561231'
       values: ['18561231']
   name: ch.swisstopo.zeitreihen_18561231
   sources: [ch.swisstopo.zeitreihen_18561231_cache_out]
   title: Zeitreise - Kartenwerke (18561231)
-- dimensions: *id716
+- dimensions: *id715
   name: ch.swisstopo.zeitreihen_18561231_source
   sources: [ch.swisstopo.zeitreihen_18561231_cache]
   title: Zeitreise - Kartenwerke (18561231, source)
-- dimensions: &id717
+- dimensions: &id716
     Time:
       default: '18551231'
       values: ['18551231']
   name: ch.swisstopo.zeitreihen_18551231
   sources: [ch.swisstopo.zeitreihen_18551231_cache_out]
   title: Zeitreise - Kartenwerke (18551231)
-- dimensions: *id717
+- dimensions: *id716
   name: ch.swisstopo.zeitreihen_18551231_source
   sources: [ch.swisstopo.zeitreihen_18551231_cache]
   title: Zeitreise - Kartenwerke (18551231, source)
-- dimensions: &id718
+- dimensions: &id717
     Time:
       default: '18541231'
       values: ['18541231']
   name: ch.swisstopo.zeitreihen_18541231
   sources: [ch.swisstopo.zeitreihen_18541231_cache_out]
   title: Zeitreise - Kartenwerke (18541231)
-- dimensions: *id718
+- dimensions: *id717
   name: ch.swisstopo.zeitreihen_18541231_source
   sources: [ch.swisstopo.zeitreihen_18541231_cache]
   title: Zeitreise - Kartenwerke (18541231, source)
-- dimensions: &id719
+- dimensions: &id718
     Time:
       default: '18531231'
       values: ['18531231']
   name: ch.swisstopo.zeitreihen_18531231
   sources: [ch.swisstopo.zeitreihen_18531231_cache_out]
   title: Zeitreise - Kartenwerke (18531231)
-- dimensions: *id719
+- dimensions: *id718
   name: ch.swisstopo.zeitreihen_18531231_source
   sources: [ch.swisstopo.zeitreihen_18531231_cache]
   title: Zeitreise - Kartenwerke (18531231, source)
-- dimensions: &id720
+- dimensions: &id719
     Time:
       default: '18521231'
       values: ['18521231']
   name: ch.swisstopo.zeitreihen_18521231
   sources: [ch.swisstopo.zeitreihen_18521231_cache_out]
   title: Zeitreise - Kartenwerke (18521231)
-- dimensions: *id720
+- dimensions: *id719
   name: ch.swisstopo.zeitreihen_18521231_source
   sources: [ch.swisstopo.zeitreihen_18521231_cache]
   title: Zeitreise - Kartenwerke (18521231, source)
-- dimensions: &id721
+- dimensions: &id720
     Time:
       default: '18511231'
       values: ['18511231']
   name: ch.swisstopo.zeitreihen_18511231
   sources: [ch.swisstopo.zeitreihen_18511231_cache_out]
   title: Zeitreise - Kartenwerke (18511231)
-- dimensions: *id721
+- dimensions: *id720
   name: ch.swisstopo.zeitreihen_18511231_source
   sources: [ch.swisstopo.zeitreihen_18511231_cache]
   title: Zeitreise - Kartenwerke (18511231, source)
-- dimensions: &id722
+- dimensions: &id721
     Time:
       default: '18501231'
       values: ['18501231']
   name: ch.swisstopo.zeitreihen_18501231
   sources: [ch.swisstopo.zeitreihen_18501231_cache_out]
   title: Zeitreise - Kartenwerke (18501231)
-- dimensions: *id722
+- dimensions: *id721
   name: ch.swisstopo.zeitreihen_18501231_source
   sources: [ch.swisstopo.zeitreihen_18501231_cache]
   title: Zeitreise - Kartenwerke (18501231, source)
-- dimensions: &id723
+- dimensions: &id722
     Time:
       default: '18491231'
       values: ['18491231']
   name: ch.swisstopo.zeitreihen_18491231
   sources: [ch.swisstopo.zeitreihen_18491231_cache_out]
   title: Zeitreise - Kartenwerke (18491231)
-- dimensions: *id723
+- dimensions: *id722
   name: ch.swisstopo.zeitreihen_18491231_source
   sources: [ch.swisstopo.zeitreihen_18491231_cache]
   title: Zeitreise - Kartenwerke (18491231, source)
-- dimensions: &id724
+- dimensions: &id723
     Time:
       default: '18481231'
       values: ['18481231']
   name: ch.swisstopo.zeitreihen_18481231
   sources: [ch.swisstopo.zeitreihen_18481231_cache_out]
   title: Zeitreise - Kartenwerke (18481231)
-- dimensions: *id724
+- dimensions: *id723
   name: ch.swisstopo.zeitreihen_18481231_source
   sources: [ch.swisstopo.zeitreihen_18481231_cache]
   title: Zeitreise - Kartenwerke (18481231, source)
-- dimensions: &id725
+- dimensions: &id724
     Time:
       default: '18471231'
       values: ['18471231']
   name: ch.swisstopo.zeitreihen_18471231
   sources: [ch.swisstopo.zeitreihen_18471231_cache_out]
   title: Zeitreise - Kartenwerke (18471231)
-- dimensions: *id725
+- dimensions: *id724
   name: ch.swisstopo.zeitreihen_18471231_source
   sources: [ch.swisstopo.zeitreihen_18471231_cache]
   title: Zeitreise - Kartenwerke (18471231, source)
-- dimensions: &id726
+- dimensions: &id725
     Time:
       default: '18461231'
       values: ['18461231']
   name: ch.swisstopo.zeitreihen_18461231
   sources: [ch.swisstopo.zeitreihen_18461231_cache_out]
   title: Zeitreise - Kartenwerke (18461231)
-- dimensions: *id726
+- dimensions: *id725
   name: ch.swisstopo.zeitreihen_18461231_source
   sources: [ch.swisstopo.zeitreihen_18461231_cache]
   title: Zeitreise - Kartenwerke (18461231, source)
-- dimensions: &id727
+- dimensions: &id726
     Time:
       default: '18451231'
       values: ['18451231']
   name: ch.swisstopo.zeitreihen_18451231
   sources: [ch.swisstopo.zeitreihen_18451231_cache_out]
   title: Zeitreise - Kartenwerke (18451231)
-- dimensions: *id727
+- dimensions: *id726
   name: ch.swisstopo.zeitreihen_18451231_source
   sources: [ch.swisstopo.zeitreihen_18451231_cache]
   title: Zeitreise - Kartenwerke (18451231, source)
-- dimensions: &id728
+- dimensions: &id727
     Time:
       default: '18441231'
       values: ['18441231']
   name: ch.swisstopo.zeitreihen_18441231
   sources: [ch.swisstopo.zeitreihen_18441231_cache_out]
   title: Zeitreise - Kartenwerke (18441231)
-- dimensions: *id728
+- dimensions: *id727
   name: ch.swisstopo.zeitreihen_18441231_source
   sources: [ch.swisstopo.zeitreihen_18441231_cache]
   title: Zeitreise - Kartenwerke (18441231, source)
-- dimensions: &id729
+- dimensions: &id728
     Time:
       default: '20110501'
       values: ['20110501']
   name: ch.vbs.territorialregionen_20110501
   sources: [ch.vbs.territorialregionen_20110501_cache_out]
   title: Territorialregionen (20110501)
-- dimensions: *id729
+- dimensions: *id728
   name: ch.vbs.territorialregionen
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen ('current')
-- dimensions: *id729
+- dimensions: *id728
   name: ch.vbs.territorialregionen_20110501_source
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen (20110501, source)
@@ -18210,7 +18183,7 @@ services:
       fees: This service cant be used without permission
       online_resource: http://api3.geo.admin.ch/mapproxy/service?
       title: GeoAdmin MapProxy WMS
-    srs: ['EPSG:4326', 'EPSG:21781', 'EPSG:4258', 'EPSG:3857', 'EPSG:2056']
+    srs: ['EPSG:4326', 'CRS:84', 'EPSG:21781', 'EPSG:4258', 'EPSG:3857', 'EPSG:2056']
   wmts: {kvp: false, restful: true, restful_template: '/1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.{Format}'}
 sources:
   boundaries_source:
@@ -21533,18 +21506,6 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.geologie-eiszeit-lgm-raster/default/20081231/21781/%(z)d/%(y)d/%(x)d.%(format)s
-  ch.swisstopo.geologie-eiszeit-lgm_20110318_source:
-    coverage:
-      bbox: [0, 40, 20, 50]
-      bbox_srs: EPSG:4326
-    grid: swisstopo-pixelkarte
-    http:
-      headers: {Referer: 'http://mapproxy.geo.admin.ch'}
-    on_error:
-      204: {cache: true, response: transparent}
-    transparent: true
-    type: tile
-    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.geologie-eiszeit-lgm/default/20110318/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.swisstopo.geologie-generalkarte-ggk200_19641231_source:
     coverage:
       bbox: [0, 40, 20, 50]
@@ -24437,7 +24398,7 @@ sources:
     transparent: true
     type: tile
     url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20120225/21781/%(z)d/%(y)d/%(x)d.%(format)s
-  "ch.swisstopo.swissimage_20120809\t_source":
+  ch.swisstopo.swissimage_20120809_source:
     coverage:
       bbox: [0, 40, 20, 50]
       bbox_srs: EPSG:4326
@@ -24448,9 +24409,8 @@ sources:
       204: {cache: true, response: transparent}
     transparent: true
     type: tile
-    url: "http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20120809\t\
-      /21781/%(z)d/%(y)d/%(x)d.%(format)s"
-  "ch.swisstopo.swissimage_20130422\t_source":
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20120809/21781/%(z)d/%(y)d/%(x)d.%(format)s
+  ch.swisstopo.swissimage_20130422_source:
     coverage:
       bbox: [0, 40, 20, 50]
       bbox_srs: EPSG:4326
@@ -24461,8 +24421,7 @@ sources:
       204: {cache: true, response: transparent}
     transparent: true
     type: tile
-    url: "http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20130422\t\
-      /21781/%(z)d/%(y)d/%(x)d.%(format)s"
+    url: http://wmts6.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/20130422/21781/%(z)d/%(y)d/%(x)d.%(format)s
   ch.swisstopo.swissimage_20130916_source:
     coverage:
       bbox: [0, 40, 20, 50]

--- a/mapproxy/templates/mapproxy.tpl
+++ b/mapproxy/templates/mapproxy.tpl
@@ -12,7 +12,7 @@ services:
      restful_template: /1.0.0/{Layer}/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.{Format}
 
   wms:
-    srs: ['EPSG:4326', 'EPSG:21781', 'EPSG:4258', 'EPSG:3857', 'EPSG:2056']
+    srs: ['EPSG:4326', 'CRS:84', 'EPSG:21781', 'EPSG:4258', 'EPSG:3857', 'EPSG:2056']
     image_formats: ['image/jpeg', 'image/png']
     md:
       # metadata used in capabilities documents


### PR DESCRIPTION
WMS 1.3.0 honor the axis order, so EPSG:4326 and CRS:84 have switch order, for client supporting or not this feature.


Test link: [GetCapabilities](http://mf-chsdi3.dev.bgdi.ch/mom_mapproxy_crs84/mapproxy/service?REQUEST=GetCapabilities)