### PR TITLE
Fix test because of tilematrix set change

### DIFF
--- a/chsdi/tests/e2e/test_wmtscapabilities_auth.py
+++ b/chsdi/tests/e2e/test_wmtscapabilities_auth.py
@@ -14,7 +14,7 @@ class TestWmtsGetTileAuth(TestsBase):
         self.paths = ['/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20130903/3857/7/67/45.jpeg',
                       '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/2056/17/5/6.jpeg',
                       '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20130903/4258/10/6/4.jpeg',
-                      '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20151231/4326/21/132/180.jpeg']
+                      '/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20151231/4326/12/132/180.jpeg']
 
     def tearDown(self):
         self.mp.tearDown()


### PR DESCRIPTION
Because of https://github.com/geoadmin/mf-chsdi3/pull/1647, the tilematrix changed for the `4326` projection and a mapproxy e2e test failed because of it. This couldn't be catched by the PR jenkins build because PR jenkins build don't execute e2e tests.

Self merge.