### PR TITLE
Remove test that exclude too big geometries (handled in db now)

### DIFF
--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -344,11 +344,6 @@ class TestMapServiceView(TestsBase):
         self.assertTrue(resp.content_type == 'text/javascript')
         resp.mustcontain('cb({')
 
-    def test_feature_toobig(self):
-        resp = self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.geologie-geocover/910652', params={'geometryFormat': 'geojson'}, status=200)
-        self.assertTrue(resp.content_type == 'application/json')
-        self.assertTrue('geometry' not in resp.json['feature'])
-
     def test_feature_big_but_good(self):
         resp = self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.geologie-geocover/1080284', params={'geometryFormat': 'geojson'}, status=200)
         self.assertTrue(resp.content_type == 'application/json')


### PR DESCRIPTION
This removes another test that is not needed anymore because of changes in the db. See https://github.com/geoadmin/mf-chsdi3/issues/1641