### PR TITLE
Use wms-bod translated (DE) for test because wms-bod.map never used

### DIFF
--- a/chsdi/tests/e2e/test_wms.py
+++ b/chsdi/tests/e2e/test_wms.py
@@ -35,6 +35,7 @@ def build_wms_request(cfg):
     base_url = urlunsplit([scheme, netloc, path, None, None])
 
     payload = {'LAYERS': cfg['wmsLayers'],
+               'lang': 'de',
                'FORMAT': 'image/' + cfg['format'],
                'SRS': 'EPSG:21781',
                'BBOX': '600000,200000,610000,210000',


### PR DESCRIPTION
Add the parameter lang=de in url link because actually we test the wms-bod not translated and this wms is never used. So it's better to test the translated version (DE by default).