### PR TITLE
[3D] PNG 8bits for Mapproxy

### DIFF
--- a/chsdi/templates/wmtscapabilities.mako
+++ b/chsdi/templates/wmtscapabilities.mako
@@ -57,8 +57,9 @@ elif epsg != '21781':
      onlineressource = onlineressources['mapproxy']
 else:
      onlineressource = onlineressources['s3']
+## FIXME: Do we really have to use 3 different formats for 'zeitreihen' ?
 if layer.id == 'ch.swisstopo.zeitreihen' and epsg != '21781':
-    layer.arr_all_formats = 'png'
+    layer.arr_all_formats = 'jpeg'
 %>
         <Layer>
             <ows:Title>${layer.kurzbezeichnung|n,x,trim}</ows:Title>

--- a/mapproxy/mapproxy.yaml
+++ b/mapproxy/mapproxy.yaml
@@ -6813,2040 +6813,2040 @@ caches:
     sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   ch.swisstopo.zeitreihen_18441231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18441231_source]
   ch.swisstopo.zeitreihen_18441231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: &id009 [epsg_4258, epsg_4326, epsg_2056, epsg_3857]
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18441231_cache]
   ch.swisstopo.zeitreihen_18451231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18451231_source]
   ch.swisstopo.zeitreihen_18451231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18451231_cache]
   ch.swisstopo.zeitreihen_18461231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18461231_source]
   ch.swisstopo.zeitreihen_18461231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18461231_cache]
   ch.swisstopo.zeitreihen_18471231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18471231_source]
   ch.swisstopo.zeitreihen_18471231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18471231_cache]
   ch.swisstopo.zeitreihen_18481231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18481231_source]
   ch.swisstopo.zeitreihen_18481231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18481231_cache]
   ch.swisstopo.zeitreihen_18491231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18491231_source]
   ch.swisstopo.zeitreihen_18491231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18491231_cache]
   ch.swisstopo.zeitreihen_18501231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18501231_source]
   ch.swisstopo.zeitreihen_18501231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18501231_cache]
   ch.swisstopo.zeitreihen_18511231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18511231_source]
   ch.swisstopo.zeitreihen_18511231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18511231_cache]
   ch.swisstopo.zeitreihen_18521231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18521231_source]
   ch.swisstopo.zeitreihen_18521231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18521231_cache]
   ch.swisstopo.zeitreihen_18531231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18531231_source]
   ch.swisstopo.zeitreihen_18531231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18531231_cache]
   ch.swisstopo.zeitreihen_18541231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18541231_source]
   ch.swisstopo.zeitreihen_18541231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18541231_cache]
   ch.swisstopo.zeitreihen_18551231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18551231_source]
   ch.swisstopo.zeitreihen_18551231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18551231_cache]
   ch.swisstopo.zeitreihen_18561231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18561231_source]
   ch.swisstopo.zeitreihen_18561231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18561231_cache]
   ch.swisstopo.zeitreihen_18571231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18571231_source]
   ch.swisstopo.zeitreihen_18571231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18571231_cache]
   ch.swisstopo.zeitreihen_18581231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18581231_source]
   ch.swisstopo.zeitreihen_18581231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18581231_cache]
   ch.swisstopo.zeitreihen_18591231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18591231_source]
   ch.swisstopo.zeitreihen_18591231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18591231_cache]
   ch.swisstopo.zeitreihen_18601231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18601231_source]
   ch.swisstopo.zeitreihen_18601231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18601231_cache]
   ch.swisstopo.zeitreihen_18611231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18611231_source]
   ch.swisstopo.zeitreihen_18611231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18611231_cache]
   ch.swisstopo.zeitreihen_18621231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18621231_source]
   ch.swisstopo.zeitreihen_18621231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18621231_cache]
   ch.swisstopo.zeitreihen_18631231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18631231_source]
   ch.swisstopo.zeitreihen_18631231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18631231_cache]
   ch.swisstopo.zeitreihen_18641231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18641231_source]
   ch.swisstopo.zeitreihen_18641231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18641231_cache]
   ch.swisstopo.zeitreihen_18651231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18651231_source]
   ch.swisstopo.zeitreihen_18651231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18651231_cache]
   ch.swisstopo.zeitreihen_18661231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18661231_source]
   ch.swisstopo.zeitreihen_18661231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18661231_cache]
   ch.swisstopo.zeitreihen_18671231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18671231_source]
   ch.swisstopo.zeitreihen_18671231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18671231_cache]
   ch.swisstopo.zeitreihen_18681231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18681231_source]
   ch.swisstopo.zeitreihen_18681231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18681231_cache]
   ch.swisstopo.zeitreihen_18691231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18691231_source]
   ch.swisstopo.zeitreihen_18691231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18691231_cache]
   ch.swisstopo.zeitreihen_18701231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18701231_source]
   ch.swisstopo.zeitreihen_18701231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18701231_cache]
   ch.swisstopo.zeitreihen_18711231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18711231_source]
   ch.swisstopo.zeitreihen_18711231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18711231_cache]
   ch.swisstopo.zeitreihen_18721231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18721231_source]
   ch.swisstopo.zeitreihen_18721231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18721231_cache]
   ch.swisstopo.zeitreihen_18731231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18731231_source]
   ch.swisstopo.zeitreihen_18731231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18731231_cache]
   ch.swisstopo.zeitreihen_18741231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18741231_source]
   ch.swisstopo.zeitreihen_18741231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18741231_cache]
   ch.swisstopo.zeitreihen_18751231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18751231_source]
   ch.swisstopo.zeitreihen_18751231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18751231_cache]
   ch.swisstopo.zeitreihen_18761231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18761231_source]
   ch.swisstopo.zeitreihen_18761231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18761231_cache]
   ch.swisstopo.zeitreihen_18771231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18771231_source]
   ch.swisstopo.zeitreihen_18771231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18771231_cache]
   ch.swisstopo.zeitreihen_18781231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18781231_source]
   ch.swisstopo.zeitreihen_18781231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18781231_cache]
   ch.swisstopo.zeitreihen_18791231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18791231_source]
   ch.swisstopo.zeitreihen_18791231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18791231_cache]
   ch.swisstopo.zeitreihen_18801231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18801231_source]
   ch.swisstopo.zeitreihen_18801231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18801231_cache]
   ch.swisstopo.zeitreihen_18811231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18811231_source]
   ch.swisstopo.zeitreihen_18811231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18811231_cache]
   ch.swisstopo.zeitreihen_18821231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18821231_source]
   ch.swisstopo.zeitreihen_18821231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18821231_cache]
   ch.swisstopo.zeitreihen_18831231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18831231_source]
   ch.swisstopo.zeitreihen_18831231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18831231_cache]
   ch.swisstopo.zeitreihen_18841231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18841231_source]
   ch.swisstopo.zeitreihen_18841231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18841231_cache]
   ch.swisstopo.zeitreihen_18851231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18851231_source]
   ch.swisstopo.zeitreihen_18851231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18851231_cache]
   ch.swisstopo.zeitreihen_18861231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18861231_source]
   ch.swisstopo.zeitreihen_18861231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18861231_cache]
   ch.swisstopo.zeitreihen_18871231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18871231_source]
   ch.swisstopo.zeitreihen_18871231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18871231_cache]
   ch.swisstopo.zeitreihen_18881231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18881231_source]
   ch.swisstopo.zeitreihen_18881231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18881231_cache]
   ch.swisstopo.zeitreihen_18891231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18891231_source]
   ch.swisstopo.zeitreihen_18891231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18891231_cache]
   ch.swisstopo.zeitreihen_18901231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18901231_source]
   ch.swisstopo.zeitreihen_18901231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18901231_cache]
   ch.swisstopo.zeitreihen_18911231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18911231_source]
   ch.swisstopo.zeitreihen_18911231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18911231_cache]
   ch.swisstopo.zeitreihen_18921231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18921231_source]
   ch.swisstopo.zeitreihen_18921231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18921231_cache]
   ch.swisstopo.zeitreihen_18931231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18931231_source]
   ch.swisstopo.zeitreihen_18931231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18931231_cache]
   ch.swisstopo.zeitreihen_18941231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18941231_source]
   ch.swisstopo.zeitreihen_18941231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18941231_cache]
   ch.swisstopo.zeitreihen_18951231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18951231_source]
   ch.swisstopo.zeitreihen_18951231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18951231_cache]
   ch.swisstopo.zeitreihen_18961231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18961231_source]
   ch.swisstopo.zeitreihen_18961231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18961231_cache]
   ch.swisstopo.zeitreihen_18971231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18971231_source]
   ch.swisstopo.zeitreihen_18971231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18971231_cache]
   ch.swisstopo.zeitreihen_18981231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18981231_source]
   ch.swisstopo.zeitreihen_18981231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18981231_cache]
   ch.swisstopo.zeitreihen_18991231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_18991231_source]
   ch.swisstopo.zeitreihen_18991231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_18991231_cache]
   ch.swisstopo.zeitreihen_19001231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19001231_source]
   ch.swisstopo.zeitreihen_19001231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19001231_cache]
   ch.swisstopo.zeitreihen_19011231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19011231_source]
   ch.swisstopo.zeitreihen_19011231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19011231_cache]
   ch.swisstopo.zeitreihen_19021231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19021231_source]
   ch.swisstopo.zeitreihen_19021231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19021231_cache]
   ch.swisstopo.zeitreihen_19031231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19031231_source]
   ch.swisstopo.zeitreihen_19031231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19031231_cache]
   ch.swisstopo.zeitreihen_19041231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19041231_source]
   ch.swisstopo.zeitreihen_19041231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19041231_cache]
   ch.swisstopo.zeitreihen_19051231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19051231_source]
   ch.swisstopo.zeitreihen_19051231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19051231_cache]
   ch.swisstopo.zeitreihen_19061231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19061231_source]
   ch.swisstopo.zeitreihen_19061231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19061231_cache]
   ch.swisstopo.zeitreihen_19071231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19071231_source]
   ch.swisstopo.zeitreihen_19071231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19071231_cache]
   ch.swisstopo.zeitreihen_19081231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19081231_source]
   ch.swisstopo.zeitreihen_19081231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19081231_cache]
   ch.swisstopo.zeitreihen_19091231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19091231_source]
   ch.swisstopo.zeitreihen_19091231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19091231_cache]
   ch.swisstopo.zeitreihen_19101231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19101231_source]
   ch.swisstopo.zeitreihen_19101231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19101231_cache]
   ch.swisstopo.zeitreihen_19111231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19111231_source]
   ch.swisstopo.zeitreihen_19111231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19111231_cache]
   ch.swisstopo.zeitreihen_19121231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19121231_source]
   ch.swisstopo.zeitreihen_19121231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19121231_cache]
   ch.swisstopo.zeitreihen_19131231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19131231_source]
   ch.swisstopo.zeitreihen_19131231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19131231_cache]
   ch.swisstopo.zeitreihen_19141231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19141231_source]
   ch.swisstopo.zeitreihen_19141231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19141231_cache]
   ch.swisstopo.zeitreihen_19151231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19151231_source]
   ch.swisstopo.zeitreihen_19151231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19151231_cache]
   ch.swisstopo.zeitreihen_19161231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19161231_source]
   ch.swisstopo.zeitreihen_19161231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19161231_cache]
   ch.swisstopo.zeitreihen_19171231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19171231_source]
   ch.swisstopo.zeitreihen_19171231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19171231_cache]
   ch.swisstopo.zeitreihen_19181231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19181231_source]
   ch.swisstopo.zeitreihen_19181231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19181231_cache]
   ch.swisstopo.zeitreihen_19191231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19191231_source]
   ch.swisstopo.zeitreihen_19191231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19191231_cache]
   ch.swisstopo.zeitreihen_19201231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19201231_source]
   ch.swisstopo.zeitreihen_19201231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19201231_cache]
   ch.swisstopo.zeitreihen_19211231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19211231_source]
   ch.swisstopo.zeitreihen_19211231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19211231_cache]
   ch.swisstopo.zeitreihen_19221231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19221231_source]
   ch.swisstopo.zeitreihen_19221231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19221231_cache]
   ch.swisstopo.zeitreihen_19231231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19231231_source]
   ch.swisstopo.zeitreihen_19231231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19231231_cache]
   ch.swisstopo.zeitreihen_19241231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19241231_source]
   ch.swisstopo.zeitreihen_19241231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19241231_cache]
   ch.swisstopo.zeitreihen_19251231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19251231_source]
   ch.swisstopo.zeitreihen_19251231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19251231_cache]
   ch.swisstopo.zeitreihen_19261231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19261231_source]
   ch.swisstopo.zeitreihen_19261231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19261231_cache]
   ch.swisstopo.zeitreihen_19271231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19271231_source]
   ch.swisstopo.zeitreihen_19271231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19271231_cache]
   ch.swisstopo.zeitreihen_19281231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19281231_source]
   ch.swisstopo.zeitreihen_19281231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19281231_cache]
   ch.swisstopo.zeitreihen_19291231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19291231_source]
   ch.swisstopo.zeitreihen_19291231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19291231_cache]
   ch.swisstopo.zeitreihen_19301231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19301231_source]
   ch.swisstopo.zeitreihen_19301231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19301231_cache]
   ch.swisstopo.zeitreihen_19311231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19311231_source]
   ch.swisstopo.zeitreihen_19311231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19311231_cache]
   ch.swisstopo.zeitreihen_19321231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19321231_source]
   ch.swisstopo.zeitreihen_19321231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19321231_cache]
   ch.swisstopo.zeitreihen_19331231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19331231_source]
   ch.swisstopo.zeitreihen_19331231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19331231_cache]
   ch.swisstopo.zeitreihen_19341231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19341231_source]
   ch.swisstopo.zeitreihen_19341231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19341231_cache]
   ch.swisstopo.zeitreihen_19351231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19351231_source]
   ch.swisstopo.zeitreihen_19351231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19351231_cache]
   ch.swisstopo.zeitreihen_19361231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19361231_source]
   ch.swisstopo.zeitreihen_19361231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19361231_cache]
   ch.swisstopo.zeitreihen_19371231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19371231_source]
   ch.swisstopo.zeitreihen_19371231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19371231_cache]
   ch.swisstopo.zeitreihen_19381231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19381231_source]
   ch.swisstopo.zeitreihen_19381231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19381231_cache]
   ch.swisstopo.zeitreihen_19391231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19391231_source]
   ch.swisstopo.zeitreihen_19391231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19391231_cache]
   ch.swisstopo.zeitreihen_19401231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19401231_source]
   ch.swisstopo.zeitreihen_19401231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19401231_cache]
   ch.swisstopo.zeitreihen_19411231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19411231_source]
   ch.swisstopo.zeitreihen_19411231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19411231_cache]
   ch.swisstopo.zeitreihen_19421231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19421231_source]
   ch.swisstopo.zeitreihen_19421231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19421231_cache]
   ch.swisstopo.zeitreihen_19431231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19431231_source]
   ch.swisstopo.zeitreihen_19431231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19431231_cache]
   ch.swisstopo.zeitreihen_19441231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19441231_source]
   ch.swisstopo.zeitreihen_19441231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19441231_cache]
   ch.swisstopo.zeitreihen_19451231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19451231_source]
   ch.swisstopo.zeitreihen_19451231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19451231_cache]
   ch.swisstopo.zeitreihen_19461231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19461231_source]
   ch.swisstopo.zeitreihen_19461231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19461231_cache]
   ch.swisstopo.zeitreihen_19471231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19471231_source]
   ch.swisstopo.zeitreihen_19471231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19471231_cache]
   ch.swisstopo.zeitreihen_19481231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19481231_source]
   ch.swisstopo.zeitreihen_19481231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19481231_cache]
   ch.swisstopo.zeitreihen_19491231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19491231_source]
   ch.swisstopo.zeitreihen_19491231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19491231_cache]
   ch.swisstopo.zeitreihen_19501231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19501231_source]
   ch.swisstopo.zeitreihen_19501231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19501231_cache]
   ch.swisstopo.zeitreihen_19511231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19511231_source]
   ch.swisstopo.zeitreihen_19511231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19511231_cache]
   ch.swisstopo.zeitreihen_19521231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19521231_source]
   ch.swisstopo.zeitreihen_19521231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19521231_cache]
   ch.swisstopo.zeitreihen_19531231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19531231_source]
   ch.swisstopo.zeitreihen_19531231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19531231_cache]
   ch.swisstopo.zeitreihen_19541231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19541231_source]
   ch.swisstopo.zeitreihen_19541231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19541231_cache]
   ch.swisstopo.zeitreihen_19551231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19551231_source]
   ch.swisstopo.zeitreihen_19551231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19551231_cache]
   ch.swisstopo.zeitreihen_19561231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19561231_source]
   ch.swisstopo.zeitreihen_19561231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19561231_cache]
   ch.swisstopo.zeitreihen_19571231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19571231_source]
   ch.swisstopo.zeitreihen_19571231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19571231_cache]
   ch.swisstopo.zeitreihen_19581231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19581231_source]
   ch.swisstopo.zeitreihen_19581231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19581231_cache]
   ch.swisstopo.zeitreihen_19591231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19591231_source]
   ch.swisstopo.zeitreihen_19591231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19591231_cache]
   ch.swisstopo.zeitreihen_19601231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19601231_source]
   ch.swisstopo.zeitreihen_19601231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19601231_cache]
   ch.swisstopo.zeitreihen_19611231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19611231_source]
   ch.swisstopo.zeitreihen_19611231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19611231_cache]
   ch.swisstopo.zeitreihen_19621231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19621231_source]
   ch.swisstopo.zeitreihen_19621231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19621231_cache]
   ch.swisstopo.zeitreihen_19631231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19631231_source]
   ch.swisstopo.zeitreihen_19631231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19631231_cache]
   ch.swisstopo.zeitreihen_19641231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19641231_source]
   ch.swisstopo.zeitreihen_19641231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19641231_cache]
   ch.swisstopo.zeitreihen_19651231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19651231_source]
   ch.swisstopo.zeitreihen_19651231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19651231_cache]
   ch.swisstopo.zeitreihen_19661231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19661231_source]
   ch.swisstopo.zeitreihen_19661231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19661231_cache]
   ch.swisstopo.zeitreihen_19671231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19671231_source]
   ch.swisstopo.zeitreihen_19671231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19671231_cache]
   ch.swisstopo.zeitreihen_19681231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19681231_source]
   ch.swisstopo.zeitreihen_19681231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19681231_cache]
   ch.swisstopo.zeitreihen_19691231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19691231_source]
   ch.swisstopo.zeitreihen_19691231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19691231_cache]
   ch.swisstopo.zeitreihen_19701231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19701231_source]
   ch.swisstopo.zeitreihen_19701231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19701231_cache]
   ch.swisstopo.zeitreihen_19711231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19711231_source]
   ch.swisstopo.zeitreihen_19711231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19711231_cache]
   ch.swisstopo.zeitreihen_19721231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19721231_source]
   ch.swisstopo.zeitreihen_19721231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19721231_cache]
   ch.swisstopo.zeitreihen_19731231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19731231_source]
   ch.swisstopo.zeitreihen_19731231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19731231_cache]
   ch.swisstopo.zeitreihen_19741231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19741231_source]
   ch.swisstopo.zeitreihen_19741231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19741231_cache]
   ch.swisstopo.zeitreihen_19751231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19751231_source]
   ch.swisstopo.zeitreihen_19751231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19751231_cache]
   ch.swisstopo.zeitreihen_19761231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19761231_source]
   ch.swisstopo.zeitreihen_19761231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19761231_cache]
   ch.swisstopo.zeitreihen_19771231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19771231_source]
   ch.swisstopo.zeitreihen_19771231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19771231_cache]
   ch.swisstopo.zeitreihen_19781231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19781231_source]
   ch.swisstopo.zeitreihen_19781231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19781231_cache]
   ch.swisstopo.zeitreihen_19791231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19791231_source]
   ch.swisstopo.zeitreihen_19791231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19791231_cache]
   ch.swisstopo.zeitreihen_19801231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19801231_source]
   ch.swisstopo.zeitreihen_19801231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19801231_cache]
   ch.swisstopo.zeitreihen_19811231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19811231_source]
   ch.swisstopo.zeitreihen_19811231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19811231_cache]
   ch.swisstopo.zeitreihen_19821231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19821231_source]
   ch.swisstopo.zeitreihen_19821231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19821231_cache]
   ch.swisstopo.zeitreihen_19831231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19831231_source]
   ch.swisstopo.zeitreihen_19831231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19831231_cache]
   ch.swisstopo.zeitreihen_19841231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19841231_source]
   ch.swisstopo.zeitreihen_19841231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19841231_cache]
   ch.swisstopo.zeitreihen_19851231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19851231_source]
   ch.swisstopo.zeitreihen_19851231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19851231_cache]
   ch.swisstopo.zeitreihen_19861231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19861231_source]
   ch.swisstopo.zeitreihen_19861231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19861231_cache]
   ch.swisstopo.zeitreihen_19871231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19871231_source]
   ch.swisstopo.zeitreihen_19871231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19871231_cache]
   ch.swisstopo.zeitreihen_19881231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19881231_source]
   ch.swisstopo.zeitreihen_19881231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19881231_cache]
   ch.swisstopo.zeitreihen_19891231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19891231_source]
   ch.swisstopo.zeitreihen_19891231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19891231_cache]
   ch.swisstopo.zeitreihen_19901231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19901231_source]
   ch.swisstopo.zeitreihen_19901231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19901231_cache]
   ch.swisstopo.zeitreihen_19911231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19911231_source]
   ch.swisstopo.zeitreihen_19911231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19911231_cache]
   ch.swisstopo.zeitreihen_19921231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19921231_source]
   ch.swisstopo.zeitreihen_19921231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19921231_cache]
   ch.swisstopo.zeitreihen_19931231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19931231_source]
   ch.swisstopo.zeitreihen_19931231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19931231_cache]
   ch.swisstopo.zeitreihen_19941231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19941231_source]
   ch.swisstopo.zeitreihen_19941231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19941231_cache]
   ch.swisstopo.zeitreihen_19951231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19951231_source]
   ch.swisstopo.zeitreihen_19951231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19951231_cache]
   ch.swisstopo.zeitreihen_19961231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19961231_source]
   ch.swisstopo.zeitreihen_19961231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19961231_cache]
   ch.swisstopo.zeitreihen_19971231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19971231_source]
   ch.swisstopo.zeitreihen_19971231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19971231_cache]
   ch.swisstopo.zeitreihen_19981231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19981231_source]
   ch.swisstopo.zeitreihen_19981231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19981231_cache]
   ch.swisstopo.zeitreihen_19991231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_19991231_source]
   ch.swisstopo.zeitreihen_19991231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_19991231_cache]
   ch.swisstopo.zeitreihen_20001231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20001231_source]
   ch.swisstopo.zeitreihen_20001231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20001231_cache]
   ch.swisstopo.zeitreihen_20011231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20011231_source]
   ch.swisstopo.zeitreihen_20011231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20011231_cache]
   ch.swisstopo.zeitreihen_20021231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20021231_source]
   ch.swisstopo.zeitreihen_20021231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20021231_cache]
   ch.swisstopo.zeitreihen_20031231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20031231_source]
   ch.swisstopo.zeitreihen_20031231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20031231_cache]
   ch.swisstopo.zeitreihen_20041231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20041231_source]
   ch.swisstopo.zeitreihen_20041231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20041231_cache]
   ch.swisstopo.zeitreihen_20051231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20051231_source]
   ch.swisstopo.zeitreihen_20051231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20051231_cache]
   ch.swisstopo.zeitreihen_20061231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20061231_source]
   ch.swisstopo.zeitreihen_20061231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20061231_cache]
   ch.swisstopo.zeitreihen_20071231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20071231_source]
   ch.swisstopo.zeitreihen_20071231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20071231_cache]
   ch.swisstopo.zeitreihen_20081231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20081231_source]
   ch.swisstopo.zeitreihen_20081231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20081231_cache]
   ch.swisstopo.zeitreihen_20091231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20091231_source]
   ch.swisstopo.zeitreihen_20091231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20091231_cache]
   ch.swisstopo.zeitreihen_20101231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20101231_source]
   ch.swisstopo.zeitreihen_20101231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20101231_cache]
   ch.swisstopo.zeitreihen_20111231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20111231_source]
   ch.swisstopo.zeitreihen_20111231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20111231_cache]
   ch.swisstopo.zeitreihen_20121231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20121231_source]
   ch.swisstopo.zeitreihen_20121231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
     sources: [ch.swisstopo.zeitreihen_20121231_cache]
   ch.swisstopo.zeitreihen_20131231_cache:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: [swisstopo-pixelkarte]
     sources: [ch.swisstopo.zeitreihen_20131231_source]
   ch.swisstopo.zeitreihen_20131231_cache_out:
     disable_storage: true
-    format: image/png
+    format: image/jpeg
     grids: *id009
     meta_buffer: 0
     meta_size: [1, 1]
@@ -8880,8 +8880,7 @@ globals:
       image/jpeg:
         encoding_options: {jpeg_quality: 88}
         mode: RGB
-      image/png: {mode: RGBA, transparent: true}
-    paletted: false
+    paletted: true
     resampling_method: bicubic
   srs:
     axis_order_en: ['EPSG:21781', 'EPSG:2056']
@@ -8958,9587 +8957,9587 @@ layers:
   title: CadastralWebMap
 - dimensions: &id010
     Time:
-      default: '20140101'
-      values: ['20140101']
-  name: ch.are.agglomerationen_isolierte_staedte_20140101
-  sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache_out]
-  title: "Agglomerationen und isolierte St\xE4dte (20140101)"
-- dimensions: *id010
-  name: ch.are.agglomerationen_isolierte_staedte
-  sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache]
-  title: "Agglomerationen und isolierte St\xE4dte ('current')"
-- dimensions: *id010
-  name: ch.are.agglomerationen_isolierte_staedte_20140101_source
-  sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache]
-  title: "Agglomerationen und isolierte St\xE4dte (20140101, source)"
-- dimensions: &id011
-    Time:
       default: '20090101'
       values: ['20090101']
   name: ch.are.alpenkonvention_20090101
   sources: [ch.are.alpenkonvention_20090101_cache_out]
   title: Alpenkonvention (20090101)
-- dimensions: *id011
+- dimensions: *id010
   name: ch.are.alpenkonvention
   sources: [ch.are.alpenkonvention_20090101_cache]
   title: Alpenkonvention ('current')
-- dimensions: *id011
+- dimensions: *id010
   name: ch.are.alpenkonvention_20090101_source
   sources: [ch.are.alpenkonvention_20090101_cache]
   title: Alpenkonvention (20090101, source)
-- dimensions: &id012
-    Time:
-      default: '20120101'
-      values: ['20120101']
-  name: ch.are.bauzonen_20120101
-  sources: [ch.are.bauzonen_20120101_cache_out]
-  title: Bauzonen Schweiz (harmonisiert) (20120101)
-- dimensions: *id012
-  name: ch.are.bauzonen
-  sources: [ch.are.bauzonen_20120101_cache]
-  title: Bauzonen Schweiz (harmonisiert) ('current')
-- dimensions: *id012
-  name: ch.are.bauzonen_20120101_source
-  sources: [ch.are.bauzonen_20120101_cache]
-  title: Bauzonen Schweiz (harmonisiert) (20120101, source)
-- dimensions: &id013
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.are.belastung-gueterverkehr-bahn_20121231
-  sources: [ch.are.belastung-gueterverkehr-bahn_20121231_cache_out]
-  title: "G\xFCterverkehr Schiene (20121231)"
-- dimensions: *id013
-  name: ch.are.belastung-gueterverkehr-bahn
-  sources: [ch.are.belastung-gueterverkehr-bahn_20121231_cache]
-  title: "G\xFCterverkehr Schiene ('current')"
-- dimensions: *id013
-  name: ch.are.belastung-gueterverkehr-bahn_20121231_source
-  sources: [ch.are.belastung-gueterverkehr-bahn_20121231_cache]
-  title: "G\xFCterverkehr Schiene (20121231, source)"
-- dimensions: &id014
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.are.belastung-gueterverkehr-strasse_20121231
-  sources: [ch.are.belastung-gueterverkehr-strasse_20121231_cache_out]
-  title: "G\xFCterverkehr Strasse (20121231)"
-- dimensions: *id014
-  name: ch.are.belastung-gueterverkehr-strasse
-  sources: [ch.are.belastung-gueterverkehr-strasse_20121231_cache]
-  title: "G\xFCterverkehr Strasse ('current')"
-- dimensions: *id014
-  name: ch.are.belastung-gueterverkehr-strasse_20121231_source
-  sources: [ch.are.belastung-gueterverkehr-strasse_20121231_cache]
-  title: "G\xFCterverkehr Strasse (20121231, source)"
-- dimensions: &id015
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.are.belastung-personenverkehr-bahn_20121231
-  sources: [ch.are.belastung-personenverkehr-bahn_20121231_cache_out]
-  title: "Personenverkehr \xD6V (20121231)"
-- dimensions: *id015
-  name: ch.are.belastung-personenverkehr-bahn
-  sources: [ch.are.belastung-personenverkehr-bahn_20121231_cache]
-  title: "Personenverkehr \xD6V ('current')"
-- dimensions: *id015
-  name: ch.are.belastung-personenverkehr-bahn_20121231_source
-  sources: [ch.are.belastung-personenverkehr-bahn_20121231_cache]
-  title: "Personenverkehr \xD6V (20121231, source)"
-- dimensions: &id016
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.are.belastung-personenverkehr-strasse_20121231
-  sources: [ch.are.belastung-personenverkehr-strasse_20121231_cache_out]
-  title: Personenverkehr Strasse (20121231)
-- dimensions: *id016
-  name: ch.are.belastung-personenverkehr-strasse
-  sources: [ch.are.belastung-personenverkehr-strasse_20121231_cache]
-  title: Personenverkehr Strasse ('current')
-- dimensions: *id016
-  name: ch.are.belastung-personenverkehr-strasse_20121231_source
-  sources: [ch.are.belastung-personenverkehr-strasse_20121231_cache]
-  title: Personenverkehr Strasse (20121231, source)
-- dimensions: &id017
-    Time:
-      default: '20111231'
-      values: ['20111231']
-  name: ch.are.beschaeftigtendichte_20111231
-  sources: [ch.are.beschaeftigtendichte_20111231_cache_out]
-  title: "Besch\xE4ftigtendichte (20111231)"
-- dimensions: *id017
-  name: ch.are.beschaeftigtendichte
-  sources: [ch.are.beschaeftigtendichte_20111231_cache]
-  title: "Besch\xE4ftigtendichte ('current')"
-- dimensions: *id017
-  name: ch.are.beschaeftigtendichte_20111231_source
-  sources: [ch.are.beschaeftigtendichte_20111231_cache]
-  title: "Besch\xE4ftigtendichte (20111231, source)"
-- dimensions: &id018
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.are.bevoelkerungsdichte_20121231
-  sources: [ch.are.bevoelkerungsdichte_20121231_cache_out]
-  title: "Bev\xF6lkerungsdichte (20121231)"
-- dimensions: *id018
-  name: ch.are.bevoelkerungsdichte
-  sources: [ch.are.bevoelkerungsdichte_20121231_cache]
-  title: "Bev\xF6lkerungsdichte ('current')"
-- dimensions: *id018
-  name: ch.are.bevoelkerungsdichte_20121231_source
-  sources: [ch.are.bevoelkerungsdichte_20121231_cache]
-  title: "Bev\xF6lkerungsdichte (20121231, source)"
-- dimensions: &id019
+- dimensions: &id011
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.are.gemeindetypen_20140101
   sources: [ch.are.gemeindetypen_20140101_cache_out]
   title: Gemeindetypologie ARE (20140101)
-- dimensions: *id019
+- dimensions: *id011
   name: ch.are.gemeindetypen
   sources: [ch.are.gemeindetypen_20140101_cache]
   title: Gemeindetypologie ARE ('current')
-- dimensions: *id019
+- dimensions: *id011
   name: ch.are.gemeindetypen_20140101_source
   sources: [ch.are.gemeindetypen_20140101_cache]
   title: Gemeindetypologie ARE (20140101, source)
-- dimensions: &id020
-    Time:
-      default: '20141214'
-      values: ['20141214']
-  name: ch.are.gueteklassen_oev_20141214
-  sources: [ch.are.gueteklassen_oev_20141214_cache_out]
-  title: "\xD6V-G\xFCteklassen ARE (20141214)"
-- dimensions: *id020
-  name: ch.are.gueteklassen_oev
-  sources: [ch.are.gueteklassen_oev_20141214_cache]
-  title: "\xD6V-G\xFCteklassen ARE ('current')"
-- dimensions: *id020
-  name: ch.are.gueteklassen_oev_20141214_source
-  sources: [ch.are.gueteklassen_oev_20141214_cache]
-  title: "\xD6V-G\xFCteklassen ARE (20141214, source)"
-- dimensions: &id021
-    Time:
-      default: '20100831'
-      values: ['20100831']
-  name: ch.are.landschaftstypen_20100831
-  sources: [ch.are.landschaftstypen_20100831_cache_out]
-  title: Landschaftstypologie Schweiz (20100831)
-- dimensions: *id021
-  name: ch.are.landschaftstypen
-  sources: [ch.are.landschaftstypen_20100831_cache]
-  title: Landschaftstypologie Schweiz ('current')
-- dimensions: *id021
-  name: ch.are.landschaftstypen_20100831_source
-  sources: [ch.are.landschaftstypen_20100831_cache]
-  title: Landschaftstypologie Schweiz (20100831, source)
-- dimensions: &id022
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.are.reisezeit-miv_20121231
-  sources: [ch.are.reisezeit-miv_20121231_cache_out]
-  title: Reisezeit zu Zentren MIV (20121231)
-- dimensions: *id022
-  name: ch.are.reisezeit-miv
-  sources: [ch.are.reisezeit-miv_20121231_cache]
-  title: Reisezeit zu Zentren MIV ('current')
-- dimensions: *id022
-  name: ch.are.reisezeit-miv_20121231_source
-  sources: [ch.are.reisezeit-miv_20121231_cache]
-  title: Reisezeit zu Zentren MIV (20121231, source)
-- dimensions: &id023
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.are.reisezeit-oev_20121231
-  sources: [ch.are.reisezeit-oev_20121231_cache_out]
-  title: "Reisezeit zu Zentren \xD6V (20121231)"
-- dimensions: *id023
-  name: ch.are.reisezeit-oev
-  sources: [ch.are.reisezeit-oev_20121231_cache]
-  title: "Reisezeit zu Zentren \xD6V ('current')"
-- dimensions: *id023
-  name: ch.are.reisezeit-oev_20121231_source
-  sources: [ch.are.reisezeit-oev_20121231_cache]
-  title: "Reisezeit zu Zentren \xD6V (20121231, source)"
-- dimensions: &id024
+- dimensions: &id012
     Time:
       default: '20150211'
       values: ['20150211']
   name: ch.astra.ausnahmetransportrouten_20150211
   sources: [ch.astra.ausnahmetransportrouten_20150211_cache_out]
   title: Ausnahmetransportrouten (20150211)
-- dimensions: *id024
+- dimensions: *id012
   name: ch.astra.ausnahmetransportrouten
   sources: [ch.astra.ausnahmetransportrouten_20150211_cache]
   title: Ausnahmetransportrouten ('current')
-- dimensions: *id024
+- dimensions: *id012
   name: ch.astra.ausnahmetransportrouten_20150211_source
   sources: [ch.astra.ausnahmetransportrouten_20150211_cache]
   title: Ausnahmetransportrouten (20150211, source)
-- dimensions: &id025
+- dimensions: &id013
     Time:
       default: '19980816'
       values: ['19980816']
   name: ch.astra.ivs-gelaendekarte_19980816
   sources: [ch.astra.ivs-gelaendekarte_19980816_cache_out]
   title: "IVS Gel\xE4ndekarte (19980816)"
-- dimensions: *id025
+- dimensions: *id013
   name: ch.astra.ivs-gelaendekarte
   sources: [ch.astra.ivs-gelaendekarte_19980816_cache]
   title: "IVS Gel\xE4ndekarte ('current')"
-- dimensions: *id025
+- dimensions: *id013
   name: ch.astra.ivs-gelaendekarte_19980816_source
   sources: [ch.astra.ivs-gelaendekarte_19980816_cache]
   title: "IVS Gel\xE4ndekarte (19980816, source)"
-- dimensions: &id026
+- dimensions: &id014
     Time:
       default: '20100416'
       values: ['20100416']
   name: ch.astra.ivs-nat_20100416
   sources: [ch.astra.ivs-nat_20100416_cache_out]
   title: IVS National (20100416)
-- dimensions: *id026
+- dimensions: *id014
   name: ch.astra.ivs-nat
   sources: [ch.astra.ivs-nat_20100416_cache]
   title: IVS National ('current')
-- dimensions: *id026
+- dimensions: *id014
   name: ch.astra.ivs-nat_20100416_source
   sources: [ch.astra.ivs-nat_20100416_cache]
   title: IVS National (20100416, source)
-- dimensions: &id027
+- dimensions: &id015
     Time:
       default: '20100414'
       values: ['20100414']
   name: ch.astra.ivs-nat_abgrenzungen_20100414
   sources: [ch.astra.ivs-nat_abgrenzungen_20100414_cache_out]
   title: IVS Abgrenzungen (20100414)
-- dimensions: *id027
+- dimensions: *id015
   name: ch.astra.ivs-nat_abgrenzungen
   sources: [ch.astra.ivs-nat_abgrenzungen_20100414_cache]
   title: IVS Abgrenzungen ('current')
-- dimensions: *id027
+- dimensions: *id015
   name: ch.astra.ivs-nat_abgrenzungen_20100414_source
   sources: [ch.astra.ivs-nat_abgrenzungen_20100414_cache]
   title: IVS Abgrenzungen (20100414, source)
-- dimensions: &id028
+- dimensions: &id016
     Time:
       default: '20100416'
       values: ['20100416']
   name: ch.astra.ivs-nat-verlaeufe_20100416
   sources: [ch.astra.ivs-nat-verlaeufe_20100416_cache_out]
   title: IVS historischer Verlauf (20100416)
-- dimensions: *id028
+- dimensions: *id016
   name: ch.astra.ivs-nat-verlaeufe
   sources: [ch.astra.ivs-nat-verlaeufe_20100416_cache]
   title: IVS historischer Verlauf ('current')
-- dimensions: *id028
+- dimensions: *id016
   name: ch.astra.ivs-nat-verlaeufe_20100416_source
   sources: [ch.astra.ivs-nat-verlaeufe_20100416_cache]
   title: IVS historischer Verlauf (20100416, source)
-- dimensions: &id029
+- dimensions: &id017
     Time:
       default: '20100414'
       values: ['20100414']
   name: ch.astra.ivs-nat_wegbegleiter_20100414
   sources: [ch.astra.ivs-nat_wegbegleiter_20100414_cache_out]
   title: IVS Wegbegleiter (20100414)
-- dimensions: *id029
+- dimensions: *id017
   name: ch.astra.ivs-nat_wegbegleiter
   sources: [ch.astra.ivs-nat_wegbegleiter_20100414_cache]
   title: IVS Wegbegleiter ('current')
-- dimensions: *id029
+- dimensions: *id017
   name: ch.astra.ivs-nat_wegbegleiter_20100414_source
   sources: [ch.astra.ivs-nat_wegbegleiter_20100414_cache]
   title: IVS Wegbegleiter (20100414, source)
-- dimensions: &id030
+- dimensions: &id018
     Time:
       default: '20100416'
       values: ['20100416']
   name: ch.astra.ivs-reg_loc_20100416
   sources: [ch.astra.ivs-reg_loc_20100416_cache_out]
   title: IVS Regional und Lokal (20100416)
-- dimensions: *id030
+- dimensions: *id018
   name: ch.astra.ivs-reg_loc
   sources: [ch.astra.ivs-reg_loc_20100416_cache]
   title: IVS Regional und Lokal ('current')
-- dimensions: *id030
+- dimensions: *id018
   name: ch.astra.ivs-reg_loc_20100416_source
   sources: [ch.astra.ivs-reg_loc_20100416_cache]
   title: IVS Regional und Lokal (20100416, source)
-- dimensions: &id031
-    Time:
-      default: '20150326'
-      values: ['20150326']
-  name: ch.astra.unfaelle-personenschaeden_alle_20150326
-  sources: [ch.astra.unfaelle-personenschaeden_alle_20150326_cache_out]
-  title: "Unf\xE4lle mit Personenschaden (20150326)"
-- dimensions: *id031
-  name: ch.astra.unfaelle-personenschaeden_alle
-  sources: [ch.astra.unfaelle-personenschaeden_alle_20150326_cache]
-  title: "Unf\xE4lle mit Personenschaden ('current')"
-- dimensions: *id031
-  name: ch.astra.unfaelle-personenschaeden_alle_20150326_source
-  sources: [ch.astra.unfaelle-personenschaeden_alle_20150326_cache]
-  title: "Unf\xE4lle mit Personenschaden (20150326, source)"
-- dimensions: &id032
-    Time:
-      default: '20150326'
-      values: ['20150326']
-  name: ch.astra.unfaelle-personenschaeden_fahrraeder_20150326
-  sources: [ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_cache_out]
-  title: "Unf\xE4lle mit Fahrradbeteiligung (20150326)"
-- dimensions: *id032
-  name: ch.astra.unfaelle-personenschaeden_fahrraeder
-  sources: [ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_cache]
-  title: "Unf\xE4lle mit Fahrradbeteiligung ('current')"
-- dimensions: *id032
-  name: ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_source
-  sources: [ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_cache]
-  title: "Unf\xE4lle mit Fahrradbeteiligung (20150326, source)"
-- dimensions: &id033
-    Time:
-      default: '20150326'
-      values: ['20150326']
-  name: ch.astra.unfaelle-personenschaeden_fussgaenger_20150326
-  sources: [ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_cache_out]
-  title: "Unf\xE4lle mit Fussg\xE4ngerbeteiligung (20150326)"
-- dimensions: *id033
-  name: ch.astra.unfaelle-personenschaeden_fussgaenger
-  sources: [ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_cache]
-  title: "Unf\xE4lle mit Fussg\xE4ngerbeteiligung ('current')"
-- dimensions: *id033
-  name: ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_source
-  sources: [ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_cache]
-  title: "Unf\xE4lle mit Fussg\xE4ngerbeteiligung (20150326, source)"
-- dimensions: &id034
-    Time:
-      default: '20150326'
-      values: ['20150326']
-  name: ch.astra.unfaelle-personenschaeden_getoetete_20150326
-  sources: [ch.astra.unfaelle-personenschaeden_getoetete_20150326_cache_out]
-  title: "Unf\xE4lle mit Get\xF6teten (20150326)"
-- dimensions: *id034
-  name: ch.astra.unfaelle-personenschaeden_getoetete
-  sources: [ch.astra.unfaelle-personenschaeden_getoetete_20150326_cache]
-  title: "Unf\xE4lle mit Get\xF6teten ('current')"
-- dimensions: *id034
-  name: ch.astra.unfaelle-personenschaeden_getoetete_20150326_source
-  sources: [ch.astra.unfaelle-personenschaeden_getoetete_20150326_cache]
-  title: "Unf\xE4lle mit Get\xF6teten (20150326, source)"
-- dimensions: &id035
-    Time:
-      default: '20150326'
-      values: ['20150326']
-  name: ch.astra.unfaelle-personenschaeden_motorraeder_20150326
-  sources: [ch.astra.unfaelle-personenschaeden_motorraeder_20150326_cache_out]
-  title: "Unf\xE4lle mit Motorradbeteiligung (20150326)"
-- dimensions: *id035
-  name: ch.astra.unfaelle-personenschaeden_motorraeder
-  sources: [ch.astra.unfaelle-personenschaeden_motorraeder_20150326_cache]
-  title: "Unf\xE4lle mit Motorradbeteiligung ('current')"
-- dimensions: *id035
-  name: ch.astra.unfaelle-personenschaeden_motorraeder_20150326_source
-  sources: [ch.astra.unfaelle-personenschaeden_motorraeder_20150326_cache]
-  title: "Unf\xE4lle mit Motorradbeteiligung (20150326, source)"
-- dimensions: &id036
+- dimensions: &id019
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.babs.kulturgueter_20150101
   sources: [ch.babs.kulturgueter_20150101_cache_out]
   title: KGS Inventar (20150101)
-- dimensions: *id036
+- dimensions: *id019
   name: ch.babs.kulturgueter
   sources: [ch.babs.kulturgueter_20150101_cache]
   title: KGS Inventar ('current')
-- dimensions: *id036
+- dimensions: *id019
   name: ch.babs.kulturgueter_20150101_source
   sources: [ch.babs.kulturgueter_20150101_cache]
   title: KGS Inventar (20150101, source)
-- dimensions: &id037
-    Time:
-      default: '20081218'
-      values: ['20081218']
-  name: ch.bafu.aquaprotect_050_20081218
-  sources: [ch.bafu.aquaprotect_050_20081218_cache_out]
-  title: "\xDCberschwemmung Aquaprotect 50 (20081218)"
-- dimensions: *id037
-  name: ch.bafu.aquaprotect_050
-  sources: [ch.bafu.aquaprotect_050_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 50 ('current')"
-- dimensions: *id037
-  name: ch.bafu.aquaprotect_050_20081218_source
-  sources: [ch.bafu.aquaprotect_050_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 50 (20081218, source)"
-- dimensions: &id038
-    Time:
-      default: '20081218'
-      values: ['20081218']
-  name: ch.bafu.aquaprotect_100_20081218
-  sources: [ch.bafu.aquaprotect_100_20081218_cache_out]
-  title: "\xDCberschwemmung Aquaprotect 100 (20081218)"
-- dimensions: *id038
-  name: ch.bafu.aquaprotect_100
-  sources: [ch.bafu.aquaprotect_100_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 100 ('current')"
-- dimensions: *id038
-  name: ch.bafu.aquaprotect_100_20081218_source
-  sources: [ch.bafu.aquaprotect_100_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 100 (20081218, source)"
-- dimensions: &id039
-    Time:
-      default: '20081218'
-      values: ['20081218']
-  name: ch.bafu.aquaprotect_250_20081218
-  sources: [ch.bafu.aquaprotect_250_20081218_cache_out]
-  title: "\xDCberschwemmung Aquaprotect 250 (20081218)"
-- dimensions: *id039
-  name: ch.bafu.aquaprotect_250
-  sources: [ch.bafu.aquaprotect_250_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 250 ('current')"
-- dimensions: *id039
-  name: ch.bafu.aquaprotect_250_20081218_source
-  sources: [ch.bafu.aquaprotect_250_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 250 (20081218, source)"
-- dimensions: &id040
-    Time:
-      default: '20081218'
-      values: ['20081218']
-  name: ch.bafu.aquaprotect_500_20081218
-  sources: [ch.bafu.aquaprotect_500_20081218_cache_out]
-  title: "\xDCberschwemmung Aquaprotect 500 (20081218)"
-- dimensions: *id040
-  name: ch.bafu.aquaprotect_500
-  sources: [ch.bafu.aquaprotect_500_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 500 ('current')"
-- dimensions: *id040
-  name: ch.bafu.aquaprotect_500_20081218_source
-  sources: [ch.bafu.aquaprotect_500_20081218_cache]
-  title: "\xDCberschwemmung Aquaprotect 500 (20081218, source)"
-- dimensions: &id041
-    Time:
-      default: '20040302'
-      values: ['20040302']
-  name: ch.bafu.biogeographische_regionen_20040302
-  sources: [ch.bafu.biogeographische_regionen_20040302_cache_out]
-  title: Biogeographische Regionen (20040302)
-- dimensions: *id041
-  name: ch.bafu.biogeographische_regionen
-  sources: [ch.bafu.biogeographische_regionen_20040302_cache]
-  title: Biogeographische Regionen ('current')
-- dimensions: *id041
-  name: ch.bafu.biogeographische_regionen_20040302_source
-  sources: [ch.bafu.biogeographische_regionen_20040302_cache]
-  title: Biogeographische Regionen (20040302, source)
-- dimensions: &id042
+- dimensions: &id020
     Time:
       default: '20070702'
       values: ['20070702']
   name: ch.bafu.bundesinventare-amphibien_20070702
   sources: [ch.bafu.bundesinventare-amphibien_20070702_cache_out]
   title: Amphibien Ortsfeste Objekte (20070702)
-- dimensions: *id042
+- dimensions: *id020
   name: ch.bafu.bundesinventare-amphibien
   sources: [ch.bafu.bundesinventare-amphibien_20070702_cache]
   title: Amphibien Ortsfeste Objekte ('current')
-- dimensions: *id042
+- dimensions: *id020
   name: ch.bafu.bundesinventare-amphibien_20070702_source
   sources: [ch.bafu.bundesinventare-amphibien_20070702_cache]
   title: Amphibien Ortsfeste Objekte (20070702, source)
-- dimensions: &id043
-    Time:
-      default: '20111205'
-      values: ['20111205']
-  name: ch.bafu.bundesinventare-amphibien_anhang4_20111205
-  sources: [ch.bafu.bundesinventare-amphibien_anhang4_20111205_cache_out]
-  title: Amphibien Anhang 4 (20111205)
-- dimensions: *id043
-  name: ch.bafu.bundesinventare-amphibien_anhang4
-  sources: [ch.bafu.bundesinventare-amphibien_anhang4_20111205_cache]
-  title: Amphibien Anhang 4 ('current')
-- dimensions: *id043
-  name: ch.bafu.bundesinventare-amphibien_anhang4_20111205_source
-  sources: [ch.bafu.bundesinventare-amphibien_anhang4_20111205_cache]
-  title: Amphibien Anhang 4 (20111205, source)
-- dimensions: &id044
+- dimensions: &id021
     Time:
       default: '20150626'
       values: ['20150626']
   name: ch.bafu.bundesinventare-amphibien_anhoerung_20150626
   sources: [ch.bafu.bundesinventare-amphibien_anhoerung_20150626_cache_out]
   title: "Amphibien - Anh\xF6rung 2015 (20150626)"
-- dimensions: *id044
+- dimensions: *id021
   name: ch.bafu.bundesinventare-amphibien_anhoerung
   sources: [ch.bafu.bundesinventare-amphibien_anhoerung_20150626_cache]
   title: "Amphibien - Anh\xF6rung 2015 ('current')"
-- dimensions: *id044
+- dimensions: *id021
   name: ch.bafu.bundesinventare-amphibien_anhoerung_20150626_source
   sources: [ch.bafu.bundesinventare-amphibien_anhoerung_20150626_cache]
   title: "Amphibien - Anh\xF6rung 2015 (20150626, source)"
-- dimensions: &id045
+- dimensions: &id022
     Time:
       default: '20070702'
       values: ['20070702']
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_cache_out]
   title: Amphibien Wanderobjekte (20070702)
-- dimensions: *id045
+- dimensions: *id022
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_cache]
   title: Amphibien Wanderobjekte ('current')
-- dimensions: *id045
+- dimensions: *id022
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_source
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_20070702_cache]
   title: Amphibien Wanderobjekte (20070702, source)
-- dimensions: &id046
+- dimensions: &id023
     Time:
       default: '20141110'
       values: ['20141110']
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_20141110
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_20141110_cache_out]
   title: Amphibien Wanderobjekte 2015 (20141110)
-- dimensions: *id046
+- dimensions: *id023
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_20141110_cache]
   title: Amphibien Wanderobjekte 2015 ('current')
-- dimensions: *id046
+- dimensions: *id023
   name: ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_20141110_source
   sources: [ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung_20141110_cache]
   title: Amphibien Wanderobjekte 2015 (20141110, source)
-- dimensions: &id047
+- dimensions: &id024
     Time:
       default: '20070701'
       values: ['20070701']
   name: ch.bafu.bundesinventare-auen_20070701
   sources: [ch.bafu.bundesinventare-auen_20070701_cache_out]
   title: Auengebiete (20070701)
-- dimensions: *id047
+- dimensions: *id024
   name: ch.bafu.bundesinventare-auen
   sources: [ch.bafu.bundesinventare-auen_20070701_cache]
   title: Auengebiete ('current')
-- dimensions: *id047
+- dimensions: *id024
   name: ch.bafu.bundesinventare-auen_20070701_source
   sources: [ch.bafu.bundesinventare-auen_20070701_cache]
   title: Auengebiete (20070701, source)
-- dimensions: &id048
+- dimensions: &id025
     Time:
       default: '20141110'
       values: ['20141110']
   name: ch.bafu.bundesinventare-auen_anhoerung_20141110
   sources: [ch.bafu.bundesinventare-auen_anhoerung_20141110_cache_out]
   title: "Auen - Anh\xF6rung 2015 (20141110)"
-- dimensions: *id048
+- dimensions: *id025
   name: ch.bafu.bundesinventare-auen_anhoerung
   sources: [ch.bafu.bundesinventare-auen_anhoerung_20141110_cache]
   title: "Auen - Anh\xF6rung 2015 ('current')"
-- dimensions: *id048
+- dimensions: *id025
   name: ch.bafu.bundesinventare-auen_anhoerung_20141110_source
   sources: [ch.bafu.bundesinventare-auen_anhoerung_20141110_cache]
   title: "Auen - Anh\xF6rung 2015 (20141110, source)"
-- dimensions: &id049
+- dimensions: &id026
     Time:
       default: '20010809'
       values: ['20010809']
   name: ch.bafu.bundesinventare-bln_20010809
   sources: [ch.bafu.bundesinventare-bln_20010809_cache_out]
   title: BLN (20010809)
-- dimensions: *id049
+- dimensions: *id026
   name: ch.bafu.bundesinventare-bln
   sources: [ch.bafu.bundesinventare-bln_20010809_cache]
   title: BLN ('current')
-- dimensions: *id049
+- dimensions: *id026
   name: ch.bafu.bundesinventare-bln_20010809_source
   sources: [ch.bafu.bundesinventare-bln_20010809_cache]
   title: BLN (20010809, source)
-- dimensions: &id050
+- dimensions: &id027
     Time:
       default: '20100623'
       values: ['20100623']
   name: ch.bafu.bundesinventare-flachmoore_20100623
   sources: [ch.bafu.bundesinventare-flachmoore_20100623_cache_out]
   title: Flachmoore (20100623)
-- dimensions: *id050
+- dimensions: *id027
   name: ch.bafu.bundesinventare-flachmoore
   sources: [ch.bafu.bundesinventare-flachmoore_20100623_cache]
   title: Flachmoore ('current')
-- dimensions: *id050
+- dimensions: *id027
   name: ch.bafu.bundesinventare-flachmoore_20100623_source
   sources: [ch.bafu.bundesinventare-flachmoore_20100623_cache]
   title: Flachmoore (20100623, source)
-- dimensions: &id051
+- dimensions: &id028
     Time:
       default: '20150626'
       values: ['20150626']
   name: ch.bafu.bundesinventare-flachmoore_anhoerung_20150626
   sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_20150626_cache_out]
   title: "Flachmoore Anh\xF6rung 2015 (20150626)"
-- dimensions: *id051
+- dimensions: *id028
   name: ch.bafu.bundesinventare-flachmoore_anhoerung
   sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_20150626_cache]
   title: "Flachmoore Anh\xF6rung 2015 ('current')"
-- dimensions: *id051
+- dimensions: *id028
   name: ch.bafu.bundesinventare-flachmoore_anhoerung_20150626_source
   sources: [ch.bafu.bundesinventare-flachmoore_anhoerung_20150626_cache]
   title: "Flachmoore Anh\xF6rung 2015 (20150626, source)"
-- dimensions: &id052
-    Time:
-      default: '20070731'
-      values: ['20070731']
-  name: ch.bafu.bundesinventare-flachmoore_regional_20070731
-  sources: [ch.bafu.bundesinventare-flachmoore_regional_20070731_cache_out]
-  title: Flachmoore regional (20070731)
-- dimensions: *id052
-  name: ch.bafu.bundesinventare-flachmoore_regional
-  sources: [ch.bafu.bundesinventare-flachmoore_regional_20070731_cache]
-  title: Flachmoore regional ('current')
-- dimensions: *id052
-  name: ch.bafu.bundesinventare-flachmoore_regional_20070731_source
-  sources: [ch.bafu.bundesinventare-flachmoore_regional_20070731_cache]
-  title: Flachmoore regional (20070731, source)
-- dimensions: &id053
+- dimensions: &id029
     Time:
       default: '20080721'
       values: ['20080721']
   name: ch.bafu.bundesinventare-hochmoore_20080721
   sources: [ch.bafu.bundesinventare-hochmoore_20080721_cache_out]
   title: Hochmoore (20080721)
-- dimensions: *id053
+- dimensions: *id029
   name: ch.bafu.bundesinventare-hochmoore
   sources: [ch.bafu.bundesinventare-hochmoore_20080721_cache]
   title: Hochmoore ('current')
-- dimensions: *id053
+- dimensions: *id029
   name: ch.bafu.bundesinventare-hochmoore_20080721_source
   sources: [ch.bafu.bundesinventare-hochmoore_20080721_cache]
   title: Hochmoore (20080721, source)
-- dimensions: &id054
+- dimensions: &id030
     Time:
       default: '20141110'
       values: ['20141110']
   name: ch.bafu.bundesinventare-hochmoore_anhoerung_20141110
   sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_20141110_cache_out]
   title: "Hochmoore - Anh\xF6rung 2015 (20141110)"
-- dimensions: *id054
+- dimensions: *id030
   name: ch.bafu.bundesinventare-hochmoore_anhoerung
   sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_20141110_cache]
   title: "Hochmoore - Anh\xF6rung 2015 ('current')"
-- dimensions: *id054
+- dimensions: *id030
   name: ch.bafu.bundesinventare-hochmoore_anhoerung_20141110_source
   sources: [ch.bafu.bundesinventare-hochmoore_anhoerung_20141110_cache]
   title: "Hochmoore - Anh\xF6rung 2015 (20141110, source)"
-- dimensions: &id055
+- dimensions: &id031
     Time:
       default: '20131202'
       values: ['20131202']
   name: ch.bafu.bundesinventare-jagdbanngebiete_20131202
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20131202_cache_out]
   title: Jagdbanngebiete (20131202)
-- dimensions: *id055
+- dimensions: *id031
   name: ch.bafu.bundesinventare-jagdbanngebiete
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20131202_cache]
   title: Jagdbanngebiete ('current')
-- dimensions: *id055
+- dimensions: *id031
   name: ch.bafu.bundesinventare-jagdbanngebiete_20131202_source
   sources: [ch.bafu.bundesinventare-jagdbanngebiete_20131202_cache]
   title: Jagdbanngebiete (20131202, source)
-- dimensions: &id056
+- dimensions: &id032
     Time:
       default: '20150202'
       values: ['20150202']
   name: ch.bafu.bundesinventare-moorlandschaften_20150202
   sources: [ch.bafu.bundesinventare-moorlandschaften_20150202_cache_out]
   title: Moorlandschaften (20150202)
-- dimensions: *id056
+- dimensions: *id032
   name: ch.bafu.bundesinventare-moorlandschaften
   sources: [ch.bafu.bundesinventare-moorlandschaften_20150202_cache]
   title: Moorlandschaften ('current')
-- dimensions: *id056
+- dimensions: *id032
   name: ch.bafu.bundesinventare-moorlandschaften_20150202_source
   sources: [ch.bafu.bundesinventare-moorlandschaften_20150202_cache]
   title: Moorlandschaften (20150202, source)
-- dimensions: &id057
+- dimensions: &id033
     Time:
       default: '20130624'
       values: ['20130624']
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_cache_out]
   title: Trockenwiesen und -weiden (TWW) (20130624)
-- dimensions: *id057
+- dimensions: *id033
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_cache]
   title: Trockenwiesen und -weiden (TWW) ('current')
-- dimensions: *id057
+- dimensions: *id033
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_source
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_20130624_cache]
   title: Trockenwiesen und -weiden (TWW) (20130624, source)
-- dimensions: &id058
-    Time:
-      default: '20120111'
-      values: ['20120111']
-  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111
-  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_cache_out]
-  title: TWW Anhang 2 (20120111)
-- dimensions: *id058
-  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2
-  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_cache]
-  title: TWW Anhang 2 ('current')
-- dimensions: *id058
-  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_source
-  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_cache]
-  title: TWW Anhang 2 (20120111, source)
-- dimensions: &id059
+- dimensions: &id034
     Time:
       default: '20150626'
       values: ['20150626']
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_20150626
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_20150626_cache_out]
   title: "TWW - Anh\xF6rung 2015 (20150626)"
-- dimensions: *id059
+- dimensions: *id034
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_20150626_cache]
   title: "TWW - Anh\xF6rung 2015 ('current')"
-- dimensions: *id059
+- dimensions: *id034
   name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_20150626_source
   sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung_20150626_cache]
   title: "TWW - Anh\xF6rung 2015 (20150626, source)"
-- dimensions: &id060
+- dimensions: &id035
     Time:
       default: '20150622'
       values: ['20150622']
   name: ch.bafu.bundesinventare-vogelreservate_20150622
   sources: [ch.bafu.bundesinventare-vogelreservate_20150622_cache_out]
   title: Wasser- und Zugvogelreservate (20150622)
-- dimensions: *id060
+- dimensions: *id035
   name: ch.bafu.bundesinventare-vogelreservate
   sources: [ch.bafu.bundesinventare-vogelreservate_20150622_cache]
   title: Wasser- und Zugvogelreservate ('current')
-- dimensions: *id060
+- dimensions: *id035
   name: ch.bafu.bundesinventare-vogelreservate_20150622_source
   sources: [ch.bafu.bundesinventare-vogelreservate_20150622_cache]
   title: Wasser- und Zugvogelreservate (20150622, source)
-- dimensions: &id061
+- dimensions: &id036
     Time:
       default: '20150506'
       values: ['20150506']
   name: ch.bafu.fauna-steinbockkolonien_20150506
   sources: [ch.bafu.fauna-steinbockkolonien_20150506_cache_out]
   title: Steinbockkolonien (20150506)
-- dimensions: *id061
+- dimensions: *id036
   name: ch.bafu.fauna-steinbockkolonien
   sources: [ch.bafu.fauna-steinbockkolonien_20150506_cache]
   title: Steinbockkolonien ('current')
-- dimensions: *id061
+- dimensions: *id036
   name: ch.bafu.fauna-steinbockkolonien_20150506_source
   sources: [ch.bafu.fauna-steinbockkolonien_20150506_cache]
   title: Steinbockkolonien (20150506, source)
-- dimensions: &id062
-    Time:
-      default: '20130528'
-      values: ['20130528']
-  name: ch.bafu.fauna-vernetzungsachsen_national_20130528
-  sources: [ch.bafu.fauna-vernetzungsachsen_national_20130528_cache_out]
-  title: Vernetzungssystem Wildtiere (20130528)
-- dimensions: *id062
-  name: ch.bafu.fauna-vernetzungsachsen_national
-  sources: [ch.bafu.fauna-vernetzungsachsen_national_20130528_cache]
-  title: Vernetzungssystem Wildtiere ('current')
-- dimensions: *id062
-  name: ch.bafu.fauna-vernetzungsachsen_national_20130528_source
-  sources: [ch.bafu.fauna-vernetzungsachsen_national_20130528_cache]
-  title: Vernetzungssystem Wildtiere (20130528, source)
-- dimensions: &id063
-    Time:
-      default: '20130528'
-      values: ['20130528']
-  name: ch.bafu.fauna-wildtierkorridor_national_20130528
-  sources: [ch.bafu.fauna-wildtierkorridor_national_20130528_cache_out]
-  title: "Wildtierkorridore \xDCberregional (20130528)"
-- dimensions: *id063
-  name: ch.bafu.fauna-wildtierkorridor_national
-  sources: [ch.bafu.fauna-wildtierkorridor_national_20130528_cache]
-  title: "Wildtierkorridore \xDCberregional ('current')"
-- dimensions: *id063
-  name: ch.bafu.fauna-wildtierkorridor_national_20130528_source
-  sources: [ch.bafu.fauna-wildtierkorridor_national_20130528_cache]
-  title: "Wildtierkorridore \xDCberregional (20130528, source)"
-- dimensions: &id064
-    Time:
-      default: '20090101'
-      values: ['20090101']
-  name: ch.bafu.feststoffe-geschiebemessnetz_20090101
-  sources: [ch.bafu.feststoffe-geschiebemessnetz_20090101_cache_out]
-  title: SOLID Bund, Geschiebe (20090101)
-- dimensions: *id064
-  name: ch.bafu.feststoffe-geschiebemessnetz
-  sources: [ch.bafu.feststoffe-geschiebemessnetz_20090101_cache]
-  title: SOLID Bund, Geschiebe ('current')
-- dimensions: *id064
-  name: ch.bafu.feststoffe-geschiebemessnetz_20090101_source
-  sources: [ch.bafu.feststoffe-geschiebemessnetz_20090101_cache]
-  title: SOLID Bund, Geschiebe (20090101, source)
-- dimensions: &id065
-    Time:
-      default: '20110829'
-      values: ['20110829']
-  name: ch.bafu.fischerei-aeschen_kernzonen_20110829
-  sources: [ch.bafu.fischerei-aeschen_kernzonen_20110829_cache_out]
-  title: "\xC4schen: Kernzonen (20110829)"
-- dimensions: *id065
-  name: ch.bafu.fischerei-aeschen_kernzonen
-  sources: [ch.bafu.fischerei-aeschen_kernzonen_20110829_cache]
-  title: "\xC4schen: Kernzonen ('current')"
-- dimensions: *id065
-  name: ch.bafu.fischerei-aeschen_kernzonen_20110829_source
-  sources: [ch.bafu.fischerei-aeschen_kernzonen_20110829_cache]
-  title: "\xC4schen: Kernzonen (20110829, source)"
-- dimensions: &id066
-    Time:
-      default: '20110829'
-      values: ['20110829']
-  name: ch.bafu.fischerei-aeschen_laichplaetze_20110829
-  sources: [ch.bafu.fischerei-aeschen_laichplaetze_20110829_cache_out]
-  title: "\xC4schen: Laichpl\xE4tze (20110829)"
-- dimensions: *id066
-  name: ch.bafu.fischerei-aeschen_laichplaetze
-  sources: [ch.bafu.fischerei-aeschen_laichplaetze_20110829_cache]
-  title: "\xC4schen: Laichpl\xE4tze ('current')"
-- dimensions: *id066
-  name: ch.bafu.fischerei-aeschen_laichplaetze_20110829_source
-  sources: [ch.bafu.fischerei-aeschen_laichplaetze_20110829_cache]
-  title: "\xC4schen: Laichpl\xE4tze (20110829, source)"
-- dimensions: &id067
-    Time:
-      default: '20110829'
-      values: ['20110829']
-  name: ch.bafu.fischerei-aeschen_larvenhabitate_20110829
-  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_20110829_cache_out]
-  title: "\xC4schen: Larvenhabitate (20110829)"
-- dimensions: *id067
-  name: ch.bafu.fischerei-aeschen_larvenhabitate
-  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_20110829_cache]
-  title: "\xC4schen: Larvenhabitate ('current')"
-- dimensions: *id067
-  name: ch.bafu.fischerei-aeschen_larvenhabitate_20110829_source
-  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_20110829_cache]
-  title: "\xC4schen: Larvenhabitate (20110829, source)"
-- dimensions: &id068
-    Time:
-      default: '20110905'
-      values: ['20110905']
-  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905
-  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_cache_out]
-  title: "\xC4schen: Verbreitungsgebiet (20110905)"
-- dimensions: *id068
-  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet
-  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_cache]
-  title: "\xC4schen: Verbreitungsgebiet ('current')"
-- dimensions: *id068
-  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_source
-  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_cache]
-  title: "\xC4schen: Verbreitungsgebiet (20110905, source)"
-- dimensions: &id069
-    Time:
-      default: '20110107'
-      values: ['20110107']
-  name: ch.bafu.fischerei-krebspest_20110107
-  sources: [ch.bafu.fischerei-krebspest_20110107_cache_out]
-  title: Krebspest (20110107)
-- dimensions: *id069
-  name: ch.bafu.fischerei-krebspest
-  sources: [ch.bafu.fischerei-krebspest_20110107_cache]
-  title: Krebspest ('current')
-- dimensions: *id069
-  name: ch.bafu.fischerei-krebspest_20110107_source
-  sources: [ch.bafu.fischerei-krebspest_20110107_cache]
-  title: Krebspest (20110107, source)
-- dimensions: &id070
-    Time:
-      default: '20060220'
-      values: ['20060220']
-  name: ch.bafu.fischerei-nasenlaichplaetze_20060220
-  sources: [ch.bafu.fischerei-nasenlaichplaetze_20060220_cache_out]
-  title: "Nasenlaichpl\xE4tze (20060220)"
-- dimensions: *id070
-  name: ch.bafu.fischerei-nasenlaichplaetze
-  sources: [ch.bafu.fischerei-nasenlaichplaetze_20060220_cache]
-  title: "Nasenlaichpl\xE4tze ('current')"
-- dimensions: *id070
-  name: ch.bafu.fischerei-nasenlaichplaetze_20060220_source
-  sources: [ch.bafu.fischerei-nasenlaichplaetze_20060220_cache]
-  title: "Nasenlaichpl\xE4tze (20060220, source)"
-- dimensions: &id071
-    Time:
-      default: '20140120'
-      values: ['20140120']
-  name: ch.bafu.fischerei-proliferative_nierenkrankheit_20140120
-  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_cache_out]
-  title: PKD (Proliferative Nierenkrankheit) (20140120)
-- dimensions: *id071
-  name: ch.bafu.fischerei-proliferative_nierenkrankheit
-  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_cache]
-  title: PKD (Proliferative Nierenkrankheit) ('current')
-- dimensions: *id071
-  name: ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_source
-  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_cache]
-  title: PKD (Proliferative Nierenkrankheit) (20140120, source)
-- dimensions: &id072
-    Time:
-      default: '19920822'
-      values: ['19920822']
-  name: ch.bafu.flora-schwingrasen_19920822
-  sources: [ch.bafu.flora-schwingrasen_19920822_cache_out]
-  title: Schwingrasen (19920822)
-- dimensions: *id072
-  name: ch.bafu.flora-schwingrasen
-  sources: [ch.bafu.flora-schwingrasen_19920822_cache]
-  title: Schwingrasen ('current')
-- dimensions: *id072
-  name: ch.bafu.flora-schwingrasen_19920822_source
-  sources: [ch.bafu.flora-schwingrasen_19920822_cache]
-  title: Schwingrasen (19920822, source)
-- dimensions: &id073
-    Time:
-      default: '20080612'
-      values: ['20080612']
-  name: ch.bafu.flora-verbreitungskarten_20080612
-  sources: [ch.bafu.flora-verbreitungskarten_20080612_cache_out]
-  title: Raster Verbreitungskarten (20080612)
-- dimensions: *id073
-  name: ch.bafu.flora-verbreitungskarten
-  sources: [ch.bafu.flora-verbreitungskarten_20080612_cache]
-  title: Raster Verbreitungskarten ('current')
-- dimensions: *id073
-  name: ch.bafu.flora-verbreitungskarten_20080612_source
-  sources: [ch.bafu.flora-verbreitungskarten_20080612_cache]
-  title: Raster Verbreitungskarten (20080612, source)
-- dimensions: &id074
-    Time:
-      default: '20080612'
-      values: ['20080612']
-  name: ch.bafu.flora-weltensutter_atlas_20080612
-  sources: [ch.bafu.flora-weltensutter_atlas_20080612_cache_out]
-  title: Atlas Welten&Sutter (20080612)
-- dimensions: *id074
-  name: ch.bafu.flora-weltensutter_atlas
-  sources: [ch.bafu.flora-weltensutter_atlas_20080612_cache]
-  title: Atlas Welten&Sutter ('current')
-- dimensions: *id074
-  name: ch.bafu.flora-weltensutter_atlas_20080612_source
-  sources: [ch.bafu.flora-weltensutter_atlas_20080612_cache]
-  title: Atlas Welten&Sutter (20080612, source)
-- dimensions: &id075
+- dimensions: &id037
     Time:
       default: '20140805'
       values: ['20140805']
   name: ch.bafu.flussordnungszahlen-strahler_20140805
   sources: [ch.bafu.flussordnungszahlen-strahler_20140805_cache_out]
   title: Flussordnung (20140805)
-- dimensions: *id075
+- dimensions: *id037
   name: ch.bafu.flussordnungszahlen-strahler
   sources: [ch.bafu.flussordnungszahlen-strahler_20140805_cache]
   title: Flussordnung ('current')
-- dimensions: *id075
+- dimensions: *id037
   name: ch.bafu.flussordnungszahlen-strahler_20140805_source
   sources: [ch.bafu.flussordnungszahlen-strahler_20140805_cache]
   title: Flussordnung (20140805, source)
-- dimensions: &id076
-    Time:
-      default: '20140314'
-      values: ['20140314']
-  name: ch.bafu.gefahren-baugrundklassen_20140314
-  sources: [ch.bafu.gefahren-baugrundklassen_20140314_cache_out]
-  title: Seismische Baugrundklassen (20140314)
-- dimensions: *id076
-  name: ch.bafu.gefahren-baugrundklassen
-  sources: [ch.bafu.gefahren-baugrundklassen_20140314_cache]
-  title: Seismische Baugrundklassen ('current')
-- dimensions: *id076
-  name: ch.bafu.gefahren-baugrundklassen_20140314_source
-  sources: [ch.bafu.gefahren-baugrundklassen_20140314_cache]
-  title: Seismische Baugrundklassen (20140314, source)
-- dimensions: &id077
-    Time:
-      default: '20030102'
-      values: ['20030102']
-  name: ch.bafu.gefahren-gefaehrdungszonen_20030102
-  sources: [ch.bafu.gefahren-gefaehrdungszonen_20030102_cache_out]
-  title: Erdbebenzonen (20030102)
-- dimensions: *id077
-  name: ch.bafu.gefahren-gefaehrdungszonen
-  sources: [ch.bafu.gefahren-gefaehrdungszonen_20030102_cache]
-  title: Erdbebenzonen ('current')
-- dimensions: *id077
-  name: ch.bafu.gefahren-gefaehrdungszonen_20030102_source
-  sources: [ch.bafu.gefahren-gefaehrdungszonen_20030102_cache]
-  title: Erdbebenzonen (20030102, source)
-- dimensions: &id078
-    Time:
-      default: '20110428'
-      values: ['20110428']
-  name: ch.bafu.gefahren-historische_erdbeben_20110428
-  sources: [ch.bafu.gefahren-historische_erdbeben_20110428_cache_out]
-  title: Historische Erdbeben (20110428)
-- dimensions: *id078
-  name: ch.bafu.gefahren-historische_erdbeben
-  sources: [ch.bafu.gefahren-historische_erdbeben_20110428_cache]
-  title: Historische Erdbeben ('current')
-- dimensions: *id078
-  name: ch.bafu.gefahren-historische_erdbeben_20110428_source
-  sources: [ch.bafu.gefahren-historische_erdbeben_20110428_cache]
-  title: Historische Erdbeben (20110428, source)
-- dimensions: &id079
-    Time:
-      default: '20140314'
-      values: ['20140314']
-  name: ch.bafu.gefahren-spektral_20140314
-  sources: [ch.bafu.gefahren-spektral_20140314_cache_out]
-  title: Spektrale Mikrozonierung (20140314)
-- dimensions: *id079
-  name: ch.bafu.gefahren-spektral
-  sources: [ch.bafu.gefahren-spektral_20140314_cache]
-  title: Spektrale Mikrozonierung ('current')
-- dimensions: *id079
-  name: ch.bafu.gefahren-spektral_20140314_source
-  sources: [ch.bafu.gefahren-spektral_20140314_cache]
-  title: Spektrale Mikrozonierung (20140314, source)
-- dimensions: &id080
-    Time:
-      default: '20140101'
-      values: ['20140101']
-  name: ch.bafu.gewaesserschutz-badewasserqualitaet_20140101
-  sources: [ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_cache_out]
-  title: "Badegew\xE4sserqualit\xE4t (20140101)"
-- dimensions: *id080
-  name: ch.bafu.gewaesserschutz-badewasserqualitaet
-  sources: [ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_cache]
-  title: "Badegew\xE4sserqualit\xE4t ('current')"
-- dimensions: *id080
-  name: ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_source
-  sources: [ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_cache]
-  title: "Badegew\xE4sserqualit\xE4t (20140101, source)"
-- dimensions: &id081
+- dimensions: &id038
     Time:
       default: '20131001'
       values: ['20131001']
   name: ch.bafu.gewaesserschutzbereiche_20131001
   sources: [ch.bafu.gewaesserschutzbereiche_20131001_cache_out]
   title: "Gew\xE4sserschutzbereiche (20131001)"
-- dimensions: *id081
+- dimensions: *id038
   name: ch.bafu.gewaesserschutzbereiche
   sources: [ch.bafu.gewaesserschutzbereiche_20131001_cache]
   title: "Gew\xE4sserschutzbereiche ('current')"
-- dimensions: *id081
+- dimensions: *id038
   name: ch.bafu.gewaesserschutzbereiche_20131001_source
   sources: [ch.bafu.gewaesserschutzbereiche_20131001_cache]
   title: "Gew\xE4sserschutzbereiche (20131001, source)"
-- dimensions: &id082
-    Time:
-      default: '20140101'
-      values: ['20140101']
-  name: ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_cache_out]
-  title: ARA-DB - Abwasserant. an Q347 (20140101)
-- dimensions: *id082
-  name: ch.bafu.gewaesserschutz-klaeranlagen_anteilq347
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_cache]
-  title: ARA-DB - Abwasserant. an Q347 ('current')
-- dimensions: *id082
-  name: ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_source
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_cache]
-  title: ARA-DB - Abwasserant. an Q347 (20140101, source)
-- dimensions: &id083
-    Time:
-      default: '20140101'
-      values: ['20140101']
-  name: ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_cache_out]
-  title: "ARA-DB - Ausbaugr\xF6sse (EGW) (20140101)"
-- dimensions: *id083
-  name: ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_cache]
-  title: "ARA-DB - Ausbaugr\xF6sse (EGW) ('current')"
-- dimensions: *id083
-  name: ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_source
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_cache]
-  title: "ARA-DB - Ausbaugr\xF6sse (EGW) (20140101, source)"
-- dimensions: &id084
-    Time:
-      default: '20140101'
-      values: ['20140101']
-  name: ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_cache_out]
-  title: ARA-DB - Reinigungstyp (20140101)
-- dimensions: *id084
-  name: ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_cache]
-  title: ARA-DB - Reinigungstyp ('current')
-- dimensions: *id084
-  name: ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_source
-  sources: [ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_cache]
-  title: ARA-DB - Reinigungstyp (20140101, source)
-- dimensions: &id085
+- dimensions: &id039
     Time:
       default: '20131001'
       values: ['20131001']
   name: ch.bafu.grundwasserschutzareale_20131001
   sources: [ch.bafu.grundwasserschutzareale_20131001_cache_out]
   title: Schutzareale (20131001)
-- dimensions: *id085
+- dimensions: *id039
   name: ch.bafu.grundwasserschutzareale
   sources: [ch.bafu.grundwasserschutzareale_20131001_cache]
   title: Schutzareale ('current')
-- dimensions: *id085
+- dimensions: *id039
   name: ch.bafu.grundwasserschutzareale_20131001_source
   sources: [ch.bafu.grundwasserschutzareale_20131001_cache]
   title: Schutzareale (20131001, source)
-- dimensions: &id086
+- dimensions: &id040
     Time:
       default: '20131001'
       values: ['20131001']
   name: ch.bafu.grundwasserschutzzonen_20131001
   sources: [ch.bafu.grundwasserschutzzonen_20131001_cache_out]
   title: Schutzzonen (20131001)
-- dimensions: *id086
+- dimensions: *id040
   name: ch.bafu.grundwasserschutzzonen
   sources: [ch.bafu.grundwasserschutzzonen_20131001_cache]
   title: Schutzzonen ('current')
-- dimensions: *id086
+- dimensions: *id040
   name: ch.bafu.grundwasserschutzzonen_20131001_source
   sources: [ch.bafu.grundwasserschutzzonen_20131001_cache]
   title: Schutzzonen (20131001, source)
-- dimensions: &id087
-    Time:
-      default: '20100310'
-      values: ['20100310']
-  name: ch.bafu.holznutzung_20100310
-  sources: [ch.bafu.holznutzung_20100310_cache_out]
-  title: "Holznutzung und Mortalit\xE4t (LFI) (20100310)"
-- dimensions: *id087
-  name: ch.bafu.holznutzung
-  sources: [ch.bafu.holznutzung_20100310_cache]
-  title: "Holznutzung und Mortalit\xE4t (LFI) ('current')"
-- dimensions: *id087
-  name: ch.bafu.holznutzung_20100310_source
-  sources: [ch.bafu.holznutzung_20100310_cache]
-  title: "Holznutzung und Mortalit\xE4t (LFI) (20100310, source)"
-- dimensions: &id088
-    Time:
-      default: '20100310'
-      values: ['20100310']
-  name: ch.bafu.holzvorrat_20100310
-  sources: [ch.bafu.holzvorrat_20100310_cache_out]
-  title: Holzvorrat (LFI) (20100310)
-- dimensions: *id088
-  name: ch.bafu.holzvorrat
-  sources: [ch.bafu.holzvorrat_20100310_cache]
-  title: Holzvorrat (LFI) ('current')
-- dimensions: *id088
-  name: ch.bafu.holzvorrat_20100310_source
-  sources: [ch.bafu.holzvorrat_20100310_cache]
-  title: Holzvorrat (LFI) (20100310, source)
-- dimensions: &id089
-    Time:
-      default: '20100310'
-      values: ['20100310']
-  name: ch.bafu.holzzuwachs_20100310
-  sources: [ch.bafu.holzzuwachs_20100310_cache_out]
-  title: Holzzuwachs (LFI) (20100310)
-- dimensions: *id089
-  name: ch.bafu.holzzuwachs
-  sources: [ch.bafu.holzzuwachs_20100310_cache]
-  title: Holzzuwachs (LFI) ('current')
-- dimensions: *id089
-  name: ch.bafu.holzzuwachs_20100310_source
-  sources: [ch.bafu.holzzuwachs_20100310_cache]
-  title: Holzzuwachs (LFI) (20100310, source)
-- dimensions: &id090
-    Time:
-      default: '20090101'
-      values: ['20090101']
-  name: ch.bafu.hydrogeologie-uebersichtskarte_20090101
-  sources: [ch.bafu.hydrogeologie-uebersichtskarte_20090101_cache_out]
-  title: "\xDCbersichtskarte Hydrogeologie (20090101)"
-- dimensions: *id090
-  name: ch.bafu.hydrogeologie-uebersichtskarte
-  sources: [ch.bafu.hydrogeologie-uebersichtskarte_20090101_cache]
-  title: "\xDCbersichtskarte Hydrogeologie ('current')"
-- dimensions: *id090
-  name: ch.bafu.hydrogeologie-uebersichtskarte_20090101_source
-  sources: [ch.bafu.hydrogeologie-uebersichtskarte_20090101_cache]
-  title: "\xDCbersichtskarte Hydrogeologie (20090101, source)"
-- dimensions: &id091
-    Time:
-      default: '20090101'
-      values: ['20090101']
-  name: ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101
-  sources: [ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_cache_out]
-  title: NADUF (20090101)
-- dimensions: *id091
-  name: ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser
-  sources: [ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_cache]
-  title: NADUF ('current')
-- dimensions: *id091
-  name: ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_source
-  sources: [ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_cache]
-  title: NADUF (20090101, source)
-- dimensions: &id092
+- dimensions: &id041
     Time:
       default: '20130301'
       values: ['20130301']
   name: ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301
   sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_cache_out]
   title: "Messstandorte Gew\xE4sserzustand (20130301)"
-- dimensions: *id092
+- dimensions: *id041
   name: ch.bafu.hydrologie-gewaesserzustandsmessstationen
   sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_cache]
   title: "Messstandorte Gew\xE4sserzustand ('current')"
-- dimensions: *id092
+- dimensions: *id041
   name: ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_source
   sources: [ch.bafu.hydrologie-gewaesserzustandsmessstationen_20130301_cache]
   title: "Messstandorte Gew\xE4sserzustand (20130301, source)"
-- dimensions: &id093
+- dimensions: &id042
     Time:
       default: '20141023'
       values: ['20141023']
   name: ch.bafu.hydrologie-hintergrundkarte_20141023
   sources: [ch.bafu.hydrologie-hintergrundkarte_20141023_cache_out]
   title: Hintergrundkarte hydrol. Daten (20141023)
-- dimensions: *id093
+- dimensions: *id042
   name: ch.bafu.hydrologie-hintergrundkarte
   sources: [ch.bafu.hydrologie-hintergrundkarte_20141023_cache]
   title: Hintergrundkarte hydrol. Daten ('current')
-- dimensions: *id093
+- dimensions: *id042
   name: ch.bafu.hydrologie-hintergrundkarte_20141023_source
   sources: [ch.bafu.hydrologie-hintergrundkarte_20141023_cache]
   title: Hintergrundkarte hydrol. Daten (20141023, source)
-- dimensions: &id094
-    Time:
-      default: '20050101'
-      values: ['20050101']
-  name: ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101
-  sources: [ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_cache_out]
-  title: HWGWP (20050101)
-- dimensions: *id094
-  name: ch.bafu.hydrologie-hochwassergrenzwertpegel
-  sources: [ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_cache]
-  title: HWGWP ('current')
-- dimensions: *id094
-  name: ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_source
-  sources: [ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_cache]
-  title: HWGWP (20050101, source)
-- dimensions: &id095
-    Time:
-      default: '20140101'
-      values: ['20140101']
-  name: ch.bafu.hydrologie-hochwasserstatistik_20140101
-  sources: [ch.bafu.hydrologie-hochwasserstatistik_20140101_cache_out]
-  title: HQStat (20140101)
-- dimensions: *id095
-  name: ch.bafu.hydrologie-hochwasserstatistik
-  sources: [ch.bafu.hydrologie-hochwasserstatistik_20140101_cache]
-  title: HQStat ('current')
-- dimensions: *id095
-  name: ch.bafu.hydrologie-hochwasserstatistik_20140101_source
-  sources: [ch.bafu.hydrologie-hochwasserstatistik_20140101_cache]
-  title: HQStat (20140101, source)
-- dimensions: &id096
+- dimensions: &id043
     Time:
       default: '20141201'
       values: ['20141201']
   name: ch.bafu.hydrologie-hydromessstationen_20141201
   sources: [ch.bafu.hydrologie-hydromessstationen_20141201_cache_out]
   title: Hydrologische Messstationen (20141201)
-- dimensions: *id096
+- dimensions: *id043
   name: ch.bafu.hydrologie-hydromessstationen
   sources: [ch.bafu.hydrologie-hydromessstationen_20141201_cache]
   title: Hydrologische Messstationen ('current')
-- dimensions: *id096
+- dimensions: *id043
   name: ch.bafu.hydrologie-hydromessstationen_20141201_source
   sources: [ch.bafu.hydrologie-hydromessstationen_20141201_cache]
   title: Hydrologische Messstationen (20141201, source)
-- dimensions: &id097
-    Time:
-      default: '20130101'
-      values: ['20130101']
-  name: ch.bafu.hydrologie-niedrigwasserstatistik_20130101
-  sources: [ch.bafu.hydrologie-niedrigwasserstatistik_20130101_cache_out]
-  title: NQSTAT (20130101)
-- dimensions: *id097
-  name: ch.bafu.hydrologie-niedrigwasserstatistik
-  sources: [ch.bafu.hydrologie-niedrigwasserstatistik_20130101_cache]
-  title: NQSTAT ('current')
-- dimensions: *id097
-  name: ch.bafu.hydrologie-niedrigwasserstatistik_20130101_source
-  sources: [ch.bafu.hydrologie-niedrigwasserstatistik_20130101_cache]
-  title: NQSTAT (20130101, source)
-- dimensions: &id098
-    Time:
-      default: '20130101'
-      values: ['20130101']
-  name: ch.bafu.hydrologie-q347_20130101
-  sources: [ch.bafu.hydrologie-q347_20130101_cache_out]
-  title: Q347 (20130101)
-- dimensions: *id098
-  name: ch.bafu.hydrologie-q347
-  sources: [ch.bafu.hydrologie-q347_20130101_cache]
-  title: Q347 ('current')
-- dimensions: *id098
-  name: ch.bafu.hydrologie-q347_20130101_source
-  sources: [ch.bafu.hydrologie-q347_20130101_cache]
-  title: Q347 (20130101, source)
-- dimensions: &id099
-    Time:
-      default: '20130101'
-      values: ['20130101']
-  name: ch.bafu.hydrologie-untersuchungsgebiete_20130101
-  sources: [ch.bafu.hydrologie-untersuchungsgebiete_20130101_cache_out]
-  title: HUG Hydro. Untersuchungsgebiete (20130101)
-- dimensions: *id099
-  name: ch.bafu.hydrologie-untersuchungsgebiete
-  sources: [ch.bafu.hydrologie-untersuchungsgebiete_20130101_cache]
-  title: HUG Hydro. Untersuchungsgebiete ('current')
-- dimensions: *id099
-  name: ch.bafu.hydrologie-untersuchungsgebiete_20130101_source
-  sources: [ch.bafu.hydrologie-untersuchungsgebiete_20130101_cache]
-  title: HUG Hydro. Untersuchungsgebiete (20130101, source)
-- dimensions: &id100
-    Time:
-      default: '20130101'
-      values: ['20130101']
-  name: ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101
-  sources: [ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_cache_out]
-  title: HUG-Messstationen (20130101)
-- dimensions: *id100
-  name: ch.bafu.hydrologie-untersuchungsgebiete_stationen
-  sources: [ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_cache]
-  title: HUG-Messstationen ('current')
-- dimensions: *id100
-  name: ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_source
-  sources: [ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_cache]
-  title: HUG-Messstationen (20130101, source)
-- dimensions: &id101
+- dimensions: &id044
     Time:
       default: '20141201'
       values: ['20141201']
   name: ch.bafu.hydrologie-wassertemperaturmessstationen_20141201
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache_out]
   title: Messstationen Wassertemperatur (20141201)
-- dimensions: *id101
+- dimensions: *id044
   name: ch.bafu.hydrologie-wassertemperaturmessstationen
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache]
   title: Messstationen Wassertemperatur ('current')
-- dimensions: *id101
+- dimensions: *id044
   name: ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_source
   sources: [ch.bafu.hydrologie-wassertemperaturmessstationen_20141201_cache]
   title: Messstationen Wassertemperatur (20141201, source)
-- dimensions: &id102
-    Time:
-      default: '20040101'
-      values: ['20040101']
-  name: ch.bafu.hydrologischer-atlas_basisgebiete_20040101
-  sources: [ch.bafu.hydrologischer-atlas_basisgebiete_20040101_cache_out]
-  title: Basisgebiet (20040101)
-- dimensions: *id102
-  name: ch.bafu.hydrologischer-atlas_basisgebiete
-  sources: [ch.bafu.hydrologischer-atlas_basisgebiete_20040101_cache]
-  title: Basisgebiet ('current')
-- dimensions: *id102
-  name: ch.bafu.hydrologischer-atlas_basisgebiete_20040101_source
-  sources: [ch.bafu.hydrologischer-atlas_basisgebiete_20040101_cache]
-  title: Basisgebiet (20040101, source)
-- dimensions: &id103
-    Time:
-      default: '20040101'
-      values: ['20040101']
-  name: ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101
-  sources: [ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_cache_out]
-  title: Bilanzgebiet (20040101)
-- dimensions: *id103
-  name: ch.bafu.hydrologischer-atlas_bilanzgebiete
-  sources: [ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_cache]
-  title: Bilanzgebiet ('current')
-- dimensions: *id103
-  name: ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_source
-  sources: [ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_cache]
-  title: Bilanzgebiet (20040101, source)
-- dimensions: &id104
-    Time:
-      default: '20040101'
-      values: ['20040101']
-  name: ch.bafu.hydrologischer-atlas_flussgebiete_20040101
-  sources: [ch.bafu.hydrologischer-atlas_flussgebiete_20040101_cache_out]
-  title: Flussgebiet (20040101)
-- dimensions: *id104
-  name: ch.bafu.hydrologischer-atlas_flussgebiete
-  sources: [ch.bafu.hydrologischer-atlas_flussgebiete_20040101_cache]
-  title: Flussgebiet ('current')
-- dimensions: *id104
-  name: ch.bafu.hydrologischer-atlas_flussgebiete_20040101_source
-  sources: [ch.bafu.hydrologischer-atlas_flussgebiete_20040101_cache]
-  title: Flussgebiet (20040101, source)
-- dimensions: &id105
-    Time:
-      default: '20030101'
-      values: ['20030101']
-  name: ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101
-  sources: [ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_cache_out]
-  title: HADES Atlasblatt 5.1.2 (20030101)
-- dimensions: *id105
-  name: ch.bafu.hydrologischer-atlas_kantonale-messstationen
-  sources: [ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_cache]
-  title: HADES Atlasblatt 5.1.2 ('current')
-- dimensions: *id105
-  name: ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_source
-  sources: [ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_cache]
-  title: HADES Atlasblatt 5.1.2 (20030101, source)
-- dimensions: &id106
+- dimensions: &id045
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.bafu.laerm-bahnlaerm_nacht_20061231
   sources: [ch.bafu.laerm-bahnlaerm_nacht_20061231_cache_out]
   title: "Eisenbahnl\xE4rm Nacht (20061231)"
-- dimensions: *id106
+- dimensions: *id045
   name: ch.bafu.laerm-bahnlaerm_nacht
   sources: [ch.bafu.laerm-bahnlaerm_nacht_20061231_cache]
   title: "Eisenbahnl\xE4rm Nacht ('current')"
-- dimensions: *id106
+- dimensions: *id045
   name: ch.bafu.laerm-bahnlaerm_nacht_20061231_source
   sources: [ch.bafu.laerm-bahnlaerm_nacht_20061231_cache]
   title: "Eisenbahnl\xE4rm Nacht (20061231, source)"
-- dimensions: &id107
+- dimensions: &id046
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.bafu.laerm-bahnlaerm_tag_20061231
   sources: [ch.bafu.laerm-bahnlaerm_tag_20061231_cache_out]
   title: "Eisenbahnl\xE4rm Tag (20061231)"
-- dimensions: *id107
+- dimensions: *id046
   name: ch.bafu.laerm-bahnlaerm_tag
   sources: [ch.bafu.laerm-bahnlaerm_tag_20061231_cache]
   title: "Eisenbahnl\xE4rm Tag ('current')"
-- dimensions: *id107
+- dimensions: *id046
   name: ch.bafu.laerm-bahnlaerm_tag_20061231_source
   sources: [ch.bafu.laerm-bahnlaerm_tag_20061231_cache]
   title: "Eisenbahnl\xE4rm Tag (20061231, source)"
-- dimensions: &id108
+- dimensions: &id047
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.bafu.laerm-strassenlaerm_nacht_20101231
   sources: [ch.bafu.laerm-strassenlaerm_nacht_20101231_cache_out]
   title: "Strassenverkehrsl\xE4rm Nacht (20101231)"
-- dimensions: *id108
+- dimensions: *id047
   name: ch.bafu.laerm-strassenlaerm_nacht
   sources: [ch.bafu.laerm-strassenlaerm_nacht_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Nacht ('current')"
-- dimensions: *id108
+- dimensions: *id047
   name: ch.bafu.laerm-strassenlaerm_nacht_20101231_source
   sources: [ch.bafu.laerm-strassenlaerm_nacht_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Nacht (20101231, source)"
-- dimensions: &id109
+- dimensions: &id048
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.bafu.laerm-strassenlaerm_tag_20101231
   sources: [ch.bafu.laerm-strassenlaerm_tag_20101231_cache_out]
   title: "Strassenverkehrsl\xE4rm Tag (20101231)"
-- dimensions: *id109
+- dimensions: *id048
   name: ch.bafu.laerm-strassenlaerm_tag
   sources: [ch.bafu.laerm-strassenlaerm_tag_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Tag ('current')"
-- dimensions: *id109
+- dimensions: *id048
   name: ch.bafu.laerm-strassenlaerm_tag_20101231_source
   sources: [ch.bafu.laerm-strassenlaerm_tag_20101231_cache]
   title: "Strassenverkehrsl\xE4rm Tag (20101231, source)"
-- dimensions: &id110
-    Time:
-      default: '20100310'
-      values: ['20100310']
-  name: ch.bafu.landesforstinventar-baumarten_20100310
-  sources: [ch.bafu.landesforstinventar-baumarten_20100310_cache_out]
-  title: Baumarten (LFI) (20100310)
-- dimensions: *id110
-  name: ch.bafu.landesforstinventar-baumarten
-  sources: [ch.bafu.landesforstinventar-baumarten_20100310_cache]
-  title: Baumarten (LFI) ('current')
-- dimensions: *id110
-  name: ch.bafu.landesforstinventar-baumarten_20100310_source
-  sources: [ch.bafu.landesforstinventar-baumarten_20100310_cache]
-  title: Baumarten (LFI) (20100310, source)
-- dimensions: &id111
-    Time:
-      default: '20100310'
-      values: ['20100310']
-  name: ch.bafu.landesforstinventar-totholz_20100310
-  sources: [ch.bafu.landesforstinventar-totholz_20100310_cache_out]
-  title: Totholz (LFI) (20100310)
-- dimensions: *id111
-  name: ch.bafu.landesforstinventar-totholz
-  sources: [ch.bafu.landesforstinventar-totholz_20100310_cache]
-  title: Totholz (LFI) ('current')
-- dimensions: *id111
-  name: ch.bafu.landesforstinventar-totholz_20100310_source
-  sources: [ch.bafu.landesforstinventar-totholz_20100310_cache]
-  title: Totholz (LFI) (20100310, source)
-- dimensions: &id112
-    Time:
-      default: '20100310'
-      values: ['20100310']
-  name: ch.bafu.landesforstinventar-waldanteil_20100310
-  sources: [ch.bafu.landesforstinventar-waldanteil_20100310_cache_out]
-  title: Waldanteil (LFI) (20100310)
-- dimensions: *id112
-  name: ch.bafu.landesforstinventar-waldanteil
-  sources: [ch.bafu.landesforstinventar-waldanteil_20100310_cache]
-  title: Waldanteil (LFI) ('current')
-- dimensions: *id112
-  name: ch.bafu.landesforstinventar-waldanteil_20100310_source
-  sources: [ch.bafu.landesforstinventar-waldanteil_20100310_cache]
-  title: Waldanteil (LFI) (20100310, source)
-- dimensions: &id113
-    Time:
-      default: '20001231'
-      values: ['20001231']
-  name: ch.bafu.mittlere-abfluesse_20001231
-  sources: [ch.bafu.mittlere-abfluesse_20001231_cache_out]
-  title: "Mittlere Abfl\xFCsse (m\xB3/s) (20001231)"
-- dimensions: *id113
-  name: ch.bafu.mittlere-abfluesse
-  sources: [ch.bafu.mittlere-abfluesse_20001231_cache]
-  title: "Mittlere Abfl\xFCsse (m\xB3/s) ('current')"
-- dimensions: *id113
-  name: ch.bafu.mittlere-abfluesse_20001231_source
-  sources: [ch.bafu.mittlere-abfluesse_20001231_cache]
-  title: "Mittlere Abfl\xFCsse (m\xB3/s) (20001231, source)"
-- dimensions: &id114
+- dimensions: &id049
     Time:
       default: '20120416'
       values: ['20120416']
   name: ch.bafu.moose_20120416
   sources: [ch.bafu.moose_20120416_cache_out]
   title: Rote Liste Moose (20120416)
-- dimensions: *id114
+- dimensions: *id049
   name: ch.bafu.moose
   sources: [ch.bafu.moose_20120416_cache]
   title: Rote Liste Moose ('current')
-- dimensions: *id114
+- dimensions: *id049
   name: ch.bafu.moose_20120416_source
   sources: [ch.bafu.moose_20120416_cache]
   title: Rote Liste Moose (20120416, source)
-- dimensions: &id115
+- dimensions: &id050
     Time:
       default: '20110309'
       values: ['20110309']
   name: ch.bafu.nabelstationen_20110309
   sources: [ch.bafu.nabelstationen_20110309_cache_out]
   title: "Messstationen Luftqualit\xE4t (20110309)"
-- dimensions: *id115
+- dimensions: *id050
   name: ch.bafu.nabelstationen
   sources: [ch.bafu.nabelstationen_20110309_cache]
   title: "Messstationen Luftqualit\xE4t ('current')"
-- dimensions: *id115
+- dimensions: *id050
   name: ch.bafu.nabelstationen_20110309_source
   sources: [ch.bafu.nabelstationen_20110309_cache]
   title: "Messstationen Luftqualit\xE4t (20110309, source)"
-- dimensions: &id116
-    Time:
-      default: '20130305'
-      values: ['20130305']
-  name: ch.bafu.naqua-grundwasser_nitrat_20130305
-  sources: [ch.bafu.naqua-grundwasser_nitrat_20130305_cache_out]
-  title: 'Grundwasser: Nitrat (20130305)'
-- dimensions: *id116
-  name: ch.bafu.naqua-grundwasser_nitrat
-  sources: [ch.bafu.naqua-grundwasser_nitrat_20130305_cache]
-  title: 'Grundwasser: Nitrat (''current'')'
-- dimensions: *id116
-  name: ch.bafu.naqua-grundwasser_nitrat_20130305_source
-  sources: [ch.bafu.naqua-grundwasser_nitrat_20130305_cache]
-  title: 'Grundwasser: Nitrat (20130305, source)'
-- dimensions: &id117
-    Time:
-      default: '20130305'
-      values: ['20130305']
-  name: ch.bafu.naqua-grundwasser_psm_20130305
-  sources: [ch.bafu.naqua-grundwasser_psm_20130305_cache_out]
-  title: 'Grundwasser: Pestizide (20130305)'
-- dimensions: *id117
-  name: ch.bafu.naqua-grundwasser_psm
-  sources: [ch.bafu.naqua-grundwasser_psm_20130305_cache]
-  title: 'Grundwasser: Pestizide (''current'')'
-- dimensions: *id117
-  name: ch.bafu.naqua-grundwasser_psm_20130305_source
-  sources: [ch.bafu.naqua-grundwasser_psm_20130305_cache]
-  title: 'Grundwasser: Pestizide (20130305, source)'
-- dimensions: &id118
-    Time:
-      default: '20130305'
-      values: ['20130305']
-  name: ch.bafu.naqua-grundwasser_voc_20130305
-  sources: [ch.bafu.naqua-grundwasser_voc_20130305_cache_out]
-  title: 'Grundwasser: VOC (20130305)'
-- dimensions: *id118
-  name: ch.bafu.naqua-grundwasser_voc
-  sources: [ch.bafu.naqua-grundwasser_voc_20130305_cache]
-  title: 'Grundwasser: VOC (''current'')'
-- dimensions: *id118
-  name: ch.bafu.naqua-grundwasser_voc_20130305_source
-  sources: [ch.bafu.naqua-grundwasser_voc_20130305_cache]
-  title: 'Grundwasser: VOC (20130305, source)'
-- dimensions: &id119
+- dimensions: &id051
     Time:
       default: '20140825'
       values: ['20140825']
   name: ch.bafu.neophyten-japanisches_geissblatt_20140825
   sources: [ch.bafu.neophyten-japanisches_geissblatt_20140825_cache_out]
   title: Japanisches Geissblatt (20140825)
-- dimensions: *id119
+- dimensions: *id051
   name: ch.bafu.neophyten-japanisches_geissblatt
   sources: [ch.bafu.neophyten-japanisches_geissblatt_20140825_cache]
   title: Japanisches Geissblatt ('current')
-- dimensions: *id119
+- dimensions: *id051
   name: ch.bafu.neophyten-japanisches_geissblatt_20140825_source
   sources: [ch.bafu.neophyten-japanisches_geissblatt_20140825_cache]
   title: Japanisches Geissblatt (20140825, source)
-- dimensions: &id120
+- dimensions: &id052
     Time:
       default: '20140825'
       values: ['20140825']
   name: ch.bafu.neophyten-riesenbaerenklau_20140825
   sources: [ch.bafu.neophyten-riesenbaerenklau_20140825_cache_out]
   title: "Riesenb\xE4renklau (20140825)"
-- dimensions: *id120
+- dimensions: *id052
   name: ch.bafu.neophyten-riesenbaerenklau
   sources: [ch.bafu.neophyten-riesenbaerenklau_20140825_cache]
   title: "Riesenb\xE4renklau ('current')"
-- dimensions: *id120
+- dimensions: *id052
   name: ch.bafu.neophyten-riesenbaerenklau_20140825_source
   sources: [ch.bafu.neophyten-riesenbaerenklau_20140825_cache]
   title: "Riesenb\xE4renklau (20140825, source)"
-- dimensions: &id121
+- dimensions: &id053
     Time:
       default: '20080913'
       values: ['20080913']
   name: ch.bafu.oekomorphologie-f_abschnitte_20080913
   sources: [ch.bafu.oekomorphologie-f_abschnitte_20080913_cache_out]
   title: "\xD6komorphologie F - Abschnitte (20080913)"
-- dimensions: *id121
+- dimensions: *id053
   name: ch.bafu.oekomorphologie-f_abschnitte
   sources: [ch.bafu.oekomorphologie-f_abschnitte_20080913_cache]
   title: "\xD6komorphologie F - Abschnitte ('current')"
-- dimensions: *id121
+- dimensions: *id053
   name: ch.bafu.oekomorphologie-f_abschnitte_20080913_source
   sources: [ch.bafu.oekomorphologie-f_abschnitte_20080913_cache]
   title: "\xD6komorphologie F - Abschnitte (20080913, source)"
-- dimensions: &id122
+- dimensions: &id054
     Time:
       default: '20110912'
       values: ['20110912']
   name: ch.bafu.oekomorphologie-f_abstuerze_20110912
   sources: [ch.bafu.oekomorphologie-f_abstuerze_20110912_cache_out]
   title: "\xD6komorphologie F - Abst\xFCrze (20110912)"
-- dimensions: *id122
+- dimensions: *id054
   name: ch.bafu.oekomorphologie-f_abstuerze
   sources: [ch.bafu.oekomorphologie-f_abstuerze_20110912_cache]
   title: "\xD6komorphologie F - Abst\xFCrze ('current')"
-- dimensions: *id122
+- dimensions: *id054
   name: ch.bafu.oekomorphologie-f_abstuerze_20110912_source
   sources: [ch.bafu.oekomorphologie-f_abstuerze_20110912_cache]
   title: "\xD6komorphologie F - Abst\xFCrze (20110912, source)"
-- dimensions: &id123
+- dimensions: &id055
     Time:
       default: '20110912'
       values: ['20110912']
   name: ch.bafu.oekomorphologie-f_bauwerke_20110912
   sources: [ch.bafu.oekomorphologie-f_bauwerke_20110912_cache_out]
   title: "\xD6komorphologie F - Bauwerke (20110912)"
-- dimensions: *id123
+- dimensions: *id055
   name: ch.bafu.oekomorphologie-f_bauwerke
   sources: [ch.bafu.oekomorphologie-f_bauwerke_20110912_cache]
   title: "\xD6komorphologie F - Bauwerke ('current')"
-- dimensions: *id123
+- dimensions: *id055
   name: ch.bafu.oekomorphologie-f_bauwerke_20110912_source
   sources: [ch.bafu.oekomorphologie-f_bauwerke_20110912_cache]
   title: "\xD6komorphologie F - Bauwerke (20110912, source)"
-- dimensions: &id124
+- dimensions: &id056
     Time:
       default: '20110317'
       values: ['20110317']
   name: ch.bafu.permafrost_20110317
   sources: [ch.bafu.permafrost_20110317_cache_out]
   title: Permafrosthinweiskarte (20110317)
-- dimensions: *id124
+- dimensions: *id056
   name: ch.bafu.permafrost
   sources: [ch.bafu.permafrost_20110317_cache]
   title: Permafrosthinweiskarte ('current')
-- dimensions: *id124
+- dimensions: *id056
   name: ch.bafu.permafrost_20110317_source
   sources: [ch.bafu.permafrost_20110317_cache]
   title: Permafrosthinweiskarte (20110317, source)
-- dimensions: &id125
+- dimensions: &id057
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214
   sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_cache_out]
   title: REN  Extensives Landwirtschaftsgebiet (20110214)
-- dimensions: *id125
+- dimensions: *id057
   name: ch.bafu.ren-extensive_landwirtschaftsgebiete
   sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_cache]
   title: REN  Extensives Landwirtschaftsgebiet ('current')
-- dimensions: *id125
+- dimensions: *id057
   name: ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_source
   sources: [ch.bafu.ren-extensive_landwirtschaftsgebiete_20110214_cache]
   title: REN  Extensives Landwirtschaftsgebiet (20110214, source)
-- dimensions: &id126
+- dimensions: &id058
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-feuchtgebiete_20110214
   sources: [ch.bafu.ren-feuchtgebiete_20110214_cache_out]
   title: REN  Feuchtgebiet (20110214)
-- dimensions: *id126
+- dimensions: *id058
   name: ch.bafu.ren-feuchtgebiete
   sources: [ch.bafu.ren-feuchtgebiete_20110214_cache]
   title: REN  Feuchtgebiet ('current')
-- dimensions: *id126
+- dimensions: *id058
   name: ch.bafu.ren-feuchtgebiete_20110214_source
   sources: [ch.bafu.ren-feuchtgebiete_20110214_cache]
   title: REN  Feuchtgebiet (20110214, source)
-- dimensions: &id127
+- dimensions: &id059
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-fliessgewaesser_seen_20110214
   sources: [ch.bafu.ren-fliessgewaesser_seen_20110214_cache_out]
   title: "REN  Fliessgew\xE4sser / Seen (20110214)"
-- dimensions: *id127
+- dimensions: *id059
   name: ch.bafu.ren-fliessgewaesser_seen
   sources: [ch.bafu.ren-fliessgewaesser_seen_20110214_cache]
   title: "REN  Fliessgew\xE4sser / Seen ('current')"
-- dimensions: *id127
+- dimensions: *id059
   name: ch.bafu.ren-fliessgewaesser_seen_20110214_source
   sources: [ch.bafu.ren-fliessgewaesser_seen_20110214_cache]
   title: "REN  Fliessgew\xE4sser / Seen (20110214, source)"
-- dimensions: &id128
+- dimensions: &id060
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-trockenstandorte_20110214
   sources: [ch.bafu.ren-trockenstandorte_20110214_cache_out]
   title: REN  Trockenstandort (20110214)
-- dimensions: *id128
+- dimensions: *id060
   name: ch.bafu.ren-trockenstandorte
   sources: [ch.bafu.ren-trockenstandorte_20110214_cache]
   title: REN  Trockenstandort ('current')
-- dimensions: *id128
+- dimensions: *id060
   name: ch.bafu.ren-trockenstandorte_20110214_source
   sources: [ch.bafu.ren-trockenstandorte_20110214_cache]
   title: REN  Trockenstandort (20110214, source)
-- dimensions: &id129
+- dimensions: &id061
     Time:
       default: '20110214'
       values: ['20110214']
   name: ch.bafu.ren-wald_20110214
   sources: [ch.bafu.ren-wald_20110214_cache_out]
   title: REN  Wald (20110214)
-- dimensions: *id129
+- dimensions: *id061
   name: ch.bafu.ren-wald
   sources: [ch.bafu.ren-wald_20110214_cache]
   title: REN  Wald ('current')
-- dimensions: *id129
+- dimensions: *id061
   name: ch.bafu.ren-wald_20110214_source
   sources: [ch.bafu.ren-wald_20110214_cache]
   title: REN  Wald (20110214, source)
-- dimensions: &id130
-    Time:
-      default: '20070701'
-      values: ['20070701']
-  name: ch.bafu.schutzgebiete-aulav_auen_20070701
-  sources: [ch.bafu.schutzgebiete-aulav_auen_20070701_cache_out]
-  title: Auengebiete AuLaV (20070701)
-- dimensions: *id130
-  name: ch.bafu.schutzgebiete-aulav_auen
-  sources: [ch.bafu.schutzgebiete-aulav_auen_20070701_cache]
-  title: Auengebiete AuLaV ('current')
-- dimensions: *id130
-  name: ch.bafu.schutzgebiete-aulav_auen_20070701_source
-  sources: [ch.bafu.schutzgebiete-aulav_auen_20070701_cache]
-  title: Auengebiete AuLaV (20070701, source)
-- dimensions: &id131
-    Time:
-      default: '20131220'
-      values: ['20131220']
-  name: ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220
-  sources: [ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_cache_out]
-  title: Jagdbanngebiete AuLaV (20131220)
-- dimensions: *id131
-  name: ch.bafu.schutzgebiete-aulav_jagdbanngebiete
-  sources: [ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_cache]
-  title: Jagdbanngebiete AuLaV ('current')
-- dimensions: *id131
-  name: ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_source
-  sources: [ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_cache]
-  title: Jagdbanngebiete AuLaV (20131220, source)
-- dimensions: &id132
-    Time:
-      default: '20070701'
-      values: ['20070701']
-  name: ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701
-  sources: [ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_cache_out]
-  title: Moorlandschaften AuLaV (20070701)
-- dimensions: *id132
-  name: ch.bafu.schutzgebiete-aulav_moorlandschaften
-  sources: [ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_cache]
-  title: Moorlandschaften AuLaV ('current')
-- dimensions: *id132
-  name: ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_source
-  sources: [ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_cache]
-  title: Moorlandschaften AuLaV (20070701, source)
-- dimensions: &id133
-    Time:
-      default: '20130523'
-      values: ['20130523']
-  name: ch.bafu.schutzgebiete-aulav_uebrige_20130523
-  sources: [ch.bafu.schutzgebiete-aulav_uebrige_20130523_cache_out]
-  title: "\xDCbrige Schutzgebiete AuLaV (20130523)"
-- dimensions: *id133
-  name: ch.bafu.schutzgebiete-aulav_uebrige
-  sources: [ch.bafu.schutzgebiete-aulav_uebrige_20130523_cache]
-  title: "\xDCbrige Schutzgebiete AuLaV ('current')"
-- dimensions: *id133
-  name: ch.bafu.schutzgebiete-aulav_uebrige_20130523_source
-  sources: [ch.bafu.schutzgebiete-aulav_uebrige_20130523_cache]
-  title: "\xDCbrige Schutzgebiete AuLaV (20130523, source)"
-- dimensions: &id134
-    Time:
-      default: '20120109'
-      values: ['20120109']
-  name: ch.bafu.schutzgebiete-biosphaerenreservate_20120109
-  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_20120109_cache_out]
-  title: "Biosph\xE4renreservate (20120109)"
-- dimensions: *id134
-  name: ch.bafu.schutzgebiete-biosphaerenreservate
-  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_20120109_cache]
-  title: "Biosph\xE4renreservate ('current')"
-- dimensions: *id134
-  name: ch.bafu.schutzgebiete-biosphaerenreservate_20120109_source
-  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_20120109_cache]
-  title: "Biosph\xE4renreservate (20120109, source)"
-- dimensions: &id135
-    Time:
-      default: '20140923'
-      values: ['20140923']
-  name: ch.bafu.schutzgebiete-luftfahrt_20140923
-  sources: [ch.bafu.schutzgebiete-luftfahrt_20140923_cache_out]
-  title: Schutzgebiete MIL (20140923)
-- dimensions: *id135
-  name: ch.bafu.schutzgebiete-luftfahrt
-  sources: [ch.bafu.schutzgebiete-luftfahrt_20140923_cache]
-  title: Schutzgebiete MIL ('current')
-- dimensions: *id135
-  name: ch.bafu.schutzgebiete-luftfahrt_20140923_source
-  sources: [ch.bafu.schutzgebiete-luftfahrt_20140923_cache]
-  title: Schutzgebiete MIL (20140923, source)
-- dimensions: &id136
+- dimensions: &id062
     Time:
       default: '20150422'
       values: ['20150422']
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache_out]
   title: "P\xE4rke (20150422)"
-- dimensions: *id136
+- dimensions: *id062
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache]
   title: "P\xE4rke ('current')"
-- dimensions: *id136
+- dimensions: *id062
   name: ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_source
   sources: [ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_20150422_cache]
   title: "P\xE4rke (20150422, source)"
-- dimensions: &id137
+- dimensions: &id063
     Time:
       default: '20110830'
       values: ['20110830']
   name: ch.bafu.schutzgebiete-ramsar_20110830
   sources: [ch.bafu.schutzgebiete-ramsar_20110830_cache_out]
   title: Ramsar (20110830)
-- dimensions: *id137
+- dimensions: *id063
   name: ch.bafu.schutzgebiete-ramsar
   sources: [ch.bafu.schutzgebiete-ramsar_20110830_cache]
   title: Ramsar ('current')
-- dimensions: *id137
+- dimensions: *id063
   name: ch.bafu.schutzgebiete-ramsar_20110830_source
   sources: [ch.bafu.schutzgebiete-ramsar_20110830_cache]
   title: Ramsar (20110830, source)
-- dimensions: &id138
+- dimensions: &id064
     Time:
       default: '20010117'
       values: ['20010117']
   name: ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117
   sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_cache_out]
   title: Nationalpark (20010117)
-- dimensions: *id138
+- dimensions: *id064
   name: ch.bafu.schutzgebiete-schweizerischer_nationalpark
   sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_cache]
   title: Nationalpark ('current')
-- dimensions: *id138
+- dimensions: *id064
   name: ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_source
   sources: [ch.bafu.schutzgebiete-schweizerischer_nationalpark_20010117_cache]
   title: Nationalpark (20010117, source)
-- dimensions: &id139
+- dimensions: &id065
     Time:
       default: '20090917'
       values: ['20090917']
   name: ch.bafu.schutzgebiete-smaragd_20090917
   sources: [ch.bafu.schutzgebiete-smaragd_20090917_cache_out]
   title: Smaragd (20090917)
-- dimensions: *id139
+- dimensions: *id065
   name: ch.bafu.schutzgebiete-smaragd
   sources: [ch.bafu.schutzgebiete-smaragd_20090917_cache]
   title: Smaragd ('current')
-- dimensions: *id139
+- dimensions: *id065
   name: ch.bafu.schutzgebiete-smaragd_20090917_source
   sources: [ch.bafu.schutzgebiete-smaragd_20090917_cache]
   title: Smaragd (20090917, source)
-- dimensions: &id140
+- dimensions: &id066
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_hochwasser_20150101
   sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache_out]
   title: 'ShowMe Gemeinden: Hochwasser (20150101)'
-- dimensions: *id140
+- dimensions: *id066
   name: ch.bafu.showme-gemeinden_hochwasser
   sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (''current'')'
-- dimensions: *id140
+- dimensions: *id066
   name: ch.bafu.showme-gemeinden_hochwasser_20150101_source
   sources: [ch.bafu.showme-gemeinden_hochwasser_20150101_cache]
   title: 'ShowMe Gemeinden: Hochwasser (20150101, source)'
-- dimensions: &id141
+- dimensions: &id067
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_lawinen_20150101
   sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache_out]
   title: 'ShowMe Gemeinden: Lawinen (20150101)'
-- dimensions: *id141
+- dimensions: *id067
   name: ch.bafu.showme-gemeinden_lawinen
   sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
   title: 'ShowMe Gemeinden: Lawinen (''current'')'
-- dimensions: *id141
+- dimensions: *id067
   name: ch.bafu.showme-gemeinden_lawinen_20150101_source
   sources: [ch.bafu.showme-gemeinden_lawinen_20150101_cache]
   title: 'ShowMe Gemeinden: Lawinen (20150101, source)'
-- dimensions: &id142
+- dimensions: &id068
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_rutschungen_20150101
   sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache_out]
   title: 'ShowMe Gemeinden: Rutschungen (20150101)'
-- dimensions: *id142
+- dimensions: *id068
   name: ch.bafu.showme-gemeinden_rutschungen
   sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (''current'')'
-- dimensions: *id142
+- dimensions: *id068
   name: ch.bafu.showme-gemeinden_rutschungen_20150101_source
   sources: [ch.bafu.showme-gemeinden_rutschungen_20150101_cache]
   title: 'ShowMe Gemeinden: Rutschungen (20150101, source)'
-- dimensions: &id143
+- dimensions: &id069
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-gemeinden_sturzprozesse_20150101
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache_out]
   title: 'ShowMe Gemeinden: Sturzprozesse (20150101)'
-- dimensions: *id143
+- dimensions: *id069
   name: ch.bafu.showme-gemeinden_sturzprozesse
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (''current'')'
-- dimensions: *id143
+- dimensions: *id069
   name: ch.bafu.showme-gemeinden_sturzprozesse_20150101_source
   sources: [ch.bafu.showme-gemeinden_sturzprozesse_20150101_cache]
   title: 'ShowMe Gemeinden: Sturzprozesse (20150101, source)'
-- dimensions: &id144
+- dimensions: &id070
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_hochwasser_20150101
   sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache_out]
   title: 'ShowMe Kantone: Hochwasser (20150101)'
-- dimensions: *id144
+- dimensions: *id070
   name: ch.bafu.showme-kantone_hochwasser
   sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
   title: 'ShowMe Kantone: Hochwasser (''current'')'
-- dimensions: *id144
+- dimensions: *id070
   name: ch.bafu.showme-kantone_hochwasser_20150101_source
   sources: [ch.bafu.showme-kantone_hochwasser_20150101_cache]
   title: 'ShowMe Kantone: Hochwasser (20150101, source)'
-- dimensions: &id145
+- dimensions: &id071
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_lawinen_20150101
   sources: [ch.bafu.showme-kantone_lawinen_20150101_cache_out]
   title: 'ShowMe Kantone: Lawinen (20150101)'
-- dimensions: *id145
+- dimensions: *id071
   name: ch.bafu.showme-kantone_lawinen
   sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
   title: 'ShowMe Kantone: Lawinen (''current'')'
-- dimensions: *id145
+- dimensions: *id071
   name: ch.bafu.showme-kantone_lawinen_20150101_source
   sources: [ch.bafu.showme-kantone_lawinen_20150101_cache]
   title: 'ShowMe Kantone: Lawinen (20150101, source)'
-- dimensions: &id146
+- dimensions: &id072
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_rutschungen_20150101
   sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache_out]
   title: 'ShowMe Kantone: Rutschungen (20150101)'
-- dimensions: *id146
+- dimensions: *id072
   name: ch.bafu.showme-kantone_rutschungen
   sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
   title: 'ShowMe Kantone: Rutschungen (''current'')'
-- dimensions: *id146
+- dimensions: *id072
   name: ch.bafu.showme-kantone_rutschungen_20150101_source
   sources: [ch.bafu.showme-kantone_rutschungen_20150101_cache]
   title: 'ShowMe Kantone: Rutschungen (20150101, source)'
-- dimensions: &id147
+- dimensions: &id073
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.bafu.showme-kantone_sturzprozesse_20150101
   sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache_out]
   title: 'ShowMe Kantone: Sturzprozesse (20150101)'
-- dimensions: *id147
+- dimensions: *id073
   name: ch.bafu.showme-kantone_sturzprozesse
   sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (''current'')'
-- dimensions: *id147
+- dimensions: *id073
   name: ch.bafu.showme-kantone_sturzprozesse_20150101_source
   sources: [ch.bafu.showme-kantone_sturzprozesse_20150101_cache]
   title: 'ShowMe Kantone: Sturzprozesse (20150101, source)'
-- dimensions: &id148
-    Time:
-      default: '20060701'
-      values: ['20060701']
-  name: ch.bafu.silvaprotect-hangmuren_20060701
-  sources: [ch.bafu.silvaprotect-hangmuren_20060701_cache_out]
-  title: Hangmuren (20060701)
-- dimensions: *id148
-  name: ch.bafu.silvaprotect-hangmuren
-  sources: [ch.bafu.silvaprotect-hangmuren_20060701_cache]
-  title: Hangmuren ('current')
-- dimensions: *id148
-  name: ch.bafu.silvaprotect-hangmuren_20060701_source
-  sources: [ch.bafu.silvaprotect-hangmuren_20060701_cache]
-  title: Hangmuren (20060701, source)
-- dimensions: &id149
-    Time:
-      default: '20060701'
-      values: ['20060701']
-  name: ch.bafu.silvaprotect-lawinen_20060701
-  sources: [ch.bafu.silvaprotect-lawinen_20060701_cache_out]
-  title: Lawinen (20060701)
-- dimensions: *id149
-  name: ch.bafu.silvaprotect-lawinen
-  sources: [ch.bafu.silvaprotect-lawinen_20060701_cache]
-  title: Lawinen ('current')
-- dimensions: *id149
-  name: ch.bafu.silvaprotect-lawinen_20060701_source
-  sources: [ch.bafu.silvaprotect-lawinen_20060701_cache]
-  title: Lawinen (20060701, source)
-- dimensions: &id150
-    Time:
-      default: '20060701'
-      values: ['20060701']
-  name: ch.bafu.silvaprotect-murgang_20060701
-  sources: [ch.bafu.silvaprotect-murgang_20060701_cache_out]
-  title: Murgang (20060701)
-- dimensions: *id150
-  name: ch.bafu.silvaprotect-murgang
-  sources: [ch.bafu.silvaprotect-murgang_20060701_cache]
-  title: Murgang ('current')
-- dimensions: *id150
-  name: ch.bafu.silvaprotect-murgang_20060701_source
-  sources: [ch.bafu.silvaprotect-murgang_20060701_cache]
-  title: Murgang (20060701, source)
-- dimensions: &id151
-    Time:
-      default: '20060701'
-      values: ['20060701']
-  name: ch.bafu.silvaprotect-sturz_20060701
-  sources: [ch.bafu.silvaprotect-sturz_20060701_cache_out]
-  title: Sturz (20060701)
-- dimensions: *id151
-  name: ch.bafu.silvaprotect-sturz
-  sources: [ch.bafu.silvaprotect-sturz_20060701_cache]
-  title: Sturz ('current')
-- dimensions: *id151
-  name: ch.bafu.silvaprotect-sturz_20060701_source
-  sources: [ch.bafu.silvaprotect-sturz_20060701_cache]
-  title: Sturz (20060701, source)
-- dimensions: &id152
-    Time:
-      default: '20080501'
-      values: ['20080501']
-  name: ch.bafu.silvaprotect-uebersarung_20080501
-  sources: [ch.bafu.silvaprotect-uebersarung_20080501_cache_out]
-  title: "\xDCbersarung (20080501)"
-- dimensions: *id152
-  name: ch.bafu.silvaprotect-uebersarung
-  sources: [ch.bafu.silvaprotect-uebersarung_20080501_cache]
-  title: "\xDCbersarung ('current')"
-- dimensions: *id152
-  name: ch.bafu.silvaprotect-uebersarung_20080501_source
-  sources: [ch.bafu.silvaprotect-uebersarung_20080501_cache]
-  title: "\xDCbersarung (20080501, source)"
-- dimensions: &id153
-    Time:
-      default: '20020101'
-      values: ['20020101']
-  name: ch.bafu.strukturguete-hochrhein_linkesufer_20020101
-  sources: [ch.bafu.strukturguete-hochrhein_linkesufer_20020101_cache_out]
-  title: "Strukturg\xFCte Linkes Ufer (20020101)"
-- dimensions: *id153
-  name: ch.bafu.strukturguete-hochrhein_linkesufer
-  sources: [ch.bafu.strukturguete-hochrhein_linkesufer_20020101_cache]
-  title: "Strukturg\xFCte Linkes Ufer ('current')"
-- dimensions: *id153
-  name: ch.bafu.strukturguete-hochrhein_linkesufer_20020101_source
-  sources: [ch.bafu.strukturguete-hochrhein_linkesufer_20020101_cache]
-  title: "Strukturg\xFCte Linkes Ufer (20020101, source)"
-- dimensions: &id154
-    Time:
-      default: '20020101'
-      values: ['20020101']
-  name: ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101
-  sources: [ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_cache_out]
-  title: "Strukturg\xFCte Linkes Umfeld (20020101)"
-- dimensions: *id154
-  name: ch.bafu.strukturguete-hochrhein_linkesumfeld
-  sources: [ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_cache]
-  title: "Strukturg\xFCte Linkes Umfeld ('current')"
-- dimensions: *id154
-  name: ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_source
-  sources: [ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_cache]
-  title: "Strukturg\xFCte Linkes Umfeld (20020101, source)"
-- dimensions: &id155
-    Time:
-      default: '20020101'
-      values: ['20020101']
-  name: ch.bafu.strukturguete-hochrhein_rechtesufer_20020101
-  sources: [ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_cache_out]
-  title: "Strukturg\xFCte Rechtes Ufer (20020101)"
-- dimensions: *id155
-  name: ch.bafu.strukturguete-hochrhein_rechtesufer
-  sources: [ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_cache]
-  title: "Strukturg\xFCte Rechtes Ufer ('current')"
-- dimensions: *id155
-  name: ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_source
-  sources: [ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_cache]
-  title: "Strukturg\xFCte Rechtes Ufer (20020101, source)"
-- dimensions: &id156
-    Time:
-      default: '20020101'
-      values: ['20020101']
-  name: ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101
-  sources: [ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_cache_out]
-  title: "Strukturg\xFCte Rechtes Umfeld (20020101)"
-- dimensions: *id156
-  name: ch.bafu.strukturguete-hochrhein_rechtesumfeld
-  sources: [ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_cache]
-  title: "Strukturg\xFCte Rechtes Umfeld ('current')"
-- dimensions: *id156
-  name: ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_source
-  sources: [ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_cache]
-  title: "Strukturg\xFCte Rechtes Umfeld (20020101, source)"
-- dimensions: &id157
-    Time:
-      default: '20020101'
-      values: ['20020101']
-  name: ch.bafu.strukturguete-hochrhein_sohle_20020101
-  sources: [ch.bafu.strukturguete-hochrhein_sohle_20020101_cache_out]
-  title: "Strukturg\xFCte Sohle (20020101)"
-- dimensions: *id157
-  name: ch.bafu.strukturguete-hochrhein_sohle
-  sources: [ch.bafu.strukturguete-hochrhein_sohle_20020101_cache]
-  title: "Strukturg\xFCte Sohle ('current')"
-- dimensions: *id157
-  name: ch.bafu.strukturguete-hochrhein_sohle_20020101_source
-  sources: [ch.bafu.strukturguete-hochrhein_sohle_20020101_cache]
-  title: "Strukturg\xFCte Sohle (20020101, source)"
-- dimensions: &id158
+- dimensions: &id074
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_100_20141107
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 (20141107)"
-- dimensions: *id158
+- dimensions: *id074
   name: ch.bafu.sturm-boeenspitzen_100
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 ('current')"
-- dimensions: *id158
+- dimensions: *id074
   name: ch.bafu.sturm-boeenspitzen_100_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_100_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 100 (20141107, source)"
-- dimensions: &id159
+- dimensions: &id075
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_30_20141107
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 (20141107)"
-- dimensions: *id159
+- dimensions: *id075
   name: ch.bafu.sturm-boeenspitzen_30
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 ('current')"
-- dimensions: *id159
+- dimensions: *id075
   name: ch.bafu.sturm-boeenspitzen_30_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_30_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 30 (20141107, source)"
-- dimensions: &id160
+- dimensions: &id076
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_300_20141107
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 (20141107)"
-- dimensions: *id160
+- dimensions: *id076
   name: ch.bafu.sturm-boeenspitzen_300
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 ('current')"
-- dimensions: *id160
+- dimensions: *id076
   name: ch.bafu.sturm-boeenspitzen_300_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_300_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 300 (20141107, source)"
-- dimensions: &id161
+- dimensions: &id077
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-boeenspitzen_50_20141107
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache_out]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 (20141107)"
-- dimensions: *id161
+- dimensions: *id077
   name: ch.bafu.sturm-boeenspitzen_50
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 ('current')"
-- dimensions: *id161
+- dimensions: *id077
   name: ch.bafu.sturm-boeenspitzen_50_20141107_source
   sources: [ch.bafu.sturm-boeenspitzen_50_20141107_cache]
   title: "Sturmgef\xE4hrdung B\xF6enspitzen 50 (20141107, source)"
-- dimensions: &id162
+- dimensions: &id078
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_100_20141107
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 100 (20141107)"
-- dimensions: *id162
+- dimensions: *id078
   name: ch.bafu.sturm-staudruck_100
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 100 ('current')"
-- dimensions: *id162
+- dimensions: *id078
   name: ch.bafu.sturm-staudruck_100_20141107_source
   sources: [ch.bafu.sturm-staudruck_100_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 100 (20141107, source)"
-- dimensions: &id163
+- dimensions: &id079
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_30_20141107
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 30 (20141107)"
-- dimensions: *id163
+- dimensions: *id079
   name: ch.bafu.sturm-staudruck_30
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 30 ('current')"
-- dimensions: *id163
+- dimensions: *id079
   name: ch.bafu.sturm-staudruck_30_20141107_source
   sources: [ch.bafu.sturm-staudruck_30_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 30 (20141107, source)"
-- dimensions: &id164
+- dimensions: &id080
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_300_20141107
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 300 (20141107)"
-- dimensions: *id164
+- dimensions: *id080
   name: ch.bafu.sturm-staudruck_300
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 300 ('current')"
-- dimensions: *id164
+- dimensions: *id080
   name: ch.bafu.sturm-staudruck_300_20141107_source
   sources: [ch.bafu.sturm-staudruck_300_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 300 (20141107, source)"
-- dimensions: &id165
+- dimensions: &id081
     Time:
       default: '20141107'
       values: ['20141107']
   name: ch.bafu.sturm-staudruck_50_20141107
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache_out]
   title: "Sturmgef\xE4hrdung Staudruck 50 (20141107)"
-- dimensions: *id165
+- dimensions: *id081
   name: ch.bafu.sturm-staudruck_50
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 50 ('current')"
-- dimensions: *id165
+- dimensions: *id081
   name: ch.bafu.sturm-staudruck_50_20141107_source
   sources: [ch.bafu.sturm-staudruck_50_20141107_cache]
   title: "Sturmgef\xE4hrdung Staudruck 50 (20141107, source)"
-- dimensions: &id166
-    Time:
-      default: '20150226'
-      values: ['20150226']
-  name: ch.bafu.swissprtr_20150226
-  sources: [ch.bafu.swissprtr_20150226_cache_out]
-  title: Schadstoff-Freisetzungen (SwissPRTR) (20150226)
-- dimensions: *id166
-  name: ch.bafu.swissprtr
-  sources: [ch.bafu.swissprtr_20150226_cache]
-  title: Schadstoff-Freisetzungen (SwissPRTR) ('current')
-- dimensions: *id166
-  name: ch.bafu.swissprtr_20150226_source
-  sources: [ch.bafu.swissprtr_20150226_cache]
-  title: Schadstoff-Freisetzungen (SwissPRTR) (20150226, source)
-- dimensions: &id167
-    Time:
-      default: '20130101'
-      values: ['20130101']
-  name: ch.bafu.typisierung-fliessgewaesser_20130101
-  sources: [ch.bafu.typisierung-fliessgewaesser_20130101_cache_out]
-  title: "Typisierung Fliessgew\xE4sser (20130101)"
-- dimensions: *id167
-  name: ch.bafu.typisierung-fliessgewaesser
-  sources: [ch.bafu.typisierung-fliessgewaesser_20130101_cache]
-  title: "Typisierung Fliessgew\xE4sser ('current')"
-- dimensions: *id167
-  name: ch.bafu.typisierung-fliessgewaesser_20130101_source
-  sources: [ch.bafu.typisierung-fliessgewaesser_20130101_cache]
-  title: "Typisierung Fliessgew\xE4sser (20130101, source)"
-- dimensions: &id168
+- dimensions: &id082
     Time:
       default: '20080724'
       values: ['20080724']
   name: ch.bafu.unesco-weltnaturerbe_20080724
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache_out]
   title: "UNESCO-Welterbe Naturst\xE4tten (20080724)"
-- dimensions: *id168
+- dimensions: *id082
   name: ch.bafu.unesco-weltnaturerbe
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache]
   title: "UNESCO-Welterbe Naturst\xE4tten ('current')"
-- dimensions: *id168
+- dimensions: *id082
   name: ch.bafu.unesco-weltnaturerbe_20080724_source
   sources: [ch.bafu.unesco-weltnaturerbe_20080724_cache]
   title: "UNESCO-Welterbe Naturst\xE4tten (20080724, source)"
-- dimensions: &id169
-    Time:
-      default: '20070101'
-      values: ['20070101']
-  name: ch.bafu.vec25-gewaessernetz_2000_20070101
-  sources: [ch.bafu.vec25-gewaessernetz_2000_20070101_cache_out]
-  title: "Gew\xE4ssernetz 1:2 Mio. (20070101)"
-- dimensions: *id169
-  name: ch.bafu.vec25-gewaessernetz_2000
-  sources: [ch.bafu.vec25-gewaessernetz_2000_20070101_cache]
-  title: "Gew\xE4ssernetz 1:2 Mio. ('current')"
-- dimensions: *id169
-  name: ch.bafu.vec25-gewaessernetz_2000_20070101_source
-  sources: [ch.bafu.vec25-gewaessernetz_2000_20070101_cache]
-  title: "Gew\xE4ssernetz 1:2 Mio. (20070101, source)"
-- dimensions: &id170
-    Time:
-      default: '20070101'
-      values: ['20070101']
-  name: ch.bafu.vec25-seen_20070101
-  sources: [ch.bafu.vec25-seen_20070101_cache_out]
-  title: Seen (20070101)
-- dimensions: *id170
-  name: ch.bafu.vec25-seen
-  sources: [ch.bafu.vec25-seen_20070101_cache]
-  title: Seen ('current')
-- dimensions: *id170
-  name: ch.bafu.vec25-seen_20070101_source
-  sources: [ch.bafu.vec25-seen_20070101_cache]
-  title: Seen (20070101, source)
-- dimensions: &id171
-    Time:
-      default: '20150622'
-      values: ['20150622']
-  name: ch.bafu.waldreservate_20150622
-  sources: [ch.bafu.waldreservate_20150622_cache_out]
-  title: Waldreservate (20150622)
-- dimensions: *id171
-  name: ch.bafu.waldreservate
-  sources: [ch.bafu.waldreservate_20150622_cache]
-  title: Waldreservate ('current')
-- dimensions: *id171
-  name: ch.bafu.waldreservate_20150622_source
-  sources: [ch.bafu.waldreservate_20150622_cache]
-  title: Waldreservate (20150622, source)
-- dimensions: &id172
-    Time:
-      default: '20001001'
-      values: ['20001001']
-  name: ch.bafu.waldschadenflaechen-lothar_20001001
-  sources: [ch.bafu.waldschadenflaechen-lothar_20001001_cache_out]
-  title: Sturmschaden Lothar (20001001)
-- dimensions: *id172
-  name: ch.bafu.waldschadenflaechen-lothar
-  sources: [ch.bafu.waldschadenflaechen-lothar_20001001_cache]
-  title: Sturmschaden Lothar ('current')
-- dimensions: *id172
-  name: ch.bafu.waldschadenflaechen-lothar_20001001_source
-  sources: [ch.bafu.waldschadenflaechen-lothar_20001001_cache]
-  title: Sturmschaden Lothar (20001001, source)
-- dimensions: &id173
-    Time:
-      default: '19920115'
-      values: ['19920115']
-  name: ch.bafu.waldschadenflaechen-vivian_19920115
-  sources: [ch.bafu.waldschadenflaechen-vivian_19920115_cache_out]
-  title: Sturmschaden Vivian (19920115)
-- dimensions: *id173
-  name: ch.bafu.waldschadenflaechen-vivian
-  sources: [ch.bafu.waldschadenflaechen-vivian_19920115_cache]
-  title: Sturmschaden Vivian ('current')
-- dimensions: *id173
-  name: ch.bafu.waldschadenflaechen-vivian_19920115_source
-  sources: [ch.bafu.waldschadenflaechen-vivian_19920115_cache]
-  title: Sturmschaden Vivian (19920115, source)
-- dimensions: &id174
-    Time:
-      default: '20090101'
-      values: ['20090101']
-  name: ch.bafu.wasserbau-querprofilmarken_20090101
-  sources: [ch.bafu.wasserbau-querprofilmarken_20090101_cache_out]
-  title: Querprofilmarke (20090101)
-- dimensions: *id174
-  name: ch.bafu.wasserbau-querprofilmarken
-  sources: [ch.bafu.wasserbau-querprofilmarken_20090101_cache]
-  title: Querprofilmarke ('current')
-- dimensions: *id174
-  name: ch.bafu.wasserbau-querprofilmarken_20090101_source
-  sources: [ch.bafu.wasserbau-querprofilmarken_20090101_cache]
-  title: Querprofilmarke (20090101, source)
-- dimensions: &id175
-    Time:
-      default: '20140101'
-      values: ['20140101']
-  name: ch.bafu.wasserbau-vermessungsstrecken_20140101
-  sources: [ch.bafu.wasserbau-vermessungsstrecken_20140101_cache_out]
-  title: Vermessungsstrecken (20140101)
-- dimensions: *id175
-  name: ch.bafu.wasserbau-vermessungsstrecken
-  sources: [ch.bafu.wasserbau-vermessungsstrecken_20140101_cache]
-  title: Vermessungsstrecken ('current')
-- dimensions: *id175
-  name: ch.bafu.wasserbau-vermessungsstrecken_20140101_source
-  sources: [ch.bafu.wasserbau-vermessungsstrecken_20140101_cache]
-  title: Vermessungsstrecken (20140101, source)
-- dimensions: &id176
-    Time:
-      default: '20040101'
-      values: ['20040101']
-  name: ch.bafu.wasser-entnahme_20040101
-  sources: [ch.bafu.wasser-entnahme_20040101_cache_out]
-  title: Wasserentnahme (20040101)
-- dimensions: *id176
-  name: ch.bafu.wasser-entnahme
-  sources: [ch.bafu.wasser-entnahme_20040101_cache]
-  title: Wasserentnahme ('current')
-- dimensions: *id176
-  name: ch.bafu.wasser-entnahme_20040101_source
-  sources: [ch.bafu.wasser-entnahme_20040101_cache]
-  title: Wasserentnahme (20040101, source)
-- dimensions: &id177
+- dimensions: &id083
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-gebietsauslaesse_20120701
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache_out]
   title: "Gebietsausl\xE4sse (20120701)"
-- dimensions: *id177
+- dimensions: *id083
   name: ch.bafu.wasser-gebietsauslaesse
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache]
   title: "Gebietsausl\xE4sse ('current')"
-- dimensions: *id177
+- dimensions: *id083
   name: ch.bafu.wasser-gebietsauslaesse_20120701_source
   sources: [ch.bafu.wasser-gebietsauslaesse_20120701_cache]
   title: "Gebietsausl\xE4sse (20120701, source)"
-- dimensions: &id178
+- dimensions: &id084
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-leitungen_20040101
   sources: [ch.bafu.wasser-leitungen_20040101_cache_out]
   title: Zuleitung (20040101)
-- dimensions: *id178
+- dimensions: *id084
   name: ch.bafu.wasser-leitungen
   sources: [ch.bafu.wasser-leitungen_20040101_cache]
   title: Zuleitung ('current')
-- dimensions: *id178
+- dimensions: *id084
   name: ch.bafu.wasser-leitungen_20040101_source
   sources: [ch.bafu.wasser-leitungen_20040101_cache]
   title: Zuleitung (20040101, source)
-- dimensions: &id179
+- dimensions: &id085
     Time:
       default: '20040101'
       values: ['20040101']
   name: ch.bafu.wasser-rueckgabe_20040101
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache_out]
   title: "Wasserr\xFCckgabe (20040101)"
-- dimensions: *id179
+- dimensions: *id085
   name: ch.bafu.wasser-rueckgabe
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache]
   title: "Wasserr\xFCckgabe ('current')"
-- dimensions: *id179
+- dimensions: *id085
   name: ch.bafu.wasser-rueckgabe_20040101_source
   sources: [ch.bafu.wasser-rueckgabe_20040101_cache]
   title: "Wasserr\xFCckgabe (20040101, source)"
-- dimensions: &id180
+- dimensions: &id086
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-teileinzugsgebiete_2_20120701
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache_out]
   title: Teileinzugsgebiete 2km2 (20120701)
-- dimensions: *id180
+- dimensions: *id086
   name: ch.bafu.wasser-teileinzugsgebiete_2
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache]
   title: Teileinzugsgebiete 2km2 ('current')
-- dimensions: *id180
+- dimensions: *id086
   name: ch.bafu.wasser-teileinzugsgebiete_2_20120701_source
   sources: [ch.bafu.wasser-teileinzugsgebiete_2_20120701_cache]
   title: Teileinzugsgebiete 2km2 (20120701, source)
-- dimensions: &id181
+- dimensions: &id087
     Time:
       default: '20120701'
       values: ['20120701']
   name: ch.bafu.wasser-teileinzugsgebiete_40_20120701
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache_out]
   title: Teileinzugsgebiete 40km2 (20120701)
-- dimensions: *id181
+- dimensions: *id087
   name: ch.bafu.wasser-teileinzugsgebiete_40
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache]
   title: Teileinzugsgebiete 40km2 ('current')
-- dimensions: *id181
+- dimensions: *id087
   name: ch.bafu.wasser-teileinzugsgebiete_40_20120701_source
   sources: [ch.bafu.wasser-teileinzugsgebiete_40_20120701_cache]
   title: Teileinzugsgebiete 40km2 (20120701, source)
-- dimensions: &id182
+- dimensions: &id088
     Time:
       default: '20120702'
       values: ['20120702']
   name: ch.bafu.wasser-vorfluter_20120702
   sources: [ch.bafu.wasser-vorfluter_20120702_cache_out]
   title: Ablussregimetyp (20120702)
-- dimensions: *id182
+- dimensions: *id088
   name: ch.bafu.wasser-vorfluter
   sources: [ch.bafu.wasser-vorfluter_20120702_cache]
   title: Ablussregimetyp ('current')
-- dimensions: *id182
+- dimensions: *id088
   name: ch.bafu.wasser-vorfluter_20120702_source
   sources: [ch.bafu.wasser-vorfluter_20120702_cache]
   title: Ablussregimetyp (20120702, source)
-- dimensions: &id183
-    Time:
-      default: '20111129'
-      values: ['20111129']
-  name: ch.bafu.wildruhezonen-jagdbanngebiete_20111129
-  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_20111129_cache_out]
-  title: Wildruhezonen (20111129)
-- dimensions: *id183
-  name: ch.bafu.wildruhezonen-jagdbanngebiete
-  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_20111129_cache]
-  title: Wildruhezonen ('current')
-- dimensions: *id183
-  name: ch.bafu.wildruhezonen-jagdbanngebiete_20111129_source
-  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_20111129_cache]
-  title: Wildruhezonen (20111129, source)
-- dimensions: &id184
+- dimensions: &id089
     Time:
       default: '20150106'
       values: ['20150106']
   name: ch.bafu.wrz-jagdbanngebiete_select_20150106
   sources: [ch.bafu.wrz-jagdbanngebiete_select_20150106_cache_out]
   title: Wildschutzgebiete (20150106)
-- dimensions: *id184
+- dimensions: *id089
   name: ch.bafu.wrz-jagdbanngebiete_select
   sources: [ch.bafu.wrz-jagdbanngebiete_select_20150106_cache]
   title: Wildschutzgebiete ('current')
-- dimensions: *id184
+- dimensions: *id089
   name: ch.bafu.wrz-jagdbanngebiete_select_20150106_source
   sources: [ch.bafu.wrz-jagdbanngebiete_select_20150106_cache]
   title: Wildschutzgebiete (20150106, source)
-- dimensions: &id185
+- dimensions: &id090
     Time:
       default: '20150106'
       values: ['20150106']
   name: ch.bafu.wrz-wildruhezonen_portal_20150106
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache_out]
   title: Wildruhezonen (20150106)
-- dimensions: *id185
+- dimensions: *id090
   name: ch.bafu.wrz-wildruhezonen_portal
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache]
   title: Wildruhezonen ('current')
-- dimensions: *id185
+- dimensions: *id090
   name: ch.bafu.wrz-wildruhezonen_portal_20150106_source
   sources: [ch.bafu.wrz-wildruhezonen_portal_20150106_cache]
   title: Wildruhezonen (20150106, source)
-- dimensions: &id186
-    Time:
-      default: '20141231'
-      values: ['20141231']
-  name: ch.bag.zecken-fsme-faelle_20141231
-  sources: [ch.bag.zecken-fsme-faelle_20141231_cache_out]
-  title: "FSME - Lokale H\xE4ufungen (20141231)"
-- dimensions: *id186
-  name: ch.bag.zecken-fsme-faelle
-  sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
-  title: "FSME - Lokale H\xE4ufungen ('current')"
-- dimensions: *id186
-  name: ch.bag.zecken-fsme-faelle_20141231_source
-  sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
-  title: "FSME - Lokale H\xE4ufungen (20141231, source)"
-- dimensions: &id187
-    Time:
-      default: '20141231'
-      values: ['20141231']
-  name: ch.bag.zecken-fsme-impfung_20141231
-  sources: [ch.bag.zecken-fsme-impfung_20141231_cache_out]
-  title: FSME - Impfempfehlung (20141231)
-- dimensions: *id187
-  name: ch.bag.zecken-fsme-impfung
-  sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
-  title: FSME - Impfempfehlung ('current')
-- dimensions: *id187
-  name: ch.bag.zecken-fsme-impfung_20141231_source
-  sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
-  title: FSME - Impfempfehlung (20141231, source)
-- dimensions: &id188
+- dimensions: &id091
     Time:
       default: '20110613'
       values: ['20110613']
   name: ch.bag.zecken-lyme_20110613
   sources: [ch.bag.zecken-lyme_20110613_cache_out]
   title: Borreliose Risikogebiete (20110613)
-- dimensions: *id188
+- dimensions: *id091
   name: ch.bag.zecken-lyme
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete ('current')
-- dimensions: *id188
+- dimensions: *id091
   name: ch.bag.zecken-lyme_20110613_source
   sources: [ch.bag.zecken-lyme_20110613_cache]
   title: Borreliose Risikogebiete (20110613, source)
-- dimensions: &id189
+- dimensions: &id092
     Time:
       default: '20150511'
       values: ['20150511']
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache_out]
   title: Bundesinventar ISOS (20150511)
-- dimensions: *id189
+- dimensions: *id092
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache]
   title: Bundesinventar ISOS ('current')
-- dimensions: *id189
+- dimensions: *id092
   name: ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_source
   sources: [ch.bak.bundesinventar-schuetzenswerte-ortsbilder_20150511_cache]
   title: Bundesinventar ISOS (20150511, source)
-- dimensions: &id190
+- dimensions: &id093
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.anbieter-eigenes_festnetz_20150521
   sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_cache_out]
   title: Anzahl Leitungsanbieter (20150521)
-- dimensions: *id190
+- dimensions: *id093
   name: ch.bakom.anbieter-eigenes_festnetz
   sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_cache]
   title: Anzahl Leitungsanbieter ('current')
-- dimensions: *id190
+- dimensions: *id093
   name: ch.bakom.anbieter-eigenes_festnetz_20150521_source
   sources: [ch.bakom.anbieter-eigenes_festnetz_20150521_cache]
   title: Anzahl Leitungsanbieter (20150521, source)
-- dimensions: &id191
+- dimensions: &id094
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.anschlussart-glasfaser_20150521
   sources: [ch.bakom.anschlussart-glasfaser_20150521_cache_out]
   title: Glasfaser (20150521)
-- dimensions: *id191
+- dimensions: *id094
   name: ch.bakom.anschlussart-glasfaser
   sources: [ch.bakom.anschlussart-glasfaser_20150521_cache]
   title: Glasfaser ('current')
-- dimensions: *id191
+- dimensions: *id094
   name: ch.bakom.anschlussart-glasfaser_20150521_source
   sources: [ch.bakom.anschlussart-glasfaser_20150521_cache]
   title: Glasfaser (20150521, source)
-- dimensions: &id192
+- dimensions: &id095
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.anschlussart-koaxialkabel_20150521
   sources: [ch.bakom.anschlussart-koaxialkabel_20150521_cache_out]
   title: Koaxial-Kabel (20150521)
-- dimensions: *id192
+- dimensions: *id095
   name: ch.bakom.anschlussart-koaxialkabel
   sources: [ch.bakom.anschlussart-koaxialkabel_20150521_cache]
   title: Koaxial-Kabel ('current')
-- dimensions: *id192
+- dimensions: *id095
   name: ch.bakom.anschlussart-koaxialkabel_20150521_source
   sources: [ch.bakom.anschlussart-koaxialkabel_20150521_cache]
   title: Koaxial-Kabel (20150521, source)
-- dimensions: &id193
+- dimensions: &id096
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.anschlussart-kupferdraht_20150521
   sources: [ch.bakom.anschlussart-kupferdraht_20150521_cache_out]
   title: Kupfer-Draht (20150521)
-- dimensions: *id193
+- dimensions: *id096
   name: ch.bakom.anschlussart-kupferdraht
   sources: [ch.bakom.anschlussart-kupferdraht_20150521_cache]
   title: Kupfer-Draht ('current')
-- dimensions: *id193
+- dimensions: *id096
   name: ch.bakom.anschlussart-kupferdraht_20150521_source
   sources: [ch.bakom.anschlussart-kupferdraht_20150521_cache]
   title: Kupfer-Draht (20150521, source)
-- dimensions: &id194
+- dimensions: &id097
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.downlink1_20150521
   sources: [ch.bakom.downlink1_20150521_cache_out]
   title: "Download \u2265 1 Mbit/s (20150521)"
-- dimensions: *id194
+- dimensions: *id097
   name: ch.bakom.downlink1
   sources: [ch.bakom.downlink1_20150521_cache]
   title: "Download \u2265 1 Mbit/s ('current')"
-- dimensions: *id194
+- dimensions: *id097
   name: ch.bakom.downlink1_20150521_source
   sources: [ch.bakom.downlink1_20150521_cache]
   title: "Download \u2265 1 Mbit/s (20150521, source)"
-- dimensions: &id195
+- dimensions: &id098
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.downlink10_20150521
   sources: [ch.bakom.downlink10_20150521_cache_out]
   title: "Download \u2265 10 Mbit/s (20150521)"
-- dimensions: *id195
+- dimensions: *id098
   name: ch.bakom.downlink10
   sources: [ch.bakom.downlink10_20150521_cache]
   title: "Download \u2265 10 Mbit/s ('current')"
-- dimensions: *id195
+- dimensions: *id098
   name: ch.bakom.downlink10_20150521_source
   sources: [ch.bakom.downlink10_20150521_cache]
   title: "Download \u2265 10 Mbit/s (20150521, source)"
-- dimensions: &id196
+- dimensions: &id099
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.downlink100_20150521
   sources: [ch.bakom.downlink100_20150521_cache_out]
   title: "Download \u2265 100 Mbit/s (20150521)"
-- dimensions: *id196
+- dimensions: *id099
   name: ch.bakom.downlink100
   sources: [ch.bakom.downlink100_20150521_cache]
   title: "Download \u2265 100 Mbit/s ('current')"
-- dimensions: *id196
+- dimensions: *id099
   name: ch.bakom.downlink100_20150521_source
   sources: [ch.bakom.downlink100_20150521_cache]
   title: "Download \u2265 100 Mbit/s (20150521, source)"
-- dimensions: &id197
+- dimensions: &id100
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.downlink2_20150521
   sources: [ch.bakom.downlink2_20150521_cache_out]
   title: "Download \u2265 2 Mbit/s (20150521)"
-- dimensions: *id197
+- dimensions: *id100
   name: ch.bakom.downlink2
   sources: [ch.bakom.downlink2_20150521_cache]
   title: "Download \u2265 2 Mbit/s ('current')"
-- dimensions: *id197
+- dimensions: *id100
   name: ch.bakom.downlink2_20150521_source
   sources: [ch.bakom.downlink2_20150521_cache]
   title: "Download \u2265 2 Mbit/s (20150521, source)"
-- dimensions: &id198
+- dimensions: &id101
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.downlink20_20150521
   sources: [ch.bakom.downlink20_20150521_cache_out]
   title: "Download \u2265 20 Mbit/s (20150521)"
-- dimensions: *id198
+- dimensions: *id101
   name: ch.bakom.downlink20
   sources: [ch.bakom.downlink20_20150521_cache]
   title: "Download \u2265 20 Mbit/s ('current')"
-- dimensions: *id198
+- dimensions: *id101
   name: ch.bakom.downlink20_20150521_source
   sources: [ch.bakom.downlink20_20150521_cache]
   title: "Download \u2265 20 Mbit/s (20150521, source)"
-- dimensions: &id199
+- dimensions: &id102
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.downlink50_20150521
   sources: [ch.bakom.downlink50_20150521_cache_out]
   title: "Download \u2265 50 Mbit/s (20150521)"
-- dimensions: *id199
+- dimensions: *id102
   name: ch.bakom.downlink50
   sources: [ch.bakom.downlink50_20150521_cache]
   title: "Download \u2265 50 Mbit/s ('current')"
-- dimensions: *id199
+- dimensions: *id102
   name: ch.bakom.downlink50_20150521_source
   sources: [ch.bakom.downlink50_20150521_cache]
   title: "Download \u2265 50 Mbit/s (20150521, source)"
-- dimensions: &id200
+- dimensions: &id103
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.uplink1_20150521
   sources: [ch.bakom.uplink1_20150521_cache_out]
   title: "Upload \u2265 1 Mbit/s (20150521)"
-- dimensions: *id200
+- dimensions: *id103
   name: ch.bakom.uplink1
   sources: [ch.bakom.uplink1_20150521_cache]
   title: "Upload \u2265 1 Mbit/s ('current')"
-- dimensions: *id200
+- dimensions: *id103
   name: ch.bakom.uplink1_20150521_source
   sources: [ch.bakom.uplink1_20150521_cache]
   title: "Upload \u2265 1 Mbit/s (20150521, source)"
-- dimensions: &id201
+- dimensions: &id104
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.uplink10_20150521
   sources: [ch.bakom.uplink10_20150521_cache_out]
   title: "Upload \u2265 10 Mbit/s (20150521)"
-- dimensions: *id201
+- dimensions: *id104
   name: ch.bakom.uplink10
   sources: [ch.bakom.uplink10_20150521_cache]
   title: "Upload \u2265 10 Mbit/s ('current')"
-- dimensions: *id201
+- dimensions: *id104
   name: ch.bakom.uplink10_20150521_source
   sources: [ch.bakom.uplink10_20150521_cache]
   title: "Upload \u2265 10 Mbit/s (20150521, source)"
-- dimensions: &id202
+- dimensions: &id105
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.uplink100_20150521
   sources: [ch.bakom.uplink100_20150521_cache_out]
   title: ch.bakom.uplink100 (20150521)
-- dimensions: *id202
+- dimensions: *id105
   name: ch.bakom.uplink100
   sources: [ch.bakom.uplink100_20150521_cache]
   title: ch.bakom.uplink100 ('current')
-- dimensions: *id202
+- dimensions: *id105
   name: ch.bakom.uplink100_20150521_source
   sources: [ch.bakom.uplink100_20150521_cache]
   title: ch.bakom.uplink100 (20150521, source)
-- dimensions: &id203
+- dimensions: &id106
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.uplink2_20150521
   sources: [ch.bakom.uplink2_20150521_cache_out]
   title: "Upload \u2265 2 Mbit/s (20150521)"
-- dimensions: *id203
+- dimensions: *id106
   name: ch.bakom.uplink2
   sources: [ch.bakom.uplink2_20150521_cache]
   title: "Upload \u2265 2 Mbit/s ('current')"
-- dimensions: *id203
+- dimensions: *id106
   name: ch.bakom.uplink2_20150521_source
   sources: [ch.bakom.uplink2_20150521_cache]
   title: "Upload \u2265 2 Mbit/s (20150521, source)"
-- dimensions: &id204
+- dimensions: &id107
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.uplink20_20150521
   sources: [ch.bakom.uplink20_20150521_cache_out]
   title: "Upload \u2265 20 Mbit/s (20150521)"
-- dimensions: *id204
+- dimensions: *id107
   name: ch.bakom.uplink20
   sources: [ch.bakom.uplink20_20150521_cache]
   title: "Upload \u2265 20 Mbit/s ('current')"
-- dimensions: *id204
+- dimensions: *id107
   name: ch.bakom.uplink20_20150521_source
   sources: [ch.bakom.uplink20_20150521_cache]
   title: "Upload \u2265 20 Mbit/s (20150521, source)"
-- dimensions: &id205
+- dimensions: &id108
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.uplink50_20150521
   sources: [ch.bakom.uplink50_20150521_cache_out]
   title: "Upload \u2265 50 Mbit/s (20150521)"
-- dimensions: *id205
+- dimensions: *id108
   name: ch.bakom.uplink50
   sources: [ch.bakom.uplink50_20150521_cache]
   title: "Upload \u2265 50 Mbit/s ('current')"
-- dimensions: *id205
+- dimensions: *id108
   name: ch.bakom.uplink50_20150521_source
   sources: [ch.bakom.uplink50_20150521_cache]
   title: "Upload \u2265 50 Mbit/s (20150521, source)"
-- dimensions: &id206
+- dimensions: &id109
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.verfuegbarkeit-hdtv_20150521
   sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_cache_out]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20150521)"
-- dimensions: *id206
+- dimensions: *id109
   name: ch.bakom.verfuegbarkeit-hdtv
   sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz ('current')"
-- dimensions: *id206
+- dimensions: *id109
   name: ch.bakom.verfuegbarkeit-hdtv_20150521_source
   sources: [ch.bakom.verfuegbarkeit-hdtv_20150521_cache]
   title: "HDTV-Verf\xFCgbarkeit Festnetz (20150521, source)"
-- dimensions: &id207
+- dimensions: &id110
     Time:
       default: '20150521'
       values: ['20150521']
   name: ch.bakom.verfuegbarkeit-tv_20150521
   sources: [ch.bakom.verfuegbarkeit-tv_20150521_cache_out]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20150521)"
-- dimensions: *id207
+- dimensions: *id110
   name: ch.bakom.verfuegbarkeit-tv
   sources: [ch.bakom.verfuegbarkeit-tv_20150521_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz ('current')"
-- dimensions: *id207
+- dimensions: *id110
   name: ch.bakom.verfuegbarkeit-tv_20150521_source
   sources: [ch.bakom.verfuegbarkeit-tv_20150521_cache]
   title: "TV-Verf\xFCgbarkeit via Festnetz (20150521, source)"
-- dimensions: &id208
+- dimensions: &id111
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-tv_20070704
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache_out]
   title: Versorgungsgebiete TV (20070704)
-- dimensions: *id208
+- dimensions: *id111
   name: ch.bakom.versorgungsgebiet-tv
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV ('current')
-- dimensions: *id208
+- dimensions: *id111
   name: ch.bakom.versorgungsgebiet-tv_20070704_source
   sources: [ch.bakom.versorgungsgebiet-tv_20070704_cache]
   title: Versorgungsgebiete TV (20070704, source)
-- dimensions: &id209
+- dimensions: &id112
     Time:
       default: '20070704'
       values: ['20070704']
   name: ch.bakom.versorgungsgebiet-ukw_20070704
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache_out]
   title: Versorgungsgebiete Radio (20070704)
-- dimensions: *id209
+- dimensions: *id112
   name: ch.bakom.versorgungsgebiet-ukw
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio ('current')
-- dimensions: *id209
+- dimensions: *id112
   name: ch.bakom.versorgungsgebiet-ukw_20070704_source
   sources: [ch.bakom.versorgungsgebiet-ukw_20070704_cache]
   title: Versorgungsgebiete Radio (20070704, source)
-- dimensions: &id210
+- dimensions: &id113
     Time:
       default: '20120203'
       values: ['20120203']
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache_out]
   title: "UNESCO-Welterbe Kulturst\xE4tten (20120203)"
-- dimensions: *id210
+- dimensions: *id113
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten ('current')"
-- dimensions: *id210
+- dimensions: *id113
   name: ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_source
   sources: [ch.bak.schutzgebiete-unesco_weltkulturerbe_20120203_cache]
   title: "UNESCO-Welterbe Kulturst\xE4tten (20120203, source)"
-- dimensions: &id211
+- dimensions: &id114
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.bav.laerm-emissionsplan_eisenbahn_nacht_20140106
   sources: [ch.bav.laerm-emissionsplan_eisenbahn_nacht_20140106_cache_out]
   title: "Emissionsplan Eisenbahnl\xE4rm 2015 N (20140106)"
-- dimensions: *id211
+- dimensions: *id114
   name: ch.bav.laerm-emissionsplan_eisenbahn_nacht
   sources: [ch.bav.laerm-emissionsplan_eisenbahn_nacht_20140106_cache]
   title: "Emissionsplan Eisenbahnl\xE4rm 2015 N ('current')"
-- dimensions: *id211
+- dimensions: *id114
   name: ch.bav.laerm-emissionsplan_eisenbahn_nacht_20140106_source
   sources: [ch.bav.laerm-emissionsplan_eisenbahn_nacht_20140106_cache]
   title: "Emissionsplan Eisenbahnl\xE4rm 2015 N (20140106, source)"
-- dimensions: &id212
+- dimensions: &id115
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.bav.laerm-emissionsplan_eisenbahn_tag_20140106
   sources: [ch.bav.laerm-emissionsplan_eisenbahn_tag_20140106_cache_out]
   title: "Emissionsplan Eisenbahnl\xE4rm 2015 T (20140106)"
-- dimensions: *id212
+- dimensions: *id115
   name: ch.bav.laerm-emissionsplan_eisenbahn_tag
   sources: [ch.bav.laerm-emissionsplan_eisenbahn_tag_20140106_cache]
   title: "Emissionsplan Eisenbahnl\xE4rm 2015 T ('current')"
-- dimensions: *id212
+- dimensions: *id115
   name: ch.bav.laerm-emissionsplan_eisenbahn_tag_20140106_source
   sources: [ch.bav.laerm-emissionsplan_eisenbahn_tag_20140106_cache]
   title: "Emissionsplan Eisenbahnl\xE4rm 2015 T (20140106, source)"
-- dimensions: &id213
-    Time:
-      default: '20141126'
-      values: ['20141126']
-  name: ch.bazl.heliports-gebirgslandeplaetze_20141126
-  sources: [ch.bazl.heliports-gebirgslandeplaetze_20141126_cache_out]
-  title: "Heliports/Gebirgslandepl\xE4tze (20141126)"
-- dimensions: *id213
-  name: ch.bazl.heliports-gebirgslandeplaetze
-  sources: [ch.bazl.heliports-gebirgslandeplaetze_20141126_cache]
-  title: "Heliports/Gebirgslandepl\xE4tze ('current')"
-- dimensions: *id213
-  name: ch.bazl.heliports-gebirgslandeplaetze_20141126_source
-  sources: [ch.bazl.heliports-gebirgslandeplaetze_20141126_cache]
-  title: "Heliports/Gebirgslandepl\xE4tze (20141126, source)"
-- dimensions: &id214
-    Time:
-      default: '20110101'
-      values: ['20110101']
-  name: ch.bazl.landschaftsruhezonen_20110101
-  sources: [ch.bazl.landschaftsruhezonen_20110101_cache_out]
-  title: Landschaftsruhezonen Luftfahrt (20110101)
-- dimensions: *id214
-  name: ch.bazl.landschaftsruhezonen
-  sources: [ch.bazl.landschaftsruhezonen_20110101_cache]
-  title: Landschaftsruhezonen Luftfahrt ('current')
-- dimensions: *id214
-  name: ch.bazl.landschaftsruhezonen_20110101_source
-  sources: [ch.bazl.landschaftsruhezonen_20110101_cache]
-  title: Landschaftsruhezonen Luftfahrt (20110101, source)
-- dimensions: &id215
+- dimensions: &id116
     Time:
       default: '20150305'
       values: ['20150305']
   name: ch.bazl.luftfahrtkarten-icao_20150305
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache_out]
   title: Luftfahrtkarte ICAO (20150305)
-- dimensions: *id215
+- dimensions: *id116
   name: ch.bazl.luftfahrtkarten-icao
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache]
   title: Luftfahrtkarte ICAO ('current')
-- dimensions: *id215
+- dimensions: *id116
   name: ch.bazl.luftfahrtkarten-icao_20150305_source
   sources: [ch.bazl.luftfahrtkarten-icao_20150305_cache]
   title: Luftfahrtkarte ICAO (20150305, source)
-- dimensions: &id216
-    Time:
-      default: '20120829'
-      values: ['20120829']
-  name: ch.bazl.points-of-interest_20120829
-  sources: [ch.bazl.points-of-interest_20120829_cache_out]
-  title: Points of Interest (20120829)
-- dimensions: *id216
-  name: ch.bazl.points-of-interest
-  sources: [ch.bazl.points-of-interest_20120829_cache]
-  title: Points of Interest ('current')
-- dimensions: *id216
-  name: ch.bazl.points-of-interest_20120829_source
-  sources: [ch.bazl.points-of-interest_20120829_cache]
-  title: Points of Interest (20120829, source)
-- dimensions: &id217
+- dimensions: &id117
     Time:
       default: '20130822'
       values: ['20130822']
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache_out]
   title: "Projektierungszonen: Flugh\xE4fen (20130822)"
-- dimensions: *id217
+- dimensions: *id117
   name: ch.bazl.projektierungszonen-flughafenanlagen
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen ('current')"
-- dimensions: *id217
+- dimensions: *id117
   name: ch.bazl.projektierungszonen-flughafenanlagen_20130822_source
   sources: [ch.bazl.projektierungszonen-flughafenanlagen_20130822_cache]
   title: "Projektierungszonen: Flugh\xE4fen (20130822, source)"
-- dimensions: &id218
+- dimensions: &id118
     Time:
       default: '20150305'
       values: ['20150305']
   name: ch.bazl.segelflugkarte_20150305
   sources: [ch.bazl.segelflugkarte_20150305_cache_out]
   title: Segelflugkarte (20150305)
-- dimensions: *id218
+- dimensions: *id118
   name: ch.bazl.segelflugkarte
   sources: [ch.bazl.segelflugkarte_20150305_cache]
   title: Segelflugkarte ('current')
-- dimensions: *id218
+- dimensions: *id118
   name: ch.bazl.segelflugkarte_20150305_source
   sources: [ch.bazl.segelflugkarte_20150305_cache]
   title: Segelflugkarte (20150305, source)
-- dimensions: &id219
+- dimensions: &id119
     Time:
       default: '20120911'
       values: ['20120911']
   name: ch.bfe.kernkraftwerke_20120911
   sources: [ch.bfe.kernkraftwerke_20120911_cache_out]
   title: Kernkraftwerke (20120911)
-- dimensions: *id219
+- dimensions: *id119
   name: ch.bfe.kernkraftwerke
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke ('current')
-- dimensions: *id219
+- dimensions: *id119
   name: ch.bfe.kernkraftwerke_20120911_source
   sources: [ch.bfe.kernkraftwerke_20120911_cache]
   title: Kernkraftwerke (20120911, source)
-- dimensions: &id220
+- dimensions: &id120
     Time:
       default: '20120531'
       values: ['20120531']
   name: ch.bfe.kleinwasserkraftpotentiale_20120531
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache_out]
   title: Kleinwasserkraftpotentiale (20120531)
-- dimensions: *id220
+- dimensions: *id120
   name: ch.bfe.kleinwasserkraftpotentiale
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale ('current')
-- dimensions: *id220
+- dimensions: *id120
   name: ch.bfe.kleinwasserkraftpotentiale_20120531_source
   sources: [ch.bfe.kleinwasserkraftpotentiale_20120531_cache]
   title: Kleinwasserkraftpotentiale (20120531, source)
-- dimensions: &id221
+- dimensions: &id121
     Time:
       default: '20140101'
       values: ['20140101']
   name: ch.bfe.windenergieanlagen_20140101
   sources: [ch.bfe.windenergieanlagen_20140101_cache_out]
   title: Windenergieanlagen (20140101)
-- dimensions: *id221
+- dimensions: *id121
   name: ch.bfe.windenergieanlagen
   sources: [ch.bfe.windenergieanlagen_20140101_cache]
   title: Windenergieanlagen ('current')
-- dimensions: *id221
+- dimensions: *id121
   name: ch.bfe.windenergieanlagen_20140101_source
   sources: [ch.bfe.windenergieanlagen_20140101_cache]
   title: Windenergieanlagen (20140101, source)
-- dimensions: &id222
-    Time:
-      default: '20131121'
-      values: ['20131121']
-  name: ch.bfs.arealstatistik_20131121
-  sources: [ch.bfs.arealstatistik_20131121_cache_out]
-  title: Arealstatistik 2004/09 NOAS04 (20131121)
-- dimensions: *id222
-  name: ch.bfs.arealstatistik
-  sources: [ch.bfs.arealstatistik_20131121_cache]
-  title: Arealstatistik 2004/09 NOAS04 ('current')
-- dimensions: *id222
-  name: ch.bfs.arealstatistik_20131121_source
-  sources: [ch.bfs.arealstatistik_20131121_cache]
-  title: Arealstatistik 2004/09 NOAS04 (20131121, source)
-- dimensions: &id223
-    Time:
-      default: '20131121'
-      values: ['20131121']
-  name: ch.bfs.arealstatistik-1985_20131121
-  sources: [ch.bfs.arealstatistik-1985_20131121_cache_out]
-  title: Arealstatistik 1979/85 NOAS04 (20131121)
-- dimensions: *id223
-  name: ch.bfs.arealstatistik-1985
-  sources: [ch.bfs.arealstatistik-1985_20131121_cache]
-  title: Arealstatistik 1979/85 NOAS04 ('current')
-- dimensions: *id223
-  name: ch.bfs.arealstatistik-1985_20131121_source
-  sources: [ch.bfs.arealstatistik-1985_20131121_cache]
-  title: Arealstatistik 1979/85 NOAS04 (20131121, source)
-- dimensions: &id224
-    Time:
-      default: '20131121'
-      values: ['20131121']
-  name: ch.bfs.arealstatistik-1997_20131121
-  sources: [ch.bfs.arealstatistik-1997_20131121_cache_out]
-  title: Arealstatistik 1992/97 NOAS04 (20131121)
-- dimensions: *id224
-  name: ch.bfs.arealstatistik-1997
-  sources: [ch.bfs.arealstatistik-1997_20131121_cache]
-  title: Arealstatistik 1992/97 NOAS04 ('current')
-- dimensions: *id224
-  name: ch.bfs.arealstatistik-1997_20131121_source
-  sources: [ch.bfs.arealstatistik-1997_20131121_cache]
-  title: Arealstatistik 1992/97 NOAS04 (20131121, source)
-- dimensions: &id225
+- dimensions: &id122
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache_out]
   title: Arealstatistik 2004/09 NOLC04 (20131121)
-- dimensions: *id225
+- dimensions: *id122
   name: ch.bfs.arealstatistik-bodenbedeckung
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04 ('current')
-- dimensions: *id225
+- dimensions: *id122
   name: ch.bfs.arealstatistik-bodenbedeckung_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung_20131121_cache]
   title: Arealstatistik 2004/09 NOLC04 (20131121, source)
-- dimensions: &id226
+- dimensions: &id123
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLC04 (20131121)
-- dimensions: *id226
+- dimensions: *id123
   name: ch.bfs.arealstatistik-bodenbedeckung-1985
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04 ('current')
-- dimensions: *id226
+- dimensions: *id123
   name: ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLC04 (20131121, source)
-- dimensions: &id227
+- dimensions: &id124
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLC04 (20131121)
-- dimensions: *id227
+- dimensions: *id124
   name: ch.bfs.arealstatistik-bodenbedeckung-1997
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04 ('current')
-- dimensions: *id227
+- dimensions: *id124
   name: ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodenbedeckung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLC04 (20131121, source)
-- dimensions: &id228
+- dimensions: &id125
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache_out]
   title: Arealstatistik 2004/09 NOLU04  (20131121)
-- dimensions: *id228
+- dimensions: *id125
   name: ch.bfs.arealstatistik-bodennutzung
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: Arealstatistik 2004/09 NOLU04  ('current')
-- dimensions: *id228
+- dimensions: *id125
   name: ch.bfs.arealstatistik-bodennutzung_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung_20131121_cache]
   title: Arealstatistik 2004/09 NOLU04  (20131121, source)
-- dimensions: &id229
+- dimensions: &id126
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache_out]
   title: Arealstatistik 1979/85 NOLU04 (20131121)
-- dimensions: *id229
+- dimensions: *id126
   name: ch.bfs.arealstatistik-bodennutzung-1985
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04 ('current')
-- dimensions: *id229
+- dimensions: *id126
   name: ch.bfs.arealstatistik-bodennutzung-1985_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1985_20131121_cache]
   title: Arealstatistik 1979/85 NOLU04 (20131121, source)
-- dimensions: &id230
+- dimensions: &id127
     Time:
       default: '20131121'
       values: ['20131121']
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache_out]
   title: Arealstatistik 1992/97 NOLU04 (20131121)
-- dimensions: *id230
+- dimensions: *id127
   name: ch.bfs.arealstatistik-bodennutzung-1997
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04 ('current')
-- dimensions: *id230
+- dimensions: *id127
   name: ch.bfs.arealstatistik-bodennutzung-1997_20131121_source
   sources: [ch.bfs.arealstatistik-bodennutzung-1997_20131121_cache]
   title: Arealstatistik 1992/97 NOLU04 (20131121, source)
-- dimensions: &id231
-    Time:
-      default: '20070116'
-      values: ['20070116']
-  name: ch.bfs.arealstatistik-hintergrund_20070116
-  sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache_out]
-  title: Vereinfachte Bodennutzung (20070116)
-- dimensions: *id231
-  name: ch.bfs.arealstatistik-hintergrund
-  sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
-  title: Vereinfachte Bodennutzung ('current')
-- dimensions: *id231
-  name: ch.bfs.arealstatistik-hintergrund_20070116_source
-  sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
-  title: Vereinfachte Bodennutzung (20070116, source)
-- dimensions: &id232
+- dimensions: &id128
     Time:
       default: '19970901'
       values: ['19970901']
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache_out]
   title: Waldmischungsgrad 1990/1992 (19970901)
-- dimensions: *id232
+- dimensions: *id128
   name: ch.bfs.arealstatistik-waldmischungsgrad
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992 ('current')
-- dimensions: *id232
+- dimensions: *id128
   name: ch.bfs.arealstatistik-waldmischungsgrad_19970901_source
   sources: [ch.bfs.arealstatistik-waldmischungsgrad_19970901_cache]
   title: Waldmischungsgrad 1990/1992 (19970901, source)
-- dimensions: &id233
-    Time:
-      default: '20130212'
-      values: ['20130212']
-  name: ch.bfs.gebaeude_wohnungs_register_20130212
-  sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache_out]
-  title: "Geb\xE4ude- und Wohnungsregister (20130212)"
-- dimensions: *id233
-  name: ch.bfs.gebaeude_wohnungs_register
-  sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
-  title: "Geb\xE4ude- und Wohnungsregister ('current')"
-- dimensions: *id233
-  name: ch.bfs.gebaeude_wohnungs_register_20130212_source
-  sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
-  title: "Geb\xE4ude- und Wohnungsregister (20130212, source)"
-- dimensions: &id234
+- dimensions: &id129
     Time:
       default: '20150422'
       values: ['20150422']
   name: ch.blw.alpprodukte_20150422
   sources: [ch.blw.alpprodukte_20150422_cache_out]
   title: Alpprodukte (20150422)
-- dimensions: *id234
+- dimensions: *id129
   name: ch.blw.alpprodukte
   sources: [ch.blw.alpprodukte_20150422_cache]
   title: Alpprodukte ('current')
-- dimensions: *id234
+- dimensions: *id129
   name: ch.blw.alpprodukte_20150422_source
   sources: [ch.blw.alpprodukte_20150422_cache]
   title: Alpprodukte (20150422, source)
-- dimensions: &id235
+- dimensions: &id130
     Time:
       default: '20150422'
       values: ['20150422']
   name: ch.blw.bergprodukte_20150422
   sources: [ch.blw.bergprodukte_20150422_cache_out]
   title: Bergprodukte (20150422)
-- dimensions: *id235
+- dimensions: *id130
   name: ch.blw.bergprodukte
   sources: [ch.blw.bergprodukte_20150422_cache]
   title: Bergprodukte ('current')
-- dimensions: *id235
+- dimensions: *id130
   name: ch.blw.bergprodukte_20150422_source
   sources: [ch.blw.bergprodukte_20150422_cache]
   title: Bergprodukte (20150422, source)
-- dimensions: &id236
+- dimensions: &id131
     Time:
       default: '20091110'
       values: ['20091110']
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache_out]
   title: "Bew\xE4sserungsbed\xFCrftigkeit (20091110)"
-- dimensions: *id236
+- dimensions: *id131
   name: ch.blw.bewaesserungsbeduerftigkeit
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit ('current')"
-- dimensions: *id236
+- dimensions: *id131
   name: ch.blw.bewaesserungsbeduerftigkeit_20091110_source
   sources: [ch.blw.bewaesserungsbeduerftigkeit_20091110_cache]
   title: "Bew\xE4sserungsbed\xFCrftigkeit (20091110, source)"
-- dimensions: &id237
+- dimensions: &id132
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-gruendigkeit_20120601
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache_out]
   title: "Gr\xFCndigkeit (20120601)"
-- dimensions: *id237
+- dimensions: *id132
   name: ch.blw.bodeneignung-gruendigkeit
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit ('current')"
-- dimensions: *id237
+- dimensions: *id132
   name: ch.blw.bodeneignung-gruendigkeit_20120601_source
   sources: [ch.blw.bodeneignung-gruendigkeit_20120601_cache]
   title: "Gr\xFCndigkeit (20120601, source)"
-- dimensions: &id238
+- dimensions: &id133
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturland_20081024
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache_out]
   title: "Bodeneignung f\xFCr Kulturland (20081024)"
-- dimensions: *id238
+- dimensions: *id133
   name: ch.blw.bodeneignung-kulturland
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland ('current')"
-- dimensions: *id238
+- dimensions: *id133
   name: ch.blw.bodeneignung-kulturland_20081024_source
   sources: [ch.blw.bodeneignung-kulturland_20081024_cache]
   title: "Bodeneignung f\xFCr Kulturland (20081024, source)"
-- dimensions: &id239
+- dimensions: &id134
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.bodeneignung-kulturtyp_20081024
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache_out]
   title: 'Bodeneignung: Kulturtyp (20081024)'
-- dimensions: *id239
+- dimensions: *id134
   name: ch.blw.bodeneignung-kulturtyp
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp (''current'')'
-- dimensions: *id239
+- dimensions: *id134
   name: ch.blw.bodeneignung-kulturtyp_20081024_source
   sources: [ch.blw.bodeneignung-kulturtyp_20081024_cache]
   title: 'Bodeneignung: Kulturtyp (20081024, source)'
-- dimensions: &id240
+- dimensions: &id135
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache_out]
   title: "N\xE4hrstoffspeicherverm\xF6gen (20120601)"
-- dimensions: *id240
+- dimensions: *id135
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen ('current')"
-- dimensions: *id240
+- dimensions: *id135
   name: ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-naehrstoffspeichervermoegen_20120601_cache]
   title: "N\xE4hrstoffspeicherverm\xF6gen (20120601, source)"
-- dimensions: &id241
+- dimensions: &id136
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-skelettgehalt_20120601
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache_out]
   title: Skelettgehalt (20120601)
-- dimensions: *id241
+- dimensions: *id136
   name: ch.blw.bodeneignung-skelettgehalt
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt ('current')
-- dimensions: *id241
+- dimensions: *id136
   name: ch.blw.bodeneignung-skelettgehalt_20120601_source
   sources: [ch.blw.bodeneignung-skelettgehalt_20120601_cache]
   title: Skelettgehalt (20120601, source)
-- dimensions: &id242
+- dimensions: &id137
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-vernaessung_20120601
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache_out]
   title: "Vern\xE4ssung (20120601)"
-- dimensions: *id242
+- dimensions: *id137
   name: ch.blw.bodeneignung-vernaessung
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung ('current')"
-- dimensions: *id242
+- dimensions: *id137
   name: ch.blw.bodeneignung-vernaessung_20120601_source
   sources: [ch.blw.bodeneignung-vernaessung_20120601_cache]
   title: "Vern\xE4ssung (20120601, source)"
-- dimensions: &id243
+- dimensions: &id138
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache_out]
   title: "Wasserdurchl\xE4ssigkeit (20120601)"
-- dimensions: *id243
+- dimensions: *id138
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit ('current')"
-- dimensions: *id243
+- dimensions: *id138
   name: ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_source
   sources: [ch.blw.bodeneignung-wasserdurchlaessigkeit_20120601_cache]
   title: "Wasserdurchl\xE4ssigkeit (20120601, source)"
-- dimensions: &id244
+- dimensions: &id139
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache_out]
   title: "Wasserspeicherverm\xF6gen (20120601)"
-- dimensions: *id244
+- dimensions: *id139
   name: ch.blw.bodeneignung-wasserspeichervermoegen
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen ('current')"
-- dimensions: *id244
+- dimensions: *id139
   name: ch.blw.bodeneignung-wasserspeichervermoegen_20120601_source
   sources: [ch.blw.bodeneignung-wasserspeichervermoegen_20120601_cache]
   title: "Wasserspeicherverm\xF6gen (20120601, source)"
-- dimensions: &id245
+- dimensions: &id140
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion_20100103
   sources: [ch.blw.erosion_20100103_cache_out]
   title: Erosionsrisiko qualitativ 1 (20100103)
-- dimensions: *id245
+- dimensions: *id140
   name: ch.blw.erosion
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1 ('current')
-- dimensions: *id245
+- dimensions: *id140
   name: ch.blw.erosion_20100103_source
   sources: [ch.blw.erosion_20100103_cache]
   title: Erosionsrisiko qualitativ 1 (20100103, source)
-- dimensions: &id246
+- dimensions: &id141
     Time:
       default: '20100103'
       values: ['20100103']
   name: ch.blw.erosion-mit_bergzonen_20100103
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache_out]
   title: Erosionsrisiko qualitativ 2 (20100103)
-- dimensions: *id246
+- dimensions: *id141
   name: ch.blw.erosion-mit_bergzonen
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2 ('current')
-- dimensions: *id246
+- dimensions: *id141
   name: ch.blw.erosion-mit_bergzonen_20100103_source
   sources: [ch.blw.erosion-mit_bergzonen_20100103_cache]
   title: Erosionsrisiko qualitativ 2 (20100103, source)
-- dimensions: &id247
+- dimensions: &id142
     Time:
       default: '20100601'
       values: ['20100601']
   name: ch.blw.erosion-quantitativ_20100601
   sources: [ch.blw.erosion-quantitativ_20100601_cache_out]
   title: Erosionsrisiko quantitativ (20100601)
-- dimensions: *id247
+- dimensions: *id142
   name: ch.blw.erosion-quantitativ
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ ('current')
-- dimensions: *id247
+- dimensions: *id142
   name: ch.blw.erosion-quantitativ_20100601_source
   sources: [ch.blw.erosion-quantitativ_20100601_cache]
   title: Erosionsrisiko quantitativ (20100601, source)
-- dimensions: &id248
+- dimensions: &id143
     Time:
       default: '20120601'
       values: ['20120601']
   name: ch.blw.feldblockkarte_20120601
   sources: [ch.blw.feldblockkarte_20120601_cache_out]
   title: Feldblockkarte (20120601)
-- dimensions: *id248
+- dimensions: *id143
   name: ch.blw.feldblockkarte
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte ('current')
-- dimensions: *id248
+- dimensions: *id143
   name: ch.blw.feldblockkarte_20120601_source
   sources: [ch.blw.feldblockkarte_20120601_cache]
   title: Feldblockkarte (20120601, source)
-- dimensions: &id249
+- dimensions: &id144
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte_20121201
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache_out]
   title: "Gew\xE4sseranschluss (20121201)"
-- dimensions: *id249
+- dimensions: *id144
   name: ch.blw.gewaesseranschlusskarte
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss ('current')"
-- dimensions: *id249
+- dimensions: *id144
   name: ch.blw.gewaesseranschlusskarte_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte_20121201_cache]
   title: "Gew\xE4sseranschluss (20121201, source)"
-- dimensions: &id250
+- dimensions: &id145
     Time:
       default: '20121201'
       values: ['20121201']
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache_out]
   title: "Gew\xE4sseranschluss erweitert (20121201)"
-- dimensions: *id250
+- dimensions: *id145
   name: ch.blw.gewaesseranschlusskarte-direkt
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert ('current')"
-- dimensions: *id250
+- dimensions: *id145
   name: ch.blw.gewaesseranschlusskarte-direkt_20121201_source
   sources: [ch.blw.gewaesseranschlusskarte-direkt_20121201_cache]
   title: "Gew\xE4sseranschluss erweitert (20121201, source)"
-- dimensions: &id251
+- dimensions: &id146
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.hang_steillagen_20121231
   sources: [ch.blw.hang_steillagen_20121231_cache_out]
   title: Hanglagen (20121231)
-- dimensions: *id251
+- dimensions: *id146
   name: ch.blw.hang_steillagen
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen ('current')
-- dimensions: *id251
+- dimensions: *id146
   name: ch.blw.hang_steillagen_20121231_source
   sources: [ch.blw.hang_steillagen_20121231_cache]
   title: Hanglagen (20121231, source)
-- dimensions: &id252
+- dimensions: &id147
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-futterbau_20081024
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache_out]
   title: Klimaeignung Futterbau (20081024)
-- dimensions: *id252
+- dimensions: *id147
   name: ch.blw.klimaeignung-futterbau
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau ('current')
-- dimensions: *id252
+- dimensions: *id147
   name: ch.blw.klimaeignung-futterbau_20081024_source
   sources: [ch.blw.klimaeignung-futterbau_20081024_cache]
   title: Klimaeignung Futterbau (20081024, source)
-- dimensions: &id253
+- dimensions: &id148
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-getreidebau_20081024
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache_out]
   title: Klimaeignung Getreidebau (20081024)
-- dimensions: *id253
+- dimensions: *id148
   name: ch.blw.klimaeignung-getreidebau
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau ('current')
-- dimensions: *id253
+- dimensions: *id148
   name: ch.blw.klimaeignung-getreidebau_20081024_source
   sources: [ch.blw.klimaeignung-getreidebau_20081024_cache]
   title: Klimaeignung Getreidebau (20081024, source)
-- dimensions: &id254
+- dimensions: &id149
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kartoffeln_20081024
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache_out]
   title: Klimaeignung Kartoffeln (20081024)
-- dimensions: *id254
+- dimensions: *id149
   name: ch.blw.klimaeignung-kartoffeln
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln ('current')
-- dimensions: *id254
+- dimensions: *id149
   name: ch.blw.klimaeignung-kartoffeln_20081024_source
   sources: [ch.blw.klimaeignung-kartoffeln_20081024_cache]
   title: Klimaeignung Kartoffeln (20081024, source)
-- dimensions: &id255
+- dimensions: &id150
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-koernermais_20081024
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache_out]
   title: "Klimaeignung K\xF6rnermais (20081024)"
-- dimensions: *id255
+- dimensions: *id150
   name: ch.blw.klimaeignung-koernermais
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais ('current')"
-- dimensions: *id255
+- dimensions: *id150
   name: ch.blw.klimaeignung-koernermais_20081024_source
   sources: [ch.blw.klimaeignung-koernermais_20081024_cache]
   title: "Klimaeignung K\xF6rnermais (20081024, source)"
-- dimensions: &id256
+- dimensions: &id151
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-kulturland_20081024
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache_out]
   title: Klimaeignung Kulturland (20081024)
-- dimensions: *id256
+- dimensions: *id151
   name: ch.blw.klimaeignung-kulturland
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland ('current')
-- dimensions: *id256
+- dimensions: *id151
   name: ch.blw.klimaeignung-kulturland_20081024_source
   sources: [ch.blw.klimaeignung-kulturland_20081024_cache]
   title: Klimaeignung Kulturland (20081024, source)
-- dimensions: &id257
+- dimensions: &id152
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-spezialkulturen_20081024
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache_out]
   title: Klimaeignung Spezialkulturen (20081024)
-- dimensions: *id257
+- dimensions: *id152
   name: ch.blw.klimaeignung-spezialkulturen
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen ('current')
-- dimensions: *id257
+- dimensions: *id152
   name: ch.blw.klimaeignung-spezialkulturen_20081024_source
   sources: [ch.blw.klimaeignung-spezialkulturen_20081024_cache]
   title: Klimaeignung Spezialkulturen (20081024, source)
-- dimensions: &id258
+- dimensions: &id153
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-typ_20081024
   sources: [ch.blw.klimaeignung-typ_20081024_cache_out]
   title: "Klimaeignung \xDCbersicht (20081024)"
-- dimensions: *id258
+- dimensions: *id153
   name: ch.blw.klimaeignung-typ
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht ('current')"
-- dimensions: *id258
+- dimensions: *id153
   name: ch.blw.klimaeignung-typ_20081024_source
   sources: [ch.blw.klimaeignung-typ_20081024_cache]
   title: "Klimaeignung \xDCbersicht (20081024, source)"
-- dimensions: &id259
+- dimensions: &id154
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache_out]
   title: Klimaeignung Zwischenfruchtbau (20081024)
-- dimensions: *id259
+- dimensions: *id154
   name: ch.blw.klimaeignung-zwischenfruchtbau
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau ('current')
-- dimensions: *id259
+- dimensions: *id154
   name: ch.blw.klimaeignung-zwischenfruchtbau_20081024_source
   sources: [ch.blw.klimaeignung-zwischenfruchtbau_20081024_cache]
   title: Klimaeignung Zwischenfruchtbau (20081024, source)
-- dimensions: &id260
+- dimensions: &id155
     Time:
       default: '20150708'
       values: ['20150708']
   name: ch.blw.landwirtschaftliche-zonengrenzen_20150708
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache_out]
   title: Landwirtschaftliche Zonengrenzen (20150708)
-- dimensions: *id260
+- dimensions: *id155
   name: ch.blw.landwirtschaftliche-zonengrenzen
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache]
   title: Landwirtschaftliche Zonengrenzen ('current')
-- dimensions: *id260
+- dimensions: *id155
   name: ch.blw.landwirtschaftliche-zonengrenzen_20150708_source
   sources: [ch.blw.landwirtschaftliche-zonengrenzen_20150708_cache]
   title: Landwirtschaftliche Zonengrenzen (20150708, source)
-- dimensions: &id261
+- dimensions: &id156
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.niederschlagshaushalt_20081024
   sources: [ch.blw.niederschlagshaushalt_20081024_cache_out]
   title: Niederschlagshaushalt (20081024)
-- dimensions: *id261
+- dimensions: *id156
   name: ch.blw.niederschlagshaushalt
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt ('current')
-- dimensions: *id261
+- dimensions: *id156
   name: ch.blw.niederschlagshaushalt_20081024_source
   sources: [ch.blw.niederschlagshaushalt_20081024_cache]
   title: Niederschlagshaushalt (20081024, source)
-- dimensions: &id262
+- dimensions: &id157
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.blw.steil_terrassenlagen_rebbau_20121231
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache_out]
   title: "Rebfl\xE4chen in Hanglagen (20121231)"
-- dimensions: *id262
+- dimensions: *id157
   name: ch.blw.steil_terrassenlagen_rebbau
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen ('current')"
-- dimensions: *id262
+- dimensions: *id157
   name: ch.blw.steil_terrassenlagen_rebbau_20121231_source
   sources: [ch.blw.steil_terrassenlagen_rebbau_20121231_cache]
   title: "Rebfl\xE4chen in Hanglagen (20121231, source)"
-- dimensions: &id263
+- dimensions: &id158
     Time:
       default: '20110805'
       values: ['20110805']
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache_out]
   title: GGA Fleischware (20110805)
-- dimensions: *id263
+- dimensions: *id158
   name: ch.blw.ursprungsbezeichnungen-fleisch
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware ('current')
-- dimensions: *id263
+- dimensions: *id158
   name: ch.blw.ursprungsbezeichnungen-fleisch_20110805_source
   sources: [ch.blw.ursprungsbezeichnungen-fleisch_20110805_cache]
   title: GGA Fleischware (20110805, source)
-- dimensions: &id264
+- dimensions: &id159
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache_out]
   title: "GUB K\xE4se (20081024)"
-- dimensions: *id264
+- dimensions: *id159
   name: ch.blw.ursprungsbezeichnungen-kaese
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se ('current')"
-- dimensions: *id264
+- dimensions: *id159
   name: ch.blw.ursprungsbezeichnungen-kaese_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-kaese_20081024_cache]
   title: "GUB K\xE4se (20081024, source)"
-- dimensions: &id265
+- dimensions: &id160
     Time:
       default: '20150306'
       values: ['20150306']
   name: ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306
   sources: [ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_cache_out]
   title: GGA Konditoreiware (20150306)
-- dimensions: *id265
+- dimensions: *id160
   name: ch.blw.ursprungsbezeichnungen-konditoreiwaren
   sources: [ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_cache]
   title: GGA Konditoreiware ('current')
-- dimensions: *id265
+- dimensions: *id160
   name: ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_source
   sources: [ch.blw.ursprungsbezeichnungen-konditoreiwaren_20150306_cache]
   title: GGA Konditoreiware (20150306, source)
-- dimensions: &id266
+- dimensions: &id161
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache_out]
   title: GUB Pflanzliche Produkte (20081024)
-- dimensions: *id266
+- dimensions: *id161
   name: ch.blw.ursprungsbezeichnungen-pflanzen
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte ('current')
-- dimensions: *id266
+- dimensions: *id161
   name: ch.blw.ursprungsbezeichnungen-pflanzen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-pflanzen_20081024_cache]
   title: GUB Pflanzliche Produkte (20081024, source)
-- dimensions: &id267
+- dimensions: &id162
     Time:
       default: '20081024'
       values: ['20081024']
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache_out]
   title: GUB Spirituosen (20081024)
-- dimensions: *id267
+- dimensions: *id162
   name: ch.blw.ursprungsbezeichnungen-spirituosen
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen ('current')
-- dimensions: *id267
+- dimensions: *id162
   name: ch.blw.ursprungsbezeichnungen-spirituosen_20081024_source
   sources: [ch.blw.ursprungsbezeichnungen-spirituosen_20081024_cache]
   title: GUB Spirituosen (20081024, source)
-- dimensions: &id268
+- dimensions: &id163
     Time:
       default: '20120101'
       values: ['20120101']
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache_out]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20120101)"
-- dimensions: *id268
+- dimensions: *id163
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz ('current')"
-- dimensions: *id268
+- dimensions: *id163
   name: ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_source
   sources: [ch.ensi.zonenplan-notfallschutz-kernanlagen_20120101_cache]
   title: "Zonenpl\xE4ne f\xFCr den Notfallschutz (20120101, source)"
-- dimensions: &id269
-    Time:
-      default: '20121201'
-      values: ['20121201']
-  name: ch.kantone.cadastralwebmap-farbe_20121201
-  sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache_out]
-  title: CadastralWebMap (20121201)
-- dimensions: *id269
-  name: ch.kantone.cadastralwebmap-farbe
-  sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
-  title: CadastralWebMap ('current')
-- dimensions: *id269
-  name: ch.kantone.cadastralwebmap-farbe_20121201_source
-  sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
-  title: CadastralWebMap (20121201, source)
-- dimensions: &id270
-    Time:
-      default: '20070101'
-      values: ['20070101']
-  name: ch.kantone.ivs-reg_loc_20070101
-  sources: [ch.kantone.ivs-reg_loc_20070101_cache_out]
-  title: IVS Kanton Bern (20070101)
-- dimensions: *id270
-  name: ch.kantone.ivs-reg_loc
-  sources: [ch.kantone.ivs-reg_loc_20070101_cache]
-  title: IVS Kanton Bern ('current')
-- dimensions: *id270
-  name: ch.kantone.ivs-reg_loc_20070101_source
-  sources: [ch.kantone.ivs-reg_loc_20070101_cache]
-  title: IVS Kanton Bern (20070101, source)
-- dimensions: &id271
-    Time:
-      default: '19821231'
-      values: ['19821231']
-  name: ch.nagra.aeromagnetische-karte_1100_19821231
-  sources: [ch.nagra.aeromagnetische-karte_1100_19821231_cache_out]
-  title: Aeromagnetik Aargau 1100 m 100 (19821231)
-- dimensions: *id271
-  name: ch.nagra.aeromagnetische-karte_1100
-  sources: [ch.nagra.aeromagnetische-karte_1100_19821231_cache]
-  title: Aeromagnetik Aargau 1100 m 100 ('current')
-- dimensions: *id271
-  name: ch.nagra.aeromagnetische-karte_1100_19821231_source
-  sources: [ch.nagra.aeromagnetische-karte_1100_19821231_cache]
-  title: Aeromagnetik Aargau 1100 m 100 (19821231, source)
-- dimensions: &id272
-    Time:
-      default: '19821231'
-      values: ['19821231']
-  name: ch.nagra.aeromagnetische-karte_1500_19821231
-  sources: [ch.nagra.aeromagnetische-karte_1500_19821231_cache_out]
-  title: Aeromagnetik Aargau 1500 m 100 (19821231)
-- dimensions: *id272
-  name: ch.nagra.aeromagnetische-karte_1500
-  sources: [ch.nagra.aeromagnetische-karte_1500_19821231_cache]
-  title: Aeromagnetik Aargau 1500 m 100 ('current')
-- dimensions: *id272
-  name: ch.nagra.aeromagnetische-karte_1500_19821231_source
-  sources: [ch.nagra.aeromagnetische-karte_1500_19821231_cache]
-  title: Aeromagnetik Aargau 1500 m 100 (19821231, source)
-- dimensions: &id273
+- dimensions: &id164
     Time:
       default: '20150624'
       values: ['20150624']
   name: ch.pronatura.waldreservate_20150624
   sources: [ch.pronatura.waldreservate_20150624_cache_out]
   title: Waldreservate Pro Natura (20150624)
-- dimensions: *id273
+- dimensions: *id164
   name: ch.pronatura.waldreservate
   sources: [ch.pronatura.waldreservate_20150624_cache]
   title: Waldreservate Pro Natura ('current')
-- dimensions: *id273
+- dimensions: *id164
   name: ch.pronatura.waldreservate_20150624_source
   sources: [ch.pronatura.waldreservate_20150624_cache]
   title: Waldreservate Pro Natura (20150624, source)
-- dimensions: &id274
+- dimensions: &id165
     Time:
       default: '20120918'
       values: ['20120918']
   name: ch.sgpk.maechtigkeit-lockergesteine_20120918
   sources: [ch.sgpk.maechtigkeit-lockergesteine_20120918_cache_out]
   title: "M\xE4chtigkeit der Lockergesteine (20120918)"
-- dimensions: *id274
+- dimensions: *id165
   name: ch.sgpk.maechtigkeit-lockergesteine
   sources: [ch.sgpk.maechtigkeit-lockergesteine_20120918_cache]
   title: "M\xE4chtigkeit der Lockergesteine ('current')"
-- dimensions: *id274
+- dimensions: *id165
   name: ch.sgpk.maechtigkeit-lockergesteine_20120918_source
   sources: [ch.sgpk.maechtigkeit-lockergesteine_20120918_cache]
   title: "M\xE4chtigkeit der Lockergesteine (20120918, source)"
-- dimensions: &id275
+- dimensions: &id166
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.dreiecksvermaschung_20061231
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache_out]
   title: LV95 Dreiecksvermaschung (20061231)
-- dimensions: *id275
+- dimensions: *id166
   name: ch.swisstopo.dreiecksvermaschung
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung ('current')
-- dimensions: *id275
+- dimensions: *id166
   name: ch.swisstopo.dreiecksvermaschung_20061231_source
   sources: [ch.swisstopo.dreiecksvermaschung_20061231_cache]
   title: LV95 Dreiecksvermaschung (20061231, source)
-- dimensions: &id276
+- dimensions: &id167
     Time:
       default: '20140924'
       values: ['20140924']
   name: ch.swisstopo.fixpunkte-agnes_20140924
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache_out]
   title: AGNES (20140924)
-- dimensions: *id276
+- dimensions: *id167
   name: ch.swisstopo.fixpunkte-agnes
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES ('current')
-- dimensions: *id276
+- dimensions: *id167
   name: ch.swisstopo.fixpunkte-agnes_20140924_source
   sources: [ch.swisstopo.fixpunkte-agnes_20140924_cache]
   title: AGNES (20140924, source)
-- dimensions: &id277
+- dimensions: &id168
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp1_20121212
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP1 (20121212)"
-- dimensions: *id277
+- dimensions: *id168
   name: ch.swisstopo.fixpunkte-hfp1
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1 ('current')"
-- dimensions: *id277
+- dimensions: *id168
   name: ch.swisstopo.fixpunkte-hfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp1_20121212_cache]
   title: "H\xF6henfixpunkte HFP1 (20121212, source)"
-- dimensions: &id278
+- dimensions: &id169
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-hfp2_20121212
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache_out]
   title: "H\xF6henfixpunkte HFP2 (20121212)"
-- dimensions: *id278
+- dimensions: *id169
   name: ch.swisstopo.fixpunkte-hfp2
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2 ('current')"
-- dimensions: *id278
+- dimensions: *id169
   name: ch.swisstopo.fixpunkte-hfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-hfp2_20121212_cache]
   title: "H\xF6henfixpunkte HFP2 (20121212, source)"
-- dimensions: &id279
+- dimensions: &id170
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp1_20121212
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache_out]
   title: Lagefixpunkte LFP1 (20121212)
-- dimensions: *id279
+- dimensions: *id170
   name: ch.swisstopo.fixpunkte-lfp1
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1 ('current')
-- dimensions: *id279
+- dimensions: *id170
   name: ch.swisstopo.fixpunkte-lfp1_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp1_20121212_cache]
   title: Lagefixpunkte LFP1 (20121212, source)
-- dimensions: &id280
+- dimensions: &id171
     Time:
       default: '20121212'
       values: ['20121212']
   name: ch.swisstopo.fixpunkte-lfp2_20121212
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache_out]
   title: Lagefixpunkte LFP2 (20121212)
-- dimensions: *id280
+- dimensions: *id171
   name: ch.swisstopo.fixpunkte-lfp2
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2 ('current')
-- dimensions: *id280
+- dimensions: *id171
   name: ch.swisstopo.fixpunkte-lfp2_20121212_source
   sources: [ch.swisstopo.fixpunkte-lfp2_20121212_cache]
   title: Lagefixpunkte LFP2 (20121212, source)
-- dimensions: &id281
+- dimensions: &id172
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-ch1903_20041231
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache_out]
   title: Geoidmodell in CH1903 (20041231)
-- dimensions: *id281
+- dimensions: *id172
   name: ch.swisstopo.geoidmodell-ch1903
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903 ('current')
-- dimensions: *id281
+- dimensions: *id172
   name: ch.swisstopo.geoidmodell-ch1903_20041231_source
   sources: [ch.swisstopo.geoidmodell-ch1903_20041231_cache]
   title: Geoidmodell in CH1903 (20041231, source)
-- dimensions: &id282
+- dimensions: &id173
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.geoidmodell-etrs89_20041231
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache_out]
   title: Geoidmodell in ETRS89 (20041231)
-- dimensions: *id282
+- dimensions: *id173
   name: ch.swisstopo.geoidmodell-etrs89
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89 ('current')
-- dimensions: *id282
+- dimensions: *id173
   name: ch.swisstopo.geoidmodell-etrs89_20041231_source
   sources: [ch.swisstopo.geoidmodell-etrs89_20041231_cache]
   title: Geoidmodell in ETRS89 (20041231, source)
-- dimensions: &id283
+- dimensions: &id174
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache_out]
   title: Eiszeitliches Maximum 500 (20081231)
-- dimensions: *id283
+- dimensions: *id174
   name: ch.swisstopo.geologie-eiszeit-lgm-raster
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Eiszeitliches Maximum 500 ('current')
-- dimensions: *id283
+- dimensions: *id174
   name: ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_source
   sources: [ch.swisstopo.geologie-eiszeit-lgm-raster_20081231_cache]
   title: Eiszeitliches Maximum 500 (20081231, source)
-- dimensions: &id284
-    Time:
-      default: '19641231'
-      values: ['19641231']
-  name: ch.swisstopo.geologie-generalkarte-ggk200_19641231
-  sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache_out]
-  title: Geologische Generalkarte (19641231)
-- dimensions: *id284
-  name: ch.swisstopo.geologie-generalkarte-ggk200
-  sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache]
-  title: Geologische Generalkarte ('current')
-- dimensions: *id284
-  name: ch.swisstopo.geologie-generalkarte-ggk200_19641231_source
-  sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache]
-  title: Geologische Generalkarte (19641231, source)
-- dimensions: &id285
+- dimensions: &id175
     Time:
       default: '20140601'
       values: ['20140601']
   name: ch.swisstopo.geologie-geocover_20140601
   sources: [ch.swisstopo.geologie-geocover_20140601_cache_out]
   title: "GeoCover - Geol. Vektordatens\xE4tze (20140601)"
-- dimensions: *id285
+- dimensions: *id175
   name: ch.swisstopo.geologie-geocover
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: "GeoCover - Geol. Vektordatens\xE4tze ('current')"
-- dimensions: *id285
+- dimensions: *id175
   name: ch.swisstopo.geologie-geocover_20140601_source
   sources: [ch.swisstopo.geologie-geocover_20140601_cache]
   title: "GeoCover - Geol. Vektordatens\xE4tze (20140601, source)"
-- dimensions: &id286
+- dimensions: &id176
     Time:
       default: '20110406'
       values: ['20110406']
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache_out]
   title: Bouguer-Anomalien 500 (20110406)
-- dimensions: *id286
+- dimensions: *id176
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache]
   title: Bouguer-Anomalien 500 ('current')
-- dimensions: *id286
+- dimensions: *id176
   name: ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_source
   sources: [ch.swisstopo.geologie-geodaesie-bouguer_anomalien_20110406_cache]
   title: Bouguer-Anomalien 500 (20110406, source)
-- dimensions: &id287
+- dimensions: &id177
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache_out]
   title: Isostatische Anomalien (19791231)
-- dimensions: *id287
+- dimensions: *id177
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien ('current')
-- dimensions: *id287
+- dimensions: *id177
   name: ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_source
   sources: [ch.swisstopo.geologie-geodaesie-isostatische_anomalien_19791231_cache]
   title: Isostatische Anomalien (19791231, source)
-- dimensions: &id288
+- dimensions: &id178
     Time:
       default: '20070425'
       values: ['20070425']
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache_out]
   title: Blatteinteilung GeoKarten 500 (20070425)
-- dimensions: *id288
+- dimensions: *id178
   name: ch.swisstopo.geologie-geolkarten500.metadata
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 ('current')
-- dimensions: *id288
+- dimensions: *id178
   name: ch.swisstopo.geologie-geolkarten500.metadata_20070425_source
   sources: [ch.swisstopo.geologie-geolkarten500.metadata_20070425_cache]
   title: Blatteinteilung GeoKarten 500 (20070425, source)
-- dimensions: &id289
+- dimensions: &id179
     Time:
       default: '20080630'
       values: ['20080630']
   name: ch.swisstopo.geologie-geologische_karte_20080630
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache_out]
   title: Geologische Karte 500 (20080630)
-- dimensions: *id289
+- dimensions: *id179
   name: ch.swisstopo.geologie-geologische_karte
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologische Karte 500 ('current')
-- dimensions: *id289
+- dimensions: *id179
   name: ch.swisstopo.geologie-geologische_karte_20080630_source
   sources: [ch.swisstopo.geologie-geologische_karte_20080630_cache]
   title: Geologische Karte 500 (20080630, source)
-- dimensions: &id290
+- dimensions: &id180
     Time:
       default: '20131120'
       values: ['20131120']
   name: ch.swisstopo.geologie-geologischer_atlas_20131120
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache_out]
   title: Geol. Atlas der Schweiz 1:25000 (20131120)
-- dimensions: *id290
+- dimensions: *id180
   name: ch.swisstopo.geologie-geologischer_atlas
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geol. Atlas der Schweiz 1:25000 ('current')
-- dimensions: *id290
+- dimensions: *id180
   name: ch.swisstopo.geologie-geologischer_atlas_20131120_source
   sources: [ch.swisstopo.geologie-geologischer_atlas_20131120_cache]
   title: Geol. Atlas der Schweiz 1:25000 (20131120, source)
-- dimensions: &id291
+- dimensions: &id181
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache_out]
   title: Aeromagnetik Voralpen/Jura (19831231)
-- dimensions: *id291
+- dimensions: *id181
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Voralpen/Jura ('current')
-- dimensions: *id291
+- dimensions: *id181
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura_19831231_cache]
   title: Aeromagnetik Voralpen/Jura (19831231, source)
-- dimensions: &id292
+- dimensions: &id182
     Time:
       default: '20120628'
       values: ['20120628']
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache_out]
   title: Aeromagnetik (20120628)
-- dimensions: *id292
+- dimensions: *id182
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik ('current')
-- dimensions: *id292
+- dimensions: *id182
   name: ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_source
   sources: [ch.swisstopo.geologie-geophysik-aeromagnetische_karte_schweiz_20120628_cache]
   title: Aeromagnetik (20120628, source)
-- dimensions: &id293
+- dimensions: &id183
     Time:
       default: '20011203'
       values: ['20011203']
   name: ch.swisstopo.geologie-geophysik-deklination_20011203
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache_out]
   title: Deklination (20011203)
-- dimensions: *id293
+- dimensions: *id183
   name: ch.swisstopo.geologie-geophysik-deklination
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination ('current')
-- dimensions: *id293
+- dimensions: *id183
   name: ch.swisstopo.geologie-geophysik-deklination_20011203_source
   sources: [ch.swisstopo.geologie-geophysik-deklination_20011203_cache]
   title: Deklination (20011203, source)
-- dimensions: &id294
+- dimensions: &id184
     Time:
       default: '20111121'
       values: ['20111121']
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache_out]
   title: Geothermie (20111121)
-- dimensions: *id294
+- dimensions: *id184
   name: ch.swisstopo.geologie-geophysik-geothermie
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: Geothermie ('current')
-- dimensions: *id294
+- dimensions: *id184
   name: ch.swisstopo.geologie-geophysik-geothermie_20111121_source
   sources: [ch.swisstopo.geologie-geophysik-geothermie_20111121_cache]
   title: Geothermie (20111121, source)
-- dimensions: &id295
+- dimensions: &id185
     Time:
       default: '20111128'
       values: ['20111128']
   name: ch.swisstopo.geologie-geophysik-inklination_20111128
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache_out]
   title: Inklination (20111128)
-- dimensions: *id295
+- dimensions: *id185
   name: ch.swisstopo.geologie-geophysik-inklination
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination ('current')
-- dimensions: *id295
+- dimensions: *id185
   name: ch.swisstopo.geologie-geophysik-inklination_20111128_source
   sources: [ch.swisstopo.geologie-geophysik-inklination_20111128_cache]
   title: Inklination (20111128, source)
-- dimensions: &id296
+- dimensions: &id186
     Time:
       default: '19800101'
       values: ['19800101']
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache_out]
   title: "Magnetfeldst\xE4rke (19800101)"
-- dimensions: *id296
+- dimensions: *id186
   name: ch.swisstopo.geologie-geophysik-totalintensitaet
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke ('current')"
-- dimensions: *id296
+- dimensions: *id186
   name: ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_source
   sources: [ch.swisstopo.geologie-geophysik-totalintensitaet_19800101_cache]
   title: "Magnetfeldst\xE4rke (19800101, source)"
-- dimensions: &id297
+- dimensions: &id187
     Time:
       default: '19670101'
       values: ['19670101']
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache_out]
   title: Geotechnik und Gesteine (19670101)
-- dimensions: *id297
+- dimensions: *id187
   name: ch.swisstopo.geologie-geotechnik-gk200
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnik und Gesteine ('current')
-- dimensions: *id297
+- dimensions: *id187
   name: ch.swisstopo.geologie-geotechnik-gk200_19670101_source
   sources: [ch.swisstopo.geologie-geotechnik-gk200_19670101_cache]
   title: Geotechnik und Gesteine (19670101, source)
-- dimensions: &id298
+- dimensions: &id188
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache_out]
   title: Entstehung der Gesteine (20060304)
-- dimensions: *id298
+- dimensions: *id188
   name: ch.swisstopo.geologie-geotechnik-gk500-genese
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine ('current')
-- dimensions: *id298
+- dimensions: *id188
   name: ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-genese_20060304_cache]
   title: Entstehung der Gesteine (20060304, source)
-- dimensions: &id299
+- dimensions: &id189
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache_out]
   title: Gesteinklassierung (20060304)
-- dimensions: *id299
+- dimensions: *id189
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinklassierung ('current')
-- dimensions: *id299
+- dimensions: *id189
   name: ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung_20060304_cache]
   title: Gesteinklassierung (20060304, source)
-- dimensions: &id300
+- dimensions: &id190
     Time:
       default: '20060304'
       values: ['20060304']
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache_out]
   title: Lithologie-Hauptgruppen (20060304)
-- dimensions: *id300
+- dimensions: *id190
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie-Hauptgruppen ('current')
-- dimensions: *id300
+- dimensions: *id190
   name: ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_source
   sources: [ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen_20060304_cache]
   title: Lithologie-Hauptgruppen (20060304, source)
-- dimensions: &id301
+- dimensions: &id191
     Time:
       default: '19900101'
       values: ['19900101']
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache_out]
   title: Mineralische Rohstoffe (19900101)
-- dimensions: *id301
+- dimensions: *id191
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe ('current')
-- dimensions: *id301
+- dimensions: *id191
   name: ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_source
   sources: [ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200_19900101_cache]
   title: Mineralische Rohstoffe (19900101, source)
-- dimensions: &id302
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache_out]
-  title: "Steinbr\xFCche 1915 (20060304)"
-- dimensions: *id302
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache]
-  title: "Steinbr\xFCche 1915 ('current')"
-- dimensions: *id302
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache]
-  title: "Steinbr\xFCche 1915 (20060304, source)"
-- dimensions: &id303
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache_out]
-  title: "Steinbr\xFCche 1965 (20060304)"
-- dimensions: *id303
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache]
-  title: "Steinbr\xFCche 1965 ('current')"
-- dimensions: *id303
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache]
-  title: "Steinbr\xFCche 1965 (20060304, source)"
-- dimensions: &id304
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache_out]
-  title: "Steinbr\xFCche 1980 (20060304)"
-- dimensions: *id304
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache]
-  title: "Steinbr\xFCche 1980 ('current')"
-- dimensions: *id304
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache]
-  title: "Steinbr\xFCche 1980 (20060304, source)"
-- dimensions: &id305
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache_out]
-  title: "Steinbr\xFCche 1995 (20060304)"
-- dimensions: *id305
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache]
-  title: "Steinbr\xFCche 1995 ('current')"
-- dimensions: *id305
-  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache]
-  title: "Steinbr\xFCche 1995 (20060304, source)"
-- dimensions: &id306
+- dimensions: &id192
     Time:
       default: '20130620'
       values: ['20130620']
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache_out]
   title: Steine an historischen Bauwerken (20130620)
-- dimensions: *id306
+- dimensions: *id192
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an historischen Bauwerken ('current')
-- dimensions: *id306
+- dimensions: *id192
   name: ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_source
   sources: [ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke_20130620_cache]
   title: Steine an historischen Bauwerken (20130620, source)
-- dimensions: &id307
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache_out]
-  title: Bindemittelindustrie 1965 (20060304)
-- dimensions: *id307
-  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965
-  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache]
-  title: Bindemittelindustrie 1965 ('current')
-- dimensions: *id307
-  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache]
-  title: Bindemittelindustrie 1965 (20060304, source)
-- dimensions: &id308
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache_out]
-  title: Bindemittelindustrie 1995 (20060304)
-- dimensions: *id308
-  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995
-  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache]
-  title: Bindemittelindustrie 1995 ('current')
-- dimensions: *id308
-  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache]
-  title: Bindemittelindustrie 1995 (20060304, source)
-- dimensions: &id309
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache_out]
-  title: Ziegeleien 1907 (20060304)
-- dimensions: *id309
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache]
-  title: Ziegeleien 1907 ('current')
-- dimensions: *id309
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache]
-  title: Ziegeleien 1907 (20060304, source)
-- dimensions: &id310
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache_out]
-  title: Ziegeleien 1965 (20060304)
-- dimensions: *id310
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache]
-  title: Ziegeleien 1965 ('current')
-- dimensions: *id310
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache]
-  title: Ziegeleien 1965 (20060304, source)
-- dimensions: &id311
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache_out]
-  title: Ziegeleien 1995 (20060304)
-- dimensions: *id311
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache]
-  title: Ziegeleien 1995 ('current')
-- dimensions: *id311
-  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_source
-  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache]
-  title: Ziegeleien 1995 (20060304, source)
-- dimensions: &id312
-    Time:
-      default: '20130107'
-      values: ['20130107']
-  name: ch.swisstopo.geologie-geotope_20130107
-  sources: [ch.swisstopo.geologie-geotope_20130107_cache_out]
-  title: Geotope der Schweiz (20130107)
-- dimensions: *id312
-  name: ch.swisstopo.geologie-geotope
-  sources: [ch.swisstopo.geologie-geotope_20130107_cache]
-  title: Geotope der Schweiz ('current')
-- dimensions: *id312
-  name: ch.swisstopo.geologie-geotope_20130107_source
-  sources: [ch.swisstopo.geologie-geotope_20130107_cache]
-  title: Geotope der Schweiz (20130107, source)
-- dimensions: &id313
+- dimensions: &id193
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache_out]
   title: Gravimetrischer Atlas 1:100000 (20021231)
-- dimensions: *id313
+- dimensions: *id193
   name: ch.swisstopo.geologie-gravimetrischer_atlas
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas 1:100000 ('current')
-- dimensions: *id313
+- dimensions: *id193
   name: ch.swisstopo.geologie-gravimetrischer_atlas_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas_20021231_cache]
   title: Gravimetrischer Atlas 1:100000 (20021231, source)
-- dimensions: &id314
+- dimensions: &id194
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache_out]
   title: Einteilung gravimetrischer Atlas (20021231)
-- dimensions: *id314
+- dimensions: *id194
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravimetrischer Atlas ('current')
-- dimensions: *id314
+- dimensions: *id194
   name: ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_source
   sources: [ch.swisstopo.geologie-gravimetrischer_atlas.metadata_20021231_cache]
   title: Einteilung gravimetrischer Atlas (20021231, source)
-- dimensions: &id315
+- dimensions: &id195
     Time:
       default: '20081103'
       values: ['20081103']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache_out]
   title: Grundwasservorkommen 500 (20081103)
-- dimensions: *id315
+- dimensions: *id195
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 ('current')
-- dimensions: *id315
+- dimensions: *id195
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen_20081103_cache]
   title: Grundwasservorkommen 500 (20081103, source)
-- dimensions: &id316
+- dimensions: &id196
     Time:
       default: '20081016'
       values: ['20081016']
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache_out]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016)"
-- dimensions: *id316
+- dimensions: *id196
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 ('current')"
-- dimensions: *id316
+- dimensions: *id196
   name: ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_source
   sources: [ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet_20081016_cache]
   title: "Grundwasservulnerabilit\xE4t 500 (20081016, source)"
-- dimensions: &id317
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304
-  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache_out]
-  title: Industrieminerale (20060304)
-- dimensions: *id317
-  name: ch.swisstopo.geologie-rohstoffe-industrieminerale
-  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache]
-  title: Industrieminerale ('current')
-- dimensions: *id317
-  name: ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_source
-  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache]
-  title: Industrieminerale (20060304, source)
-- dimensions: &id318
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304
-  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache_out]
-  title: Mineralische Energierohstoffe (20060304)
-- dimensions: *id318
-  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas
-  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache]
-  title: Mineralische Energierohstoffe ('current')
-- dimensions: *id318
-  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_source
-  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache]
-  title: Mineralische Energierohstoffe (20060304, source)
-- dimensions: &id319
-    Time:
-      default: '20060304'
-      values: ['20060304']
-  name: ch.swisstopo.geologie-rohstoffe-vererzungen_20060304
-  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache_out]
-  title: Vererzungen (20060304)
-- dimensions: *id319
-  name: ch.swisstopo.geologie-rohstoffe-vererzungen
-  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache]
-  title: Vererzungen ('current')
-- dimensions: *id319
-  name: ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_source
-  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache]
-  title: Vererzungen (20060304, source)
-- dimensions: &id320
+- dimensions: &id197
     Time:
       default: '20110101'
       values: ['20110101']
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache_out]
   title: Einteilung geol. Spezialkarten (20110101)
-- dimensions: *id320
+- dimensions: *id197
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten ('current')
-- dimensions: *id320
+- dimensions: *id197
   name: ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_source
   sources: [ch.swisstopo.geologie-spezialkarten_schweiz.metadata_20110101_cache]
   title: Einteilung geol. Spezialkarten (20110101, source)
-- dimensions: &id321
+- dimensions: &id198
     Time:
       default: '20080522'
       values: ['20080522']
   name: ch.swisstopo.geologie-tektonische_karte_20080522
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache_out]
   title: Tektonische Karte 500 (20080522)
-- dimensions: *id321
+- dimensions: *id198
   name: ch.swisstopo.geologie-tektonische_karte
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonische Karte 500 ('current')
-- dimensions: *id321
+- dimensions: *id198
   name: ch.swisstopo.geologie-tektonische_karte_20080522_source
   sources: [ch.swisstopo.geologie-tektonische_karte_20080522_cache]
   title: Tektonische Karte 500 (20080522, source)
-- dimensions: &id322
-    Time:
-      default: '20130101'
-      values: ['20130101']
-  name: ch.swisstopo.hangneigung-ueber_30_20130101
-  sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache_out]
-  title: "Hangneigungen ab 30\xB0 (20130101)"
-- dimensions: *id322
-  name: ch.swisstopo.hangneigung-ueber_30
-  sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache]
-  title: "Hangneigungen ab 30\xB0 ('current')"
-- dimensions: *id322
-  name: ch.swisstopo.hangneigung-ueber_30_20130101_source
-  sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache]
-  title: "Hangneigungen ab 30\xB0 (20130101, source)"
-- dimensions: &id323
+- dimensions: &id199
     Time:
       default: '18650101'
       values: ['18650101']
   name: ch.swisstopo.hiks-dufour_18650101
   sources: [ch.swisstopo.hiks-dufour_18650101_cache_out]
   title: Dufourkarte Erstausgabe (18650101)
-- dimensions: *id323
+- dimensions: *id199
   name: ch.swisstopo.hiks-dufour
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe ('current')
-- dimensions: *id323
+- dimensions: *id199
   name: ch.swisstopo.hiks-dufour_18650101_source
   sources: [ch.swisstopo.hiks-dufour_18650101_cache]
   title: Dufourkarte Erstausgabe (18650101, source)
-- dimensions: &id324
+- dimensions: &id200
     Time:
       default: '19260101'
       values: ['19260101']
   name: ch.swisstopo.hiks-siegfried_19260101
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache_out]
   title: Siegfriedkarte Erstausgabe (19260101)
-- dimensions: *id324
+- dimensions: *id200
   name: ch.swisstopo.hiks-siegfried
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe ('current')
-- dimensions: *id324
+- dimensions: *id200
   name: ch.swisstopo.hiks-siegfried_19260101_source
   sources: [ch.swisstopo.hiks-siegfried_19260101_cache]
   title: Siegfriedkarte Erstausgabe (19260101, source)
-- dimensions: &id325
+- dimensions: &id201
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.koordinatenaenderung_20061231
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache_out]
   title: "LV95 Koordinaten\xE4nderung (20061231)"
-- dimensions: *id325
+- dimensions: *id201
   name: ch.swisstopo.koordinatenaenderung
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung ('current')"
-- dimensions: *id325
+- dimensions: *id201
   name: ch.swisstopo.koordinatenaenderung_20061231_source
   sources: [ch.swisstopo.koordinatenaenderung_20061231_cache]
   title: "LV95 Koordinaten\xE4nderung (20061231, source)"
-- dimensions: &id326
+- dimensions: &id202
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache_out]
   title: Luftbilder Privater (99991231)
-- dimensions: *id326
+- dimensions: *id202
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater ('current')
-- dimensions: *id326
+- dimensions: *id202
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_99991231_cache]
   title: Luftbilder Privater (99991231, source)
-- dimensions: &id327
+- dimensions: &id203
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache_out]
   title: Luftbilder Privater (20091231)
-- dimensions: *id327
+- dimensions: *id203
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20091231_cache]
   title: Luftbilder Privater (20091231, source)
-- dimensions: &id328
+- dimensions: &id204
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache_out]
   title: Luftbilder Privater (20081231)
-- dimensions: *id328
+- dimensions: *id204
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20081231_cache]
   title: Luftbilder Privater (20081231, source)
-- dimensions: &id329
+- dimensions: &id205
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache_out]
   title: Luftbilder Privater (20071231)
-- dimensions: *id329
+- dimensions: *id205
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20071231_cache]
   title: Luftbilder Privater (20071231, source)
-- dimensions: &id330
+- dimensions: &id206
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache_out]
   title: Luftbilder Privater (20061231)
-- dimensions: *id330
+- dimensions: *id206
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20061231_cache]
   title: Luftbilder Privater (20061231, source)
-- dimensions: &id331
+- dimensions: &id207
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache_out]
   title: Luftbilder Privater (20051231)
-- dimensions: *id331
+- dimensions: *id207
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20051231_cache]
   title: Luftbilder Privater (20051231, source)
-- dimensions: &id332
+- dimensions: &id208
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache_out]
   title: Luftbilder Privater (20041231)
-- dimensions: *id332
+- dimensions: *id208
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20041231_cache]
   title: Luftbilder Privater (20041231, source)
-- dimensions: &id333
+- dimensions: &id209
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache_out]
   title: Luftbilder Privater (20031231)
-- dimensions: *id333
+- dimensions: *id209
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20031231_cache]
   title: Luftbilder Privater (20031231, source)
-- dimensions: &id334
+- dimensions: &id210
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache_out]
   title: Luftbilder Privater (20021231)
-- dimensions: *id334
+- dimensions: *id210
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20021231_cache]
   title: Luftbilder Privater (20021231, source)
-- dimensions: &id335
+- dimensions: &id211
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache_out]
   title: Luftbilder Privater (20011231)
-- dimensions: *id335
+- dimensions: *id211
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20011231_cache]
   title: Luftbilder Privater (20011231, source)
-- dimensions: &id336
+- dimensions: &id212
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache_out]
   title: Luftbilder Privater (20001231)
-- dimensions: *id336
+- dimensions: *id212
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_20001231_cache]
   title: Luftbilder Privater (20001231, source)
-- dimensions: &id337
+- dimensions: &id213
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache_out]
   title: Luftbilder Privater (19991231)
-- dimensions: *id337
+- dimensions: *id213
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19991231_cache]
   title: Luftbilder Privater (19991231, source)
-- dimensions: &id338
+- dimensions: &id214
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache_out]
   title: Luftbilder Privater (19981231)
-- dimensions: *id338
+- dimensions: *id214
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19981231_cache]
   title: Luftbilder Privater (19981231, source)
-- dimensions: &id339
+- dimensions: &id215
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache_out]
   title: Luftbilder Privater (19971231)
-- dimensions: *id339
+- dimensions: *id215
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19971231_cache]
   title: Luftbilder Privater (19971231, source)
-- dimensions: &id340
+- dimensions: &id216
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache_out]
   title: Luftbilder Privater (19961231)
-- dimensions: *id340
+- dimensions: *id216
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19961231_cache]
   title: Luftbilder Privater (19961231, source)
-- dimensions: &id341
+- dimensions: &id217
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache_out]
   title: Luftbilder Privater (19951231)
-- dimensions: *id341
+- dimensions: *id217
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19951231_cache]
   title: Luftbilder Privater (19951231, source)
-- dimensions: &id342
+- dimensions: &id218
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache_out]
   title: Luftbilder Privater (19941231)
-- dimensions: *id342
+- dimensions: *id218
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19941231_cache]
   title: Luftbilder Privater (19941231, source)
-- dimensions: &id343
+- dimensions: &id219
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache_out]
   title: Luftbilder Privater (19931231)
-- dimensions: *id343
+- dimensions: *id219
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19931231_cache]
   title: Luftbilder Privater (19931231, source)
-- dimensions: &id344
+- dimensions: &id220
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache_out]
   title: Luftbilder Privater (19921231)
-- dimensions: *id344
+- dimensions: *id220
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19921231_cache]
   title: Luftbilder Privater (19921231, source)
-- dimensions: &id345
+- dimensions: &id221
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache_out]
   title: Luftbilder Privater (19911231)
-- dimensions: *id345
+- dimensions: *id221
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19911231_cache]
   title: Luftbilder Privater (19911231, source)
-- dimensions: &id346
+- dimensions: &id222
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache_out]
   title: Luftbilder Privater (19901231)
-- dimensions: *id346
+- dimensions: *id222
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19901231_cache]
   title: Luftbilder Privater (19901231, source)
-- dimensions: &id347
+- dimensions: &id223
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache_out]
   title: Luftbilder Privater (19891231)
-- dimensions: *id347
+- dimensions: *id223
   name: ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-firmen_19891231_cache]
   title: Luftbilder Privater (19891231, source)
-- dimensions: &id348
+- dimensions: &id224
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache_out]
   title: Luftbilder Kantone (99991231)
-- dimensions: *id348
+- dimensions: *id224
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone ('current')
-- dimensions: *id348
+- dimensions: *id224
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_99991231_cache]
   title: Luftbilder Kantone (99991231, source)
-- dimensions: &id349
+- dimensions: &id225
     Time:
       default: '20141231'
       values: ['20141231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache_out]
   title: Luftbilder Kantone (20141231)
-- dimensions: *id349
+- dimensions: *id225
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20141231_cache]
   title: Luftbilder Kantone (20141231, source)
-- dimensions: &id350
+- dimensions: &id226
     Time:
       default: '20131231'
       values: ['20131231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache_out]
   title: Luftbilder Kantone (20131231)
-- dimensions: *id350
+- dimensions: *id226
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20131231_cache]
   title: Luftbilder Kantone (20131231, source)
-- dimensions: &id351
+- dimensions: &id227
     Time:
       default: '20121231'
       values: ['20121231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache_out]
   title: Luftbilder Kantone (20121231)
-- dimensions: *id351
+- dimensions: *id227
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20121231_cache]
   title: Luftbilder Kantone (20121231, source)
-- dimensions: &id352
+- dimensions: &id228
     Time:
       default: '20111231'
       values: ['20111231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache_out]
   title: Luftbilder Kantone (20111231)
-- dimensions: *id352
+- dimensions: *id228
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20111231_cache]
   title: Luftbilder Kantone (20111231, source)
-- dimensions: &id353
+- dimensions: &id229
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache_out]
   title: Luftbilder Kantone (20091231)
-- dimensions: *id353
+- dimensions: *id229
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_20091231_cache]
   title: Luftbilder Kantone (20091231, source)
-- dimensions: &id354
+- dimensions: &id230
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache_out]
   title: Luftbilder Kantone (19841231)
-- dimensions: *id354
+- dimensions: *id230
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19841231_cache]
   title: Luftbilder Kantone (19841231, source)
-- dimensions: &id355
+- dimensions: &id231
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache_out]
   title: Luftbilder Kantone (19671231)
-- dimensions: *id355
+- dimensions: *id231
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19671231_cache]
   title: Luftbilder Kantone (19671231, source)
-- dimensions: &id356
+- dimensions: &id232
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache_out]
   title: Luftbilder Kantone (19661231)
-- dimensions: *id356
+- dimensions: *id232
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19661231_cache]
   title: Luftbilder Kantone (19661231, source)
-- dimensions: &id357
+- dimensions: &id233
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache_out]
   title: Luftbilder Kantone (19651231)
-- dimensions: *id357
+- dimensions: *id233
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19651231_cache]
   title: Luftbilder Kantone (19651231, source)
-- dimensions: &id358
+- dimensions: &id234
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache_out]
   title: Luftbilder Kantone (19641231)
-- dimensions: *id358
+- dimensions: *id234
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19641231_cache]
   title: Luftbilder Kantone (19641231, source)
-- dimensions: &id359
+- dimensions: &id235
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache_out]
   title: Luftbilder Kantone (19631231)
-- dimensions: *id359
+- dimensions: *id235
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19631231_cache]
   title: Luftbilder Kantone (19631231, source)
-- dimensions: &id360
+- dimensions: &id236
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache_out]
   title: Luftbilder Kantone (19621231)
-- dimensions: *id360
+- dimensions: *id236
   name: ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder-dritte-kantone_19621231_cache]
   title: Luftbilder Kantone (19621231, source)
-- dimensions: &id361
+- dimensions: &id237
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache_out]
   title: Luftbilder swisstopo farbig (99991231)
-- dimensions: *id361
+- dimensions: *id237
   name: ch.swisstopo.lubis-luftbilder_farbe
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig ('current')
-- dimensions: *id361
+- dimensions: *id237
   name: ch.swisstopo.lubis-luftbilder_farbe_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_99991231_cache]
   title: Luftbilder swisstopo farbig (99991231, source)
-- dimensions: &id362
+- dimensions: &id238
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache_out]
   title: Luftbilder swisstopo farbig (20101231)
-- dimensions: *id362
+- dimensions: *id238
   name: ch.swisstopo.lubis-luftbilder_farbe_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20101231_cache]
   title: Luftbilder swisstopo farbig (20101231, source)
-- dimensions: &id363
+- dimensions: &id239
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache_out]
   title: Luftbilder swisstopo farbig (20091231)
-- dimensions: *id363
+- dimensions: *id239
   name: ch.swisstopo.lubis-luftbilder_farbe_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20091231_cache]
   title: Luftbilder swisstopo farbig (20091231, source)
-- dimensions: &id364
+- dimensions: &id240
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache_out]
   title: Luftbilder swisstopo farbig (20081231)
-- dimensions: *id364
+- dimensions: *id240
   name: ch.swisstopo.lubis-luftbilder_farbe_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20081231_cache]
   title: Luftbilder swisstopo farbig (20081231, source)
-- dimensions: &id365
+- dimensions: &id241
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache_out]
   title: Luftbilder swisstopo farbig (20071231)
-- dimensions: *id365
+- dimensions: *id241
   name: ch.swisstopo.lubis-luftbilder_farbe_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20071231_cache]
   title: Luftbilder swisstopo farbig (20071231, source)
-- dimensions: &id366
+- dimensions: &id242
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache_out]
   title: Luftbilder swisstopo farbig (20061231)
-- dimensions: *id366
+- dimensions: *id242
   name: ch.swisstopo.lubis-luftbilder_farbe_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20061231_cache]
   title: Luftbilder swisstopo farbig (20061231, source)
-- dimensions: &id367
+- dimensions: &id243
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache_out]
   title: Luftbilder swisstopo farbig (20051231)
-- dimensions: *id367
+- dimensions: *id243
   name: ch.swisstopo.lubis-luftbilder_farbe_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20051231_cache]
   title: Luftbilder swisstopo farbig (20051231, source)
-- dimensions: &id368
+- dimensions: &id244
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache_out]
   title: Luftbilder swisstopo farbig (20041231)
-- dimensions: *id368
+- dimensions: *id244
   name: ch.swisstopo.lubis-luftbilder_farbe_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20041231_cache]
   title: Luftbilder swisstopo farbig (20041231, source)
-- dimensions: &id369
+- dimensions: &id245
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache_out]
   title: Luftbilder swisstopo farbig (20031231)
-- dimensions: *id369
+- dimensions: *id245
   name: ch.swisstopo.lubis-luftbilder_farbe_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20031231_cache]
   title: Luftbilder swisstopo farbig (20031231, source)
-- dimensions: &id370
+- dimensions: &id246
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache_out]
   title: Luftbilder swisstopo farbig (20021231)
-- dimensions: *id370
+- dimensions: *id246
   name: ch.swisstopo.lubis-luftbilder_farbe_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20021231_cache]
   title: Luftbilder swisstopo farbig (20021231, source)
-- dimensions: &id371
+- dimensions: &id247
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache_out]
   title: Luftbilder swisstopo farbig (20011231)
-- dimensions: *id371
+- dimensions: *id247
   name: ch.swisstopo.lubis-luftbilder_farbe_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20011231_cache]
   title: Luftbilder swisstopo farbig (20011231, source)
-- dimensions: &id372
+- dimensions: &id248
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache_out]
   title: Luftbilder swisstopo farbig (20001231)
-- dimensions: *id372
+- dimensions: *id248
   name: ch.swisstopo.lubis-luftbilder_farbe_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_20001231_cache]
   title: Luftbilder swisstopo farbig (20001231, source)
-- dimensions: &id373
+- dimensions: &id249
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache_out]
   title: Luftbilder swisstopo farbig (19991231)
-- dimensions: *id373
+- dimensions: *id249
   name: ch.swisstopo.lubis-luftbilder_farbe_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19991231_cache]
   title: Luftbilder swisstopo farbig (19991231, source)
-- dimensions: &id374
+- dimensions: &id250
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache_out]
   title: Luftbilder swisstopo farbig (19981231)
-- dimensions: *id374
+- dimensions: *id250
   name: ch.swisstopo.lubis-luftbilder_farbe_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19981231_cache]
   title: Luftbilder swisstopo farbig (19981231, source)
-- dimensions: &id375
+- dimensions: &id251
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache_out]
   title: Luftbilder swisstopo farbig (19971231)
-- dimensions: *id375
+- dimensions: *id251
   name: ch.swisstopo.lubis-luftbilder_farbe_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19971231_cache]
   title: Luftbilder swisstopo farbig (19971231, source)
-- dimensions: &id376
+- dimensions: &id252
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache_out]
   title: Luftbilder swisstopo farbig (19961231)
-- dimensions: *id376
+- dimensions: *id252
   name: ch.swisstopo.lubis-luftbilder_farbe_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19961231_cache]
   title: Luftbilder swisstopo farbig (19961231, source)
-- dimensions: &id377
+- dimensions: &id253
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache_out]
   title: Luftbilder swisstopo farbig (19951231)
-- dimensions: *id377
+- dimensions: *id253
   name: ch.swisstopo.lubis-luftbilder_farbe_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19951231_cache]
   title: Luftbilder swisstopo farbig (19951231, source)
-- dimensions: &id378
+- dimensions: &id254
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache_out]
   title: Luftbilder swisstopo farbig (19941231)
-- dimensions: *id378
+- dimensions: *id254
   name: ch.swisstopo.lubis-luftbilder_farbe_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19941231_cache]
   title: Luftbilder swisstopo farbig (19941231, source)
-- dimensions: &id379
+- dimensions: &id255
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache_out]
   title: Luftbilder swisstopo farbig (19931231)
-- dimensions: *id379
+- dimensions: *id255
   name: ch.swisstopo.lubis-luftbilder_farbe_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19931231_cache]
   title: Luftbilder swisstopo farbig (19931231, source)
-- dimensions: &id380
+- dimensions: &id256
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache_out]
   title: Luftbilder swisstopo farbig (19921231)
-- dimensions: *id380
+- dimensions: *id256
   name: ch.swisstopo.lubis-luftbilder_farbe_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19921231_cache]
   title: Luftbilder swisstopo farbig (19921231, source)
-- dimensions: &id381
+- dimensions: &id257
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache_out]
   title: Luftbilder swisstopo farbig (19911231)
-- dimensions: *id381
+- dimensions: *id257
   name: ch.swisstopo.lubis-luftbilder_farbe_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19911231_cache]
   title: Luftbilder swisstopo farbig (19911231, source)
-- dimensions: &id382
+- dimensions: &id258
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache_out]
   title: Luftbilder swisstopo farbig (19901231)
-- dimensions: *id382
+- dimensions: *id258
   name: ch.swisstopo.lubis-luftbilder_farbe_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19901231_cache]
   title: Luftbilder swisstopo farbig (19901231, source)
-- dimensions: &id383
+- dimensions: &id259
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache_out]
   title: Luftbilder swisstopo farbig (19891231)
-- dimensions: *id383
+- dimensions: *id259
   name: ch.swisstopo.lubis-luftbilder_farbe_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19891231_cache]
   title: Luftbilder swisstopo farbig (19891231, source)
-- dimensions: &id384
+- dimensions: &id260
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache_out]
   title: Luftbilder swisstopo farbig (19881231)
-- dimensions: *id384
+- dimensions: *id260
   name: ch.swisstopo.lubis-luftbilder_farbe_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19881231_cache]
   title: Luftbilder swisstopo farbig (19881231, source)
-- dimensions: &id385
+- dimensions: &id261
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache_out]
   title: Luftbilder swisstopo farbig (19871231)
-- dimensions: *id385
+- dimensions: *id261
   name: ch.swisstopo.lubis-luftbilder_farbe_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19871231_cache]
   title: Luftbilder swisstopo farbig (19871231, source)
-- dimensions: &id386
+- dimensions: &id262
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache_out]
   title: Luftbilder swisstopo farbig (19861231)
-- dimensions: *id386
+- dimensions: *id262
   name: ch.swisstopo.lubis-luftbilder_farbe_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19861231_cache]
   title: Luftbilder swisstopo farbig (19861231, source)
-- dimensions: &id387
+- dimensions: &id263
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache_out]
   title: Luftbilder swisstopo farbig (19851231)
-- dimensions: *id387
+- dimensions: *id263
   name: ch.swisstopo.lubis-luftbilder_farbe_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19851231_cache]
   title: Luftbilder swisstopo farbig (19851231, source)
-- dimensions: &id388
+- dimensions: &id264
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache_out]
   title: Luftbilder swisstopo farbig (19841231)
-- dimensions: *id388
+- dimensions: *id264
   name: ch.swisstopo.lubis-luftbilder_farbe_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19841231_cache]
   title: Luftbilder swisstopo farbig (19841231, source)
-- dimensions: &id389
+- dimensions: &id265
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache_out]
   title: Luftbilder swisstopo farbig (19831231)
-- dimensions: *id389
+- dimensions: *id265
   name: ch.swisstopo.lubis-luftbilder_farbe_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19831231_cache]
   title: Luftbilder swisstopo farbig (19831231, source)
-- dimensions: &id390
+- dimensions: &id266
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache_out]
   title: Luftbilder swisstopo farbig (19821231)
-- dimensions: *id390
+- dimensions: *id266
   name: ch.swisstopo.lubis-luftbilder_farbe_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19821231_cache]
   title: Luftbilder swisstopo farbig (19821231, source)
-- dimensions: &id391
+- dimensions: &id267
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache_out]
   title: Luftbilder swisstopo farbig (19811231)
-- dimensions: *id391
+- dimensions: *id267
   name: ch.swisstopo.lubis-luftbilder_farbe_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_farbe_19811231_cache]
   title: Luftbilder swisstopo farbig (19811231, source)
-- dimensions: &id392
+- dimensions: &id268
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache_out]
   title: Luftbilder swisstopo infrarot (99991231)
-- dimensions: *id392
+- dimensions: *id268
   name: ch.swisstopo.lubis-luftbilder_infrarot
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot ('current')
-- dimensions: *id392
+- dimensions: *id268
   name: ch.swisstopo.lubis-luftbilder_infrarot_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_99991231_cache]
   title: Luftbilder swisstopo infrarot (99991231, source)
-- dimensions: &id393
+- dimensions: &id269
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache_out]
   title: Luftbilder swisstopo infrarot (20091231)
-- dimensions: *id393
+- dimensions: *id269
   name: ch.swisstopo.lubis-luftbilder_infrarot_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20091231_cache]
   title: Luftbilder swisstopo infrarot (20091231, source)
-- dimensions: &id394
+- dimensions: &id270
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache_out]
   title: Luftbilder swisstopo infrarot (20081231)
-- dimensions: *id394
+- dimensions: *id270
   name: ch.swisstopo.lubis-luftbilder_infrarot_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20081231_cache]
   title: Luftbilder swisstopo infrarot (20081231, source)
-- dimensions: &id395
+- dimensions: &id271
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache_out]
   title: Luftbilder swisstopo infrarot (20071231)
-- dimensions: *id395
+- dimensions: *id271
   name: ch.swisstopo.lubis-luftbilder_infrarot_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20071231_cache]
   title: Luftbilder swisstopo infrarot (20071231, source)
-- dimensions: &id396
+- dimensions: &id272
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache_out]
   title: Luftbilder swisstopo infrarot (20061231)
-- dimensions: *id396
+- dimensions: *id272
   name: ch.swisstopo.lubis-luftbilder_infrarot_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20061231_cache]
   title: Luftbilder swisstopo infrarot (20061231, source)
-- dimensions: &id397
+- dimensions: &id273
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache_out]
   title: Luftbilder swisstopo infrarot (20051231)
-- dimensions: *id397
+- dimensions: *id273
   name: ch.swisstopo.lubis-luftbilder_infrarot_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20051231_cache]
   title: Luftbilder swisstopo infrarot (20051231, source)
-- dimensions: &id398
+- dimensions: &id274
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache_out]
   title: Luftbilder swisstopo infrarot (20041231)
-- dimensions: *id398
+- dimensions: *id274
   name: ch.swisstopo.lubis-luftbilder_infrarot_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20041231_cache]
   title: Luftbilder swisstopo infrarot (20041231, source)
-- dimensions: &id399
+- dimensions: &id275
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache_out]
   title: Luftbilder swisstopo infrarot (20031231)
-- dimensions: *id399
+- dimensions: *id275
   name: ch.swisstopo.lubis-luftbilder_infrarot_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20031231_cache]
   title: Luftbilder swisstopo infrarot (20031231, source)
-- dimensions: &id400
+- dimensions: &id276
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache_out]
   title: Luftbilder swisstopo infrarot (20021231)
-- dimensions: *id400
+- dimensions: *id276
   name: ch.swisstopo.lubis-luftbilder_infrarot_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20021231_cache]
   title: Luftbilder swisstopo infrarot (20021231, source)
-- dimensions: &id401
+- dimensions: &id277
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache_out]
   title: Luftbilder swisstopo infrarot (20011231)
-- dimensions: *id401
+- dimensions: *id277
   name: ch.swisstopo.lubis-luftbilder_infrarot_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20011231_cache]
   title: Luftbilder swisstopo infrarot (20011231, source)
-- dimensions: &id402
+- dimensions: &id278
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache_out]
   title: Luftbilder swisstopo infrarot (20001231)
-- dimensions: *id402
+- dimensions: *id278
   name: ch.swisstopo.lubis-luftbilder_infrarot_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_20001231_cache]
   title: Luftbilder swisstopo infrarot (20001231, source)
-- dimensions: &id403
+- dimensions: &id279
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache_out]
   title: Luftbilder swisstopo infrarot (19991231)
-- dimensions: *id403
+- dimensions: *id279
   name: ch.swisstopo.lubis-luftbilder_infrarot_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19991231_cache]
   title: Luftbilder swisstopo infrarot (19991231, source)
-- dimensions: &id404
+- dimensions: &id280
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache_out]
   title: Luftbilder swisstopo infrarot (19981231)
-- dimensions: *id404
+- dimensions: *id280
   name: ch.swisstopo.lubis-luftbilder_infrarot_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19981231_cache]
   title: Luftbilder swisstopo infrarot (19981231, source)
-- dimensions: &id405
+- dimensions: &id281
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache_out]
   title: Luftbilder swisstopo infrarot (19971231)
-- dimensions: *id405
+- dimensions: *id281
   name: ch.swisstopo.lubis-luftbilder_infrarot_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19971231_cache]
   title: Luftbilder swisstopo infrarot (19971231, source)
-- dimensions: &id406
+- dimensions: &id282
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache_out]
   title: Luftbilder swisstopo infrarot (19961231)
-- dimensions: *id406
+- dimensions: *id282
   name: ch.swisstopo.lubis-luftbilder_infrarot_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19961231_cache]
   title: Luftbilder swisstopo infrarot (19961231, source)
-- dimensions: &id407
+- dimensions: &id283
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache_out]
   title: Luftbilder swisstopo infrarot (19951231)
-- dimensions: *id407
+- dimensions: *id283
   name: ch.swisstopo.lubis-luftbilder_infrarot_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19951231_cache]
   title: Luftbilder swisstopo infrarot (19951231, source)
-- dimensions: &id408
+- dimensions: &id284
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache_out]
   title: Luftbilder swisstopo infrarot (19941231)
-- dimensions: *id408
+- dimensions: *id284
   name: ch.swisstopo.lubis-luftbilder_infrarot_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19941231_cache]
   title: Luftbilder swisstopo infrarot (19941231, source)
-- dimensions: &id409
+- dimensions: &id285
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache_out]
   title: Luftbilder swisstopo infrarot (19931231)
-- dimensions: *id409
+- dimensions: *id285
   name: ch.swisstopo.lubis-luftbilder_infrarot_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19931231_cache]
   title: Luftbilder swisstopo infrarot (19931231, source)
-- dimensions: &id410
+- dimensions: &id286
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache_out]
   title: Luftbilder swisstopo infrarot (19921231)
-- dimensions: *id410
+- dimensions: *id286
   name: ch.swisstopo.lubis-luftbilder_infrarot_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19921231_cache]
   title: Luftbilder swisstopo infrarot (19921231, source)
-- dimensions: &id411
+- dimensions: &id287
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache_out]
   title: Luftbilder swisstopo infrarot (19911231)
-- dimensions: *id411
+- dimensions: *id287
   name: ch.swisstopo.lubis-luftbilder_infrarot_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19911231_cache]
   title: Luftbilder swisstopo infrarot (19911231, source)
-- dimensions: &id412
+- dimensions: &id288
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache_out]
   title: Luftbilder swisstopo infrarot (19901231)
-- dimensions: *id412
+- dimensions: *id288
   name: ch.swisstopo.lubis-luftbilder_infrarot_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19901231_cache]
   title: Luftbilder swisstopo infrarot (19901231, source)
-- dimensions: &id413
+- dimensions: &id289
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache_out]
   title: Luftbilder swisstopo infrarot (19891231)
-- dimensions: *id413
+- dimensions: *id289
   name: ch.swisstopo.lubis-luftbilder_infrarot_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19891231_cache]
   title: Luftbilder swisstopo infrarot (19891231, source)
-- dimensions: &id414
+- dimensions: &id290
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache_out]
   title: Luftbilder swisstopo infrarot (19881231)
-- dimensions: *id414
+- dimensions: *id290
   name: ch.swisstopo.lubis-luftbilder_infrarot_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19881231_cache]
   title: Luftbilder swisstopo infrarot (19881231, source)
-- dimensions: &id415
+- dimensions: &id291
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache_out]
   title: Luftbilder swisstopo infrarot (19871231)
-- dimensions: *id415
+- dimensions: *id291
   name: ch.swisstopo.lubis-luftbilder_infrarot_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19871231_cache]
   title: Luftbilder swisstopo infrarot (19871231, source)
-- dimensions: &id416
+- dimensions: &id292
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache_out]
   title: Luftbilder swisstopo infrarot (19861231)
-- dimensions: *id416
+- dimensions: *id292
   name: ch.swisstopo.lubis-luftbilder_infrarot_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19861231_cache]
   title: Luftbilder swisstopo infrarot (19861231, source)
-- dimensions: &id417
+- dimensions: &id293
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache_out]
   title: Luftbilder swisstopo infrarot (19851231)
-- dimensions: *id417
+- dimensions: *id293
   name: ch.swisstopo.lubis-luftbilder_infrarot_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19851231_cache]
   title: Luftbilder swisstopo infrarot (19851231, source)
-- dimensions: &id418
+- dimensions: &id294
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache_out]
   title: Luftbilder swisstopo infrarot (19841231)
-- dimensions: *id418
+- dimensions: *id294
   name: ch.swisstopo.lubis-luftbilder_infrarot_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19841231_cache]
   title: Luftbilder swisstopo infrarot (19841231, source)
-- dimensions: &id419
+- dimensions: &id295
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache_out]
   title: Luftbilder swisstopo infrarot (19831231)
-- dimensions: *id419
+- dimensions: *id295
   name: ch.swisstopo.lubis-luftbilder_infrarot_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19831231_cache]
   title: Luftbilder swisstopo infrarot (19831231, source)
-- dimensions: &id420
+- dimensions: &id296
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache_out]
   title: Luftbilder swisstopo infrarot (19811231)
-- dimensions: *id420
+- dimensions: *id296
   name: ch.swisstopo.lubis-luftbilder_infrarot_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_infrarot_19811231_cache]
   title: Luftbilder swisstopo infrarot (19811231, source)
-- dimensions: &id421
+- dimensions: &id297
     Time:
       default: '99991231'
       values: ['99991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache_out]
   title: Luftbilder swisstopo s/w (99991231)
-- dimensions: *id421
+- dimensions: *id297
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w ('current')
-- dimensions: *id421
+- dimensions: *id297
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_99991231_cache]
   title: Luftbilder swisstopo s/w (99991231, source)
-- dimensions: &id422
+- dimensions: &id298
     Time:
       default: '20101231'
       values: ['20101231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache_out]
   title: Luftbilder swisstopo s/w (20101231)
-- dimensions: *id422
+- dimensions: *id298
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20101231_cache]
   title: Luftbilder swisstopo s/w (20101231, source)
-- dimensions: &id423
+- dimensions: &id299
     Time:
       default: '20091231'
       values: ['20091231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache_out]
   title: Luftbilder swisstopo s/w (20091231)
-- dimensions: *id423
+- dimensions: *id299
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20091231_cache]
   title: Luftbilder swisstopo s/w (20091231, source)
-- dimensions: &id424
+- dimensions: &id300
     Time:
       default: '20081231'
       values: ['20081231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache_out]
   title: Luftbilder swisstopo s/w (20081231)
-- dimensions: *id424
+- dimensions: *id300
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20081231_cache]
   title: Luftbilder swisstopo s/w (20081231, source)
-- dimensions: &id425
+- dimensions: &id301
     Time:
       default: '20071231'
       values: ['20071231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache_out]
   title: Luftbilder swisstopo s/w (20071231)
-- dimensions: *id425
+- dimensions: *id301
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20071231_cache]
   title: Luftbilder swisstopo s/w (20071231, source)
-- dimensions: &id426
+- dimensions: &id302
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache_out]
   title: Luftbilder swisstopo s/w (20061231)
-- dimensions: *id426
+- dimensions: *id302
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20061231_cache]
   title: Luftbilder swisstopo s/w (20061231, source)
-- dimensions: &id427
+- dimensions: &id303
     Time:
       default: '20051231'
       values: ['20051231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache_out]
   title: Luftbilder swisstopo s/w (20051231)
-- dimensions: *id427
+- dimensions: *id303
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20051231_cache]
   title: Luftbilder swisstopo s/w (20051231, source)
-- dimensions: &id428
+- dimensions: &id304
     Time:
       default: '20041231'
       values: ['20041231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache_out]
   title: Luftbilder swisstopo s/w (20041231)
-- dimensions: *id428
+- dimensions: *id304
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20041231_cache]
   title: Luftbilder swisstopo s/w (20041231, source)
-- dimensions: &id429
+- dimensions: &id305
     Time:
       default: '20031231'
       values: ['20031231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache_out]
   title: Luftbilder swisstopo s/w (20031231)
-- dimensions: *id429
+- dimensions: *id305
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20031231_cache]
   title: Luftbilder swisstopo s/w (20031231, source)
-- dimensions: &id430
+- dimensions: &id306
     Time:
       default: '20021231'
       values: ['20021231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache_out]
   title: Luftbilder swisstopo s/w (20021231)
-- dimensions: *id430
+- dimensions: *id306
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20021231_cache]
   title: Luftbilder swisstopo s/w (20021231, source)
-- dimensions: &id431
+- dimensions: &id307
     Time:
       default: '20011231'
       values: ['20011231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache_out]
   title: Luftbilder swisstopo s/w (20011231)
-- dimensions: *id431
+- dimensions: *id307
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20011231_cache]
   title: Luftbilder swisstopo s/w (20011231, source)
-- dimensions: &id432
+- dimensions: &id308
     Time:
       default: '20001231'
       values: ['20001231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache_out]
   title: Luftbilder swisstopo s/w (20001231)
-- dimensions: *id432
+- dimensions: *id308
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_20001231_cache]
   title: Luftbilder swisstopo s/w (20001231, source)
-- dimensions: &id433
+- dimensions: &id309
     Time:
       default: '19991231'
       values: ['19991231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache_out]
   title: Luftbilder swisstopo s/w (19991231)
-- dimensions: *id433
+- dimensions: *id309
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19991231_cache]
   title: Luftbilder swisstopo s/w (19991231, source)
-- dimensions: &id434
+- dimensions: &id310
     Time:
       default: '19981231'
       values: ['19981231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache_out]
   title: Luftbilder swisstopo s/w (19981231)
-- dimensions: *id434
+- dimensions: *id310
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19981231_cache]
   title: Luftbilder swisstopo s/w (19981231, source)
-- dimensions: &id435
+- dimensions: &id311
     Time:
       default: '19971231'
       values: ['19971231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache_out]
   title: Luftbilder swisstopo s/w (19971231)
-- dimensions: *id435
+- dimensions: *id311
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19971231_cache]
   title: Luftbilder swisstopo s/w (19971231, source)
-- dimensions: &id436
+- dimensions: &id312
     Time:
       default: '19961231'
       values: ['19961231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache_out]
   title: Luftbilder swisstopo s/w (19961231)
-- dimensions: *id436
+- dimensions: *id312
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19961231_cache]
   title: Luftbilder swisstopo s/w (19961231, source)
-- dimensions: &id437
+- dimensions: &id313
     Time:
       default: '19951231'
       values: ['19951231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache_out]
   title: Luftbilder swisstopo s/w (19951231)
-- dimensions: *id437
+- dimensions: *id313
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19951231_cache]
   title: Luftbilder swisstopo s/w (19951231, source)
-- dimensions: &id438
+- dimensions: &id314
     Time:
       default: '19941231'
       values: ['19941231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache_out]
   title: Luftbilder swisstopo s/w (19941231)
-- dimensions: *id438
+- dimensions: *id314
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19941231_cache]
   title: Luftbilder swisstopo s/w (19941231, source)
-- dimensions: &id439
+- dimensions: &id315
     Time:
       default: '19931231'
       values: ['19931231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache_out]
   title: Luftbilder swisstopo s/w (19931231)
-- dimensions: *id439
+- dimensions: *id315
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19931231_cache]
   title: Luftbilder swisstopo s/w (19931231, source)
-- dimensions: &id440
+- dimensions: &id316
     Time:
       default: '19921231'
       values: ['19921231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache_out]
   title: Luftbilder swisstopo s/w (19921231)
-- dimensions: *id440
+- dimensions: *id316
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19921231_cache]
   title: Luftbilder swisstopo s/w (19921231, source)
-- dimensions: &id441
+- dimensions: &id317
     Time:
       default: '19911231'
       values: ['19911231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache_out]
   title: Luftbilder swisstopo s/w (19911231)
-- dimensions: *id441
+- dimensions: *id317
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19911231_cache]
   title: Luftbilder swisstopo s/w (19911231, source)
-- dimensions: &id442
+- dimensions: &id318
     Time:
       default: '19901231'
       values: ['19901231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache_out]
   title: Luftbilder swisstopo s/w (19901231)
-- dimensions: *id442
+- dimensions: *id318
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19901231_cache]
   title: Luftbilder swisstopo s/w (19901231, source)
-- dimensions: &id443
+- dimensions: &id319
     Time:
       default: '19891231'
       values: ['19891231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache_out]
   title: Luftbilder swisstopo s/w (19891231)
-- dimensions: *id443
+- dimensions: *id319
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19891231_cache]
   title: Luftbilder swisstopo s/w (19891231, source)
-- dimensions: &id444
+- dimensions: &id320
     Time:
       default: '19881231'
       values: ['19881231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache_out]
   title: Luftbilder swisstopo s/w (19881231)
-- dimensions: *id444
+- dimensions: *id320
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19881231_cache]
   title: Luftbilder swisstopo s/w (19881231, source)
-- dimensions: &id445
+- dimensions: &id321
     Time:
       default: '19871231'
       values: ['19871231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache_out]
   title: Luftbilder swisstopo s/w (19871231)
-- dimensions: *id445
+- dimensions: *id321
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19871231_cache]
   title: Luftbilder swisstopo s/w (19871231, source)
-- dimensions: &id446
+- dimensions: &id322
     Time:
       default: '19861231'
       values: ['19861231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache_out]
   title: Luftbilder swisstopo s/w (19861231)
-- dimensions: *id446
+- dimensions: *id322
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19861231_cache]
   title: Luftbilder swisstopo s/w (19861231, source)
-- dimensions: &id447
+- dimensions: &id323
     Time:
       default: '19851231'
       values: ['19851231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache_out]
   title: Luftbilder swisstopo s/w (19851231)
-- dimensions: *id447
+- dimensions: *id323
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19851231_cache]
   title: Luftbilder swisstopo s/w (19851231, source)
-- dimensions: &id448
+- dimensions: &id324
     Time:
       default: '19841231'
       values: ['19841231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache_out]
   title: Luftbilder swisstopo s/w (19841231)
-- dimensions: *id448
+- dimensions: *id324
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19841231_cache]
   title: Luftbilder swisstopo s/w (19841231, source)
-- dimensions: &id449
+- dimensions: &id325
     Time:
       default: '19831231'
       values: ['19831231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache_out]
   title: Luftbilder swisstopo s/w (19831231)
-- dimensions: *id449
+- dimensions: *id325
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19831231_cache]
   title: Luftbilder swisstopo s/w (19831231, source)
-- dimensions: &id450
+- dimensions: &id326
     Time:
       default: '19821231'
       values: ['19821231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache_out]
   title: Luftbilder swisstopo s/w (19821231)
-- dimensions: *id450
+- dimensions: *id326
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19821231_cache]
   title: Luftbilder swisstopo s/w (19821231, source)
-- dimensions: &id451
+- dimensions: &id327
     Time:
       default: '19811231'
       values: ['19811231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache_out]
   title: Luftbilder swisstopo s/w (19811231)
-- dimensions: *id451
+- dimensions: *id327
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19811231_cache]
   title: Luftbilder swisstopo s/w (19811231, source)
-- dimensions: &id452
+- dimensions: &id328
     Time:
       default: '19801231'
       values: ['19801231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache_out]
   title: Luftbilder swisstopo s/w (19801231)
-- dimensions: *id452
+- dimensions: *id328
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19801231_cache]
   title: Luftbilder swisstopo s/w (19801231, source)
-- dimensions: &id453
+- dimensions: &id329
     Time:
       default: '19791231'
       values: ['19791231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache_out]
   title: Luftbilder swisstopo s/w (19791231)
-- dimensions: *id453
+- dimensions: *id329
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19791231_cache]
   title: Luftbilder swisstopo s/w (19791231, source)
-- dimensions: &id454
+- dimensions: &id330
     Time:
       default: '19781231'
       values: ['19781231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache_out]
   title: Luftbilder swisstopo s/w (19781231)
-- dimensions: *id454
+- dimensions: *id330
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19781231_cache]
   title: Luftbilder swisstopo s/w (19781231, source)
-- dimensions: &id455
+- dimensions: &id331
     Time:
       default: '19771231'
       values: ['19771231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache_out]
   title: Luftbilder swisstopo s/w (19771231)
-- dimensions: *id455
+- dimensions: *id331
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19771231_cache]
   title: Luftbilder swisstopo s/w (19771231, source)
-- dimensions: &id456
+- dimensions: &id332
     Time:
       default: '19761231'
       values: ['19761231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache_out]
   title: Luftbilder swisstopo s/w (19761231)
-- dimensions: *id456
+- dimensions: *id332
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19761231_cache]
   title: Luftbilder swisstopo s/w (19761231, source)
-- dimensions: &id457
+- dimensions: &id333
     Time:
       default: '19751231'
       values: ['19751231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache_out]
   title: Luftbilder swisstopo s/w (19751231)
-- dimensions: *id457
+- dimensions: *id333
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19751231_cache]
   title: Luftbilder swisstopo s/w (19751231, source)
-- dimensions: &id458
+- dimensions: &id334
     Time:
       default: '19741231'
       values: ['19741231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache_out]
   title: Luftbilder swisstopo s/w (19741231)
-- dimensions: *id458
+- dimensions: *id334
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19741231_cache]
   title: Luftbilder swisstopo s/w (19741231, source)
-- dimensions: &id459
+- dimensions: &id335
     Time:
       default: '19731231'
       values: ['19731231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache_out]
   title: Luftbilder swisstopo s/w (19731231)
-- dimensions: *id459
+- dimensions: *id335
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19731231_cache]
   title: Luftbilder swisstopo s/w (19731231, source)
-- dimensions: &id460
+- dimensions: &id336
     Time:
       default: '19721231'
       values: ['19721231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache_out]
   title: Luftbilder swisstopo s/w (19721231)
-- dimensions: *id460
+- dimensions: *id336
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19721231_cache]
   title: Luftbilder swisstopo s/w (19721231, source)
-- dimensions: &id461
+- dimensions: &id337
     Time:
       default: '19711231'
       values: ['19711231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache_out]
   title: Luftbilder swisstopo s/w (19711231)
-- dimensions: *id461
+- dimensions: *id337
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19711231_cache]
   title: Luftbilder swisstopo s/w (19711231, source)
-- dimensions: &id462
+- dimensions: &id338
     Time:
       default: '19701231'
       values: ['19701231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache_out]
   title: Luftbilder swisstopo s/w (19701231)
-- dimensions: *id462
+- dimensions: *id338
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19701231_cache]
   title: Luftbilder swisstopo s/w (19701231, source)
-- dimensions: &id463
+- dimensions: &id339
     Time:
       default: '19691231'
       values: ['19691231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache_out]
   title: Luftbilder swisstopo s/w (19691231)
-- dimensions: *id463
+- dimensions: *id339
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19691231_cache]
   title: Luftbilder swisstopo s/w (19691231, source)
-- dimensions: &id464
+- dimensions: &id340
     Time:
       default: '19681231'
       values: ['19681231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache_out]
   title: Luftbilder swisstopo s/w (19681231)
-- dimensions: *id464
+- dimensions: *id340
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19681231_cache]
   title: Luftbilder swisstopo s/w (19681231, source)
-- dimensions: &id465
+- dimensions: &id341
     Time:
       default: '19671231'
       values: ['19671231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache_out]
   title: Luftbilder swisstopo s/w (19671231)
-- dimensions: *id465
+- dimensions: *id341
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19671231_cache]
   title: Luftbilder swisstopo s/w (19671231, source)
-- dimensions: &id466
+- dimensions: &id342
     Time:
       default: '19661231'
       values: ['19661231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache_out]
   title: Luftbilder swisstopo s/w (19661231)
-- dimensions: *id466
+- dimensions: *id342
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19661231_cache]
   title: Luftbilder swisstopo s/w (19661231, source)
-- dimensions: &id467
+- dimensions: &id343
     Time:
       default: '19651231'
       values: ['19651231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache_out]
   title: Luftbilder swisstopo s/w (19651231)
-- dimensions: *id467
+- dimensions: *id343
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19651231_cache]
   title: Luftbilder swisstopo s/w (19651231, source)
-- dimensions: &id468
+- dimensions: &id344
     Time:
       default: '19641231'
       values: ['19641231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache_out]
   title: Luftbilder swisstopo s/w (19641231)
-- dimensions: *id468
+- dimensions: *id344
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19641231_cache]
   title: Luftbilder swisstopo s/w (19641231, source)
-- dimensions: &id469
+- dimensions: &id345
     Time:
       default: '19631231'
       values: ['19631231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache_out]
   title: Luftbilder swisstopo s/w (19631231)
-- dimensions: *id469
+- dimensions: *id345
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19631231_cache]
   title: Luftbilder swisstopo s/w (19631231, source)
-- dimensions: &id470
+- dimensions: &id346
     Time:
       default: '19621231'
       values: ['19621231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache_out]
   title: Luftbilder swisstopo s/w (19621231)
-- dimensions: *id470
+- dimensions: *id346
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19621231_cache]
   title: Luftbilder swisstopo s/w (19621231, source)
-- dimensions: &id471
+- dimensions: &id347
     Time:
       default: '19611231'
       values: ['19611231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache_out]
   title: Luftbilder swisstopo s/w (19611231)
-- dimensions: *id471
+- dimensions: *id347
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19611231_cache]
   title: Luftbilder swisstopo s/w (19611231, source)
-- dimensions: &id472
+- dimensions: &id348
     Time:
       default: '19601231'
       values: ['19601231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache_out]
   title: Luftbilder swisstopo s/w (19601231)
-- dimensions: *id472
+- dimensions: *id348
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19601231_cache]
   title: Luftbilder swisstopo s/w (19601231, source)
-- dimensions: &id473
+- dimensions: &id349
     Time:
       default: '19591231'
       values: ['19591231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache_out]
   title: Luftbilder swisstopo s/w (19591231)
-- dimensions: *id473
+- dimensions: *id349
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19591231_cache]
   title: Luftbilder swisstopo s/w (19591231, source)
-- dimensions: &id474
+- dimensions: &id350
     Time:
       default: '19581231'
       values: ['19581231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache_out]
   title: Luftbilder swisstopo s/w (19581231)
-- dimensions: *id474
+- dimensions: *id350
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19581231_cache]
   title: Luftbilder swisstopo s/w (19581231, source)
-- dimensions: &id475
+- dimensions: &id351
     Time:
       default: '19571231'
       values: ['19571231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache_out]
   title: Luftbilder swisstopo s/w (19571231)
-- dimensions: *id475
+- dimensions: *id351
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19571231_cache]
   title: Luftbilder swisstopo s/w (19571231, source)
-- dimensions: &id476
+- dimensions: &id352
     Time:
       default: '19561231'
       values: ['19561231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache_out]
   title: Luftbilder swisstopo s/w (19561231)
-- dimensions: *id476
+- dimensions: *id352
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19561231_cache]
   title: Luftbilder swisstopo s/w (19561231, source)
-- dimensions: &id477
+- dimensions: &id353
     Time:
       default: '19551231'
       values: ['19551231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache_out]
   title: Luftbilder swisstopo s/w (19551231)
-- dimensions: *id477
+- dimensions: *id353
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19551231_cache]
   title: Luftbilder swisstopo s/w (19551231, source)
-- dimensions: &id478
+- dimensions: &id354
     Time:
       default: '19541231'
       values: ['19541231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache_out]
   title: Luftbilder swisstopo s/w (19541231)
-- dimensions: *id478
+- dimensions: *id354
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19541231_cache]
   title: Luftbilder swisstopo s/w (19541231, source)
-- dimensions: &id479
+- dimensions: &id355
     Time:
       default: '19531231'
       values: ['19531231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache_out]
   title: Luftbilder swisstopo s/w (19531231)
-- dimensions: *id479
+- dimensions: *id355
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19531231_cache]
   title: Luftbilder swisstopo s/w (19531231, source)
-- dimensions: &id480
+- dimensions: &id356
     Time:
       default: '19521231'
       values: ['19521231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache_out]
   title: Luftbilder swisstopo s/w (19521231)
-- dimensions: *id480
+- dimensions: *id356
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19521231_cache]
   title: Luftbilder swisstopo s/w (19521231, source)
-- dimensions: &id481
+- dimensions: &id357
     Time:
       default: '19511231'
       values: ['19511231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache_out]
   title: Luftbilder swisstopo s/w (19511231)
-- dimensions: *id481
+- dimensions: *id357
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19511231_cache]
   title: Luftbilder swisstopo s/w (19511231, source)
-- dimensions: &id482
+- dimensions: &id358
     Time:
       default: '19501231'
       values: ['19501231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache_out]
   title: Luftbilder swisstopo s/w (19501231)
-- dimensions: *id482
+- dimensions: *id358
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19501231_cache]
   title: Luftbilder swisstopo s/w (19501231, source)
-- dimensions: &id483
+- dimensions: &id359
     Time:
       default: '19491231'
       values: ['19491231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache_out]
   title: Luftbilder swisstopo s/w (19491231)
-- dimensions: *id483
+- dimensions: *id359
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19491231_cache]
   title: Luftbilder swisstopo s/w (19491231, source)
-- dimensions: &id484
+- dimensions: &id360
     Time:
       default: '19481231'
       values: ['19481231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache_out]
   title: Luftbilder swisstopo s/w (19481231)
-- dimensions: *id484
+- dimensions: *id360
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19481231_cache]
   title: Luftbilder swisstopo s/w (19481231, source)
-- dimensions: &id485
+- dimensions: &id361
     Time:
       default: '19471231'
       values: ['19471231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache_out]
   title: Luftbilder swisstopo s/w (19471231)
-- dimensions: *id485
+- dimensions: *id361
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19471231_cache]
   title: Luftbilder swisstopo s/w (19471231, source)
-- dimensions: &id486
+- dimensions: &id362
     Time:
       default: '19461231'
       values: ['19461231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache_out]
   title: Luftbilder swisstopo s/w (19461231)
-- dimensions: *id486
+- dimensions: *id362
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19461231_cache]
   title: Luftbilder swisstopo s/w (19461231, source)
-- dimensions: &id487
+- dimensions: &id363
     Time:
       default: '19451231'
       values: ['19451231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache_out]
   title: Luftbilder swisstopo s/w (19451231)
-- dimensions: *id487
+- dimensions: *id363
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19451231_cache]
   title: Luftbilder swisstopo s/w (19451231, source)
-- dimensions: &id488
+- dimensions: &id364
     Time:
       default: '19441231'
       values: ['19441231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache_out]
   title: Luftbilder swisstopo s/w (19441231)
-- dimensions: *id488
+- dimensions: *id364
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19441231_cache]
   title: Luftbilder swisstopo s/w (19441231, source)
-- dimensions: &id489
+- dimensions: &id365
     Time:
       default: '19431231'
       values: ['19431231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache_out]
   title: Luftbilder swisstopo s/w (19431231)
-- dimensions: *id489
+- dimensions: *id365
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19431231_cache]
   title: Luftbilder swisstopo s/w (19431231, source)
-- dimensions: &id490
+- dimensions: &id366
     Time:
       default: '19421231'
       values: ['19421231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache_out]
   title: Luftbilder swisstopo s/w (19421231)
-- dimensions: *id490
+- dimensions: *id366
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19421231_cache]
   title: Luftbilder swisstopo s/w (19421231, source)
-- dimensions: &id491
+- dimensions: &id367
     Time:
       default: '19411231'
       values: ['19411231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache_out]
   title: Luftbilder swisstopo s/w (19411231)
-- dimensions: *id491
+- dimensions: *id367
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19411231_cache]
   title: Luftbilder swisstopo s/w (19411231, source)
-- dimensions: &id492
+- dimensions: &id368
     Time:
       default: '19401231'
       values: ['19401231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache_out]
   title: Luftbilder swisstopo s/w (19401231)
-- dimensions: *id492
+- dimensions: *id368
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19401231_cache]
   title: Luftbilder swisstopo s/w (19401231, source)
-- dimensions: &id493
+- dimensions: &id369
     Time:
       default: '19391231'
       values: ['19391231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache_out]
   title: Luftbilder swisstopo s/w (19391231)
-- dimensions: *id493
+- dimensions: *id369
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19391231_cache]
   title: Luftbilder swisstopo s/w (19391231, source)
-- dimensions: &id494
+- dimensions: &id370
     Time:
       default: '19381231'
       values: ['19381231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache_out]
   title: Luftbilder swisstopo s/w (19381231)
-- dimensions: *id494
+- dimensions: *id370
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19381231_cache]
   title: Luftbilder swisstopo s/w (19381231, source)
-- dimensions: &id495
+- dimensions: &id371
     Time:
       default: '19371231'
       values: ['19371231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache_out]
   title: Luftbilder swisstopo s/w (19371231)
-- dimensions: *id495
+- dimensions: *id371
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19371231_cache]
   title: Luftbilder swisstopo s/w (19371231, source)
-- dimensions: &id496
+- dimensions: &id372
     Time:
       default: '19361231'
       values: ['19361231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache_out]
   title: Luftbilder swisstopo s/w (19361231)
-- dimensions: *id496
+- dimensions: *id372
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19361231_cache]
   title: Luftbilder swisstopo s/w (19361231, source)
-- dimensions: &id497
+- dimensions: &id373
     Time:
       default: '19351231'
       values: ['19351231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache_out]
   title: Luftbilder swisstopo s/w (19351231)
-- dimensions: *id497
+- dimensions: *id373
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19351231_cache]
   title: Luftbilder swisstopo s/w (19351231, source)
-- dimensions: &id498
+- dimensions: &id374
     Time:
       default: '19341231'
       values: ['19341231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache_out]
   title: Luftbilder swisstopo s/w (19341231)
-- dimensions: *id498
+- dimensions: *id374
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19341231_cache]
   title: Luftbilder swisstopo s/w (19341231, source)
-- dimensions: &id499
+- dimensions: &id375
     Time:
       default: '19331231'
       values: ['19331231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache_out]
   title: Luftbilder swisstopo s/w (19331231)
-- dimensions: *id499
+- dimensions: *id375
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19331231_cache]
   title: Luftbilder swisstopo s/w (19331231, source)
-- dimensions: &id500
+- dimensions: &id376
     Time:
       default: '19321231'
       values: ['19321231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache_out]
   title: Luftbilder swisstopo s/w (19321231)
-- dimensions: *id500
+- dimensions: *id376
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19321231_cache]
   title: Luftbilder swisstopo s/w (19321231, source)
-- dimensions: &id501
+- dimensions: &id377
     Time:
       default: '19311231'
       values: ['19311231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache_out]
   title: Luftbilder swisstopo s/w (19311231)
-- dimensions: *id501
+- dimensions: *id377
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19311231_cache]
   title: Luftbilder swisstopo s/w (19311231, source)
-- dimensions: &id502
+- dimensions: &id378
     Time:
       default: '19301231'
       values: ['19301231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache_out]
   title: Luftbilder swisstopo s/w (19301231)
-- dimensions: *id502
+- dimensions: *id378
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19301231_cache]
   title: Luftbilder swisstopo s/w (19301231, source)
-- dimensions: &id503
+- dimensions: &id379
     Time:
       default: '19291231'
       values: ['19291231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache_out]
   title: Luftbilder swisstopo s/w (19291231)
-- dimensions: *id503
+- dimensions: *id379
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19291231_cache]
   title: Luftbilder swisstopo s/w (19291231, source)
-- dimensions: &id504
+- dimensions: &id380
     Time:
       default: '19281231'
       values: ['19281231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache_out]
   title: Luftbilder swisstopo s/w (19281231)
-- dimensions: *id504
+- dimensions: *id380
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19281231_cache]
   title: Luftbilder swisstopo s/w (19281231, source)
-- dimensions: &id505
+- dimensions: &id381
     Time:
       default: '19271231'
       values: ['19271231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache_out]
   title: Luftbilder swisstopo s/w (19271231)
-- dimensions: *id505
+- dimensions: *id381
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19271231_cache]
   title: Luftbilder swisstopo s/w (19271231, source)
-- dimensions: &id506
+- dimensions: &id382
     Time:
       default: '19261231'
       values: ['19261231']
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache_out]
   title: Luftbilder swisstopo s/w (19261231)
-- dimensions: *id506
+- dimensions: *id382
   name: ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_source
   sources: [ch.swisstopo.lubis-luftbilder_schwarzweiss_19261231_cache]
   title: Luftbilder swisstopo s/w (19261231, source)
-- dimensions: &id507
+- dimensions: &id383
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-farbe_20151231
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id507
+- dimensions: *id383
   name: ch.swisstopo.pixelkarte-farbe
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id507
+- dimensions: *id383
   name: ch.swisstopo.pixelkarte-farbe_20151231_source
   sources: [ch.swisstopo.pixelkarte-farbe_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id508
+- dimensions: &id384
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-farbe_20140520
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140520)
-- dimensions: *id508
+- dimensions: *id384
   name: ch.swisstopo.pixelkarte-farbe_20140520_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140520_cache]
   title: Landeskarte 1:25'000 | LK25 (20140520, source)
-- dimensions: &id509
+- dimensions: &id385
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe_20140106
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140106)
-- dimensions: *id509
+- dimensions: *id385
   name: ch.swisstopo.pixelkarte-farbe_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe_20140106_cache]
   title: Landeskarte 1:25'000 | LK25 (20140106, source)
-- dimensions: &id510
+- dimensions: &id386
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-farbe_20130903
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130903)
-- dimensions: *id510
+- dimensions: *id386
   name: ch.swisstopo.pixelkarte-farbe_20130903_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130903_cache]
   title: Landeskarte 1:25'000 | LK25 (20130903, source)
-- dimensions: &id511
+- dimensions: &id387
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-farbe_20130213
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130213)
-- dimensions: *id511
+- dimensions: *id387
   name: ch.swisstopo.pixelkarte-farbe_20130213_source
   sources: [ch.swisstopo.pixelkarte-farbe_20130213_cache]
   title: Landeskarte 1:25'000 | LK25 (20130213, source)
-- dimensions: &id512
+- dimensions: &id388
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-farbe_20120809
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20120809)
-- dimensions: *id512
+- dimensions: *id388
   name: ch.swisstopo.pixelkarte-farbe_20120809_source
   sources: [ch.swisstopo.pixelkarte-farbe_20120809_cache]
   title: Landeskarte 1:25'000 | LK25 (20120809, source)
-- dimensions: &id513
+- dimensions: &id389
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-farbe_20111206
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111206)
-- dimensions: *id513
+- dimensions: *id389
   name: ch.swisstopo.pixelkarte-farbe_20111206_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111206_cache]
   title: Landeskarte 1:25'000 | LK25 (20111206, source)
-- dimensions: &id514
+- dimensions: &id390
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-farbe_20111027
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111027)
-- dimensions: *id514
+- dimensions: *id390
   name: ch.swisstopo.pixelkarte-farbe_20111027_source
   sources: [ch.swisstopo.pixelkarte-farbe_20111027_cache]
   title: Landeskarte 1:25'000 | LK25 (20111027, source)
-- dimensions: &id515
+- dimensions: &id391
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-farbe_20110401
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20110401)
-- dimensions: *id515
+- dimensions: *id391
   name: ch.swisstopo.pixelkarte-farbe_20110401_source
   sources: [ch.swisstopo.pixelkarte-farbe_20110401_cache]
   title: Landeskarte 1:25'000 | LK25 (20110401, source)
-- dimensions: &id516
+- dimensions: &id392
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache_out]
   title: Landeskarte 1:1 Million | LK1000 (20140106)
-- dimensions: *id516
+- dimensions: *id392
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Million | LK1000 ('current')
-- dimensions: *id516
+- dimensions: *id392
   name: ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_source
   sources: [ch.swisstopo.pixelkarte-farbe-pk1000.noscale_20140106_cache]
   title: Landeskarte 1:1 Million | LK1000 (20140106, source)
-- dimensions: &id517
-    Time:
-      default: '20151231'
-      values: ['20151231']
-  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231
-  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache_out]
-  title: Landeskarte 1:100'000 | LK100 (20151231)
-- dimensions: *id517
-  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale
-  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
-  title: Landeskarte 1:100'000 | LK100 ('current')
-- dimensions: *id517
-  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_source
-  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
-  title: Landeskarte 1:100'000 | LK100 (20151231, source)
-- dimensions: &id518
-    Time:
-      default: '20151231'
-      values: ['20151231']
-  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231
-  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache_out]
-  title: Landeskarte 1:200'000 | LK200 (20151231)
-- dimensions: *id518
-  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale
-  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
-  title: Landeskarte 1:200'000 | LK200 ('current')
-- dimensions: *id518
-  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_source
-  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
-  title: Landeskarte 1:200'000 | LK200 (20151231, source)
-- dimensions: &id519
-    Time:
-      default: '20151231'
-      values: ['20151231']
-  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231
-  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache_out]
-  title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id519
-  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale
-  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
-  title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id519
-  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_source
-  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
-  title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id520
-    Time:
-      default: '20151231'
-      values: ['20151231']
-  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231
-  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache_out]
-  title: Landeskarte 1:500'000 | LK500 (20151231)
-- dimensions: *id520
-  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale
-  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
-  title: Landeskarte 1:500'000 | LK500 ('current')
-- dimensions: *id520
-  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_source
-  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
-  title: Landeskarte 1:500'000 | LK500 (20151231, source)
-- dimensions: &id521
-    Time:
-      default: '20151231'
-      values: ['20151231']
-  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231
-  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache_out]
-  title: Landeskarte 1:50'000 | LK50 (20151231)
-- dimensions: *id521
-  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale
-  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
-  title: Landeskarte 1:50'000 | LK50 ('current')
-- dimensions: *id521
-  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_source
-  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
-  title: Landeskarte 1:50'000 | LK50 (20151231, source)
-- dimensions: &id522
+- dimensions: &id393
     Time:
       default: '20151231'
       values: ['20151231']
   name: ch.swisstopo.pixelkarte-grau_20151231
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20151231)
-- dimensions: *id522
+- dimensions: *id393
   name: ch.swisstopo.pixelkarte-grau
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 ('current')
-- dimensions: *id522
+- dimensions: *id393
   name: ch.swisstopo.pixelkarte-grau_20151231_source
   sources: [ch.swisstopo.pixelkarte-grau_20151231_cache]
   title: Landeskarte 1:25'000 | LK25 (20151231, source)
-- dimensions: &id523
+- dimensions: &id394
     Time:
       default: '20140520'
       values: ['20140520']
   name: ch.swisstopo.pixelkarte-grau_20140520
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140520)
-- dimensions: *id523
+- dimensions: *id394
   name: ch.swisstopo.pixelkarte-grau_20140520_source
   sources: [ch.swisstopo.pixelkarte-grau_20140520_cache]
   title: Landeskarte 1:25'000 | LK25 (20140520, source)
-- dimensions: &id524
+- dimensions: &id395
     Time:
       default: '20140106'
       values: ['20140106']
   name: ch.swisstopo.pixelkarte-grau_20140106
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20140106)
-- dimensions: *id524
+- dimensions: *id395
   name: ch.swisstopo.pixelkarte-grau_20140106_source
   sources: [ch.swisstopo.pixelkarte-grau_20140106_cache]
   title: Landeskarte 1:25'000 | LK25 (20140106, source)
-- dimensions: &id525
+- dimensions: &id396
     Time:
       default: '20130903'
       values: ['20130903']
   name: ch.swisstopo.pixelkarte-grau_20130903
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130903)
-- dimensions: *id525
+- dimensions: *id396
   name: ch.swisstopo.pixelkarte-grau_20130903_source
   sources: [ch.swisstopo.pixelkarte-grau_20130903_cache]
   title: Landeskarte 1:25'000 | LK25 (20130903, source)
-- dimensions: &id526
+- dimensions: &id397
     Time:
       default: '20130213'
       values: ['20130213']
   name: ch.swisstopo.pixelkarte-grau_20130213
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20130213)
-- dimensions: *id526
+- dimensions: *id397
   name: ch.swisstopo.pixelkarte-grau_20130213_source
   sources: [ch.swisstopo.pixelkarte-grau_20130213_cache]
   title: Landeskarte 1:25'000 | LK25 (20130213, source)
-- dimensions: &id527
+- dimensions: &id398
     Time:
       default: '20120809'
       values: ['20120809']
   name: ch.swisstopo.pixelkarte-grau_20120809
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20120809)
-- dimensions: *id527
+- dimensions: *id398
   name: ch.swisstopo.pixelkarte-grau_20120809_source
   sources: [ch.swisstopo.pixelkarte-grau_20120809_cache]
   title: Landeskarte 1:25'000 | LK25 (20120809, source)
-- dimensions: &id528
+- dimensions: &id399
     Time:
       default: '20111206'
       values: ['20111206']
   name: ch.swisstopo.pixelkarte-grau_20111206
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111206)
-- dimensions: *id528
+- dimensions: *id399
   name: ch.swisstopo.pixelkarte-grau_20111206_source
   sources: [ch.swisstopo.pixelkarte-grau_20111206_cache]
   title: Landeskarte 1:25'000 | LK25 (20111206, source)
-- dimensions: &id529
+- dimensions: &id400
     Time:
       default: '20111027'
       values: ['20111027']
   name: ch.swisstopo.pixelkarte-grau_20111027
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20111027)
-- dimensions: *id529
+- dimensions: *id400
   name: ch.swisstopo.pixelkarte-grau_20111027_source
   sources: [ch.swisstopo.pixelkarte-grau_20111027_cache]
   title: Landeskarte 1:25'000 | LK25 (20111027, source)
-- dimensions: &id530
+- dimensions: &id401
     Time:
       default: '20110401'
       values: ['20110401']
   name: ch.swisstopo.pixelkarte-grau_20110401
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache_out]
   title: Landeskarte 1:25'000 | LK25 (20110401)
-- dimensions: *id530
+- dimensions: *id401
   name: ch.swisstopo.pixelkarte-grau_20110401_source
   sources: [ch.swisstopo.pixelkarte-grau_20110401_cache]
   title: Landeskarte 1:25'000 | LK25 (20110401, source)
-- dimensions: &id531
+- dimensions: &id402
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache_out]
   title: swissALTI3D Reliefschattierung (20150101)
-- dimensions: *id531
+- dimensions: *id402
   name: ch.swisstopo.swissalti3d-reliefschattierung
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung ('current')
-- dimensions: *id531
+- dimensions: *id402
   name: ch.swisstopo.swissalti3d-reliefschattierung_20150101_source
   sources: [ch.swisstopo.swissalti3d-reliefschattierung_20150101_cache]
   title: swissALTI3D Reliefschattierung (20150101, source)
-- dimensions: &id532
+- dimensions: &id403
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache_out]
   title: Bezirksgrenzen (20150101)
-- dimensions: *id532
+- dimensions: *id403
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen ('current')
-- dimensions: *id532
+- dimensions: *id403
   name: ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill_20150101_cache]
   title: Bezirksgrenzen (20150101, source)
-- dimensions: &id533
+- dimensions: &id404
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache_out]
   title: Gemeindegrenzen (20150101)
-- dimensions: *id533
+- dimensions: *id404
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen ('current')
-- dimensions: *id533
+- dimensions: *id404
   name: ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill_20150101_cache]
   title: Gemeindegrenzen (20150101, source)
-- dimensions: &id534
+- dimensions: &id405
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache_out]
   title: Kantonsgrenzen (20150101)
-- dimensions: *id534
+- dimensions: *id405
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen ('current')
-- dimensions: *id534
+- dimensions: *id405
   name: ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-kanton-flaeche.fill_20150101_cache]
   title: Kantonsgrenzen (20150101, source)
-- dimensions: &id535
+- dimensions: &id406
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache_out]
   title: Landesgrenzen (20150101)
-- dimensions: *id535
+- dimensions: *id406
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen ('current')
-- dimensions: *id535
+- dimensions: *id406
   name: ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_source
   sources: [ch.swisstopo.swissboundaries3d-land-flaeche.fill_20150101_cache]
   title: Landesgrenzen (20150101, source)
-- dimensions: &id536
-    Time:
-      default: '19980101'
-      values: ['19980101']
-  name: ch.swisstopo.swissbuildings3d_19980101
-  sources: [ch.swisstopo.swissbuildings3d_19980101_cache_out]
-  title: "Vereinfachte 3D-Geb\xE4ude (19980101)"
-- dimensions: *id536
-  name: ch.swisstopo.swissbuildings3d
-  sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
-  title: "Vereinfachte 3D-Geb\xE4ude ('current')"
-- dimensions: *id536
-  name: ch.swisstopo.swissbuildings3d_19980101_source
-  sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
-  title: "Vereinfachte 3D-Geb\xE4ude (19980101, source)"
-- dimensions: &id537
-    Time:
-      default: '20151231'
-      values: ['20151231']
-  name: ch.swisstopo.swissimage_20151231
-  sources: [ch.swisstopo.swissimage_20151231_cache_out]
-  title: SWISSIMAGE (20151231)
-- dimensions: *id537
-  name: ch.swisstopo.swissimage
-  sources: [ch.swisstopo.swissimage_20151231_cache]
-  title: SWISSIMAGE ('current')
-- dimensions: *id537
-  name: ch.swisstopo.swissimage_20151231_source
-  sources: [ch.swisstopo.swissimage_20151231_cache]
-  title: SWISSIMAGE (20151231, source)
-- dimensions: &id538
-    Time:
-      default: '20140620'
-      values: ['20140620']
-  name: ch.swisstopo.swissimage_20140620
-  sources: [ch.swisstopo.swissimage_20140620_cache_out]
-  title: SWISSIMAGE (20140620)
-- dimensions: *id538
-  name: ch.swisstopo.swissimage_20140620_source
-  sources: [ch.swisstopo.swissimage_20140620_cache]
-  title: SWISSIMAGE (20140620, source)
-- dimensions: &id539
-    Time:
-      default: '20131107'
-      values: ['20131107']
-  name: ch.swisstopo.swissimage_20131107
-  sources: [ch.swisstopo.swissimage_20131107_cache_out]
-  title: SWISSIMAGE (20131107)
-- dimensions: *id539
-  name: ch.swisstopo.swissimage_20131107_source
-  sources: [ch.swisstopo.swissimage_20131107_cache]
-  title: SWISSIMAGE (20131107, source)
-- dimensions: &id540
-    Time:
-      default: '20130916'
-      values: ['20130916']
-  name: ch.swisstopo.swissimage_20130916
-  sources: [ch.swisstopo.swissimage_20130916_cache_out]
-  title: SWISSIMAGE (20130916)
-- dimensions: *id540
-  name: ch.swisstopo.swissimage_20130916_source
-  sources: [ch.swisstopo.swissimage_20130916_cache]
-  title: SWISSIMAGE (20130916, source)
-- dimensions: &id541
-    Time:
-      default: '20130422'
-      values: ['20130422']
-  name: ch.swisstopo.swissimage_20130422
-  sources: [ch.swisstopo.swissimage_20130422_cache_out]
-  title: SWISSIMAGE (20130422)
-- dimensions: *id541
-  name: ch.swisstopo.swissimage_20130422_source
-  sources: [ch.swisstopo.swissimage_20130422_cache]
-  title: SWISSIMAGE (20130422, source)
-- dimensions: &id542
-    Time:
-      default: '20120809'
-      values: ['20120809']
-  name: ch.swisstopo.swissimage_20120809
-  sources: [ch.swisstopo.swissimage_20120809_cache_out]
-  title: SWISSIMAGE (20120809)
-- dimensions: *id542
-  name: ch.swisstopo.swissimage_20120809_source
-  sources: [ch.swisstopo.swissimage_20120809_cache]
-  title: SWISSIMAGE (20120809, source)
-- dimensions: &id543
-    Time:
-      default: '20120225'
-      values: ['20120225']
-  name: ch.swisstopo.swissimage_20120225
-  sources: [ch.swisstopo.swissimage_20120225_cache_out]
-  title: SWISSIMAGE (20120225)
-- dimensions: *id543
-  name: ch.swisstopo.swissimage_20120225_source
-  sources: [ch.swisstopo.swissimage_20120225_cache]
-  title: SWISSIMAGE (20120225, source)
-- dimensions: &id544
-    Time:
-      default: '20110914'
-      values: ['20110914']
-  name: ch.swisstopo.swissimage_20110914
-  sources: [ch.swisstopo.swissimage_20110914_cache_out]
-  title: SWISSIMAGE (20110914)
-- dimensions: *id544
-  name: ch.swisstopo.swissimage_20110914_source
-  sources: [ch.swisstopo.swissimage_20110914_cache]
-  title: SWISSIMAGE (20110914, source)
-- dimensions: &id545
-    Time:
-      default: '20110228'
-      values: ['20110228']
-  name: ch.swisstopo.swissimage_20110228
-  sources: [ch.swisstopo.swissimage_20110228_cache_out]
-  title: SWISSIMAGE (20110228)
-- dimensions: *id545
-  name: ch.swisstopo.swissimage_20110228_source
-  sources: [ch.swisstopo.swissimage_20110228_cache]
-  title: SWISSIMAGE (20110228, source)
-- dimensions: &id546
-    Time:
-      default: '20151231'
-      values: ['20151231']
-  name: ch.swisstopo.swissimage-product_20151231
-  sources: [ch.swisstopo.swissimage-product_20151231_cache_out]
-  title: SWISSIMAGE (20151231)
-- dimensions: *id546
-  name: ch.swisstopo.swissimage-product
-  sources: [ch.swisstopo.swissimage-product_20151231_cache]
-  title: SWISSIMAGE ('current')
-- dimensions: *id546
-  name: ch.swisstopo.swissimage-product_20151231_source
-  sources: [ch.swisstopo.swissimage-product_20151231_cache]
-  title: SWISSIMAGE (20151231, source)
-- dimensions: &id547
+- dimensions: &id407
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swissnames3d_20150101
   sources: [ch.swisstopo.swissnames3d_20150101_cache_out]
   title: Geografische Namen swissNAMES3D (20150101)
-- dimensions: *id547
+- dimensions: *id407
   name: ch.swisstopo.swissnames3d
   sources: [ch.swisstopo.swissnames3d_20150101_cache]
   title: Geografische Namen swissNAMES3D ('current')
-- dimensions: *id547
+- dimensions: *id407
   name: ch.swisstopo.swissnames3d_20150101_source
   sources: [ch.swisstopo.swissnames3d_20150101_cache]
   title: Geografische Namen swissNAMES3D (20150101, source)
-- dimensions: &id548
+- dimensions: &id408
     Time:
       default: '20150401'
       values: ['20150401']
   name: ch.swisstopo.swisstlm3d-karte-farbe_20150401
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache_out]
   title: Karte swissTLM (farbig) (20150401)
-- dimensions: *id548
+- dimensions: *id408
   name: ch.swisstopo.swisstlm3d-karte-farbe
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache]
   title: Karte swissTLM (farbig) ('current')
-- dimensions: *id548
+- dimensions: *id408
   name: ch.swisstopo.swisstlm3d-karte-farbe_20150401_source
   sources: [ch.swisstopo.swisstlm3d-karte-farbe_20150401_cache]
   title: Karte swissTLM (farbig) (20150401, source)
-- dimensions: &id549
+- dimensions: &id409
     Time:
       default: '20150401'
       values: ['20150401']
   name: ch.swisstopo.swisstlm3d-karte-grau_20150401
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache_out]
   title: Karte swissTLM (grau) (20150401)
-- dimensions: *id549
+- dimensions: *id409
   name: ch.swisstopo.swisstlm3d-karte-grau
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache]
   title: Karte swissTLM (grau) ('current')
-- dimensions: *id549
+- dimensions: *id409
   name: ch.swisstopo.swisstlm3d-karte-grau_20150401_source
   sources: [ch.swisstopo.swisstlm3d-karte-grau_20150401_cache]
   title: Karte swissTLM (grau) (20150401, source)
-- dimensions: &id550
+- dimensions: &id410
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.swisstlm3d-wanderwege_20150101
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache_out]
   title: Wanderwege (20150101)
-- dimensions: *id550
+- dimensions: *id410
   name: ch.swisstopo.swisstlm3d-wanderwege
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
   title: Wanderwege ('current')
-- dimensions: *id550
+- dimensions: *id410
   name: ch.swisstopo.swisstlm3d-wanderwege_20150101_source
   sources: [ch.swisstopo.swisstlm3d-wanderwege_20150101_cache]
   title: Wanderwege (20150101, source)
-- dimensions: &id551
+- dimensions: &id411
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo.transformationsgenauigkeit_20141101
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache_out]
   title: LV95 Transformationsgenauigkeit (20141101)
-- dimensions: *id551
+- dimensions: *id411
   name: ch.swisstopo.transformationsgenauigkeit
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit ('current')
-- dimensions: *id551
+- dimensions: *id411
   name: ch.swisstopo.transformationsgenauigkeit_20141101_source
   sources: [ch.swisstopo.transformationsgenauigkeit_20141101_cache]
   title: LV95 Transformationsgenauigkeit (20141101, source)
-- dimensions: &id552
-    Time:
-      default: '20140703'
-      values: ['20140703']
-  name: ch.swisstopo.treasurehunt_20140703
-  sources: [ch.swisstopo.treasurehunt_20140703_cache_out]
-  title: Schatzkarte (20140703)
-- dimensions: *id552
-  name: ch.swisstopo.treasurehunt
-  sources: [ch.swisstopo.treasurehunt_20140703_cache]
-  title: Schatzkarte ('current')
-- dimensions: *id552
-  name: ch.swisstopo.treasurehunt_20140703_source
-  sources: [ch.swisstopo.treasurehunt_20140703_cache]
-  title: Schatzkarte (20140703, source)
-- dimensions: &id553
+- dimensions: &id412
     Time:
       default: '20131101'
       values: ['20131101']
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache_out]
   title: PLZ und Ortschaften (20131101)
-- dimensions: *id553
+- dimensions: *id412
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften ('current')
-- dimensions: *id553
+- dimensions: *id412
   name: ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_source
   sources: [ch.swisstopo-vd.ortschaftenverzeichnis_plz_20131101_cache]
   title: PLZ und Ortschaften (20131101, source)
-- dimensions: &id554
+- dimensions: &id413
     Time:
       default: '20141101'
       values: ['20141101']
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache_out]
   title: Spannungsarme Gebiete (20141101)
-- dimensions: *id554
+- dimensions: *id413
   name: ch.swisstopo-vd.spannungsarme-gebiete
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete ('current')
-- dimensions: *id554
+- dimensions: *id413
   name: ch.swisstopo-vd.spannungsarme-gebiete_20141101_source
   sources: [ch.swisstopo-vd.spannungsarme-gebiete_20141101_cache]
   title: Spannungsarme Gebiete (20141101, source)
-- dimensions: &id555
+- dimensions: &id414
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20150101
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache_out]
   title: Schutzgebiete VECTOR200 (20150101)
-- dimensions: *id555
+- dimensions: *id414
   name: ch.swisstopo.vec200-adminboundaries-protectedarea
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache]
   title: Schutzgebiete VECTOR200 ('current')
-- dimensions: *id555
+- dimensions: *id414
   name: ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_source
   sources: [ch.swisstopo.vec200-adminboundaries-protectedarea_20150101_cache]
   title: Schutzgebiete VECTOR200 (20150101, source)
-- dimensions: &id556
+- dimensions: &id415
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-building_20150101
   sources: [ch.swisstopo.vec200-building_20150101_cache_out]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20150101)"
-- dimensions: *id556
+- dimensions: *id415
   name: ch.swisstopo.vec200-building
   sources: [ch.swisstopo.vec200-building_20150101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 ('current')"
-- dimensions: *id556
+- dimensions: *id415
   name: ch.swisstopo.vec200-building_20150101_source
   sources: [ch.swisstopo.vec200-building_20150101_cache]
   title: "Einzelgeb\xE4ude gen. VECTOR200 (20150101, source)"
-- dimensions: &id557
-    Time:
-      default: '20150101'
-      values: ['20150101']
-  name: ch.swisstopo.vec200-hydrography_20150101
-  sources: [ch.swisstopo.vec200-hydrography_20150101_cache_out]
-  title: "Gew\xE4ssernetz VECTOR200 (20150101)"
-- dimensions: *id557
-  name: ch.swisstopo.vec200-hydrography
-  sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
-  title: "Gew\xE4ssernetz VECTOR200 ('current')"
-- dimensions: *id557
-  name: ch.swisstopo.vec200-hydrography_20150101_source
-  sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
-  title: "Gew\xE4ssernetz VECTOR200 (20150101, source)"
-- dimensions: &id558
+- dimensions: &id416
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-landcover_20150101
   sources: [ch.swisstopo.vec200-landcover_20150101_cache_out]
   title: Prim. Bodenbedeckung VECTOR200 (20150101)
-- dimensions: *id558
+- dimensions: *id416
   name: ch.swisstopo.vec200-landcover
   sources: [ch.swisstopo.vec200-landcover_20150101_cache]
   title: Prim. Bodenbedeckung VECTOR200 ('current')
-- dimensions: *id558
+- dimensions: *id416
   name: ch.swisstopo.vec200-landcover_20150101_source
   sources: [ch.swisstopo.vec200-landcover_20150101_cache]
   title: Prim. Bodenbedeckung VECTOR200 (20150101, source)
-- dimensions: &id559
-    Time:
-      default: '20150101'
-      values: ['20150101']
-  name: ch.swisstopo.vec200-landcover-wald_20150101
-  sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache_out]
-  title: "Waldfl\xE4chen (20150101)"
-- dimensions: *id559
-  name: ch.swisstopo.vec200-landcover-wald
-  sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
-  title: "Waldfl\xE4chen ('current')"
-- dimensions: *id559
-  name: ch.swisstopo.vec200-landcover-wald_20150101_source
-  sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
-  title: "Waldfl\xE4chen (20150101, source)"
-- dimensions: &id560
-    Time:
-      default: '20150101'
-      values: ['20150101']
-  name: ch.swisstopo.vec200-miscellaneous_20150101
-  sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache_out]
-  title: Einzelobjekte VECTOR200 (20150101)
-- dimensions: *id560
-  name: ch.swisstopo.vec200-miscellaneous
-  sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
-  title: Einzelobjekte VECTOR200 ('current')
-- dimensions: *id560
-  name: ch.swisstopo.vec200-miscellaneous_20150101_source
-  sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
-  title: Einzelobjekte VECTOR200 (20150101, source)
-- dimensions: &id561
+- dimensions: &id417
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20150101
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache_out]
   title: "H\xF6henkoten VECTOR200 (20150101)"
-- dimensions: *id561
+- dimensions: *id417
   name: ch.swisstopo.vec200-miscellaneous-geodpoint
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache]
   title: "H\xF6henkoten VECTOR200 ('current')"
-- dimensions: *id561
+- dimensions: *id417
   name: ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_source
   sources: [ch.swisstopo.vec200-miscellaneous-geodpoint_20150101_cache]
   title: "H\xF6henkoten VECTOR200 (20150101, source)"
-- dimensions: &id562
+- dimensions: &id418
     Time:
       default: '20150101'
       values: ['20150101']
   name: ch.swisstopo.vec200-names-namedlocation_20150101
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache_out]
   title: Namen VECTOR200 (20150101)
-- dimensions: *id562
+- dimensions: *id418
   name: ch.swisstopo.vec200-names-namedlocation
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache]
   title: Namen VECTOR200 ('current')
-- dimensions: *id562
+- dimensions: *id418
   name: ch.swisstopo.vec200-names-namedlocation_20150101_source
   sources: [ch.swisstopo.vec200-names-namedlocation_20150101_cache]
   title: Namen VECTOR200 (20150101, source)
-- dimensions: &id563
-    Time:
-      default: '20150101'
-      values: ['20150101']
-  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101
-  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache_out]
-  title: "\xD6ffentlicher Verkehr VECTOR200 (20150101)"
-- dimensions: *id563
-  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr
-  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
-  title: "\xD6ffentlicher Verkehr VECTOR200 ('current')"
-- dimensions: *id563
-  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_source
-  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
-  title: "\xD6ffentlicher Verkehr VECTOR200 (20150101, source)"
-- dimensions: &id564
-    Time:
-      default: '20150101'
-      values: ['20150101']
-  name: ch.swisstopo.vec200-transportation-strassennetz_20150101
-  sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache_out]
-  title: Strassennetz VECTOR200 (20150101)
-- dimensions: *id564
-  name: ch.swisstopo.vec200-transportation-strassennetz
-  sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
-  title: Strassennetz VECTOR200 ('current')
-- dimensions: *id564
-  name: ch.swisstopo.vec200-transportation-strassennetz_20150101_source
-  sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
-  title: Strassennetz VECTOR200 (20150101, source)
-- dimensions: &id565
-    Time:
-      default: '20090401'
-      values: ['20090401']
-  name: ch.swisstopo.vec25-anlagen_20090401
-  sources: [ch.swisstopo.vec25-anlagen_20090401_cache_out]
-  title: Anlagen VECTOR25 (20090401)
-- dimensions: *id565
-  name: ch.swisstopo.vec25-anlagen
-  sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
-  title: Anlagen VECTOR25 ('current')
-- dimensions: *id565
-  name: ch.swisstopo.vec25-anlagen_20090401_source
-  sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
-  title: Anlagen VECTOR25 (20090401, source)
-- dimensions: &id566
-    Time:
-      default: '19980101'
-      values: ['19980101']
-  name: ch.swisstopo.vec25-einzelobjekte_19980101
-  sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache_out]
-  title: Einzelobjekte VECTOR25 (19980101)
-- dimensions: *id566
-  name: ch.swisstopo.vec25-einzelobjekte
-  sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
-  title: Einzelobjekte VECTOR25 ('current')
-- dimensions: *id566
-  name: ch.swisstopo.vec25-einzelobjekte_19980101_source
-  sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
-  title: Einzelobjekte VECTOR25 (19980101, source)
-- dimensions: &id567
-    Time:
-      default: '20090401'
-      values: ['20090401']
-  name: ch.swisstopo.vec25-eisenbahnnetz_20090401
-  sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache_out]
-  title: Eisenbahnnetz VECTOR25 (20090401)
-- dimensions: *id567
-  name: ch.swisstopo.vec25-eisenbahnnetz
-  sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
-  title: Eisenbahnnetz VECTOR25 ('current')
-- dimensions: *id567
-  name: ch.swisstopo.vec25-eisenbahnnetz_20090401_source
-  sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
-  title: Eisenbahnnetz VECTOR25 (20090401, source)
-- dimensions: &id568
-    Time:
-      default: '20090401'
-      values: ['20090401']
-  name: ch.swisstopo.vec25-gebaeude_20090401
-  sources: [ch.swisstopo.vec25-gebaeude_20090401_cache_out]
-  title: "Geb\xE4ude VECTOR25 (20090401)"
-- dimensions: *id568
-  name: ch.swisstopo.vec25-gebaeude
-  sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
-  title: "Geb\xE4ude VECTOR25 ('current')"
-- dimensions: *id568
-  name: ch.swisstopo.vec25-gebaeude_20090401_source
-  sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
-  title: "Geb\xE4ude VECTOR25 (20090401, source)"
-- dimensions: &id569
-    Time:
-      default: '20090401'
-      values: ['20090401']
-  name: ch.swisstopo.vec25-gewaessernetz_20090401
-  sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache_out]
-  title: "Gew\xE4ssernetz VECTOR25 (20090401)"
-- dimensions: *id569
-  name: ch.swisstopo.vec25-gewaessernetz
-  sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
-  title: "Gew\xE4ssernetz VECTOR25 ('current')"
-- dimensions: *id569
-  name: ch.swisstopo.vec25-gewaessernetz_20090401_source
-  sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
-  title: "Gew\xE4ssernetz VECTOR25 (20090401, source)"
-- dimensions: &id570
-    Time:
-      default: '19980101'
-      values: ['19980101']
-  name: ch.swisstopo.vec25-heckenbaeume_19980101
-  sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache_out]
-  title: "Hecken und B\xE4ume VECTOR25 (19980101)"
-- dimensions: *id570
-  name: ch.swisstopo.vec25-heckenbaeume
-  sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
-  title: "Hecken und B\xE4ume VECTOR25 ('current')"
-- dimensions: *id570
-  name: ch.swisstopo.vec25-heckenbaeume_19980101_source
-  sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
-  title: "Hecken und B\xE4ume VECTOR25 (19980101, source)"
-- dimensions: &id571
-    Time:
-      default: '20090401'
-      values: ['20090401']
-  name: ch.swisstopo.vec25-primaerflaechen_20090401
-  sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache_out]
-  title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401)"
-- dimensions: *id571
-  name: ch.swisstopo.vec25-primaerflaechen
-  sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
-  title: "Prim\xE4rfl\xE4chen VECTOR25 ('current')"
-- dimensions: *id571
-  name: ch.swisstopo.vec25-primaerflaechen_20090401_source
-  sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
-  title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401, source)"
-- dimensions: &id572
-    Time:
-      default: '20090401'
-      values: ['20090401']
-  name: ch.swisstopo.vec25-strassennetz_20090401
-  sources: [ch.swisstopo.vec25-strassennetz_20090401_cache_out]
-  title: Strassennetz VECTOR25 (20090401)
-- dimensions: *id572
-  name: ch.swisstopo.vec25-strassennetz
-  sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
-  title: Strassennetz VECTOR25 ('current')
-- dimensions: *id572
-  name: ch.swisstopo.vec25-strassennetz_20090401_source
-  sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
-  title: Strassennetz VECTOR25 (20090401, source)
-- dimensions: &id573
-    Time:
-      default: '20090401'
-      values: ['20090401']
-  name: ch.swisstopo.vec25-uebrigerverkehr_20090401
-  sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache_out]
-  title: "\xDCbriger Verkehr VECTOR25 (20090401)"
-- dimensions: *id573
-  name: ch.swisstopo.vec25-uebrigerverkehr
-  sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
-  title: "\xDCbriger Verkehr VECTOR25 ('current')"
-- dimensions: *id573
-  name: ch.swisstopo.vec25-uebrigerverkehr_20090401_source
-  sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
-  title: "\xDCbriger Verkehr VECTOR25 (20090401, source)"
-- dimensions: &id574
+- dimensions: &id419
     Time:
       default: '20061231'
       values: ['20061231']
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache_out]
   title: LV95 Verschiebungsvektoren TSP1 (20061231)
-- dimensions: *id574
+- dimensions: *id419
   name: ch.swisstopo.verschiebungsvektoren-tsp1
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 ('current')
-- dimensions: *id574
+- dimensions: *id419
   name: ch.swisstopo.verschiebungsvektoren-tsp1_20061231_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp1_20061231_cache]
   title: LV95 Verschiebungsvektoren TSP1 (20061231, source)
-- dimensions: &id575
+- dimensions: &id420
     Time:
       default: '20070101'
       values: ['20070101']
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache_out]
   title: LV95 Verschiebungsvektoren TSP2 (20070101)
-- dimensions: *id575
+- dimensions: *id420
   name: ch.swisstopo.verschiebungsvektoren-tsp2
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 ('current')
-- dimensions: *id575
+- dimensions: *id420
   name: ch.swisstopo.verschiebungsvektoren-tsp2_20070101_source
   sources: [ch.swisstopo.verschiebungsvektoren-tsp2_20070101_cache]
   title: LV95 Verschiebungsvektoren TSP2 (20070101, source)
-- dimensions: &id576
-    Time:
-      default: '20131231'
-      values: ['20131231']
-  name: ch.swisstopo.zeitreihen_20131231
-  sources: [ch.swisstopo.zeitreihen_20131231_cache_out]
-  title: Zeitreise - Kartenwerke (20131231)
-- dimensions: *id576
-  name: ch.swisstopo.zeitreihen
-  sources: [ch.swisstopo.zeitreihen_20131231_cache]
-  title: Zeitreise - Kartenwerke ('current')
-- dimensions: *id576
-  name: ch.swisstopo.zeitreihen_20131231_source
-  sources: [ch.swisstopo.zeitreihen_20131231_cache]
-  title: Zeitreise - Kartenwerke (20131231, source)
-- dimensions: &id577
-    Time:
-      default: '20121231'
-      values: ['20121231']
-  name: ch.swisstopo.zeitreihen_20121231
-  sources: [ch.swisstopo.zeitreihen_20121231_cache_out]
-  title: Zeitreise - Kartenwerke (20121231)
-- dimensions: *id577
-  name: ch.swisstopo.zeitreihen_20121231_source
-  sources: [ch.swisstopo.zeitreihen_20121231_cache]
-  title: Zeitreise - Kartenwerke (20121231, source)
-- dimensions: &id578
-    Time:
-      default: '20111231'
-      values: ['20111231']
-  name: ch.swisstopo.zeitreihen_20111231
-  sources: [ch.swisstopo.zeitreihen_20111231_cache_out]
-  title: Zeitreise - Kartenwerke (20111231)
-- dimensions: *id578
-  name: ch.swisstopo.zeitreihen_20111231_source
-  sources: [ch.swisstopo.zeitreihen_20111231_cache]
-  title: Zeitreise - Kartenwerke (20111231, source)
-- dimensions: &id579
-    Time:
-      default: '20101231'
-      values: ['20101231']
-  name: ch.swisstopo.zeitreihen_20101231
-  sources: [ch.swisstopo.zeitreihen_20101231_cache_out]
-  title: Zeitreise - Kartenwerke (20101231)
-- dimensions: *id579
-  name: ch.swisstopo.zeitreihen_20101231_source
-  sources: [ch.swisstopo.zeitreihen_20101231_cache]
-  title: Zeitreise - Kartenwerke (20101231, source)
-- dimensions: &id580
-    Time:
-      default: '20091231'
-      values: ['20091231']
-  name: ch.swisstopo.zeitreihen_20091231
-  sources: [ch.swisstopo.zeitreihen_20091231_cache_out]
-  title: Zeitreise - Kartenwerke (20091231)
-- dimensions: *id580
-  name: ch.swisstopo.zeitreihen_20091231_source
-  sources: [ch.swisstopo.zeitreihen_20091231_cache]
-  title: Zeitreise - Kartenwerke (20091231, source)
-- dimensions: &id581
-    Time:
-      default: '20081231'
-      values: ['20081231']
-  name: ch.swisstopo.zeitreihen_20081231
-  sources: [ch.swisstopo.zeitreihen_20081231_cache_out]
-  title: Zeitreise - Kartenwerke (20081231)
-- dimensions: *id581
-  name: ch.swisstopo.zeitreihen_20081231_source
-  sources: [ch.swisstopo.zeitreihen_20081231_cache]
-  title: Zeitreise - Kartenwerke (20081231, source)
-- dimensions: &id582
-    Time:
-      default: '20071231'
-      values: ['20071231']
-  name: ch.swisstopo.zeitreihen_20071231
-  sources: [ch.swisstopo.zeitreihen_20071231_cache_out]
-  title: Zeitreise - Kartenwerke (20071231)
-- dimensions: *id582
-  name: ch.swisstopo.zeitreihen_20071231_source
-  sources: [ch.swisstopo.zeitreihen_20071231_cache]
-  title: Zeitreise - Kartenwerke (20071231, source)
-- dimensions: &id583
-    Time:
-      default: '20061231'
-      values: ['20061231']
-  name: ch.swisstopo.zeitreihen_20061231
-  sources: [ch.swisstopo.zeitreihen_20061231_cache_out]
-  title: Zeitreise - Kartenwerke (20061231)
-- dimensions: *id583
-  name: ch.swisstopo.zeitreihen_20061231_source
-  sources: [ch.swisstopo.zeitreihen_20061231_cache]
-  title: Zeitreise - Kartenwerke (20061231, source)
-- dimensions: &id584
-    Time:
-      default: '20051231'
-      values: ['20051231']
-  name: ch.swisstopo.zeitreihen_20051231
-  sources: [ch.swisstopo.zeitreihen_20051231_cache_out]
-  title: Zeitreise - Kartenwerke (20051231)
-- dimensions: *id584
-  name: ch.swisstopo.zeitreihen_20051231_source
-  sources: [ch.swisstopo.zeitreihen_20051231_cache]
-  title: Zeitreise - Kartenwerke (20051231, source)
-- dimensions: &id585
-    Time:
-      default: '20041231'
-      values: ['20041231']
-  name: ch.swisstopo.zeitreihen_20041231
-  sources: [ch.swisstopo.zeitreihen_20041231_cache_out]
-  title: Zeitreise - Kartenwerke (20041231)
-- dimensions: *id585
-  name: ch.swisstopo.zeitreihen_20041231_source
-  sources: [ch.swisstopo.zeitreihen_20041231_cache]
-  title: Zeitreise - Kartenwerke (20041231, source)
-- dimensions: &id586
-    Time:
-      default: '20031231'
-      values: ['20031231']
-  name: ch.swisstopo.zeitreihen_20031231
-  sources: [ch.swisstopo.zeitreihen_20031231_cache_out]
-  title: Zeitreise - Kartenwerke (20031231)
-- dimensions: *id586
-  name: ch.swisstopo.zeitreihen_20031231_source
-  sources: [ch.swisstopo.zeitreihen_20031231_cache]
-  title: Zeitreise - Kartenwerke (20031231, source)
-- dimensions: &id587
-    Time:
-      default: '20021231'
-      values: ['20021231']
-  name: ch.swisstopo.zeitreihen_20021231
-  sources: [ch.swisstopo.zeitreihen_20021231_cache_out]
-  title: Zeitreise - Kartenwerke (20021231)
-- dimensions: *id587
-  name: ch.swisstopo.zeitreihen_20021231_source
-  sources: [ch.swisstopo.zeitreihen_20021231_cache]
-  title: Zeitreise - Kartenwerke (20021231, source)
-- dimensions: &id588
-    Time:
-      default: '20011231'
-      values: ['20011231']
-  name: ch.swisstopo.zeitreihen_20011231
-  sources: [ch.swisstopo.zeitreihen_20011231_cache_out]
-  title: Zeitreise - Kartenwerke (20011231)
-- dimensions: *id588
-  name: ch.swisstopo.zeitreihen_20011231_source
-  sources: [ch.swisstopo.zeitreihen_20011231_cache]
-  title: Zeitreise - Kartenwerke (20011231, source)
-- dimensions: &id589
-    Time:
-      default: '20001231'
-      values: ['20001231']
-  name: ch.swisstopo.zeitreihen_20001231
-  sources: [ch.swisstopo.zeitreihen_20001231_cache_out]
-  title: Zeitreise - Kartenwerke (20001231)
-- dimensions: *id589
-  name: ch.swisstopo.zeitreihen_20001231_source
-  sources: [ch.swisstopo.zeitreihen_20001231_cache]
-  title: Zeitreise - Kartenwerke (20001231, source)
-- dimensions: &id590
-    Time:
-      default: '19991231'
-      values: ['19991231']
-  name: ch.swisstopo.zeitreihen_19991231
-  sources: [ch.swisstopo.zeitreihen_19991231_cache_out]
-  title: Zeitreise - Kartenwerke (19991231)
-- dimensions: *id590
-  name: ch.swisstopo.zeitreihen_19991231_source
-  sources: [ch.swisstopo.zeitreihen_19991231_cache]
-  title: Zeitreise - Kartenwerke (19991231, source)
-- dimensions: &id591
-    Time:
-      default: '19981231'
-      values: ['19981231']
-  name: ch.swisstopo.zeitreihen_19981231
-  sources: [ch.swisstopo.zeitreihen_19981231_cache_out]
-  title: Zeitreise - Kartenwerke (19981231)
-- dimensions: *id591
-  name: ch.swisstopo.zeitreihen_19981231_source
-  sources: [ch.swisstopo.zeitreihen_19981231_cache]
-  title: Zeitreise - Kartenwerke (19981231, source)
-- dimensions: &id592
-    Time:
-      default: '19971231'
-      values: ['19971231']
-  name: ch.swisstopo.zeitreihen_19971231
-  sources: [ch.swisstopo.zeitreihen_19971231_cache_out]
-  title: Zeitreise - Kartenwerke (19971231)
-- dimensions: *id592
-  name: ch.swisstopo.zeitreihen_19971231_source
-  sources: [ch.swisstopo.zeitreihen_19971231_cache]
-  title: Zeitreise - Kartenwerke (19971231, source)
-- dimensions: &id593
-    Time:
-      default: '19961231'
-      values: ['19961231']
-  name: ch.swisstopo.zeitreihen_19961231
-  sources: [ch.swisstopo.zeitreihen_19961231_cache_out]
-  title: Zeitreise - Kartenwerke (19961231)
-- dimensions: *id593
-  name: ch.swisstopo.zeitreihen_19961231_source
-  sources: [ch.swisstopo.zeitreihen_19961231_cache]
-  title: Zeitreise - Kartenwerke (19961231, source)
-- dimensions: &id594
-    Time:
-      default: '19951231'
-      values: ['19951231']
-  name: ch.swisstopo.zeitreihen_19951231
-  sources: [ch.swisstopo.zeitreihen_19951231_cache_out]
-  title: Zeitreise - Kartenwerke (19951231)
-- dimensions: *id594
-  name: ch.swisstopo.zeitreihen_19951231_source
-  sources: [ch.swisstopo.zeitreihen_19951231_cache]
-  title: Zeitreise - Kartenwerke (19951231, source)
-- dimensions: &id595
-    Time:
-      default: '19941231'
-      values: ['19941231']
-  name: ch.swisstopo.zeitreihen_19941231
-  sources: [ch.swisstopo.zeitreihen_19941231_cache_out]
-  title: Zeitreise - Kartenwerke (19941231)
-- dimensions: *id595
-  name: ch.swisstopo.zeitreihen_19941231_source
-  sources: [ch.swisstopo.zeitreihen_19941231_cache]
-  title: Zeitreise - Kartenwerke (19941231, source)
-- dimensions: &id596
-    Time:
-      default: '19931231'
-      values: ['19931231']
-  name: ch.swisstopo.zeitreihen_19931231
-  sources: [ch.swisstopo.zeitreihen_19931231_cache_out]
-  title: Zeitreise - Kartenwerke (19931231)
-- dimensions: *id596
-  name: ch.swisstopo.zeitreihen_19931231_source
-  sources: [ch.swisstopo.zeitreihen_19931231_cache]
-  title: Zeitreise - Kartenwerke (19931231, source)
-- dimensions: &id597
-    Time:
-      default: '19921231'
-      values: ['19921231']
-  name: ch.swisstopo.zeitreihen_19921231
-  sources: [ch.swisstopo.zeitreihen_19921231_cache_out]
-  title: Zeitreise - Kartenwerke (19921231)
-- dimensions: *id597
-  name: ch.swisstopo.zeitreihen_19921231_source
-  sources: [ch.swisstopo.zeitreihen_19921231_cache]
-  title: Zeitreise - Kartenwerke (19921231, source)
-- dimensions: &id598
-    Time:
-      default: '19911231'
-      values: ['19911231']
-  name: ch.swisstopo.zeitreihen_19911231
-  sources: [ch.swisstopo.zeitreihen_19911231_cache_out]
-  title: Zeitreise - Kartenwerke (19911231)
-- dimensions: *id598
-  name: ch.swisstopo.zeitreihen_19911231_source
-  sources: [ch.swisstopo.zeitreihen_19911231_cache]
-  title: Zeitreise - Kartenwerke (19911231, source)
-- dimensions: &id599
-    Time:
-      default: '19901231'
-      values: ['19901231']
-  name: ch.swisstopo.zeitreihen_19901231
-  sources: [ch.swisstopo.zeitreihen_19901231_cache_out]
-  title: Zeitreise - Kartenwerke (19901231)
-- dimensions: *id599
-  name: ch.swisstopo.zeitreihen_19901231_source
-  sources: [ch.swisstopo.zeitreihen_19901231_cache]
-  title: Zeitreise - Kartenwerke (19901231, source)
-- dimensions: &id600
-    Time:
-      default: '19891231'
-      values: ['19891231']
-  name: ch.swisstopo.zeitreihen_19891231
-  sources: [ch.swisstopo.zeitreihen_19891231_cache_out]
-  title: Zeitreise - Kartenwerke (19891231)
-- dimensions: *id600
-  name: ch.swisstopo.zeitreihen_19891231_source
-  sources: [ch.swisstopo.zeitreihen_19891231_cache]
-  title: Zeitreise - Kartenwerke (19891231, source)
-- dimensions: &id601
-    Time:
-      default: '19881231'
-      values: ['19881231']
-  name: ch.swisstopo.zeitreihen_19881231
-  sources: [ch.swisstopo.zeitreihen_19881231_cache_out]
-  title: Zeitreise - Kartenwerke (19881231)
-- dimensions: *id601
-  name: ch.swisstopo.zeitreihen_19881231_source
-  sources: [ch.swisstopo.zeitreihen_19881231_cache]
-  title: Zeitreise - Kartenwerke (19881231, source)
-- dimensions: &id602
-    Time:
-      default: '19871231'
-      values: ['19871231']
-  name: ch.swisstopo.zeitreihen_19871231
-  sources: [ch.swisstopo.zeitreihen_19871231_cache_out]
-  title: Zeitreise - Kartenwerke (19871231)
-- dimensions: *id602
-  name: ch.swisstopo.zeitreihen_19871231_source
-  sources: [ch.swisstopo.zeitreihen_19871231_cache]
-  title: Zeitreise - Kartenwerke (19871231, source)
-- dimensions: &id603
-    Time:
-      default: '19861231'
-      values: ['19861231']
-  name: ch.swisstopo.zeitreihen_19861231
-  sources: [ch.swisstopo.zeitreihen_19861231_cache_out]
-  title: Zeitreise - Kartenwerke (19861231)
-- dimensions: *id603
-  name: ch.swisstopo.zeitreihen_19861231_source
-  sources: [ch.swisstopo.zeitreihen_19861231_cache]
-  title: Zeitreise - Kartenwerke (19861231, source)
-- dimensions: &id604
-    Time:
-      default: '19851231'
-      values: ['19851231']
-  name: ch.swisstopo.zeitreihen_19851231
-  sources: [ch.swisstopo.zeitreihen_19851231_cache_out]
-  title: Zeitreise - Kartenwerke (19851231)
-- dimensions: *id604
-  name: ch.swisstopo.zeitreihen_19851231_source
-  sources: [ch.swisstopo.zeitreihen_19851231_cache]
-  title: Zeitreise - Kartenwerke (19851231, source)
-- dimensions: &id605
-    Time:
-      default: '19841231'
-      values: ['19841231']
-  name: ch.swisstopo.zeitreihen_19841231
-  sources: [ch.swisstopo.zeitreihen_19841231_cache_out]
-  title: Zeitreise - Kartenwerke (19841231)
-- dimensions: *id605
-  name: ch.swisstopo.zeitreihen_19841231_source
-  sources: [ch.swisstopo.zeitreihen_19841231_cache]
-  title: Zeitreise - Kartenwerke (19841231, source)
-- dimensions: &id606
-    Time:
-      default: '19831231'
-      values: ['19831231']
-  name: ch.swisstopo.zeitreihen_19831231
-  sources: [ch.swisstopo.zeitreihen_19831231_cache_out]
-  title: Zeitreise - Kartenwerke (19831231)
-- dimensions: *id606
-  name: ch.swisstopo.zeitreihen_19831231_source
-  sources: [ch.swisstopo.zeitreihen_19831231_cache]
-  title: Zeitreise - Kartenwerke (19831231, source)
-- dimensions: &id607
-    Time:
-      default: '19821231'
-      values: ['19821231']
-  name: ch.swisstopo.zeitreihen_19821231
-  sources: [ch.swisstopo.zeitreihen_19821231_cache_out]
-  title: Zeitreise - Kartenwerke (19821231)
-- dimensions: *id607
-  name: ch.swisstopo.zeitreihen_19821231_source
-  sources: [ch.swisstopo.zeitreihen_19821231_cache]
-  title: Zeitreise - Kartenwerke (19821231, source)
-- dimensions: &id608
-    Time:
-      default: '19811231'
-      values: ['19811231']
-  name: ch.swisstopo.zeitreihen_19811231
-  sources: [ch.swisstopo.zeitreihen_19811231_cache_out]
-  title: Zeitreise - Kartenwerke (19811231)
-- dimensions: *id608
-  name: ch.swisstopo.zeitreihen_19811231_source
-  sources: [ch.swisstopo.zeitreihen_19811231_cache]
-  title: Zeitreise - Kartenwerke (19811231, source)
-- dimensions: &id609
-    Time:
-      default: '19801231'
-      values: ['19801231']
-  name: ch.swisstopo.zeitreihen_19801231
-  sources: [ch.swisstopo.zeitreihen_19801231_cache_out]
-  title: Zeitreise - Kartenwerke (19801231)
-- dimensions: *id609
-  name: ch.swisstopo.zeitreihen_19801231_source
-  sources: [ch.swisstopo.zeitreihen_19801231_cache]
-  title: Zeitreise - Kartenwerke (19801231, source)
-- dimensions: &id610
-    Time:
-      default: '19791231'
-      values: ['19791231']
-  name: ch.swisstopo.zeitreihen_19791231
-  sources: [ch.swisstopo.zeitreihen_19791231_cache_out]
-  title: Zeitreise - Kartenwerke (19791231)
-- dimensions: *id610
-  name: ch.swisstopo.zeitreihen_19791231_source
-  sources: [ch.swisstopo.zeitreihen_19791231_cache]
-  title: Zeitreise - Kartenwerke (19791231, source)
-- dimensions: &id611
-    Time:
-      default: '19781231'
-      values: ['19781231']
-  name: ch.swisstopo.zeitreihen_19781231
-  sources: [ch.swisstopo.zeitreihen_19781231_cache_out]
-  title: Zeitreise - Kartenwerke (19781231)
-- dimensions: *id611
-  name: ch.swisstopo.zeitreihen_19781231_source
-  sources: [ch.swisstopo.zeitreihen_19781231_cache]
-  title: Zeitreise - Kartenwerke (19781231, source)
-- dimensions: &id612
-    Time:
-      default: '19771231'
-      values: ['19771231']
-  name: ch.swisstopo.zeitreihen_19771231
-  sources: [ch.swisstopo.zeitreihen_19771231_cache_out]
-  title: Zeitreise - Kartenwerke (19771231)
-- dimensions: *id612
-  name: ch.swisstopo.zeitreihen_19771231_source
-  sources: [ch.swisstopo.zeitreihen_19771231_cache]
-  title: Zeitreise - Kartenwerke (19771231, source)
-- dimensions: &id613
-    Time:
-      default: '19761231'
-      values: ['19761231']
-  name: ch.swisstopo.zeitreihen_19761231
-  sources: [ch.swisstopo.zeitreihen_19761231_cache_out]
-  title: Zeitreise - Kartenwerke (19761231)
-- dimensions: *id613
-  name: ch.swisstopo.zeitreihen_19761231_source
-  sources: [ch.swisstopo.zeitreihen_19761231_cache]
-  title: Zeitreise - Kartenwerke (19761231, source)
-- dimensions: &id614
-    Time:
-      default: '19751231'
-      values: ['19751231']
-  name: ch.swisstopo.zeitreihen_19751231
-  sources: [ch.swisstopo.zeitreihen_19751231_cache_out]
-  title: Zeitreise - Kartenwerke (19751231)
-- dimensions: *id614
-  name: ch.swisstopo.zeitreihen_19751231_source
-  sources: [ch.swisstopo.zeitreihen_19751231_cache]
-  title: Zeitreise - Kartenwerke (19751231, source)
-- dimensions: &id615
-    Time:
-      default: '19741231'
-      values: ['19741231']
-  name: ch.swisstopo.zeitreihen_19741231
-  sources: [ch.swisstopo.zeitreihen_19741231_cache_out]
-  title: Zeitreise - Kartenwerke (19741231)
-- dimensions: *id615
-  name: ch.swisstopo.zeitreihen_19741231_source
-  sources: [ch.swisstopo.zeitreihen_19741231_cache]
-  title: Zeitreise - Kartenwerke (19741231, source)
-- dimensions: &id616
-    Time:
-      default: '19731231'
-      values: ['19731231']
-  name: ch.swisstopo.zeitreihen_19731231
-  sources: [ch.swisstopo.zeitreihen_19731231_cache_out]
-  title: Zeitreise - Kartenwerke (19731231)
-- dimensions: *id616
-  name: ch.swisstopo.zeitreihen_19731231_source
-  sources: [ch.swisstopo.zeitreihen_19731231_cache]
-  title: Zeitreise - Kartenwerke (19731231, source)
-- dimensions: &id617
-    Time:
-      default: '19721231'
-      values: ['19721231']
-  name: ch.swisstopo.zeitreihen_19721231
-  sources: [ch.swisstopo.zeitreihen_19721231_cache_out]
-  title: Zeitreise - Kartenwerke (19721231)
-- dimensions: *id617
-  name: ch.swisstopo.zeitreihen_19721231_source
-  sources: [ch.swisstopo.zeitreihen_19721231_cache]
-  title: Zeitreise - Kartenwerke (19721231, source)
-- dimensions: &id618
-    Time:
-      default: '19711231'
-      values: ['19711231']
-  name: ch.swisstopo.zeitreihen_19711231
-  sources: [ch.swisstopo.zeitreihen_19711231_cache_out]
-  title: Zeitreise - Kartenwerke (19711231)
-- dimensions: *id618
-  name: ch.swisstopo.zeitreihen_19711231_source
-  sources: [ch.swisstopo.zeitreihen_19711231_cache]
-  title: Zeitreise - Kartenwerke (19711231, source)
-- dimensions: &id619
-    Time:
-      default: '19701231'
-      values: ['19701231']
-  name: ch.swisstopo.zeitreihen_19701231
-  sources: [ch.swisstopo.zeitreihen_19701231_cache_out]
-  title: Zeitreise - Kartenwerke (19701231)
-- dimensions: *id619
-  name: ch.swisstopo.zeitreihen_19701231_source
-  sources: [ch.swisstopo.zeitreihen_19701231_cache]
-  title: Zeitreise - Kartenwerke (19701231, source)
-- dimensions: &id620
-    Time:
-      default: '19691231'
-      values: ['19691231']
-  name: ch.swisstopo.zeitreihen_19691231
-  sources: [ch.swisstopo.zeitreihen_19691231_cache_out]
-  title: Zeitreise - Kartenwerke (19691231)
-- dimensions: *id620
-  name: ch.swisstopo.zeitreihen_19691231_source
-  sources: [ch.swisstopo.zeitreihen_19691231_cache]
-  title: Zeitreise - Kartenwerke (19691231, source)
-- dimensions: &id621
-    Time:
-      default: '19681231'
-      values: ['19681231']
-  name: ch.swisstopo.zeitreihen_19681231
-  sources: [ch.swisstopo.zeitreihen_19681231_cache_out]
-  title: Zeitreise - Kartenwerke (19681231)
-- dimensions: *id621
-  name: ch.swisstopo.zeitreihen_19681231_source
-  sources: [ch.swisstopo.zeitreihen_19681231_cache]
-  title: Zeitreise - Kartenwerke (19681231, source)
-- dimensions: &id622
-    Time:
-      default: '19671231'
-      values: ['19671231']
-  name: ch.swisstopo.zeitreihen_19671231
-  sources: [ch.swisstopo.zeitreihen_19671231_cache_out]
-  title: Zeitreise - Kartenwerke (19671231)
-- dimensions: *id622
-  name: ch.swisstopo.zeitreihen_19671231_source
-  sources: [ch.swisstopo.zeitreihen_19671231_cache]
-  title: Zeitreise - Kartenwerke (19671231, source)
-- dimensions: &id623
-    Time:
-      default: '19661231'
-      values: ['19661231']
-  name: ch.swisstopo.zeitreihen_19661231
-  sources: [ch.swisstopo.zeitreihen_19661231_cache_out]
-  title: Zeitreise - Kartenwerke (19661231)
-- dimensions: *id623
-  name: ch.swisstopo.zeitreihen_19661231_source
-  sources: [ch.swisstopo.zeitreihen_19661231_cache]
-  title: Zeitreise - Kartenwerke (19661231, source)
-- dimensions: &id624
-    Time:
-      default: '19651231'
-      values: ['19651231']
-  name: ch.swisstopo.zeitreihen_19651231
-  sources: [ch.swisstopo.zeitreihen_19651231_cache_out]
-  title: Zeitreise - Kartenwerke (19651231)
-- dimensions: *id624
-  name: ch.swisstopo.zeitreihen_19651231_source
-  sources: [ch.swisstopo.zeitreihen_19651231_cache]
-  title: Zeitreise - Kartenwerke (19651231, source)
-- dimensions: &id625
-    Time:
-      default: '19641231'
-      values: ['19641231']
-  name: ch.swisstopo.zeitreihen_19641231
-  sources: [ch.swisstopo.zeitreihen_19641231_cache_out]
-  title: Zeitreise - Kartenwerke (19641231)
-- dimensions: *id625
-  name: ch.swisstopo.zeitreihen_19641231_source
-  sources: [ch.swisstopo.zeitreihen_19641231_cache]
-  title: Zeitreise - Kartenwerke (19641231, source)
-- dimensions: &id626
-    Time:
-      default: '19631231'
-      values: ['19631231']
-  name: ch.swisstopo.zeitreihen_19631231
-  sources: [ch.swisstopo.zeitreihen_19631231_cache_out]
-  title: Zeitreise - Kartenwerke (19631231)
-- dimensions: *id626
-  name: ch.swisstopo.zeitreihen_19631231_source
-  sources: [ch.swisstopo.zeitreihen_19631231_cache]
-  title: Zeitreise - Kartenwerke (19631231, source)
-- dimensions: &id627
-    Time:
-      default: '19621231'
-      values: ['19621231']
-  name: ch.swisstopo.zeitreihen_19621231
-  sources: [ch.swisstopo.zeitreihen_19621231_cache_out]
-  title: Zeitreise - Kartenwerke (19621231)
-- dimensions: *id627
-  name: ch.swisstopo.zeitreihen_19621231_source
-  sources: [ch.swisstopo.zeitreihen_19621231_cache]
-  title: Zeitreise - Kartenwerke (19621231, source)
-- dimensions: &id628
-    Time:
-      default: '19611231'
-      values: ['19611231']
-  name: ch.swisstopo.zeitreihen_19611231
-  sources: [ch.swisstopo.zeitreihen_19611231_cache_out]
-  title: Zeitreise - Kartenwerke (19611231)
-- dimensions: *id628
-  name: ch.swisstopo.zeitreihen_19611231_source
-  sources: [ch.swisstopo.zeitreihen_19611231_cache]
-  title: Zeitreise - Kartenwerke (19611231, source)
-- dimensions: &id629
-    Time:
-      default: '19601231'
-      values: ['19601231']
-  name: ch.swisstopo.zeitreihen_19601231
-  sources: [ch.swisstopo.zeitreihen_19601231_cache_out]
-  title: Zeitreise - Kartenwerke (19601231)
-- dimensions: *id629
-  name: ch.swisstopo.zeitreihen_19601231_source
-  sources: [ch.swisstopo.zeitreihen_19601231_cache]
-  title: Zeitreise - Kartenwerke (19601231, source)
-- dimensions: &id630
-    Time:
-      default: '19591231'
-      values: ['19591231']
-  name: ch.swisstopo.zeitreihen_19591231
-  sources: [ch.swisstopo.zeitreihen_19591231_cache_out]
-  title: Zeitreise - Kartenwerke (19591231)
-- dimensions: *id630
-  name: ch.swisstopo.zeitreihen_19591231_source
-  sources: [ch.swisstopo.zeitreihen_19591231_cache]
-  title: Zeitreise - Kartenwerke (19591231, source)
-- dimensions: &id631
-    Time:
-      default: '19581231'
-      values: ['19581231']
-  name: ch.swisstopo.zeitreihen_19581231
-  sources: [ch.swisstopo.zeitreihen_19581231_cache_out]
-  title: Zeitreise - Kartenwerke (19581231)
-- dimensions: *id631
-  name: ch.swisstopo.zeitreihen_19581231_source
-  sources: [ch.swisstopo.zeitreihen_19581231_cache]
-  title: Zeitreise - Kartenwerke (19581231, source)
-- dimensions: &id632
-    Time:
-      default: '19571231'
-      values: ['19571231']
-  name: ch.swisstopo.zeitreihen_19571231
-  sources: [ch.swisstopo.zeitreihen_19571231_cache_out]
-  title: Zeitreise - Kartenwerke (19571231)
-- dimensions: *id632
-  name: ch.swisstopo.zeitreihen_19571231_source
-  sources: [ch.swisstopo.zeitreihen_19571231_cache]
-  title: Zeitreise - Kartenwerke (19571231, source)
-- dimensions: &id633
-    Time:
-      default: '19561231'
-      values: ['19561231']
-  name: ch.swisstopo.zeitreihen_19561231
-  sources: [ch.swisstopo.zeitreihen_19561231_cache_out]
-  title: Zeitreise - Kartenwerke (19561231)
-- dimensions: *id633
-  name: ch.swisstopo.zeitreihen_19561231_source
-  sources: [ch.swisstopo.zeitreihen_19561231_cache]
-  title: Zeitreise - Kartenwerke (19561231, source)
-- dimensions: &id634
-    Time:
-      default: '19551231'
-      values: ['19551231']
-  name: ch.swisstopo.zeitreihen_19551231
-  sources: [ch.swisstopo.zeitreihen_19551231_cache_out]
-  title: Zeitreise - Kartenwerke (19551231)
-- dimensions: *id634
-  name: ch.swisstopo.zeitreihen_19551231_source
-  sources: [ch.swisstopo.zeitreihen_19551231_cache]
-  title: Zeitreise - Kartenwerke (19551231, source)
-- dimensions: &id635
-    Time:
-      default: '19541231'
-      values: ['19541231']
-  name: ch.swisstopo.zeitreihen_19541231
-  sources: [ch.swisstopo.zeitreihen_19541231_cache_out]
-  title: Zeitreise - Kartenwerke (19541231)
-- dimensions: *id635
-  name: ch.swisstopo.zeitreihen_19541231_source
-  sources: [ch.swisstopo.zeitreihen_19541231_cache]
-  title: Zeitreise - Kartenwerke (19541231, source)
-- dimensions: &id636
-    Time:
-      default: '19531231'
-      values: ['19531231']
-  name: ch.swisstopo.zeitreihen_19531231
-  sources: [ch.swisstopo.zeitreihen_19531231_cache_out]
-  title: Zeitreise - Kartenwerke (19531231)
-- dimensions: *id636
-  name: ch.swisstopo.zeitreihen_19531231_source
-  sources: [ch.swisstopo.zeitreihen_19531231_cache]
-  title: Zeitreise - Kartenwerke (19531231, source)
-- dimensions: &id637
-    Time:
-      default: '19521231'
-      values: ['19521231']
-  name: ch.swisstopo.zeitreihen_19521231
-  sources: [ch.swisstopo.zeitreihen_19521231_cache_out]
-  title: Zeitreise - Kartenwerke (19521231)
-- dimensions: *id637
-  name: ch.swisstopo.zeitreihen_19521231_source
-  sources: [ch.swisstopo.zeitreihen_19521231_cache]
-  title: Zeitreise - Kartenwerke (19521231, source)
-- dimensions: &id638
-    Time:
-      default: '19511231'
-      values: ['19511231']
-  name: ch.swisstopo.zeitreihen_19511231
-  sources: [ch.swisstopo.zeitreihen_19511231_cache_out]
-  title: Zeitreise - Kartenwerke (19511231)
-- dimensions: *id638
-  name: ch.swisstopo.zeitreihen_19511231_source
-  sources: [ch.swisstopo.zeitreihen_19511231_cache]
-  title: Zeitreise - Kartenwerke (19511231, source)
-- dimensions: &id639
-    Time:
-      default: '19501231'
-      values: ['19501231']
-  name: ch.swisstopo.zeitreihen_19501231
-  sources: [ch.swisstopo.zeitreihen_19501231_cache_out]
-  title: Zeitreise - Kartenwerke (19501231)
-- dimensions: *id639
-  name: ch.swisstopo.zeitreihen_19501231_source
-  sources: [ch.swisstopo.zeitreihen_19501231_cache]
-  title: Zeitreise - Kartenwerke (19501231, source)
-- dimensions: &id640
-    Time:
-      default: '19491231'
-      values: ['19491231']
-  name: ch.swisstopo.zeitreihen_19491231
-  sources: [ch.swisstopo.zeitreihen_19491231_cache_out]
-  title: Zeitreise - Kartenwerke (19491231)
-- dimensions: *id640
-  name: ch.swisstopo.zeitreihen_19491231_source
-  sources: [ch.swisstopo.zeitreihen_19491231_cache]
-  title: Zeitreise - Kartenwerke (19491231, source)
-- dimensions: &id641
-    Time:
-      default: '19481231'
-      values: ['19481231']
-  name: ch.swisstopo.zeitreihen_19481231
-  sources: [ch.swisstopo.zeitreihen_19481231_cache_out]
-  title: Zeitreise - Kartenwerke (19481231)
-- dimensions: *id641
-  name: ch.swisstopo.zeitreihen_19481231_source
-  sources: [ch.swisstopo.zeitreihen_19481231_cache]
-  title: Zeitreise - Kartenwerke (19481231, source)
-- dimensions: &id642
-    Time:
-      default: '19471231'
-      values: ['19471231']
-  name: ch.swisstopo.zeitreihen_19471231
-  sources: [ch.swisstopo.zeitreihen_19471231_cache_out]
-  title: Zeitreise - Kartenwerke (19471231)
-- dimensions: *id642
-  name: ch.swisstopo.zeitreihen_19471231_source
-  sources: [ch.swisstopo.zeitreihen_19471231_cache]
-  title: Zeitreise - Kartenwerke (19471231, source)
-- dimensions: &id643
-    Time:
-      default: '19461231'
-      values: ['19461231']
-  name: ch.swisstopo.zeitreihen_19461231
-  sources: [ch.swisstopo.zeitreihen_19461231_cache_out]
-  title: Zeitreise - Kartenwerke (19461231)
-- dimensions: *id643
-  name: ch.swisstopo.zeitreihen_19461231_source
-  sources: [ch.swisstopo.zeitreihen_19461231_cache]
-  title: Zeitreise - Kartenwerke (19461231, source)
-- dimensions: &id644
-    Time:
-      default: '19451231'
-      values: ['19451231']
-  name: ch.swisstopo.zeitreihen_19451231
-  sources: [ch.swisstopo.zeitreihen_19451231_cache_out]
-  title: Zeitreise - Kartenwerke (19451231)
-- dimensions: *id644
-  name: ch.swisstopo.zeitreihen_19451231_source
-  sources: [ch.swisstopo.zeitreihen_19451231_cache]
-  title: Zeitreise - Kartenwerke (19451231, source)
-- dimensions: &id645
-    Time:
-      default: '19441231'
-      values: ['19441231']
-  name: ch.swisstopo.zeitreihen_19441231
-  sources: [ch.swisstopo.zeitreihen_19441231_cache_out]
-  title: Zeitreise - Kartenwerke (19441231)
-- dimensions: *id645
-  name: ch.swisstopo.zeitreihen_19441231_source
-  sources: [ch.swisstopo.zeitreihen_19441231_cache]
-  title: Zeitreise - Kartenwerke (19441231, source)
-- dimensions: &id646
-    Time:
-      default: '19431231'
-      values: ['19431231']
-  name: ch.swisstopo.zeitreihen_19431231
-  sources: [ch.swisstopo.zeitreihen_19431231_cache_out]
-  title: Zeitreise - Kartenwerke (19431231)
-- dimensions: *id646
-  name: ch.swisstopo.zeitreihen_19431231_source
-  sources: [ch.swisstopo.zeitreihen_19431231_cache]
-  title: Zeitreise - Kartenwerke (19431231, source)
-- dimensions: &id647
-    Time:
-      default: '19421231'
-      values: ['19421231']
-  name: ch.swisstopo.zeitreihen_19421231
-  sources: [ch.swisstopo.zeitreihen_19421231_cache_out]
-  title: Zeitreise - Kartenwerke (19421231)
-- dimensions: *id647
-  name: ch.swisstopo.zeitreihen_19421231_source
-  sources: [ch.swisstopo.zeitreihen_19421231_cache]
-  title: Zeitreise - Kartenwerke (19421231, source)
-- dimensions: &id648
-    Time:
-      default: '19411231'
-      values: ['19411231']
-  name: ch.swisstopo.zeitreihen_19411231
-  sources: [ch.swisstopo.zeitreihen_19411231_cache_out]
-  title: Zeitreise - Kartenwerke (19411231)
-- dimensions: *id648
-  name: ch.swisstopo.zeitreihen_19411231_source
-  sources: [ch.swisstopo.zeitreihen_19411231_cache]
-  title: Zeitreise - Kartenwerke (19411231, source)
-- dimensions: &id649
-    Time:
-      default: '19401231'
-      values: ['19401231']
-  name: ch.swisstopo.zeitreihen_19401231
-  sources: [ch.swisstopo.zeitreihen_19401231_cache_out]
-  title: Zeitreise - Kartenwerke (19401231)
-- dimensions: *id649
-  name: ch.swisstopo.zeitreihen_19401231_source
-  sources: [ch.swisstopo.zeitreihen_19401231_cache]
-  title: Zeitreise - Kartenwerke (19401231, source)
-- dimensions: &id650
-    Time:
-      default: '19391231'
-      values: ['19391231']
-  name: ch.swisstopo.zeitreihen_19391231
-  sources: [ch.swisstopo.zeitreihen_19391231_cache_out]
-  title: Zeitreise - Kartenwerke (19391231)
-- dimensions: *id650
-  name: ch.swisstopo.zeitreihen_19391231_source
-  sources: [ch.swisstopo.zeitreihen_19391231_cache]
-  title: Zeitreise - Kartenwerke (19391231, source)
-- dimensions: &id651
-    Time:
-      default: '19381231'
-      values: ['19381231']
-  name: ch.swisstopo.zeitreihen_19381231
-  sources: [ch.swisstopo.zeitreihen_19381231_cache_out]
-  title: Zeitreise - Kartenwerke (19381231)
-- dimensions: *id651
-  name: ch.swisstopo.zeitreihen_19381231_source
-  sources: [ch.swisstopo.zeitreihen_19381231_cache]
-  title: Zeitreise - Kartenwerke (19381231, source)
-- dimensions: &id652
-    Time:
-      default: '19371231'
-      values: ['19371231']
-  name: ch.swisstopo.zeitreihen_19371231
-  sources: [ch.swisstopo.zeitreihen_19371231_cache_out]
-  title: Zeitreise - Kartenwerke (19371231)
-- dimensions: *id652
-  name: ch.swisstopo.zeitreihen_19371231_source
-  sources: [ch.swisstopo.zeitreihen_19371231_cache]
-  title: Zeitreise - Kartenwerke (19371231, source)
-- dimensions: &id653
-    Time:
-      default: '19361231'
-      values: ['19361231']
-  name: ch.swisstopo.zeitreihen_19361231
-  sources: [ch.swisstopo.zeitreihen_19361231_cache_out]
-  title: Zeitreise - Kartenwerke (19361231)
-- dimensions: *id653
-  name: ch.swisstopo.zeitreihen_19361231_source
-  sources: [ch.swisstopo.zeitreihen_19361231_cache]
-  title: Zeitreise - Kartenwerke (19361231, source)
-- dimensions: &id654
-    Time:
-      default: '19351231'
-      values: ['19351231']
-  name: ch.swisstopo.zeitreihen_19351231
-  sources: [ch.swisstopo.zeitreihen_19351231_cache_out]
-  title: Zeitreise - Kartenwerke (19351231)
-- dimensions: *id654
-  name: ch.swisstopo.zeitreihen_19351231_source
-  sources: [ch.swisstopo.zeitreihen_19351231_cache]
-  title: Zeitreise - Kartenwerke (19351231, source)
-- dimensions: &id655
-    Time:
-      default: '19341231'
-      values: ['19341231']
-  name: ch.swisstopo.zeitreihen_19341231
-  sources: [ch.swisstopo.zeitreihen_19341231_cache_out]
-  title: Zeitreise - Kartenwerke (19341231)
-- dimensions: *id655
-  name: ch.swisstopo.zeitreihen_19341231_source
-  sources: [ch.swisstopo.zeitreihen_19341231_cache]
-  title: Zeitreise - Kartenwerke (19341231, source)
-- dimensions: &id656
-    Time:
-      default: '19331231'
-      values: ['19331231']
-  name: ch.swisstopo.zeitreihen_19331231
-  sources: [ch.swisstopo.zeitreihen_19331231_cache_out]
-  title: Zeitreise - Kartenwerke (19331231)
-- dimensions: *id656
-  name: ch.swisstopo.zeitreihen_19331231_source
-  sources: [ch.swisstopo.zeitreihen_19331231_cache]
-  title: Zeitreise - Kartenwerke (19331231, source)
-- dimensions: &id657
-    Time:
-      default: '19321231'
-      values: ['19321231']
-  name: ch.swisstopo.zeitreihen_19321231
-  sources: [ch.swisstopo.zeitreihen_19321231_cache_out]
-  title: Zeitreise - Kartenwerke (19321231)
-- dimensions: *id657
-  name: ch.swisstopo.zeitreihen_19321231_source
-  sources: [ch.swisstopo.zeitreihen_19321231_cache]
-  title: Zeitreise - Kartenwerke (19321231, source)
-- dimensions: &id658
-    Time:
-      default: '19311231'
-      values: ['19311231']
-  name: ch.swisstopo.zeitreihen_19311231
-  sources: [ch.swisstopo.zeitreihen_19311231_cache_out]
-  title: Zeitreise - Kartenwerke (19311231)
-- dimensions: *id658
-  name: ch.swisstopo.zeitreihen_19311231_source
-  sources: [ch.swisstopo.zeitreihen_19311231_cache]
-  title: Zeitreise - Kartenwerke (19311231, source)
-- dimensions: &id659
-    Time:
-      default: '19301231'
-      values: ['19301231']
-  name: ch.swisstopo.zeitreihen_19301231
-  sources: [ch.swisstopo.zeitreihen_19301231_cache_out]
-  title: Zeitreise - Kartenwerke (19301231)
-- dimensions: *id659
-  name: ch.swisstopo.zeitreihen_19301231_source
-  sources: [ch.swisstopo.zeitreihen_19301231_cache]
-  title: Zeitreise - Kartenwerke (19301231, source)
-- dimensions: &id660
-    Time:
-      default: '19291231'
-      values: ['19291231']
-  name: ch.swisstopo.zeitreihen_19291231
-  sources: [ch.swisstopo.zeitreihen_19291231_cache_out]
-  title: Zeitreise - Kartenwerke (19291231)
-- dimensions: *id660
-  name: ch.swisstopo.zeitreihen_19291231_source
-  sources: [ch.swisstopo.zeitreihen_19291231_cache]
-  title: Zeitreise - Kartenwerke (19291231, source)
-- dimensions: &id661
-    Time:
-      default: '19281231'
-      values: ['19281231']
-  name: ch.swisstopo.zeitreihen_19281231
-  sources: [ch.swisstopo.zeitreihen_19281231_cache_out]
-  title: Zeitreise - Kartenwerke (19281231)
-- dimensions: *id661
-  name: ch.swisstopo.zeitreihen_19281231_source
-  sources: [ch.swisstopo.zeitreihen_19281231_cache]
-  title: Zeitreise - Kartenwerke (19281231, source)
-- dimensions: &id662
-    Time:
-      default: '19271231'
-      values: ['19271231']
-  name: ch.swisstopo.zeitreihen_19271231
-  sources: [ch.swisstopo.zeitreihen_19271231_cache_out]
-  title: Zeitreise - Kartenwerke (19271231)
-- dimensions: *id662
-  name: ch.swisstopo.zeitreihen_19271231_source
-  sources: [ch.swisstopo.zeitreihen_19271231_cache]
-  title: Zeitreise - Kartenwerke (19271231, source)
-- dimensions: &id663
-    Time:
-      default: '19261231'
-      values: ['19261231']
-  name: ch.swisstopo.zeitreihen_19261231
-  sources: [ch.swisstopo.zeitreihen_19261231_cache_out]
-  title: Zeitreise - Kartenwerke (19261231)
-- dimensions: *id663
-  name: ch.swisstopo.zeitreihen_19261231_source
-  sources: [ch.swisstopo.zeitreihen_19261231_cache]
-  title: Zeitreise - Kartenwerke (19261231, source)
-- dimensions: &id664
-    Time:
-      default: '19251231'
-      values: ['19251231']
-  name: ch.swisstopo.zeitreihen_19251231
-  sources: [ch.swisstopo.zeitreihen_19251231_cache_out]
-  title: Zeitreise - Kartenwerke (19251231)
-- dimensions: *id664
-  name: ch.swisstopo.zeitreihen_19251231_source
-  sources: [ch.swisstopo.zeitreihen_19251231_cache]
-  title: Zeitreise - Kartenwerke (19251231, source)
-- dimensions: &id665
-    Time:
-      default: '19241231'
-      values: ['19241231']
-  name: ch.swisstopo.zeitreihen_19241231
-  sources: [ch.swisstopo.zeitreihen_19241231_cache_out]
-  title: Zeitreise - Kartenwerke (19241231)
-- dimensions: *id665
-  name: ch.swisstopo.zeitreihen_19241231_source
-  sources: [ch.swisstopo.zeitreihen_19241231_cache]
-  title: Zeitreise - Kartenwerke (19241231, source)
-- dimensions: &id666
-    Time:
-      default: '19231231'
-      values: ['19231231']
-  name: ch.swisstopo.zeitreihen_19231231
-  sources: [ch.swisstopo.zeitreihen_19231231_cache_out]
-  title: Zeitreise - Kartenwerke (19231231)
-- dimensions: *id666
-  name: ch.swisstopo.zeitreihen_19231231_source
-  sources: [ch.swisstopo.zeitreihen_19231231_cache]
-  title: Zeitreise - Kartenwerke (19231231, source)
-- dimensions: &id667
-    Time:
-      default: '19221231'
-      values: ['19221231']
-  name: ch.swisstopo.zeitreihen_19221231
-  sources: [ch.swisstopo.zeitreihen_19221231_cache_out]
-  title: Zeitreise - Kartenwerke (19221231)
-- dimensions: *id667
-  name: ch.swisstopo.zeitreihen_19221231_source
-  sources: [ch.swisstopo.zeitreihen_19221231_cache]
-  title: Zeitreise - Kartenwerke (19221231, source)
-- dimensions: &id668
-    Time:
-      default: '19211231'
-      values: ['19211231']
-  name: ch.swisstopo.zeitreihen_19211231
-  sources: [ch.swisstopo.zeitreihen_19211231_cache_out]
-  title: Zeitreise - Kartenwerke (19211231)
-- dimensions: *id668
-  name: ch.swisstopo.zeitreihen_19211231_source
-  sources: [ch.swisstopo.zeitreihen_19211231_cache]
-  title: Zeitreise - Kartenwerke (19211231, source)
-- dimensions: &id669
-    Time:
-      default: '19201231'
-      values: ['19201231']
-  name: ch.swisstopo.zeitreihen_19201231
-  sources: [ch.swisstopo.zeitreihen_19201231_cache_out]
-  title: Zeitreise - Kartenwerke (19201231)
-- dimensions: *id669
-  name: ch.swisstopo.zeitreihen_19201231_source
-  sources: [ch.swisstopo.zeitreihen_19201231_cache]
-  title: Zeitreise - Kartenwerke (19201231, source)
-- dimensions: &id670
-    Time:
-      default: '19191231'
-      values: ['19191231']
-  name: ch.swisstopo.zeitreihen_19191231
-  sources: [ch.swisstopo.zeitreihen_19191231_cache_out]
-  title: Zeitreise - Kartenwerke (19191231)
-- dimensions: *id670
-  name: ch.swisstopo.zeitreihen_19191231_source
-  sources: [ch.swisstopo.zeitreihen_19191231_cache]
-  title: Zeitreise - Kartenwerke (19191231, source)
-- dimensions: &id671
-    Time:
-      default: '19181231'
-      values: ['19181231']
-  name: ch.swisstopo.zeitreihen_19181231
-  sources: [ch.swisstopo.zeitreihen_19181231_cache_out]
-  title: Zeitreise - Kartenwerke (19181231)
-- dimensions: *id671
-  name: ch.swisstopo.zeitreihen_19181231_source
-  sources: [ch.swisstopo.zeitreihen_19181231_cache]
-  title: Zeitreise - Kartenwerke (19181231, source)
-- dimensions: &id672
-    Time:
-      default: '19171231'
-      values: ['19171231']
-  name: ch.swisstopo.zeitreihen_19171231
-  sources: [ch.swisstopo.zeitreihen_19171231_cache_out]
-  title: Zeitreise - Kartenwerke (19171231)
-- dimensions: *id672
-  name: ch.swisstopo.zeitreihen_19171231_source
-  sources: [ch.swisstopo.zeitreihen_19171231_cache]
-  title: Zeitreise - Kartenwerke (19171231, source)
-- dimensions: &id673
-    Time:
-      default: '19161231'
-      values: ['19161231']
-  name: ch.swisstopo.zeitreihen_19161231
-  sources: [ch.swisstopo.zeitreihen_19161231_cache_out]
-  title: Zeitreise - Kartenwerke (19161231)
-- dimensions: *id673
-  name: ch.swisstopo.zeitreihen_19161231_source
-  sources: [ch.swisstopo.zeitreihen_19161231_cache]
-  title: Zeitreise - Kartenwerke (19161231, source)
-- dimensions: &id674
-    Time:
-      default: '19151231'
-      values: ['19151231']
-  name: ch.swisstopo.zeitreihen_19151231
-  sources: [ch.swisstopo.zeitreihen_19151231_cache_out]
-  title: Zeitreise - Kartenwerke (19151231)
-- dimensions: *id674
-  name: ch.swisstopo.zeitreihen_19151231_source
-  sources: [ch.swisstopo.zeitreihen_19151231_cache]
-  title: Zeitreise - Kartenwerke (19151231, source)
-- dimensions: &id675
-    Time:
-      default: '19141231'
-      values: ['19141231']
-  name: ch.swisstopo.zeitreihen_19141231
-  sources: [ch.swisstopo.zeitreihen_19141231_cache_out]
-  title: Zeitreise - Kartenwerke (19141231)
-- dimensions: *id675
-  name: ch.swisstopo.zeitreihen_19141231_source
-  sources: [ch.swisstopo.zeitreihen_19141231_cache]
-  title: Zeitreise - Kartenwerke (19141231, source)
-- dimensions: &id676
-    Time:
-      default: '19131231'
-      values: ['19131231']
-  name: ch.swisstopo.zeitreihen_19131231
-  sources: [ch.swisstopo.zeitreihen_19131231_cache_out]
-  title: Zeitreise - Kartenwerke (19131231)
-- dimensions: *id676
-  name: ch.swisstopo.zeitreihen_19131231_source
-  sources: [ch.swisstopo.zeitreihen_19131231_cache]
-  title: Zeitreise - Kartenwerke (19131231, source)
-- dimensions: &id677
-    Time:
-      default: '19121231'
-      values: ['19121231']
-  name: ch.swisstopo.zeitreihen_19121231
-  sources: [ch.swisstopo.zeitreihen_19121231_cache_out]
-  title: Zeitreise - Kartenwerke (19121231)
-- dimensions: *id677
-  name: ch.swisstopo.zeitreihen_19121231_source
-  sources: [ch.swisstopo.zeitreihen_19121231_cache]
-  title: Zeitreise - Kartenwerke (19121231, source)
-- dimensions: &id678
-    Time:
-      default: '19111231'
-      values: ['19111231']
-  name: ch.swisstopo.zeitreihen_19111231
-  sources: [ch.swisstopo.zeitreihen_19111231_cache_out]
-  title: Zeitreise - Kartenwerke (19111231)
-- dimensions: *id678
-  name: ch.swisstopo.zeitreihen_19111231_source
-  sources: [ch.swisstopo.zeitreihen_19111231_cache]
-  title: Zeitreise - Kartenwerke (19111231, source)
-- dimensions: &id679
-    Time:
-      default: '19101231'
-      values: ['19101231']
-  name: ch.swisstopo.zeitreihen_19101231
-  sources: [ch.swisstopo.zeitreihen_19101231_cache_out]
-  title: Zeitreise - Kartenwerke (19101231)
-- dimensions: *id679
-  name: ch.swisstopo.zeitreihen_19101231_source
-  sources: [ch.swisstopo.zeitreihen_19101231_cache]
-  title: Zeitreise - Kartenwerke (19101231, source)
-- dimensions: &id680
-    Time:
-      default: '19091231'
-      values: ['19091231']
-  name: ch.swisstopo.zeitreihen_19091231
-  sources: [ch.swisstopo.zeitreihen_19091231_cache_out]
-  title: Zeitreise - Kartenwerke (19091231)
-- dimensions: *id680
-  name: ch.swisstopo.zeitreihen_19091231_source
-  sources: [ch.swisstopo.zeitreihen_19091231_cache]
-  title: Zeitreise - Kartenwerke (19091231, source)
-- dimensions: &id681
-    Time:
-      default: '19081231'
-      values: ['19081231']
-  name: ch.swisstopo.zeitreihen_19081231
-  sources: [ch.swisstopo.zeitreihen_19081231_cache_out]
-  title: Zeitreise - Kartenwerke (19081231)
-- dimensions: *id681
-  name: ch.swisstopo.zeitreihen_19081231_source
-  sources: [ch.swisstopo.zeitreihen_19081231_cache]
-  title: Zeitreise - Kartenwerke (19081231, source)
-- dimensions: &id682
-    Time:
-      default: '19071231'
-      values: ['19071231']
-  name: ch.swisstopo.zeitreihen_19071231
-  sources: [ch.swisstopo.zeitreihen_19071231_cache_out]
-  title: Zeitreise - Kartenwerke (19071231)
-- dimensions: *id682
-  name: ch.swisstopo.zeitreihen_19071231_source
-  sources: [ch.swisstopo.zeitreihen_19071231_cache]
-  title: Zeitreise - Kartenwerke (19071231, source)
-- dimensions: &id683
-    Time:
-      default: '19061231'
-      values: ['19061231']
-  name: ch.swisstopo.zeitreihen_19061231
-  sources: [ch.swisstopo.zeitreihen_19061231_cache_out]
-  title: Zeitreise - Kartenwerke (19061231)
-- dimensions: *id683
-  name: ch.swisstopo.zeitreihen_19061231_source
-  sources: [ch.swisstopo.zeitreihen_19061231_cache]
-  title: Zeitreise - Kartenwerke (19061231, source)
-- dimensions: &id684
-    Time:
-      default: '19051231'
-      values: ['19051231']
-  name: ch.swisstopo.zeitreihen_19051231
-  sources: [ch.swisstopo.zeitreihen_19051231_cache_out]
-  title: Zeitreise - Kartenwerke (19051231)
-- dimensions: *id684
-  name: ch.swisstopo.zeitreihen_19051231_source
-  sources: [ch.swisstopo.zeitreihen_19051231_cache]
-  title: Zeitreise - Kartenwerke (19051231, source)
-- dimensions: &id685
-    Time:
-      default: '19041231'
-      values: ['19041231']
-  name: ch.swisstopo.zeitreihen_19041231
-  sources: [ch.swisstopo.zeitreihen_19041231_cache_out]
-  title: Zeitreise - Kartenwerke (19041231)
-- dimensions: *id685
-  name: ch.swisstopo.zeitreihen_19041231_source
-  sources: [ch.swisstopo.zeitreihen_19041231_cache]
-  title: Zeitreise - Kartenwerke (19041231, source)
-- dimensions: &id686
-    Time:
-      default: '19031231'
-      values: ['19031231']
-  name: ch.swisstopo.zeitreihen_19031231
-  sources: [ch.swisstopo.zeitreihen_19031231_cache_out]
-  title: Zeitreise - Kartenwerke (19031231)
-- dimensions: *id686
-  name: ch.swisstopo.zeitreihen_19031231_source
-  sources: [ch.swisstopo.zeitreihen_19031231_cache]
-  title: Zeitreise - Kartenwerke (19031231, source)
-- dimensions: &id687
-    Time:
-      default: '19021231'
-      values: ['19021231']
-  name: ch.swisstopo.zeitreihen_19021231
-  sources: [ch.swisstopo.zeitreihen_19021231_cache_out]
-  title: Zeitreise - Kartenwerke (19021231)
-- dimensions: *id687
-  name: ch.swisstopo.zeitreihen_19021231_source
-  sources: [ch.swisstopo.zeitreihen_19021231_cache]
-  title: Zeitreise - Kartenwerke (19021231, source)
-- dimensions: &id688
-    Time:
-      default: '19011231'
-      values: ['19011231']
-  name: ch.swisstopo.zeitreihen_19011231
-  sources: [ch.swisstopo.zeitreihen_19011231_cache_out]
-  title: Zeitreise - Kartenwerke (19011231)
-- dimensions: *id688
-  name: ch.swisstopo.zeitreihen_19011231_source
-  sources: [ch.swisstopo.zeitreihen_19011231_cache]
-  title: Zeitreise - Kartenwerke (19011231, source)
-- dimensions: &id689
-    Time:
-      default: '19001231'
-      values: ['19001231']
-  name: ch.swisstopo.zeitreihen_19001231
-  sources: [ch.swisstopo.zeitreihen_19001231_cache_out]
-  title: Zeitreise - Kartenwerke (19001231)
-- dimensions: *id689
-  name: ch.swisstopo.zeitreihen_19001231_source
-  sources: [ch.swisstopo.zeitreihen_19001231_cache]
-  title: Zeitreise - Kartenwerke (19001231, source)
-- dimensions: &id690
-    Time:
-      default: '18991231'
-      values: ['18991231']
-  name: ch.swisstopo.zeitreihen_18991231
-  sources: [ch.swisstopo.zeitreihen_18991231_cache_out]
-  title: Zeitreise - Kartenwerke (18991231)
-- dimensions: *id690
-  name: ch.swisstopo.zeitreihen_18991231_source
-  sources: [ch.swisstopo.zeitreihen_18991231_cache]
-  title: Zeitreise - Kartenwerke (18991231, source)
-- dimensions: &id691
-    Time:
-      default: '18981231'
-      values: ['18981231']
-  name: ch.swisstopo.zeitreihen_18981231
-  sources: [ch.swisstopo.zeitreihen_18981231_cache_out]
-  title: Zeitreise - Kartenwerke (18981231)
-- dimensions: *id691
-  name: ch.swisstopo.zeitreihen_18981231_source
-  sources: [ch.swisstopo.zeitreihen_18981231_cache]
-  title: Zeitreise - Kartenwerke (18981231, source)
-- dimensions: &id692
-    Time:
-      default: '18971231'
-      values: ['18971231']
-  name: ch.swisstopo.zeitreihen_18971231
-  sources: [ch.swisstopo.zeitreihen_18971231_cache_out]
-  title: Zeitreise - Kartenwerke (18971231)
-- dimensions: *id692
-  name: ch.swisstopo.zeitreihen_18971231_source
-  sources: [ch.swisstopo.zeitreihen_18971231_cache]
-  title: Zeitreise - Kartenwerke (18971231, source)
-- dimensions: &id693
-    Time:
-      default: '18961231'
-      values: ['18961231']
-  name: ch.swisstopo.zeitreihen_18961231
-  sources: [ch.swisstopo.zeitreihen_18961231_cache_out]
-  title: Zeitreise - Kartenwerke (18961231)
-- dimensions: *id693
-  name: ch.swisstopo.zeitreihen_18961231_source
-  sources: [ch.swisstopo.zeitreihen_18961231_cache]
-  title: Zeitreise - Kartenwerke (18961231, source)
-- dimensions: &id694
-    Time:
-      default: '18951231'
-      values: ['18951231']
-  name: ch.swisstopo.zeitreihen_18951231
-  sources: [ch.swisstopo.zeitreihen_18951231_cache_out]
-  title: Zeitreise - Kartenwerke (18951231)
-- dimensions: *id694
-  name: ch.swisstopo.zeitreihen_18951231_source
-  sources: [ch.swisstopo.zeitreihen_18951231_cache]
-  title: Zeitreise - Kartenwerke (18951231, source)
-- dimensions: &id695
-    Time:
-      default: '18941231'
-      values: ['18941231']
-  name: ch.swisstopo.zeitreihen_18941231
-  sources: [ch.swisstopo.zeitreihen_18941231_cache_out]
-  title: Zeitreise - Kartenwerke (18941231)
-- dimensions: *id695
-  name: ch.swisstopo.zeitreihen_18941231_source
-  sources: [ch.swisstopo.zeitreihen_18941231_cache]
-  title: Zeitreise - Kartenwerke (18941231, source)
-- dimensions: &id696
-    Time:
-      default: '18931231'
-      values: ['18931231']
-  name: ch.swisstopo.zeitreihen_18931231
-  sources: [ch.swisstopo.zeitreihen_18931231_cache_out]
-  title: Zeitreise - Kartenwerke (18931231)
-- dimensions: *id696
-  name: ch.swisstopo.zeitreihen_18931231_source
-  sources: [ch.swisstopo.zeitreihen_18931231_cache]
-  title: Zeitreise - Kartenwerke (18931231, source)
-- dimensions: &id697
-    Time:
-      default: '18921231'
-      values: ['18921231']
-  name: ch.swisstopo.zeitreihen_18921231
-  sources: [ch.swisstopo.zeitreihen_18921231_cache_out]
-  title: Zeitreise - Kartenwerke (18921231)
-- dimensions: *id697
-  name: ch.swisstopo.zeitreihen_18921231_source
-  sources: [ch.swisstopo.zeitreihen_18921231_cache]
-  title: Zeitreise - Kartenwerke (18921231, source)
-- dimensions: &id698
-    Time:
-      default: '18911231'
-      values: ['18911231']
-  name: ch.swisstopo.zeitreihen_18911231
-  sources: [ch.swisstopo.zeitreihen_18911231_cache_out]
-  title: Zeitreise - Kartenwerke (18911231)
-- dimensions: *id698
-  name: ch.swisstopo.zeitreihen_18911231_source
-  sources: [ch.swisstopo.zeitreihen_18911231_cache]
-  title: Zeitreise - Kartenwerke (18911231, source)
-- dimensions: &id699
-    Time:
-      default: '18901231'
-      values: ['18901231']
-  name: ch.swisstopo.zeitreihen_18901231
-  sources: [ch.swisstopo.zeitreihen_18901231_cache_out]
-  title: Zeitreise - Kartenwerke (18901231)
-- dimensions: *id699
-  name: ch.swisstopo.zeitreihen_18901231_source
-  sources: [ch.swisstopo.zeitreihen_18901231_cache]
-  title: Zeitreise - Kartenwerke (18901231, source)
-- dimensions: &id700
-    Time:
-      default: '18891231'
-      values: ['18891231']
-  name: ch.swisstopo.zeitreihen_18891231
-  sources: [ch.swisstopo.zeitreihen_18891231_cache_out]
-  title: Zeitreise - Kartenwerke (18891231)
-- dimensions: *id700
-  name: ch.swisstopo.zeitreihen_18891231_source
-  sources: [ch.swisstopo.zeitreihen_18891231_cache]
-  title: Zeitreise - Kartenwerke (18891231, source)
-- dimensions: &id701
-    Time:
-      default: '18881231'
-      values: ['18881231']
-  name: ch.swisstopo.zeitreihen_18881231
-  sources: [ch.swisstopo.zeitreihen_18881231_cache_out]
-  title: Zeitreise - Kartenwerke (18881231)
-- dimensions: *id701
-  name: ch.swisstopo.zeitreihen_18881231_source
-  sources: [ch.swisstopo.zeitreihen_18881231_cache]
-  title: Zeitreise - Kartenwerke (18881231, source)
-- dimensions: &id702
-    Time:
-      default: '18871231'
-      values: ['18871231']
-  name: ch.swisstopo.zeitreihen_18871231
-  sources: [ch.swisstopo.zeitreihen_18871231_cache_out]
-  title: Zeitreise - Kartenwerke (18871231)
-- dimensions: *id702
-  name: ch.swisstopo.zeitreihen_18871231_source
-  sources: [ch.swisstopo.zeitreihen_18871231_cache]
-  title: Zeitreise - Kartenwerke (18871231, source)
-- dimensions: &id703
-    Time:
-      default: '18861231'
-      values: ['18861231']
-  name: ch.swisstopo.zeitreihen_18861231
-  sources: [ch.swisstopo.zeitreihen_18861231_cache_out]
-  title: Zeitreise - Kartenwerke (18861231)
-- dimensions: *id703
-  name: ch.swisstopo.zeitreihen_18861231_source
-  sources: [ch.swisstopo.zeitreihen_18861231_cache]
-  title: Zeitreise - Kartenwerke (18861231, source)
-- dimensions: &id704
-    Time:
-      default: '18851231'
-      values: ['18851231']
-  name: ch.swisstopo.zeitreihen_18851231
-  sources: [ch.swisstopo.zeitreihen_18851231_cache_out]
-  title: Zeitreise - Kartenwerke (18851231)
-- dimensions: *id704
-  name: ch.swisstopo.zeitreihen_18851231_source
-  sources: [ch.swisstopo.zeitreihen_18851231_cache]
-  title: Zeitreise - Kartenwerke (18851231, source)
-- dimensions: &id705
-    Time:
-      default: '18841231'
-      values: ['18841231']
-  name: ch.swisstopo.zeitreihen_18841231
-  sources: [ch.swisstopo.zeitreihen_18841231_cache_out]
-  title: Zeitreise - Kartenwerke (18841231)
-- dimensions: *id705
-  name: ch.swisstopo.zeitreihen_18841231_source
-  sources: [ch.swisstopo.zeitreihen_18841231_cache]
-  title: Zeitreise - Kartenwerke (18841231, source)
-- dimensions: &id706
-    Time:
-      default: '18831231'
-      values: ['18831231']
-  name: ch.swisstopo.zeitreihen_18831231
-  sources: [ch.swisstopo.zeitreihen_18831231_cache_out]
-  title: Zeitreise - Kartenwerke (18831231)
-- dimensions: *id706
-  name: ch.swisstopo.zeitreihen_18831231_source
-  sources: [ch.swisstopo.zeitreihen_18831231_cache]
-  title: Zeitreise - Kartenwerke (18831231, source)
-- dimensions: &id707
-    Time:
-      default: '18821231'
-      values: ['18821231']
-  name: ch.swisstopo.zeitreihen_18821231
-  sources: [ch.swisstopo.zeitreihen_18821231_cache_out]
-  title: Zeitreise - Kartenwerke (18821231)
-- dimensions: *id707
-  name: ch.swisstopo.zeitreihen_18821231_source
-  sources: [ch.swisstopo.zeitreihen_18821231_cache]
-  title: Zeitreise - Kartenwerke (18821231, source)
-- dimensions: &id708
-    Time:
-      default: '18811231'
-      values: ['18811231']
-  name: ch.swisstopo.zeitreihen_18811231
-  sources: [ch.swisstopo.zeitreihen_18811231_cache_out]
-  title: Zeitreise - Kartenwerke (18811231)
-- dimensions: *id708
-  name: ch.swisstopo.zeitreihen_18811231_source
-  sources: [ch.swisstopo.zeitreihen_18811231_cache]
-  title: Zeitreise - Kartenwerke (18811231, source)
-- dimensions: &id709
-    Time:
-      default: '18801231'
-      values: ['18801231']
-  name: ch.swisstopo.zeitreihen_18801231
-  sources: [ch.swisstopo.zeitreihen_18801231_cache_out]
-  title: Zeitreise - Kartenwerke (18801231)
-- dimensions: *id709
-  name: ch.swisstopo.zeitreihen_18801231_source
-  sources: [ch.swisstopo.zeitreihen_18801231_cache]
-  title: Zeitreise - Kartenwerke (18801231, source)
-- dimensions: &id710
-    Time:
-      default: '18791231'
-      values: ['18791231']
-  name: ch.swisstopo.zeitreihen_18791231
-  sources: [ch.swisstopo.zeitreihen_18791231_cache_out]
-  title: Zeitreise - Kartenwerke (18791231)
-- dimensions: *id710
-  name: ch.swisstopo.zeitreihen_18791231_source
-  sources: [ch.swisstopo.zeitreihen_18791231_cache]
-  title: Zeitreise - Kartenwerke (18791231, source)
-- dimensions: &id711
-    Time:
-      default: '18781231'
-      values: ['18781231']
-  name: ch.swisstopo.zeitreihen_18781231
-  sources: [ch.swisstopo.zeitreihen_18781231_cache_out]
-  title: Zeitreise - Kartenwerke (18781231)
-- dimensions: *id711
-  name: ch.swisstopo.zeitreihen_18781231_source
-  sources: [ch.swisstopo.zeitreihen_18781231_cache]
-  title: Zeitreise - Kartenwerke (18781231, source)
-- dimensions: &id712
-    Time:
-      default: '18771231'
-      values: ['18771231']
-  name: ch.swisstopo.zeitreihen_18771231
-  sources: [ch.swisstopo.zeitreihen_18771231_cache_out]
-  title: Zeitreise - Kartenwerke (18771231)
-- dimensions: *id712
-  name: ch.swisstopo.zeitreihen_18771231_source
-  sources: [ch.swisstopo.zeitreihen_18771231_cache]
-  title: Zeitreise - Kartenwerke (18771231, source)
-- dimensions: &id713
-    Time:
-      default: '18761231'
-      values: ['18761231']
-  name: ch.swisstopo.zeitreihen_18761231
-  sources: [ch.swisstopo.zeitreihen_18761231_cache_out]
-  title: Zeitreise - Kartenwerke (18761231)
-- dimensions: *id713
-  name: ch.swisstopo.zeitreihen_18761231_source
-  sources: [ch.swisstopo.zeitreihen_18761231_cache]
-  title: Zeitreise - Kartenwerke (18761231, source)
-- dimensions: &id714
-    Time:
-      default: '18751231'
-      values: ['18751231']
-  name: ch.swisstopo.zeitreihen_18751231
-  sources: [ch.swisstopo.zeitreihen_18751231_cache_out]
-  title: Zeitreise - Kartenwerke (18751231)
-- dimensions: *id714
-  name: ch.swisstopo.zeitreihen_18751231_source
-  sources: [ch.swisstopo.zeitreihen_18751231_cache]
-  title: Zeitreise - Kartenwerke (18751231, source)
-- dimensions: &id715
-    Time:
-      default: '18741231'
-      values: ['18741231']
-  name: ch.swisstopo.zeitreihen_18741231
-  sources: [ch.swisstopo.zeitreihen_18741231_cache_out]
-  title: Zeitreise - Kartenwerke (18741231)
-- dimensions: *id715
-  name: ch.swisstopo.zeitreihen_18741231_source
-  sources: [ch.swisstopo.zeitreihen_18741231_cache]
-  title: Zeitreise - Kartenwerke (18741231, source)
-- dimensions: &id716
-    Time:
-      default: '18731231'
-      values: ['18731231']
-  name: ch.swisstopo.zeitreihen_18731231
-  sources: [ch.swisstopo.zeitreihen_18731231_cache_out]
-  title: Zeitreise - Kartenwerke (18731231)
-- dimensions: *id716
-  name: ch.swisstopo.zeitreihen_18731231_source
-  sources: [ch.swisstopo.zeitreihen_18731231_cache]
-  title: Zeitreise - Kartenwerke (18731231, source)
-- dimensions: &id717
-    Time:
-      default: '18721231'
-      values: ['18721231']
-  name: ch.swisstopo.zeitreihen_18721231
-  sources: [ch.swisstopo.zeitreihen_18721231_cache_out]
-  title: Zeitreise - Kartenwerke (18721231)
-- dimensions: *id717
-  name: ch.swisstopo.zeitreihen_18721231_source
-  sources: [ch.swisstopo.zeitreihen_18721231_cache]
-  title: Zeitreise - Kartenwerke (18721231, source)
-- dimensions: &id718
-    Time:
-      default: '18711231'
-      values: ['18711231']
-  name: ch.swisstopo.zeitreihen_18711231
-  sources: [ch.swisstopo.zeitreihen_18711231_cache_out]
-  title: Zeitreise - Kartenwerke (18711231)
-- dimensions: *id718
-  name: ch.swisstopo.zeitreihen_18711231_source
-  sources: [ch.swisstopo.zeitreihen_18711231_cache]
-  title: Zeitreise - Kartenwerke (18711231, source)
-- dimensions: &id719
-    Time:
-      default: '18701231'
-      values: ['18701231']
-  name: ch.swisstopo.zeitreihen_18701231
-  sources: [ch.swisstopo.zeitreihen_18701231_cache_out]
-  title: Zeitreise - Kartenwerke (18701231)
-- dimensions: *id719
-  name: ch.swisstopo.zeitreihen_18701231_source
-  sources: [ch.swisstopo.zeitreihen_18701231_cache]
-  title: Zeitreise - Kartenwerke (18701231, source)
-- dimensions: &id720
-    Time:
-      default: '18691231'
-      values: ['18691231']
-  name: ch.swisstopo.zeitreihen_18691231
-  sources: [ch.swisstopo.zeitreihen_18691231_cache_out]
-  title: Zeitreise - Kartenwerke (18691231)
-- dimensions: *id720
-  name: ch.swisstopo.zeitreihen_18691231_source
-  sources: [ch.swisstopo.zeitreihen_18691231_cache]
-  title: Zeitreise - Kartenwerke (18691231, source)
-- dimensions: &id721
-    Time:
-      default: '18681231'
-      values: ['18681231']
-  name: ch.swisstopo.zeitreihen_18681231
-  sources: [ch.swisstopo.zeitreihen_18681231_cache_out]
-  title: Zeitreise - Kartenwerke (18681231)
-- dimensions: *id721
-  name: ch.swisstopo.zeitreihen_18681231_source
-  sources: [ch.swisstopo.zeitreihen_18681231_cache]
-  title: Zeitreise - Kartenwerke (18681231, source)
-- dimensions: &id722
-    Time:
-      default: '18671231'
-      values: ['18671231']
-  name: ch.swisstopo.zeitreihen_18671231
-  sources: [ch.swisstopo.zeitreihen_18671231_cache_out]
-  title: Zeitreise - Kartenwerke (18671231)
-- dimensions: *id722
-  name: ch.swisstopo.zeitreihen_18671231_source
-  sources: [ch.swisstopo.zeitreihen_18671231_cache]
-  title: Zeitreise - Kartenwerke (18671231, source)
-- dimensions: &id723
-    Time:
-      default: '18661231'
-      values: ['18661231']
-  name: ch.swisstopo.zeitreihen_18661231
-  sources: [ch.swisstopo.zeitreihen_18661231_cache_out]
-  title: Zeitreise - Kartenwerke (18661231)
-- dimensions: *id723
-  name: ch.swisstopo.zeitreihen_18661231_source
-  sources: [ch.swisstopo.zeitreihen_18661231_cache]
-  title: Zeitreise - Kartenwerke (18661231, source)
-- dimensions: &id724
-    Time:
-      default: '18651231'
-      values: ['18651231']
-  name: ch.swisstopo.zeitreihen_18651231
-  sources: [ch.swisstopo.zeitreihen_18651231_cache_out]
-  title: Zeitreise - Kartenwerke (18651231)
-- dimensions: *id724
-  name: ch.swisstopo.zeitreihen_18651231_source
-  sources: [ch.swisstopo.zeitreihen_18651231_cache]
-  title: Zeitreise - Kartenwerke (18651231, source)
-- dimensions: &id725
-    Time:
-      default: '18641231'
-      values: ['18641231']
-  name: ch.swisstopo.zeitreihen_18641231
-  sources: [ch.swisstopo.zeitreihen_18641231_cache_out]
-  title: Zeitreise - Kartenwerke (18641231)
-- dimensions: *id725
-  name: ch.swisstopo.zeitreihen_18641231_source
-  sources: [ch.swisstopo.zeitreihen_18641231_cache]
-  title: Zeitreise - Kartenwerke (18641231, source)
-- dimensions: &id726
-    Time:
-      default: '18631231'
-      values: ['18631231']
-  name: ch.swisstopo.zeitreihen_18631231
-  sources: [ch.swisstopo.zeitreihen_18631231_cache_out]
-  title: Zeitreise - Kartenwerke (18631231)
-- dimensions: *id726
-  name: ch.swisstopo.zeitreihen_18631231_source
-  sources: [ch.swisstopo.zeitreihen_18631231_cache]
-  title: Zeitreise - Kartenwerke (18631231, source)
-- dimensions: &id727
-    Time:
-      default: '18621231'
-      values: ['18621231']
-  name: ch.swisstopo.zeitreihen_18621231
-  sources: [ch.swisstopo.zeitreihen_18621231_cache_out]
-  title: Zeitreise - Kartenwerke (18621231)
-- dimensions: *id727
-  name: ch.swisstopo.zeitreihen_18621231_source
-  sources: [ch.swisstopo.zeitreihen_18621231_cache]
-  title: Zeitreise - Kartenwerke (18621231, source)
-- dimensions: &id728
-    Time:
-      default: '18611231'
-      values: ['18611231']
-  name: ch.swisstopo.zeitreihen_18611231
-  sources: [ch.swisstopo.zeitreihen_18611231_cache_out]
-  title: Zeitreise - Kartenwerke (18611231)
-- dimensions: *id728
-  name: ch.swisstopo.zeitreihen_18611231_source
-  sources: [ch.swisstopo.zeitreihen_18611231_cache]
-  title: Zeitreise - Kartenwerke (18611231, source)
-- dimensions: &id729
-    Time:
-      default: '18601231'
-      values: ['18601231']
-  name: ch.swisstopo.zeitreihen_18601231
-  sources: [ch.swisstopo.zeitreihen_18601231_cache_out]
-  title: Zeitreise - Kartenwerke (18601231)
-- dimensions: *id729
-  name: ch.swisstopo.zeitreihen_18601231_source
-  sources: [ch.swisstopo.zeitreihen_18601231_cache]
-  title: Zeitreise - Kartenwerke (18601231, source)
-- dimensions: &id730
-    Time:
-      default: '18591231'
-      values: ['18591231']
-  name: ch.swisstopo.zeitreihen_18591231
-  sources: [ch.swisstopo.zeitreihen_18591231_cache_out]
-  title: Zeitreise - Kartenwerke (18591231)
-- dimensions: *id730
-  name: ch.swisstopo.zeitreihen_18591231_source
-  sources: [ch.swisstopo.zeitreihen_18591231_cache]
-  title: Zeitreise - Kartenwerke (18591231, source)
-- dimensions: &id731
-    Time:
-      default: '18581231'
-      values: ['18581231']
-  name: ch.swisstopo.zeitreihen_18581231
-  sources: [ch.swisstopo.zeitreihen_18581231_cache_out]
-  title: Zeitreise - Kartenwerke (18581231)
-- dimensions: *id731
-  name: ch.swisstopo.zeitreihen_18581231_source
-  sources: [ch.swisstopo.zeitreihen_18581231_cache]
-  title: Zeitreise - Kartenwerke (18581231, source)
-- dimensions: &id732
-    Time:
-      default: '18571231'
-      values: ['18571231']
-  name: ch.swisstopo.zeitreihen_18571231
-  sources: [ch.swisstopo.zeitreihen_18571231_cache_out]
-  title: Zeitreise - Kartenwerke (18571231)
-- dimensions: *id732
-  name: ch.swisstopo.zeitreihen_18571231_source
-  sources: [ch.swisstopo.zeitreihen_18571231_cache]
-  title: Zeitreise - Kartenwerke (18571231, source)
-- dimensions: &id733
-    Time:
-      default: '18561231'
-      values: ['18561231']
-  name: ch.swisstopo.zeitreihen_18561231
-  sources: [ch.swisstopo.zeitreihen_18561231_cache_out]
-  title: Zeitreise - Kartenwerke (18561231)
-- dimensions: *id733
-  name: ch.swisstopo.zeitreihen_18561231_source
-  sources: [ch.swisstopo.zeitreihen_18561231_cache]
-  title: Zeitreise - Kartenwerke (18561231, source)
-- dimensions: &id734
-    Time:
-      default: '18551231'
-      values: ['18551231']
-  name: ch.swisstopo.zeitreihen_18551231
-  sources: [ch.swisstopo.zeitreihen_18551231_cache_out]
-  title: Zeitreise - Kartenwerke (18551231)
-- dimensions: *id734
-  name: ch.swisstopo.zeitreihen_18551231_source
-  sources: [ch.swisstopo.zeitreihen_18551231_cache]
-  title: Zeitreise - Kartenwerke (18551231, source)
-- dimensions: &id735
-    Time:
-      default: '18541231'
-      values: ['18541231']
-  name: ch.swisstopo.zeitreihen_18541231
-  sources: [ch.swisstopo.zeitreihen_18541231_cache_out]
-  title: Zeitreise - Kartenwerke (18541231)
-- dimensions: *id735
-  name: ch.swisstopo.zeitreihen_18541231_source
-  sources: [ch.swisstopo.zeitreihen_18541231_cache]
-  title: Zeitreise - Kartenwerke (18541231, source)
-- dimensions: &id736
-    Time:
-      default: '18531231'
-      values: ['18531231']
-  name: ch.swisstopo.zeitreihen_18531231
-  sources: [ch.swisstopo.zeitreihen_18531231_cache_out]
-  title: Zeitreise - Kartenwerke (18531231)
-- dimensions: *id736
-  name: ch.swisstopo.zeitreihen_18531231_source
-  sources: [ch.swisstopo.zeitreihen_18531231_cache]
-  title: Zeitreise - Kartenwerke (18531231, source)
-- dimensions: &id737
-    Time:
-      default: '18521231'
-      values: ['18521231']
-  name: ch.swisstopo.zeitreihen_18521231
-  sources: [ch.swisstopo.zeitreihen_18521231_cache_out]
-  title: Zeitreise - Kartenwerke (18521231)
-- dimensions: *id737
-  name: ch.swisstopo.zeitreihen_18521231_source
-  sources: [ch.swisstopo.zeitreihen_18521231_cache]
-  title: Zeitreise - Kartenwerke (18521231, source)
-- dimensions: &id738
-    Time:
-      default: '18511231'
-      values: ['18511231']
-  name: ch.swisstopo.zeitreihen_18511231
-  sources: [ch.swisstopo.zeitreihen_18511231_cache_out]
-  title: Zeitreise - Kartenwerke (18511231)
-- dimensions: *id738
-  name: ch.swisstopo.zeitreihen_18511231_source
-  sources: [ch.swisstopo.zeitreihen_18511231_cache]
-  title: Zeitreise - Kartenwerke (18511231, source)
-- dimensions: &id739
-    Time:
-      default: '18501231'
-      values: ['18501231']
-  name: ch.swisstopo.zeitreihen_18501231
-  sources: [ch.swisstopo.zeitreihen_18501231_cache_out]
-  title: Zeitreise - Kartenwerke (18501231)
-- dimensions: *id739
-  name: ch.swisstopo.zeitreihen_18501231_source
-  sources: [ch.swisstopo.zeitreihen_18501231_cache]
-  title: Zeitreise - Kartenwerke (18501231, source)
-- dimensions: &id740
-    Time:
-      default: '18491231'
-      values: ['18491231']
-  name: ch.swisstopo.zeitreihen_18491231
-  sources: [ch.swisstopo.zeitreihen_18491231_cache_out]
-  title: Zeitreise - Kartenwerke (18491231)
-- dimensions: *id740
-  name: ch.swisstopo.zeitreihen_18491231_source
-  sources: [ch.swisstopo.zeitreihen_18491231_cache]
-  title: Zeitreise - Kartenwerke (18491231, source)
-- dimensions: &id741
-    Time:
-      default: '18481231'
-      values: ['18481231']
-  name: ch.swisstopo.zeitreihen_18481231
-  sources: [ch.swisstopo.zeitreihen_18481231_cache_out]
-  title: Zeitreise - Kartenwerke (18481231)
-- dimensions: *id741
-  name: ch.swisstopo.zeitreihen_18481231_source
-  sources: [ch.swisstopo.zeitreihen_18481231_cache]
-  title: Zeitreise - Kartenwerke (18481231, source)
-- dimensions: &id742
-    Time:
-      default: '18471231'
-      values: ['18471231']
-  name: ch.swisstopo.zeitreihen_18471231
-  sources: [ch.swisstopo.zeitreihen_18471231_cache_out]
-  title: Zeitreise - Kartenwerke (18471231)
-- dimensions: *id742
-  name: ch.swisstopo.zeitreihen_18471231_source
-  sources: [ch.swisstopo.zeitreihen_18471231_cache]
-  title: Zeitreise - Kartenwerke (18471231, source)
-- dimensions: &id743
-    Time:
-      default: '18461231'
-      values: ['18461231']
-  name: ch.swisstopo.zeitreihen_18461231
-  sources: [ch.swisstopo.zeitreihen_18461231_cache_out]
-  title: Zeitreise - Kartenwerke (18461231)
-- dimensions: *id743
-  name: ch.swisstopo.zeitreihen_18461231_source
-  sources: [ch.swisstopo.zeitreihen_18461231_cache]
-  title: Zeitreise - Kartenwerke (18461231, source)
-- dimensions: &id744
-    Time:
-      default: '18451231'
-      values: ['18451231']
-  name: ch.swisstopo.zeitreihen_18451231
-  sources: [ch.swisstopo.zeitreihen_18451231_cache_out]
-  title: Zeitreise - Kartenwerke (18451231)
-- dimensions: *id744
-  name: ch.swisstopo.zeitreihen_18451231_source
-  sources: [ch.swisstopo.zeitreihen_18451231_cache]
-  title: Zeitreise - Kartenwerke (18451231, source)
-- dimensions: &id745
-    Time:
-      default: '18441231'
-      values: ['18441231']
-  name: ch.swisstopo.zeitreihen_18441231
-  sources: [ch.swisstopo.zeitreihen_18441231_cache_out]
-  title: Zeitreise - Kartenwerke (18441231)
-- dimensions: *id745
-  name: ch.swisstopo.zeitreihen_18441231_source
-  sources: [ch.swisstopo.zeitreihen_18441231_cache]
-  title: Zeitreise - Kartenwerke (18441231, source)
-- dimensions: &id746
+- dimensions: &id421
+    Time:
+      default: '20120111'
+      values: ['20120111']
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_cache_out]
+  title: TWW Anhang 2 (20120111)
+- dimensions: *id421
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_cache]
+  title: TWW Anhang 2 ('current')
+- dimensions: *id421
+  name: ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_source
+  sources: [ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2_20120111_cache]
+  title: TWW Anhang 2 (20120111, source)
+- dimensions: &id422
+    Time:
+      default: '20130212'
+      values: ['20130212']
+  name: ch.bfs.gebaeude_wohnungs_register_20130212
+  sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache_out]
+  title: "Geb\xE4ude- und Wohnungsregister (20130212)"
+- dimensions: *id422
+  name: ch.bfs.gebaeude_wohnungs_register
+  sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
+  title: "Geb\xE4ude- und Wohnungsregister ('current')"
+- dimensions: *id422
+  name: ch.bfs.gebaeude_wohnungs_register_20130212_source
+  sources: [ch.bfs.gebaeude_wohnungs_register_20130212_cache]
+  title: "Geb\xE4ude- und Wohnungsregister (20130212, source)"
+- dimensions: &id423
+    Time:
+      default: '20111129'
+      values: ['20111129']
+  name: ch.bafu.wildruhezonen-jagdbanngebiete_20111129
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_20111129_cache_out]
+  title: Wildruhezonen (20111129)
+- dimensions: *id423
+  name: ch.bafu.wildruhezonen-jagdbanngebiete
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_20111129_cache]
+  title: Wildruhezonen ('current')
+- dimensions: *id423
+  name: ch.bafu.wildruhezonen-jagdbanngebiete_20111129_source
+  sources: [ch.bafu.wildruhezonen-jagdbanngebiete_20111129_cache]
+  title: Wildruhezonen (20111129, source)
+- dimensions: &id424
+    Time:
+      default: '20130523'
+      values: ['20130523']
+  name: ch.bafu.schutzgebiete-aulav_uebrige_20130523
+  sources: [ch.bafu.schutzgebiete-aulav_uebrige_20130523_cache_out]
+  title: "\xDCbrige Schutzgebiete AuLaV (20130523)"
+- dimensions: *id424
+  name: ch.bafu.schutzgebiete-aulav_uebrige
+  sources: [ch.bafu.schutzgebiete-aulav_uebrige_20130523_cache]
+  title: "\xDCbrige Schutzgebiete AuLaV ('current')"
+- dimensions: *id424
+  name: ch.bafu.schutzgebiete-aulav_uebrige_20130523_source
+  sources: [ch.bafu.schutzgebiete-aulav_uebrige_20130523_cache]
+  title: "\xDCbrige Schutzgebiete AuLaV (20130523, source)"
+- dimensions: &id425
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.bafu.hydrologie-hochwasserstatistik_20140101
+  sources: [ch.bafu.hydrologie-hochwasserstatistik_20140101_cache_out]
+  title: HQStat (20140101)
+- dimensions: *id425
+  name: ch.bafu.hydrologie-hochwasserstatistik
+  sources: [ch.bafu.hydrologie-hochwasserstatistik_20140101_cache]
+  title: HQStat ('current')
+- dimensions: *id425
+  name: ch.bafu.hydrologie-hochwasserstatistik_20140101_source
+  sources: [ch.bafu.hydrologie-hochwasserstatistik_20140101_cache]
+  title: HQStat (20140101, source)
+- dimensions: &id426
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache_out]
+  title: "Steinbr\xFCche 1980 (20060304)"
+- dimensions: *id426
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache]
+  title: "Steinbr\xFCche 1980 ('current')"
+- dimensions: *id426
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1980_20060304_cache]
+  title: "Steinbr\xFCche 1980 (20060304, source)"
+- dimensions: &id427
+    Time:
+      default: '20111205'
+      values: ['20111205']
+  name: ch.bafu.bundesinventare-amphibien_anhang4_20111205
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_20111205_cache_out]
+  title: Amphibien Anhang 4 (20111205)
+- dimensions: *id427
+  name: ch.bafu.bundesinventare-amphibien_anhang4
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_20111205_cache]
+  title: Amphibien Anhang 4 ('current')
+- dimensions: *id427
+  name: ch.bafu.bundesinventare-amphibien_anhang4_20111205_source
+  sources: [ch.bafu.bundesinventare-amphibien_anhang4_20111205_cache]
+  title: Amphibien Anhang 4 (20111205, source)
+- dimensions: &id428
     Time:
       default: '20110501'
       values: ['20110501']
   name: ch.vbs.territorialregionen_20110501
   sources: [ch.vbs.territorialregionen_20110501_cache_out]
   title: Territorialregionen (20110501)
-- dimensions: *id746
+- dimensions: *id428
   name: ch.vbs.territorialregionen
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen ('current')
-- dimensions: *id746
+- dimensions: *id428
   name: ch.vbs.territorialregionen_20110501_source
   sources: [ch.vbs.territorialregionen_20110501_cache]
   title: Territorialregionen (20110501, source)
+- dimensions: &id429
+    Time:
+      default: '20090101'
+      values: ['20090101']
+  name: ch.bafu.wasserbau-querprofilmarken_20090101
+  sources: [ch.bafu.wasserbau-querprofilmarken_20090101_cache_out]
+  title: Querprofilmarke (20090101)
+- dimensions: *id429
+  name: ch.bafu.wasserbau-querprofilmarken
+  sources: [ch.bafu.wasserbau-querprofilmarken_20090101_cache]
+  title: Querprofilmarke ('current')
+- dimensions: *id429
+  name: ch.bafu.wasserbau-querprofilmarken_20090101_source
+  sources: [ch.bafu.wasserbau-querprofilmarken_20090101_cache]
+  title: Querprofilmarke (20090101, source)
+- dimensions: &id430
+    Time:
+      default: '20140120'
+      values: ['20140120']
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit_20140120
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_cache_out]
+  title: PKD (Proliferative Nierenkrankheit) (20140120)
+- dimensions: *id430
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_cache]
+  title: PKD (Proliferative Nierenkrankheit) ('current')
+- dimensions: *id430
+  name: ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_source
+  sources: [ch.bafu.fischerei-proliferative_nierenkrankheit_20140120_cache]
+  title: PKD (Proliferative Nierenkrankheit) (20140120, source)
+- dimensions: &id431
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.swisstopo.vec200-hydrography_20150101
+  sources: [ch.swisstopo.vec200-hydrography_20150101_cache_out]
+  title: "Gew\xE4ssernetz VECTOR200 (20150101)"
+- dimensions: *id431
+  name: ch.swisstopo.vec200-hydrography
+  sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
+  title: "Gew\xE4ssernetz VECTOR200 ('current')"
+- dimensions: *id431
+  name: ch.swisstopo.vec200-hydrography_20150101_source
+  sources: [ch.swisstopo.vec200-hydrography_20150101_cache]
+  title: "Gew\xE4ssernetz VECTOR200 (20150101, source)"
+- dimensions: &id432
+    Time:
+      default: '20141231'
+      values: ['20141231']
+  name: ch.bag.zecken-fsme-impfung_20141231
+  sources: [ch.bag.zecken-fsme-impfung_20141231_cache_out]
+  title: FSME - Impfempfehlung (20141231)
+- dimensions: *id432
+  name: ch.bag.zecken-fsme-impfung
+  sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
+  title: FSME - Impfempfehlung ('current')
+- dimensions: *id432
+  name: ch.bag.zecken-fsme-impfung_20141231_source
+  sources: [ch.bag.zecken-fsme-impfung_20141231_cache]
+  title: FSME - Impfempfehlung (20141231, source)
+- dimensions: &id433
+    Time:
+      default: '19980101'
+      values: ['19980101']
+  name: ch.swisstopo.swissbuildings3d_19980101
+  sources: [ch.swisstopo.swissbuildings3d_19980101_cache_out]
+  title: "Vereinfachte 3D-Geb\xE4ude (19980101)"
+- dimensions: *id433
+  name: ch.swisstopo.swissbuildings3d
+  sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
+  title: "Vereinfachte 3D-Geb\xE4ude ('current')"
+- dimensions: *id433
+  name: ch.swisstopo.swissbuildings3d_19980101_source
+  sources: [ch.swisstopo.swissbuildings3d_19980101_cache]
+  title: "Vereinfachte 3D-Geb\xE4ude (19980101, source)"
+- dimensions: &id434
+    Time:
+      default: '20130107'
+      values: ['20130107']
+  name: ch.swisstopo.geologie-geotope_20130107
+  sources: [ch.swisstopo.geologie-geotope_20130107_cache_out]
+  title: Geotope der Schweiz (20130107)
+- dimensions: *id434
+  name: ch.swisstopo.geologie-geotope
+  sources: [ch.swisstopo.geologie-geotope_20130107_cache]
+  title: Geotope der Schweiz ('current')
+- dimensions: *id434
+  name: ch.swisstopo.geologie-geotope_20130107_source
+  sources: [ch.swisstopo.geologie-geotope_20130107_cache]
+  title: Geotope der Schweiz (20130107, source)
+- dimensions: &id435
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.bafu.typisierung-fliessgewaesser_20130101
+  sources: [ch.bafu.typisierung-fliessgewaesser_20130101_cache_out]
+  title: "Typisierung Fliessgew\xE4sser (20130101)"
+- dimensions: *id435
+  name: ch.bafu.typisierung-fliessgewaesser
+  sources: [ch.bafu.typisierung-fliessgewaesser_20130101_cache]
+  title: "Typisierung Fliessgew\xE4sser ('current')"
+- dimensions: *id435
+  name: ch.bafu.typisierung-fliessgewaesser_20130101_source
+  sources: [ch.bafu.typisierung-fliessgewaesser_20130101_cache]
+  title: "Typisierung Fliessgew\xE4sser (20130101, source)"
+- dimensions: &id436
+    Time:
+      default: '20150226'
+      values: ['20150226']
+  name: ch.bafu.swissprtr_20150226
+  sources: [ch.bafu.swissprtr_20150226_cache_out]
+  title: Schadstoff-Freisetzungen (SwissPRTR) (20150226)
+- dimensions: *id436
+  name: ch.bafu.swissprtr
+  sources: [ch.bafu.swissprtr_20150226_cache]
+  title: Schadstoff-Freisetzungen (SwissPRTR) ('current')
+- dimensions: *id436
+  name: ch.bafu.swissprtr_20150226_source
+  sources: [ch.bafu.swissprtr_20150226_cache]
+  title: Schadstoff-Freisetzungen (SwissPRTR) (20150226, source)
+- dimensions: &id437
+    Time:
+      default: '20151231'
+      values: ['20151231']
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache_out]
+  title: Landeskarte 1:50'000 | LK50 (20151231)
+- dimensions: *id437
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
+  title: Landeskarte 1:50'000 | LK50 ('current')
+- dimensions: *id437
+  name: ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_source
+  sources: [ch.swisstopo.pixelkarte-farbe-pk50.noscale_20151231_cache]
+  title: Landeskarte 1:50'000 | LK50 (20151231, source)
+- dimensions: &id438
+    Time:
+      default: '20020101'
+      values: ['20020101']
+  name: ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101
+  sources: [ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_cache_out]
+  title: "Strukturg\xFCte Linkes Umfeld (20020101)"
+- dimensions: *id438
+  name: ch.bafu.strukturguete-hochrhein_linkesumfeld
+  sources: [ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_cache]
+  title: "Strukturg\xFCte Linkes Umfeld ('current')"
+- dimensions: *id438
+  name: ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_source
+  sources: [ch.bafu.strukturguete-hochrhein_linkesumfeld_20020101_cache]
+  title: "Strukturg\xFCte Linkes Umfeld (20020101, source)"
+- dimensions: &id439
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.belastung-gueterverkehr-bahn_20121231
+  sources: [ch.are.belastung-gueterverkehr-bahn_20121231_cache_out]
+  title: "G\xFCterverkehr Schiene (20121231)"
+- dimensions: *id439
+  name: ch.are.belastung-gueterverkehr-bahn
+  sources: [ch.are.belastung-gueterverkehr-bahn_20121231_cache]
+  title: "G\xFCterverkehr Schiene ('current')"
+- dimensions: *id439
+  name: ch.are.belastung-gueterverkehr-bahn_20121231_source
+  sources: [ch.are.belastung-gueterverkehr-bahn_20121231_cache]
+  title: "G\xFCterverkehr Schiene (20121231, source)"
+- dimensions: &id440
+    Time:
+      default: '20080612'
+      values: ['20080612']
+  name: ch.bafu.flora-verbreitungskarten_20080612
+  sources: [ch.bafu.flora-verbreitungskarten_20080612_cache_out]
+  title: Raster Verbreitungskarten (20080612)
+- dimensions: *id440
+  name: ch.bafu.flora-verbreitungskarten
+  sources: [ch.bafu.flora-verbreitungskarten_20080612_cache]
+  title: Raster Verbreitungskarten ('current')
+- dimensions: *id440
+  name: ch.bafu.flora-verbreitungskarten_20080612_source
+  sources: [ch.bafu.flora-verbreitungskarten_20080612_cache]
+  title: Raster Verbreitungskarten (20080612, source)
+- dimensions: &id441
+    Time:
+      default: '20110428'
+      values: ['20110428']
+  name: ch.bafu.gefahren-historische_erdbeben_20110428
+  sources: [ch.bafu.gefahren-historische_erdbeben_20110428_cache_out]
+  title: Historische Erdbeben (20110428)
+- dimensions: *id441
+  name: ch.bafu.gefahren-historische_erdbeben
+  sources: [ch.bafu.gefahren-historische_erdbeben_20110428_cache]
+  title: Historische Erdbeben ('current')
+- dimensions: *id441
+  name: ch.bafu.gefahren-historische_erdbeben_20110428_source
+  sources: [ch.bafu.gefahren-historische_erdbeben_20110428_cache]
+  title: Historische Erdbeben (20110428, source)
+- dimensions: &id442
+    Time:
+      default: '20141214'
+      values: ['20141214']
+  name: ch.are.gueteklassen_oev_20141214
+  sources: [ch.are.gueteklassen_oev_20141214_cache_out]
+  title: "\xD6V-G\xFCteklassen ARE (20141214)"
+- dimensions: *id442
+  name: ch.are.gueteklassen_oev
+  sources: [ch.are.gueteklassen_oev_20141214_cache]
+  title: "\xD6V-G\xFCteklassen ARE ('current')"
+- dimensions: *id442
+  name: ch.are.gueteklassen_oev_20141214_source
+  sources: [ch.are.gueteklassen_oev_20141214_cache]
+  title: "\xD6V-G\xFCteklassen ARE (20141214, source)"
+- dimensions: &id443
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_250_20081218
+  sources: [ch.bafu.aquaprotect_250_20081218_cache_out]
+  title: "\xDCberschwemmung Aquaprotect 250 (20081218)"
+- dimensions: *id443
+  name: ch.bafu.aquaprotect_250
+  sources: [ch.bafu.aquaprotect_250_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 250 ('current')"
+- dimensions: *id443
+  name: ch.bafu.aquaprotect_250_20081218_source
+  sources: [ch.bafu.aquaprotect_250_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 250 (20081218, source)"
+- dimensions: &id444
+    Time:
+      default: '19980101'
+      values: ['19980101']
+  name: ch.swisstopo.vec25-einzelobjekte_19980101
+  sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache_out]
+  title: Einzelobjekte VECTOR25 (19980101)
+- dimensions: *id444
+  name: ch.swisstopo.vec25-einzelobjekte
+  sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
+  title: Einzelobjekte VECTOR25 ('current')
+- dimensions: *id444
+  name: ch.swisstopo.vec25-einzelobjekte_19980101_source
+  sources: [ch.swisstopo.vec25-einzelobjekte_19980101_cache]
+  title: Einzelobjekte VECTOR25 (19980101, source)
+- dimensions: &id445
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.landesforstinventar-totholz_20100310
+  sources: [ch.bafu.landesforstinventar-totholz_20100310_cache_out]
+  title: Totholz (LFI) (20100310)
+- dimensions: *id445
+  name: ch.bafu.landesforstinventar-totholz
+  sources: [ch.bafu.landesforstinventar-totholz_20100310_cache]
+  title: Totholz (LFI) ('current')
+- dimensions: *id445
+  name: ch.bafu.landesforstinventar-totholz_20100310_source
+  sources: [ch.bafu.landesforstinventar-totholz_20100310_cache]
+  title: Totholz (LFI) (20100310, source)
+- dimensions: &id446
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.landesforstinventar-waldanteil_20100310
+  sources: [ch.bafu.landesforstinventar-waldanteil_20100310_cache_out]
+  title: Waldanteil (LFI) (20100310)
+- dimensions: *id446
+  name: ch.bafu.landesforstinventar-waldanteil
+  sources: [ch.bafu.landesforstinventar-waldanteil_20100310_cache]
+  title: Waldanteil (LFI) ('current')
+- dimensions: *id446
+  name: ch.bafu.landesforstinventar-waldanteil_20100310_source
+  sources: [ch.bafu.landesforstinventar-waldanteil_20100310_cache]
+  title: Waldanteil (LFI) (20100310, source)
+- dimensions: &id447
+    Time:
+      default: '20131231'
+      values: ['20131231']
+  name: ch.swisstopo.zeitreihen_20131231
+  sources: [ch.swisstopo.zeitreihen_20131231_cache_out]
+  title: Zeitreise - Kartenwerke (20131231)
+- dimensions: *id447
+  name: ch.swisstopo.zeitreihen
+  sources: [ch.swisstopo.zeitreihen_20131231_cache]
+  title: Zeitreise - Kartenwerke ('current')
+- dimensions: *id447
+  name: ch.swisstopo.zeitreihen_20131231_source
+  sources: [ch.swisstopo.zeitreihen_20131231_cache]
+  title: Zeitreise - Kartenwerke (20131231, source)
+- dimensions: &id448
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.swisstopo.zeitreihen_20121231
+  sources: [ch.swisstopo.zeitreihen_20121231_cache_out]
+  title: Zeitreise - Kartenwerke (20121231)
+- dimensions: *id448
+  name: ch.swisstopo.zeitreihen_20121231_source
+  sources: [ch.swisstopo.zeitreihen_20121231_cache]
+  title: Zeitreise - Kartenwerke (20121231, source)
+- dimensions: &id449
+    Time:
+      default: '20111231'
+      values: ['20111231']
+  name: ch.swisstopo.zeitreihen_20111231
+  sources: [ch.swisstopo.zeitreihen_20111231_cache_out]
+  title: Zeitreise - Kartenwerke (20111231)
+- dimensions: *id449
+  name: ch.swisstopo.zeitreihen_20111231_source
+  sources: [ch.swisstopo.zeitreihen_20111231_cache]
+  title: Zeitreise - Kartenwerke (20111231, source)
+- dimensions: &id450
+    Time:
+      default: '20101231'
+      values: ['20101231']
+  name: ch.swisstopo.zeitreihen_20101231
+  sources: [ch.swisstopo.zeitreihen_20101231_cache_out]
+  title: Zeitreise - Kartenwerke (20101231)
+- dimensions: *id450
+  name: ch.swisstopo.zeitreihen_20101231_source
+  sources: [ch.swisstopo.zeitreihen_20101231_cache]
+  title: Zeitreise - Kartenwerke (20101231, source)
+- dimensions: &id451
+    Time:
+      default: '20091231'
+      values: ['20091231']
+  name: ch.swisstopo.zeitreihen_20091231
+  sources: [ch.swisstopo.zeitreihen_20091231_cache_out]
+  title: Zeitreise - Kartenwerke (20091231)
+- dimensions: *id451
+  name: ch.swisstopo.zeitreihen_20091231_source
+  sources: [ch.swisstopo.zeitreihen_20091231_cache]
+  title: Zeitreise - Kartenwerke (20091231, source)
+- dimensions: &id452
+    Time:
+      default: '20081231'
+      values: ['20081231']
+  name: ch.swisstopo.zeitreihen_20081231
+  sources: [ch.swisstopo.zeitreihen_20081231_cache_out]
+  title: Zeitreise - Kartenwerke (20081231)
+- dimensions: *id452
+  name: ch.swisstopo.zeitreihen_20081231_source
+  sources: [ch.swisstopo.zeitreihen_20081231_cache]
+  title: Zeitreise - Kartenwerke (20081231, source)
+- dimensions: &id453
+    Time:
+      default: '20071231'
+      values: ['20071231']
+  name: ch.swisstopo.zeitreihen_20071231
+  sources: [ch.swisstopo.zeitreihen_20071231_cache_out]
+  title: Zeitreise - Kartenwerke (20071231)
+- dimensions: *id453
+  name: ch.swisstopo.zeitreihen_20071231_source
+  sources: [ch.swisstopo.zeitreihen_20071231_cache]
+  title: Zeitreise - Kartenwerke (20071231, source)
+- dimensions: &id454
+    Time:
+      default: '20061231'
+      values: ['20061231']
+  name: ch.swisstopo.zeitreihen_20061231
+  sources: [ch.swisstopo.zeitreihen_20061231_cache_out]
+  title: Zeitreise - Kartenwerke (20061231)
+- dimensions: *id454
+  name: ch.swisstopo.zeitreihen_20061231_source
+  sources: [ch.swisstopo.zeitreihen_20061231_cache]
+  title: Zeitreise - Kartenwerke (20061231, source)
+- dimensions: &id455
+    Time:
+      default: '20051231'
+      values: ['20051231']
+  name: ch.swisstopo.zeitreihen_20051231
+  sources: [ch.swisstopo.zeitreihen_20051231_cache_out]
+  title: Zeitreise - Kartenwerke (20051231)
+- dimensions: *id455
+  name: ch.swisstopo.zeitreihen_20051231_source
+  sources: [ch.swisstopo.zeitreihen_20051231_cache]
+  title: Zeitreise - Kartenwerke (20051231, source)
+- dimensions: &id456
+    Time:
+      default: '20041231'
+      values: ['20041231']
+  name: ch.swisstopo.zeitreihen_20041231
+  sources: [ch.swisstopo.zeitreihen_20041231_cache_out]
+  title: Zeitreise - Kartenwerke (20041231)
+- dimensions: *id456
+  name: ch.swisstopo.zeitreihen_20041231_source
+  sources: [ch.swisstopo.zeitreihen_20041231_cache]
+  title: Zeitreise - Kartenwerke (20041231, source)
+- dimensions: &id457
+    Time:
+      default: '20031231'
+      values: ['20031231']
+  name: ch.swisstopo.zeitreihen_20031231
+  sources: [ch.swisstopo.zeitreihen_20031231_cache_out]
+  title: Zeitreise - Kartenwerke (20031231)
+- dimensions: *id457
+  name: ch.swisstopo.zeitreihen_20031231_source
+  sources: [ch.swisstopo.zeitreihen_20031231_cache]
+  title: Zeitreise - Kartenwerke (20031231, source)
+- dimensions: &id458
+    Time:
+      default: '20021231'
+      values: ['20021231']
+  name: ch.swisstopo.zeitreihen_20021231
+  sources: [ch.swisstopo.zeitreihen_20021231_cache_out]
+  title: Zeitreise - Kartenwerke (20021231)
+- dimensions: *id458
+  name: ch.swisstopo.zeitreihen_20021231_source
+  sources: [ch.swisstopo.zeitreihen_20021231_cache]
+  title: Zeitreise - Kartenwerke (20021231, source)
+- dimensions: &id459
+    Time:
+      default: '20011231'
+      values: ['20011231']
+  name: ch.swisstopo.zeitreihen_20011231
+  sources: [ch.swisstopo.zeitreihen_20011231_cache_out]
+  title: Zeitreise - Kartenwerke (20011231)
+- dimensions: *id459
+  name: ch.swisstopo.zeitreihen_20011231_source
+  sources: [ch.swisstopo.zeitreihen_20011231_cache]
+  title: Zeitreise - Kartenwerke (20011231, source)
+- dimensions: &id460
+    Time:
+      default: '20001231'
+      values: ['20001231']
+  name: ch.swisstopo.zeitreihen_20001231
+  sources: [ch.swisstopo.zeitreihen_20001231_cache_out]
+  title: Zeitreise - Kartenwerke (20001231)
+- dimensions: *id460
+  name: ch.swisstopo.zeitreihen_20001231_source
+  sources: [ch.swisstopo.zeitreihen_20001231_cache]
+  title: Zeitreise - Kartenwerke (20001231, source)
+- dimensions: &id461
+    Time:
+      default: '19991231'
+      values: ['19991231']
+  name: ch.swisstopo.zeitreihen_19991231
+  sources: [ch.swisstopo.zeitreihen_19991231_cache_out]
+  title: Zeitreise - Kartenwerke (19991231)
+- dimensions: *id461
+  name: ch.swisstopo.zeitreihen_19991231_source
+  sources: [ch.swisstopo.zeitreihen_19991231_cache]
+  title: Zeitreise - Kartenwerke (19991231, source)
+- dimensions: &id462
+    Time:
+      default: '19981231'
+      values: ['19981231']
+  name: ch.swisstopo.zeitreihen_19981231
+  sources: [ch.swisstopo.zeitreihen_19981231_cache_out]
+  title: Zeitreise - Kartenwerke (19981231)
+- dimensions: *id462
+  name: ch.swisstopo.zeitreihen_19981231_source
+  sources: [ch.swisstopo.zeitreihen_19981231_cache]
+  title: Zeitreise - Kartenwerke (19981231, source)
+- dimensions: &id463
+    Time:
+      default: '19971231'
+      values: ['19971231']
+  name: ch.swisstopo.zeitreihen_19971231
+  sources: [ch.swisstopo.zeitreihen_19971231_cache_out]
+  title: Zeitreise - Kartenwerke (19971231)
+- dimensions: *id463
+  name: ch.swisstopo.zeitreihen_19971231_source
+  sources: [ch.swisstopo.zeitreihen_19971231_cache]
+  title: Zeitreise - Kartenwerke (19971231, source)
+- dimensions: &id464
+    Time:
+      default: '19961231'
+      values: ['19961231']
+  name: ch.swisstopo.zeitreihen_19961231
+  sources: [ch.swisstopo.zeitreihen_19961231_cache_out]
+  title: Zeitreise - Kartenwerke (19961231)
+- dimensions: *id464
+  name: ch.swisstopo.zeitreihen_19961231_source
+  sources: [ch.swisstopo.zeitreihen_19961231_cache]
+  title: Zeitreise - Kartenwerke (19961231, source)
+- dimensions: &id465
+    Time:
+      default: '19951231'
+      values: ['19951231']
+  name: ch.swisstopo.zeitreihen_19951231
+  sources: [ch.swisstopo.zeitreihen_19951231_cache_out]
+  title: Zeitreise - Kartenwerke (19951231)
+- dimensions: *id465
+  name: ch.swisstopo.zeitreihen_19951231_source
+  sources: [ch.swisstopo.zeitreihen_19951231_cache]
+  title: Zeitreise - Kartenwerke (19951231, source)
+- dimensions: &id466
+    Time:
+      default: '19941231'
+      values: ['19941231']
+  name: ch.swisstopo.zeitreihen_19941231
+  sources: [ch.swisstopo.zeitreihen_19941231_cache_out]
+  title: Zeitreise - Kartenwerke (19941231)
+- dimensions: *id466
+  name: ch.swisstopo.zeitreihen_19941231_source
+  sources: [ch.swisstopo.zeitreihen_19941231_cache]
+  title: Zeitreise - Kartenwerke (19941231, source)
+- dimensions: &id467
+    Time:
+      default: '19931231'
+      values: ['19931231']
+  name: ch.swisstopo.zeitreihen_19931231
+  sources: [ch.swisstopo.zeitreihen_19931231_cache_out]
+  title: Zeitreise - Kartenwerke (19931231)
+- dimensions: *id467
+  name: ch.swisstopo.zeitreihen_19931231_source
+  sources: [ch.swisstopo.zeitreihen_19931231_cache]
+  title: Zeitreise - Kartenwerke (19931231, source)
+- dimensions: &id468
+    Time:
+      default: '19921231'
+      values: ['19921231']
+  name: ch.swisstopo.zeitreihen_19921231
+  sources: [ch.swisstopo.zeitreihen_19921231_cache_out]
+  title: Zeitreise - Kartenwerke (19921231)
+- dimensions: *id468
+  name: ch.swisstopo.zeitreihen_19921231_source
+  sources: [ch.swisstopo.zeitreihen_19921231_cache]
+  title: Zeitreise - Kartenwerke (19921231, source)
+- dimensions: &id469
+    Time:
+      default: '19911231'
+      values: ['19911231']
+  name: ch.swisstopo.zeitreihen_19911231
+  sources: [ch.swisstopo.zeitreihen_19911231_cache_out]
+  title: Zeitreise - Kartenwerke (19911231)
+- dimensions: *id469
+  name: ch.swisstopo.zeitreihen_19911231_source
+  sources: [ch.swisstopo.zeitreihen_19911231_cache]
+  title: Zeitreise - Kartenwerke (19911231, source)
+- dimensions: &id470
+    Time:
+      default: '19901231'
+      values: ['19901231']
+  name: ch.swisstopo.zeitreihen_19901231
+  sources: [ch.swisstopo.zeitreihen_19901231_cache_out]
+  title: Zeitreise - Kartenwerke (19901231)
+- dimensions: *id470
+  name: ch.swisstopo.zeitreihen_19901231_source
+  sources: [ch.swisstopo.zeitreihen_19901231_cache]
+  title: Zeitreise - Kartenwerke (19901231, source)
+- dimensions: &id471
+    Time:
+      default: '19891231'
+      values: ['19891231']
+  name: ch.swisstopo.zeitreihen_19891231
+  sources: [ch.swisstopo.zeitreihen_19891231_cache_out]
+  title: Zeitreise - Kartenwerke (19891231)
+- dimensions: *id471
+  name: ch.swisstopo.zeitreihen_19891231_source
+  sources: [ch.swisstopo.zeitreihen_19891231_cache]
+  title: Zeitreise - Kartenwerke (19891231, source)
+- dimensions: &id472
+    Time:
+      default: '19881231'
+      values: ['19881231']
+  name: ch.swisstopo.zeitreihen_19881231
+  sources: [ch.swisstopo.zeitreihen_19881231_cache_out]
+  title: Zeitreise - Kartenwerke (19881231)
+- dimensions: *id472
+  name: ch.swisstopo.zeitreihen_19881231_source
+  sources: [ch.swisstopo.zeitreihen_19881231_cache]
+  title: Zeitreise - Kartenwerke (19881231, source)
+- dimensions: &id473
+    Time:
+      default: '19871231'
+      values: ['19871231']
+  name: ch.swisstopo.zeitreihen_19871231
+  sources: [ch.swisstopo.zeitreihen_19871231_cache_out]
+  title: Zeitreise - Kartenwerke (19871231)
+- dimensions: *id473
+  name: ch.swisstopo.zeitreihen_19871231_source
+  sources: [ch.swisstopo.zeitreihen_19871231_cache]
+  title: Zeitreise - Kartenwerke (19871231, source)
+- dimensions: &id474
+    Time:
+      default: '19861231'
+      values: ['19861231']
+  name: ch.swisstopo.zeitreihen_19861231
+  sources: [ch.swisstopo.zeitreihen_19861231_cache_out]
+  title: Zeitreise - Kartenwerke (19861231)
+- dimensions: *id474
+  name: ch.swisstopo.zeitreihen_19861231_source
+  sources: [ch.swisstopo.zeitreihen_19861231_cache]
+  title: Zeitreise - Kartenwerke (19861231, source)
+- dimensions: &id475
+    Time:
+      default: '19851231'
+      values: ['19851231']
+  name: ch.swisstopo.zeitreihen_19851231
+  sources: [ch.swisstopo.zeitreihen_19851231_cache_out]
+  title: Zeitreise - Kartenwerke (19851231)
+- dimensions: *id475
+  name: ch.swisstopo.zeitreihen_19851231_source
+  sources: [ch.swisstopo.zeitreihen_19851231_cache]
+  title: Zeitreise - Kartenwerke (19851231, source)
+- dimensions: &id476
+    Time:
+      default: '19841231'
+      values: ['19841231']
+  name: ch.swisstopo.zeitreihen_19841231
+  sources: [ch.swisstopo.zeitreihen_19841231_cache_out]
+  title: Zeitreise - Kartenwerke (19841231)
+- dimensions: *id476
+  name: ch.swisstopo.zeitreihen_19841231_source
+  sources: [ch.swisstopo.zeitreihen_19841231_cache]
+  title: Zeitreise - Kartenwerke (19841231, source)
+- dimensions: &id477
+    Time:
+      default: '19831231'
+      values: ['19831231']
+  name: ch.swisstopo.zeitreihen_19831231
+  sources: [ch.swisstopo.zeitreihen_19831231_cache_out]
+  title: Zeitreise - Kartenwerke (19831231)
+- dimensions: *id477
+  name: ch.swisstopo.zeitreihen_19831231_source
+  sources: [ch.swisstopo.zeitreihen_19831231_cache]
+  title: Zeitreise - Kartenwerke (19831231, source)
+- dimensions: &id478
+    Time:
+      default: '19821231'
+      values: ['19821231']
+  name: ch.swisstopo.zeitreihen_19821231
+  sources: [ch.swisstopo.zeitreihen_19821231_cache_out]
+  title: Zeitreise - Kartenwerke (19821231)
+- dimensions: *id478
+  name: ch.swisstopo.zeitreihen_19821231_source
+  sources: [ch.swisstopo.zeitreihen_19821231_cache]
+  title: Zeitreise - Kartenwerke (19821231, source)
+- dimensions: &id479
+    Time:
+      default: '19811231'
+      values: ['19811231']
+  name: ch.swisstopo.zeitreihen_19811231
+  sources: [ch.swisstopo.zeitreihen_19811231_cache_out]
+  title: Zeitreise - Kartenwerke (19811231)
+- dimensions: *id479
+  name: ch.swisstopo.zeitreihen_19811231_source
+  sources: [ch.swisstopo.zeitreihen_19811231_cache]
+  title: Zeitreise - Kartenwerke (19811231, source)
+- dimensions: &id480
+    Time:
+      default: '19801231'
+      values: ['19801231']
+  name: ch.swisstopo.zeitreihen_19801231
+  sources: [ch.swisstopo.zeitreihen_19801231_cache_out]
+  title: Zeitreise - Kartenwerke (19801231)
+- dimensions: *id480
+  name: ch.swisstopo.zeitreihen_19801231_source
+  sources: [ch.swisstopo.zeitreihen_19801231_cache]
+  title: Zeitreise - Kartenwerke (19801231, source)
+- dimensions: &id481
+    Time:
+      default: '19791231'
+      values: ['19791231']
+  name: ch.swisstopo.zeitreihen_19791231
+  sources: [ch.swisstopo.zeitreihen_19791231_cache_out]
+  title: Zeitreise - Kartenwerke (19791231)
+- dimensions: *id481
+  name: ch.swisstopo.zeitreihen_19791231_source
+  sources: [ch.swisstopo.zeitreihen_19791231_cache]
+  title: Zeitreise - Kartenwerke (19791231, source)
+- dimensions: &id482
+    Time:
+      default: '19781231'
+      values: ['19781231']
+  name: ch.swisstopo.zeitreihen_19781231
+  sources: [ch.swisstopo.zeitreihen_19781231_cache_out]
+  title: Zeitreise - Kartenwerke (19781231)
+- dimensions: *id482
+  name: ch.swisstopo.zeitreihen_19781231_source
+  sources: [ch.swisstopo.zeitreihen_19781231_cache]
+  title: Zeitreise - Kartenwerke (19781231, source)
+- dimensions: &id483
+    Time:
+      default: '19771231'
+      values: ['19771231']
+  name: ch.swisstopo.zeitreihen_19771231
+  sources: [ch.swisstopo.zeitreihen_19771231_cache_out]
+  title: Zeitreise - Kartenwerke (19771231)
+- dimensions: *id483
+  name: ch.swisstopo.zeitreihen_19771231_source
+  sources: [ch.swisstopo.zeitreihen_19771231_cache]
+  title: Zeitreise - Kartenwerke (19771231, source)
+- dimensions: &id484
+    Time:
+      default: '19761231'
+      values: ['19761231']
+  name: ch.swisstopo.zeitreihen_19761231
+  sources: [ch.swisstopo.zeitreihen_19761231_cache_out]
+  title: Zeitreise - Kartenwerke (19761231)
+- dimensions: *id484
+  name: ch.swisstopo.zeitreihen_19761231_source
+  sources: [ch.swisstopo.zeitreihen_19761231_cache]
+  title: Zeitreise - Kartenwerke (19761231, source)
+- dimensions: &id485
+    Time:
+      default: '19751231'
+      values: ['19751231']
+  name: ch.swisstopo.zeitreihen_19751231
+  sources: [ch.swisstopo.zeitreihen_19751231_cache_out]
+  title: Zeitreise - Kartenwerke (19751231)
+- dimensions: *id485
+  name: ch.swisstopo.zeitreihen_19751231_source
+  sources: [ch.swisstopo.zeitreihen_19751231_cache]
+  title: Zeitreise - Kartenwerke (19751231, source)
+- dimensions: &id486
+    Time:
+      default: '19741231'
+      values: ['19741231']
+  name: ch.swisstopo.zeitreihen_19741231
+  sources: [ch.swisstopo.zeitreihen_19741231_cache_out]
+  title: Zeitreise - Kartenwerke (19741231)
+- dimensions: *id486
+  name: ch.swisstopo.zeitreihen_19741231_source
+  sources: [ch.swisstopo.zeitreihen_19741231_cache]
+  title: Zeitreise - Kartenwerke (19741231, source)
+- dimensions: &id487
+    Time:
+      default: '19731231'
+      values: ['19731231']
+  name: ch.swisstopo.zeitreihen_19731231
+  sources: [ch.swisstopo.zeitreihen_19731231_cache_out]
+  title: Zeitreise - Kartenwerke (19731231)
+- dimensions: *id487
+  name: ch.swisstopo.zeitreihen_19731231_source
+  sources: [ch.swisstopo.zeitreihen_19731231_cache]
+  title: Zeitreise - Kartenwerke (19731231, source)
+- dimensions: &id488
+    Time:
+      default: '19721231'
+      values: ['19721231']
+  name: ch.swisstopo.zeitreihen_19721231
+  sources: [ch.swisstopo.zeitreihen_19721231_cache_out]
+  title: Zeitreise - Kartenwerke (19721231)
+- dimensions: *id488
+  name: ch.swisstopo.zeitreihen_19721231_source
+  sources: [ch.swisstopo.zeitreihen_19721231_cache]
+  title: Zeitreise - Kartenwerke (19721231, source)
+- dimensions: &id489
+    Time:
+      default: '19711231'
+      values: ['19711231']
+  name: ch.swisstopo.zeitreihen_19711231
+  sources: [ch.swisstopo.zeitreihen_19711231_cache_out]
+  title: Zeitreise - Kartenwerke (19711231)
+- dimensions: *id489
+  name: ch.swisstopo.zeitreihen_19711231_source
+  sources: [ch.swisstopo.zeitreihen_19711231_cache]
+  title: Zeitreise - Kartenwerke (19711231, source)
+- dimensions: &id490
+    Time:
+      default: '19701231'
+      values: ['19701231']
+  name: ch.swisstopo.zeitreihen_19701231
+  sources: [ch.swisstopo.zeitreihen_19701231_cache_out]
+  title: Zeitreise - Kartenwerke (19701231)
+- dimensions: *id490
+  name: ch.swisstopo.zeitreihen_19701231_source
+  sources: [ch.swisstopo.zeitreihen_19701231_cache]
+  title: Zeitreise - Kartenwerke (19701231, source)
+- dimensions: &id491
+    Time:
+      default: '19691231'
+      values: ['19691231']
+  name: ch.swisstopo.zeitreihen_19691231
+  sources: [ch.swisstopo.zeitreihen_19691231_cache_out]
+  title: Zeitreise - Kartenwerke (19691231)
+- dimensions: *id491
+  name: ch.swisstopo.zeitreihen_19691231_source
+  sources: [ch.swisstopo.zeitreihen_19691231_cache]
+  title: Zeitreise - Kartenwerke (19691231, source)
+- dimensions: &id492
+    Time:
+      default: '19681231'
+      values: ['19681231']
+  name: ch.swisstopo.zeitreihen_19681231
+  sources: [ch.swisstopo.zeitreihen_19681231_cache_out]
+  title: Zeitreise - Kartenwerke (19681231)
+- dimensions: *id492
+  name: ch.swisstopo.zeitreihen_19681231_source
+  sources: [ch.swisstopo.zeitreihen_19681231_cache]
+  title: Zeitreise - Kartenwerke (19681231, source)
+- dimensions: &id493
+    Time:
+      default: '19671231'
+      values: ['19671231']
+  name: ch.swisstopo.zeitreihen_19671231
+  sources: [ch.swisstopo.zeitreihen_19671231_cache_out]
+  title: Zeitreise - Kartenwerke (19671231)
+- dimensions: *id493
+  name: ch.swisstopo.zeitreihen_19671231_source
+  sources: [ch.swisstopo.zeitreihen_19671231_cache]
+  title: Zeitreise - Kartenwerke (19671231, source)
+- dimensions: &id494
+    Time:
+      default: '19661231'
+      values: ['19661231']
+  name: ch.swisstopo.zeitreihen_19661231
+  sources: [ch.swisstopo.zeitreihen_19661231_cache_out]
+  title: Zeitreise - Kartenwerke (19661231)
+- dimensions: *id494
+  name: ch.swisstopo.zeitreihen_19661231_source
+  sources: [ch.swisstopo.zeitreihen_19661231_cache]
+  title: Zeitreise - Kartenwerke (19661231, source)
+- dimensions: &id495
+    Time:
+      default: '19651231'
+      values: ['19651231']
+  name: ch.swisstopo.zeitreihen_19651231
+  sources: [ch.swisstopo.zeitreihen_19651231_cache_out]
+  title: Zeitreise - Kartenwerke (19651231)
+- dimensions: *id495
+  name: ch.swisstopo.zeitreihen_19651231_source
+  sources: [ch.swisstopo.zeitreihen_19651231_cache]
+  title: Zeitreise - Kartenwerke (19651231, source)
+- dimensions: &id496
+    Time:
+      default: '19641231'
+      values: ['19641231']
+  name: ch.swisstopo.zeitreihen_19641231
+  sources: [ch.swisstopo.zeitreihen_19641231_cache_out]
+  title: Zeitreise - Kartenwerke (19641231)
+- dimensions: *id496
+  name: ch.swisstopo.zeitreihen_19641231_source
+  sources: [ch.swisstopo.zeitreihen_19641231_cache]
+  title: Zeitreise - Kartenwerke (19641231, source)
+- dimensions: &id497
+    Time:
+      default: '19631231'
+      values: ['19631231']
+  name: ch.swisstopo.zeitreihen_19631231
+  sources: [ch.swisstopo.zeitreihen_19631231_cache_out]
+  title: Zeitreise - Kartenwerke (19631231)
+- dimensions: *id497
+  name: ch.swisstopo.zeitreihen_19631231_source
+  sources: [ch.swisstopo.zeitreihen_19631231_cache]
+  title: Zeitreise - Kartenwerke (19631231, source)
+- dimensions: &id498
+    Time:
+      default: '19621231'
+      values: ['19621231']
+  name: ch.swisstopo.zeitreihen_19621231
+  sources: [ch.swisstopo.zeitreihen_19621231_cache_out]
+  title: Zeitreise - Kartenwerke (19621231)
+- dimensions: *id498
+  name: ch.swisstopo.zeitreihen_19621231_source
+  sources: [ch.swisstopo.zeitreihen_19621231_cache]
+  title: Zeitreise - Kartenwerke (19621231, source)
+- dimensions: &id499
+    Time:
+      default: '19611231'
+      values: ['19611231']
+  name: ch.swisstopo.zeitreihen_19611231
+  sources: [ch.swisstopo.zeitreihen_19611231_cache_out]
+  title: Zeitreise - Kartenwerke (19611231)
+- dimensions: *id499
+  name: ch.swisstopo.zeitreihen_19611231_source
+  sources: [ch.swisstopo.zeitreihen_19611231_cache]
+  title: Zeitreise - Kartenwerke (19611231, source)
+- dimensions: &id500
+    Time:
+      default: '19601231'
+      values: ['19601231']
+  name: ch.swisstopo.zeitreihen_19601231
+  sources: [ch.swisstopo.zeitreihen_19601231_cache_out]
+  title: Zeitreise - Kartenwerke (19601231)
+- dimensions: *id500
+  name: ch.swisstopo.zeitreihen_19601231_source
+  sources: [ch.swisstopo.zeitreihen_19601231_cache]
+  title: Zeitreise - Kartenwerke (19601231, source)
+- dimensions: &id501
+    Time:
+      default: '19591231'
+      values: ['19591231']
+  name: ch.swisstopo.zeitreihen_19591231
+  sources: [ch.swisstopo.zeitreihen_19591231_cache_out]
+  title: Zeitreise - Kartenwerke (19591231)
+- dimensions: *id501
+  name: ch.swisstopo.zeitreihen_19591231_source
+  sources: [ch.swisstopo.zeitreihen_19591231_cache]
+  title: Zeitreise - Kartenwerke (19591231, source)
+- dimensions: &id502
+    Time:
+      default: '19581231'
+      values: ['19581231']
+  name: ch.swisstopo.zeitreihen_19581231
+  sources: [ch.swisstopo.zeitreihen_19581231_cache_out]
+  title: Zeitreise - Kartenwerke (19581231)
+- dimensions: *id502
+  name: ch.swisstopo.zeitreihen_19581231_source
+  sources: [ch.swisstopo.zeitreihen_19581231_cache]
+  title: Zeitreise - Kartenwerke (19581231, source)
+- dimensions: &id503
+    Time:
+      default: '19571231'
+      values: ['19571231']
+  name: ch.swisstopo.zeitreihen_19571231
+  sources: [ch.swisstopo.zeitreihen_19571231_cache_out]
+  title: Zeitreise - Kartenwerke (19571231)
+- dimensions: *id503
+  name: ch.swisstopo.zeitreihen_19571231_source
+  sources: [ch.swisstopo.zeitreihen_19571231_cache]
+  title: Zeitreise - Kartenwerke (19571231, source)
+- dimensions: &id504
+    Time:
+      default: '19561231'
+      values: ['19561231']
+  name: ch.swisstopo.zeitreihen_19561231
+  sources: [ch.swisstopo.zeitreihen_19561231_cache_out]
+  title: Zeitreise - Kartenwerke (19561231)
+- dimensions: *id504
+  name: ch.swisstopo.zeitreihen_19561231_source
+  sources: [ch.swisstopo.zeitreihen_19561231_cache]
+  title: Zeitreise - Kartenwerke (19561231, source)
+- dimensions: &id505
+    Time:
+      default: '19551231'
+      values: ['19551231']
+  name: ch.swisstopo.zeitreihen_19551231
+  sources: [ch.swisstopo.zeitreihen_19551231_cache_out]
+  title: Zeitreise - Kartenwerke (19551231)
+- dimensions: *id505
+  name: ch.swisstopo.zeitreihen_19551231_source
+  sources: [ch.swisstopo.zeitreihen_19551231_cache]
+  title: Zeitreise - Kartenwerke (19551231, source)
+- dimensions: &id506
+    Time:
+      default: '19541231'
+      values: ['19541231']
+  name: ch.swisstopo.zeitreihen_19541231
+  sources: [ch.swisstopo.zeitreihen_19541231_cache_out]
+  title: Zeitreise - Kartenwerke (19541231)
+- dimensions: *id506
+  name: ch.swisstopo.zeitreihen_19541231_source
+  sources: [ch.swisstopo.zeitreihen_19541231_cache]
+  title: Zeitreise - Kartenwerke (19541231, source)
+- dimensions: &id507
+    Time:
+      default: '19531231'
+      values: ['19531231']
+  name: ch.swisstopo.zeitreihen_19531231
+  sources: [ch.swisstopo.zeitreihen_19531231_cache_out]
+  title: Zeitreise - Kartenwerke (19531231)
+- dimensions: *id507
+  name: ch.swisstopo.zeitreihen_19531231_source
+  sources: [ch.swisstopo.zeitreihen_19531231_cache]
+  title: Zeitreise - Kartenwerke (19531231, source)
+- dimensions: &id508
+    Time:
+      default: '19521231'
+      values: ['19521231']
+  name: ch.swisstopo.zeitreihen_19521231
+  sources: [ch.swisstopo.zeitreihen_19521231_cache_out]
+  title: Zeitreise - Kartenwerke (19521231)
+- dimensions: *id508
+  name: ch.swisstopo.zeitreihen_19521231_source
+  sources: [ch.swisstopo.zeitreihen_19521231_cache]
+  title: Zeitreise - Kartenwerke (19521231, source)
+- dimensions: &id509
+    Time:
+      default: '19511231'
+      values: ['19511231']
+  name: ch.swisstopo.zeitreihen_19511231
+  sources: [ch.swisstopo.zeitreihen_19511231_cache_out]
+  title: Zeitreise - Kartenwerke (19511231)
+- dimensions: *id509
+  name: ch.swisstopo.zeitreihen_19511231_source
+  sources: [ch.swisstopo.zeitreihen_19511231_cache]
+  title: Zeitreise - Kartenwerke (19511231, source)
+- dimensions: &id510
+    Time:
+      default: '19501231'
+      values: ['19501231']
+  name: ch.swisstopo.zeitreihen_19501231
+  sources: [ch.swisstopo.zeitreihen_19501231_cache_out]
+  title: Zeitreise - Kartenwerke (19501231)
+- dimensions: *id510
+  name: ch.swisstopo.zeitreihen_19501231_source
+  sources: [ch.swisstopo.zeitreihen_19501231_cache]
+  title: Zeitreise - Kartenwerke (19501231, source)
+- dimensions: &id511
+    Time:
+      default: '19491231'
+      values: ['19491231']
+  name: ch.swisstopo.zeitreihen_19491231
+  sources: [ch.swisstopo.zeitreihen_19491231_cache_out]
+  title: Zeitreise - Kartenwerke (19491231)
+- dimensions: *id511
+  name: ch.swisstopo.zeitreihen_19491231_source
+  sources: [ch.swisstopo.zeitreihen_19491231_cache]
+  title: Zeitreise - Kartenwerke (19491231, source)
+- dimensions: &id512
+    Time:
+      default: '19481231'
+      values: ['19481231']
+  name: ch.swisstopo.zeitreihen_19481231
+  sources: [ch.swisstopo.zeitreihen_19481231_cache_out]
+  title: Zeitreise - Kartenwerke (19481231)
+- dimensions: *id512
+  name: ch.swisstopo.zeitreihen_19481231_source
+  sources: [ch.swisstopo.zeitreihen_19481231_cache]
+  title: Zeitreise - Kartenwerke (19481231, source)
+- dimensions: &id513
+    Time:
+      default: '19471231'
+      values: ['19471231']
+  name: ch.swisstopo.zeitreihen_19471231
+  sources: [ch.swisstopo.zeitreihen_19471231_cache_out]
+  title: Zeitreise - Kartenwerke (19471231)
+- dimensions: *id513
+  name: ch.swisstopo.zeitreihen_19471231_source
+  sources: [ch.swisstopo.zeitreihen_19471231_cache]
+  title: Zeitreise - Kartenwerke (19471231, source)
+- dimensions: &id514
+    Time:
+      default: '19461231'
+      values: ['19461231']
+  name: ch.swisstopo.zeitreihen_19461231
+  sources: [ch.swisstopo.zeitreihen_19461231_cache_out]
+  title: Zeitreise - Kartenwerke (19461231)
+- dimensions: *id514
+  name: ch.swisstopo.zeitreihen_19461231_source
+  sources: [ch.swisstopo.zeitreihen_19461231_cache]
+  title: Zeitreise - Kartenwerke (19461231, source)
+- dimensions: &id515
+    Time:
+      default: '19451231'
+      values: ['19451231']
+  name: ch.swisstopo.zeitreihen_19451231
+  sources: [ch.swisstopo.zeitreihen_19451231_cache_out]
+  title: Zeitreise - Kartenwerke (19451231)
+- dimensions: *id515
+  name: ch.swisstopo.zeitreihen_19451231_source
+  sources: [ch.swisstopo.zeitreihen_19451231_cache]
+  title: Zeitreise - Kartenwerke (19451231, source)
+- dimensions: &id516
+    Time:
+      default: '19441231'
+      values: ['19441231']
+  name: ch.swisstopo.zeitreihen_19441231
+  sources: [ch.swisstopo.zeitreihen_19441231_cache_out]
+  title: Zeitreise - Kartenwerke (19441231)
+- dimensions: *id516
+  name: ch.swisstopo.zeitreihen_19441231_source
+  sources: [ch.swisstopo.zeitreihen_19441231_cache]
+  title: Zeitreise - Kartenwerke (19441231, source)
+- dimensions: &id517
+    Time:
+      default: '19431231'
+      values: ['19431231']
+  name: ch.swisstopo.zeitreihen_19431231
+  sources: [ch.swisstopo.zeitreihen_19431231_cache_out]
+  title: Zeitreise - Kartenwerke (19431231)
+- dimensions: *id517
+  name: ch.swisstopo.zeitreihen_19431231_source
+  sources: [ch.swisstopo.zeitreihen_19431231_cache]
+  title: Zeitreise - Kartenwerke (19431231, source)
+- dimensions: &id518
+    Time:
+      default: '19421231'
+      values: ['19421231']
+  name: ch.swisstopo.zeitreihen_19421231
+  sources: [ch.swisstopo.zeitreihen_19421231_cache_out]
+  title: Zeitreise - Kartenwerke (19421231)
+- dimensions: *id518
+  name: ch.swisstopo.zeitreihen_19421231_source
+  sources: [ch.swisstopo.zeitreihen_19421231_cache]
+  title: Zeitreise - Kartenwerke (19421231, source)
+- dimensions: &id519
+    Time:
+      default: '19411231'
+      values: ['19411231']
+  name: ch.swisstopo.zeitreihen_19411231
+  sources: [ch.swisstopo.zeitreihen_19411231_cache_out]
+  title: Zeitreise - Kartenwerke (19411231)
+- dimensions: *id519
+  name: ch.swisstopo.zeitreihen_19411231_source
+  sources: [ch.swisstopo.zeitreihen_19411231_cache]
+  title: Zeitreise - Kartenwerke (19411231, source)
+- dimensions: &id520
+    Time:
+      default: '19401231'
+      values: ['19401231']
+  name: ch.swisstopo.zeitreihen_19401231
+  sources: [ch.swisstopo.zeitreihen_19401231_cache_out]
+  title: Zeitreise - Kartenwerke (19401231)
+- dimensions: *id520
+  name: ch.swisstopo.zeitreihen_19401231_source
+  sources: [ch.swisstopo.zeitreihen_19401231_cache]
+  title: Zeitreise - Kartenwerke (19401231, source)
+- dimensions: &id521
+    Time:
+      default: '19391231'
+      values: ['19391231']
+  name: ch.swisstopo.zeitreihen_19391231
+  sources: [ch.swisstopo.zeitreihen_19391231_cache_out]
+  title: Zeitreise - Kartenwerke (19391231)
+- dimensions: *id521
+  name: ch.swisstopo.zeitreihen_19391231_source
+  sources: [ch.swisstopo.zeitreihen_19391231_cache]
+  title: Zeitreise - Kartenwerke (19391231, source)
+- dimensions: &id522
+    Time:
+      default: '19381231'
+      values: ['19381231']
+  name: ch.swisstopo.zeitreihen_19381231
+  sources: [ch.swisstopo.zeitreihen_19381231_cache_out]
+  title: Zeitreise - Kartenwerke (19381231)
+- dimensions: *id522
+  name: ch.swisstopo.zeitreihen_19381231_source
+  sources: [ch.swisstopo.zeitreihen_19381231_cache]
+  title: Zeitreise - Kartenwerke (19381231, source)
+- dimensions: &id523
+    Time:
+      default: '19371231'
+      values: ['19371231']
+  name: ch.swisstopo.zeitreihen_19371231
+  sources: [ch.swisstopo.zeitreihen_19371231_cache_out]
+  title: Zeitreise - Kartenwerke (19371231)
+- dimensions: *id523
+  name: ch.swisstopo.zeitreihen_19371231_source
+  sources: [ch.swisstopo.zeitreihen_19371231_cache]
+  title: Zeitreise - Kartenwerke (19371231, source)
+- dimensions: &id524
+    Time:
+      default: '19361231'
+      values: ['19361231']
+  name: ch.swisstopo.zeitreihen_19361231
+  sources: [ch.swisstopo.zeitreihen_19361231_cache_out]
+  title: Zeitreise - Kartenwerke (19361231)
+- dimensions: *id524
+  name: ch.swisstopo.zeitreihen_19361231_source
+  sources: [ch.swisstopo.zeitreihen_19361231_cache]
+  title: Zeitreise - Kartenwerke (19361231, source)
+- dimensions: &id525
+    Time:
+      default: '19351231'
+      values: ['19351231']
+  name: ch.swisstopo.zeitreihen_19351231
+  sources: [ch.swisstopo.zeitreihen_19351231_cache_out]
+  title: Zeitreise - Kartenwerke (19351231)
+- dimensions: *id525
+  name: ch.swisstopo.zeitreihen_19351231_source
+  sources: [ch.swisstopo.zeitreihen_19351231_cache]
+  title: Zeitreise - Kartenwerke (19351231, source)
+- dimensions: &id526
+    Time:
+      default: '19341231'
+      values: ['19341231']
+  name: ch.swisstopo.zeitreihen_19341231
+  sources: [ch.swisstopo.zeitreihen_19341231_cache_out]
+  title: Zeitreise - Kartenwerke (19341231)
+- dimensions: *id526
+  name: ch.swisstopo.zeitreihen_19341231_source
+  sources: [ch.swisstopo.zeitreihen_19341231_cache]
+  title: Zeitreise - Kartenwerke (19341231, source)
+- dimensions: &id527
+    Time:
+      default: '19331231'
+      values: ['19331231']
+  name: ch.swisstopo.zeitreihen_19331231
+  sources: [ch.swisstopo.zeitreihen_19331231_cache_out]
+  title: Zeitreise - Kartenwerke (19331231)
+- dimensions: *id527
+  name: ch.swisstopo.zeitreihen_19331231_source
+  sources: [ch.swisstopo.zeitreihen_19331231_cache]
+  title: Zeitreise - Kartenwerke (19331231, source)
+- dimensions: &id528
+    Time:
+      default: '19321231'
+      values: ['19321231']
+  name: ch.swisstopo.zeitreihen_19321231
+  sources: [ch.swisstopo.zeitreihen_19321231_cache_out]
+  title: Zeitreise - Kartenwerke (19321231)
+- dimensions: *id528
+  name: ch.swisstopo.zeitreihen_19321231_source
+  sources: [ch.swisstopo.zeitreihen_19321231_cache]
+  title: Zeitreise - Kartenwerke (19321231, source)
+- dimensions: &id529
+    Time:
+      default: '19311231'
+      values: ['19311231']
+  name: ch.swisstopo.zeitreihen_19311231
+  sources: [ch.swisstopo.zeitreihen_19311231_cache_out]
+  title: Zeitreise - Kartenwerke (19311231)
+- dimensions: *id529
+  name: ch.swisstopo.zeitreihen_19311231_source
+  sources: [ch.swisstopo.zeitreihen_19311231_cache]
+  title: Zeitreise - Kartenwerke (19311231, source)
+- dimensions: &id530
+    Time:
+      default: '19301231'
+      values: ['19301231']
+  name: ch.swisstopo.zeitreihen_19301231
+  sources: [ch.swisstopo.zeitreihen_19301231_cache_out]
+  title: Zeitreise - Kartenwerke (19301231)
+- dimensions: *id530
+  name: ch.swisstopo.zeitreihen_19301231_source
+  sources: [ch.swisstopo.zeitreihen_19301231_cache]
+  title: Zeitreise - Kartenwerke (19301231, source)
+- dimensions: &id531
+    Time:
+      default: '19291231'
+      values: ['19291231']
+  name: ch.swisstopo.zeitreihen_19291231
+  sources: [ch.swisstopo.zeitreihen_19291231_cache_out]
+  title: Zeitreise - Kartenwerke (19291231)
+- dimensions: *id531
+  name: ch.swisstopo.zeitreihen_19291231_source
+  sources: [ch.swisstopo.zeitreihen_19291231_cache]
+  title: Zeitreise - Kartenwerke (19291231, source)
+- dimensions: &id532
+    Time:
+      default: '19281231'
+      values: ['19281231']
+  name: ch.swisstopo.zeitreihen_19281231
+  sources: [ch.swisstopo.zeitreihen_19281231_cache_out]
+  title: Zeitreise - Kartenwerke (19281231)
+- dimensions: *id532
+  name: ch.swisstopo.zeitreihen_19281231_source
+  sources: [ch.swisstopo.zeitreihen_19281231_cache]
+  title: Zeitreise - Kartenwerke (19281231, source)
+- dimensions: &id533
+    Time:
+      default: '19271231'
+      values: ['19271231']
+  name: ch.swisstopo.zeitreihen_19271231
+  sources: [ch.swisstopo.zeitreihen_19271231_cache_out]
+  title: Zeitreise - Kartenwerke (19271231)
+- dimensions: *id533
+  name: ch.swisstopo.zeitreihen_19271231_source
+  sources: [ch.swisstopo.zeitreihen_19271231_cache]
+  title: Zeitreise - Kartenwerke (19271231, source)
+- dimensions: &id534
+    Time:
+      default: '19261231'
+      values: ['19261231']
+  name: ch.swisstopo.zeitreihen_19261231
+  sources: [ch.swisstopo.zeitreihen_19261231_cache_out]
+  title: Zeitreise - Kartenwerke (19261231)
+- dimensions: *id534
+  name: ch.swisstopo.zeitreihen_19261231_source
+  sources: [ch.swisstopo.zeitreihen_19261231_cache]
+  title: Zeitreise - Kartenwerke (19261231, source)
+- dimensions: &id535
+    Time:
+      default: '19251231'
+      values: ['19251231']
+  name: ch.swisstopo.zeitreihen_19251231
+  sources: [ch.swisstopo.zeitreihen_19251231_cache_out]
+  title: Zeitreise - Kartenwerke (19251231)
+- dimensions: *id535
+  name: ch.swisstopo.zeitreihen_19251231_source
+  sources: [ch.swisstopo.zeitreihen_19251231_cache]
+  title: Zeitreise - Kartenwerke (19251231, source)
+- dimensions: &id536
+    Time:
+      default: '19241231'
+      values: ['19241231']
+  name: ch.swisstopo.zeitreihen_19241231
+  sources: [ch.swisstopo.zeitreihen_19241231_cache_out]
+  title: Zeitreise - Kartenwerke (19241231)
+- dimensions: *id536
+  name: ch.swisstopo.zeitreihen_19241231_source
+  sources: [ch.swisstopo.zeitreihen_19241231_cache]
+  title: Zeitreise - Kartenwerke (19241231, source)
+- dimensions: &id537
+    Time:
+      default: '19231231'
+      values: ['19231231']
+  name: ch.swisstopo.zeitreihen_19231231
+  sources: [ch.swisstopo.zeitreihen_19231231_cache_out]
+  title: Zeitreise - Kartenwerke (19231231)
+- dimensions: *id537
+  name: ch.swisstopo.zeitreihen_19231231_source
+  sources: [ch.swisstopo.zeitreihen_19231231_cache]
+  title: Zeitreise - Kartenwerke (19231231, source)
+- dimensions: &id538
+    Time:
+      default: '19221231'
+      values: ['19221231']
+  name: ch.swisstopo.zeitreihen_19221231
+  sources: [ch.swisstopo.zeitreihen_19221231_cache_out]
+  title: Zeitreise - Kartenwerke (19221231)
+- dimensions: *id538
+  name: ch.swisstopo.zeitreihen_19221231_source
+  sources: [ch.swisstopo.zeitreihen_19221231_cache]
+  title: Zeitreise - Kartenwerke (19221231, source)
+- dimensions: &id539
+    Time:
+      default: '19211231'
+      values: ['19211231']
+  name: ch.swisstopo.zeitreihen_19211231
+  sources: [ch.swisstopo.zeitreihen_19211231_cache_out]
+  title: Zeitreise - Kartenwerke (19211231)
+- dimensions: *id539
+  name: ch.swisstopo.zeitreihen_19211231_source
+  sources: [ch.swisstopo.zeitreihen_19211231_cache]
+  title: Zeitreise - Kartenwerke (19211231, source)
+- dimensions: &id540
+    Time:
+      default: '19201231'
+      values: ['19201231']
+  name: ch.swisstopo.zeitreihen_19201231
+  sources: [ch.swisstopo.zeitreihen_19201231_cache_out]
+  title: Zeitreise - Kartenwerke (19201231)
+- dimensions: *id540
+  name: ch.swisstopo.zeitreihen_19201231_source
+  sources: [ch.swisstopo.zeitreihen_19201231_cache]
+  title: Zeitreise - Kartenwerke (19201231, source)
+- dimensions: &id541
+    Time:
+      default: '19191231'
+      values: ['19191231']
+  name: ch.swisstopo.zeitreihen_19191231
+  sources: [ch.swisstopo.zeitreihen_19191231_cache_out]
+  title: Zeitreise - Kartenwerke (19191231)
+- dimensions: *id541
+  name: ch.swisstopo.zeitreihen_19191231_source
+  sources: [ch.swisstopo.zeitreihen_19191231_cache]
+  title: Zeitreise - Kartenwerke (19191231, source)
+- dimensions: &id542
+    Time:
+      default: '19181231'
+      values: ['19181231']
+  name: ch.swisstopo.zeitreihen_19181231
+  sources: [ch.swisstopo.zeitreihen_19181231_cache_out]
+  title: Zeitreise - Kartenwerke (19181231)
+- dimensions: *id542
+  name: ch.swisstopo.zeitreihen_19181231_source
+  sources: [ch.swisstopo.zeitreihen_19181231_cache]
+  title: Zeitreise - Kartenwerke (19181231, source)
+- dimensions: &id543
+    Time:
+      default: '19171231'
+      values: ['19171231']
+  name: ch.swisstopo.zeitreihen_19171231
+  sources: [ch.swisstopo.zeitreihen_19171231_cache_out]
+  title: Zeitreise - Kartenwerke (19171231)
+- dimensions: *id543
+  name: ch.swisstopo.zeitreihen_19171231_source
+  sources: [ch.swisstopo.zeitreihen_19171231_cache]
+  title: Zeitreise - Kartenwerke (19171231, source)
+- dimensions: &id544
+    Time:
+      default: '19161231'
+      values: ['19161231']
+  name: ch.swisstopo.zeitreihen_19161231
+  sources: [ch.swisstopo.zeitreihen_19161231_cache_out]
+  title: Zeitreise - Kartenwerke (19161231)
+- dimensions: *id544
+  name: ch.swisstopo.zeitreihen_19161231_source
+  sources: [ch.swisstopo.zeitreihen_19161231_cache]
+  title: Zeitreise - Kartenwerke (19161231, source)
+- dimensions: &id545
+    Time:
+      default: '19151231'
+      values: ['19151231']
+  name: ch.swisstopo.zeitreihen_19151231
+  sources: [ch.swisstopo.zeitreihen_19151231_cache_out]
+  title: Zeitreise - Kartenwerke (19151231)
+- dimensions: *id545
+  name: ch.swisstopo.zeitreihen_19151231_source
+  sources: [ch.swisstopo.zeitreihen_19151231_cache]
+  title: Zeitreise - Kartenwerke (19151231, source)
+- dimensions: &id546
+    Time:
+      default: '19141231'
+      values: ['19141231']
+  name: ch.swisstopo.zeitreihen_19141231
+  sources: [ch.swisstopo.zeitreihen_19141231_cache_out]
+  title: Zeitreise - Kartenwerke (19141231)
+- dimensions: *id546
+  name: ch.swisstopo.zeitreihen_19141231_source
+  sources: [ch.swisstopo.zeitreihen_19141231_cache]
+  title: Zeitreise - Kartenwerke (19141231, source)
+- dimensions: &id547
+    Time:
+      default: '19131231'
+      values: ['19131231']
+  name: ch.swisstopo.zeitreihen_19131231
+  sources: [ch.swisstopo.zeitreihen_19131231_cache_out]
+  title: Zeitreise - Kartenwerke (19131231)
+- dimensions: *id547
+  name: ch.swisstopo.zeitreihen_19131231_source
+  sources: [ch.swisstopo.zeitreihen_19131231_cache]
+  title: Zeitreise - Kartenwerke (19131231, source)
+- dimensions: &id548
+    Time:
+      default: '19121231'
+      values: ['19121231']
+  name: ch.swisstopo.zeitreihen_19121231
+  sources: [ch.swisstopo.zeitreihen_19121231_cache_out]
+  title: Zeitreise - Kartenwerke (19121231)
+- dimensions: *id548
+  name: ch.swisstopo.zeitreihen_19121231_source
+  sources: [ch.swisstopo.zeitreihen_19121231_cache]
+  title: Zeitreise - Kartenwerke (19121231, source)
+- dimensions: &id549
+    Time:
+      default: '19111231'
+      values: ['19111231']
+  name: ch.swisstopo.zeitreihen_19111231
+  sources: [ch.swisstopo.zeitreihen_19111231_cache_out]
+  title: Zeitreise - Kartenwerke (19111231)
+- dimensions: *id549
+  name: ch.swisstopo.zeitreihen_19111231_source
+  sources: [ch.swisstopo.zeitreihen_19111231_cache]
+  title: Zeitreise - Kartenwerke (19111231, source)
+- dimensions: &id550
+    Time:
+      default: '19101231'
+      values: ['19101231']
+  name: ch.swisstopo.zeitreihen_19101231
+  sources: [ch.swisstopo.zeitreihen_19101231_cache_out]
+  title: Zeitreise - Kartenwerke (19101231)
+- dimensions: *id550
+  name: ch.swisstopo.zeitreihen_19101231_source
+  sources: [ch.swisstopo.zeitreihen_19101231_cache]
+  title: Zeitreise - Kartenwerke (19101231, source)
+- dimensions: &id551
+    Time:
+      default: '19091231'
+      values: ['19091231']
+  name: ch.swisstopo.zeitreihen_19091231
+  sources: [ch.swisstopo.zeitreihen_19091231_cache_out]
+  title: Zeitreise - Kartenwerke (19091231)
+- dimensions: *id551
+  name: ch.swisstopo.zeitreihen_19091231_source
+  sources: [ch.swisstopo.zeitreihen_19091231_cache]
+  title: Zeitreise - Kartenwerke (19091231, source)
+- dimensions: &id552
+    Time:
+      default: '19081231'
+      values: ['19081231']
+  name: ch.swisstopo.zeitreihen_19081231
+  sources: [ch.swisstopo.zeitreihen_19081231_cache_out]
+  title: Zeitreise - Kartenwerke (19081231)
+- dimensions: *id552
+  name: ch.swisstopo.zeitreihen_19081231_source
+  sources: [ch.swisstopo.zeitreihen_19081231_cache]
+  title: Zeitreise - Kartenwerke (19081231, source)
+- dimensions: &id553
+    Time:
+      default: '19071231'
+      values: ['19071231']
+  name: ch.swisstopo.zeitreihen_19071231
+  sources: [ch.swisstopo.zeitreihen_19071231_cache_out]
+  title: Zeitreise - Kartenwerke (19071231)
+- dimensions: *id553
+  name: ch.swisstopo.zeitreihen_19071231_source
+  sources: [ch.swisstopo.zeitreihen_19071231_cache]
+  title: Zeitreise - Kartenwerke (19071231, source)
+- dimensions: &id554
+    Time:
+      default: '19061231'
+      values: ['19061231']
+  name: ch.swisstopo.zeitreihen_19061231
+  sources: [ch.swisstopo.zeitreihen_19061231_cache_out]
+  title: Zeitreise - Kartenwerke (19061231)
+- dimensions: *id554
+  name: ch.swisstopo.zeitreihen_19061231_source
+  sources: [ch.swisstopo.zeitreihen_19061231_cache]
+  title: Zeitreise - Kartenwerke (19061231, source)
+- dimensions: &id555
+    Time:
+      default: '19051231'
+      values: ['19051231']
+  name: ch.swisstopo.zeitreihen_19051231
+  sources: [ch.swisstopo.zeitreihen_19051231_cache_out]
+  title: Zeitreise - Kartenwerke (19051231)
+- dimensions: *id555
+  name: ch.swisstopo.zeitreihen_19051231_source
+  sources: [ch.swisstopo.zeitreihen_19051231_cache]
+  title: Zeitreise - Kartenwerke (19051231, source)
+- dimensions: &id556
+    Time:
+      default: '19041231'
+      values: ['19041231']
+  name: ch.swisstopo.zeitreihen_19041231
+  sources: [ch.swisstopo.zeitreihen_19041231_cache_out]
+  title: Zeitreise - Kartenwerke (19041231)
+- dimensions: *id556
+  name: ch.swisstopo.zeitreihen_19041231_source
+  sources: [ch.swisstopo.zeitreihen_19041231_cache]
+  title: Zeitreise - Kartenwerke (19041231, source)
+- dimensions: &id557
+    Time:
+      default: '19031231'
+      values: ['19031231']
+  name: ch.swisstopo.zeitreihen_19031231
+  sources: [ch.swisstopo.zeitreihen_19031231_cache_out]
+  title: Zeitreise - Kartenwerke (19031231)
+- dimensions: *id557
+  name: ch.swisstopo.zeitreihen_19031231_source
+  sources: [ch.swisstopo.zeitreihen_19031231_cache]
+  title: Zeitreise - Kartenwerke (19031231, source)
+- dimensions: &id558
+    Time:
+      default: '19021231'
+      values: ['19021231']
+  name: ch.swisstopo.zeitreihen_19021231
+  sources: [ch.swisstopo.zeitreihen_19021231_cache_out]
+  title: Zeitreise - Kartenwerke (19021231)
+- dimensions: *id558
+  name: ch.swisstopo.zeitreihen_19021231_source
+  sources: [ch.swisstopo.zeitreihen_19021231_cache]
+  title: Zeitreise - Kartenwerke (19021231, source)
+- dimensions: &id559
+    Time:
+      default: '19011231'
+      values: ['19011231']
+  name: ch.swisstopo.zeitreihen_19011231
+  sources: [ch.swisstopo.zeitreihen_19011231_cache_out]
+  title: Zeitreise - Kartenwerke (19011231)
+- dimensions: *id559
+  name: ch.swisstopo.zeitreihen_19011231_source
+  sources: [ch.swisstopo.zeitreihen_19011231_cache]
+  title: Zeitreise - Kartenwerke (19011231, source)
+- dimensions: &id560
+    Time:
+      default: '19001231'
+      values: ['19001231']
+  name: ch.swisstopo.zeitreihen_19001231
+  sources: [ch.swisstopo.zeitreihen_19001231_cache_out]
+  title: Zeitreise - Kartenwerke (19001231)
+- dimensions: *id560
+  name: ch.swisstopo.zeitreihen_19001231_source
+  sources: [ch.swisstopo.zeitreihen_19001231_cache]
+  title: Zeitreise - Kartenwerke (19001231, source)
+- dimensions: &id561
+    Time:
+      default: '18991231'
+      values: ['18991231']
+  name: ch.swisstopo.zeitreihen_18991231
+  sources: [ch.swisstopo.zeitreihen_18991231_cache_out]
+  title: Zeitreise - Kartenwerke (18991231)
+- dimensions: *id561
+  name: ch.swisstopo.zeitreihen_18991231_source
+  sources: [ch.swisstopo.zeitreihen_18991231_cache]
+  title: Zeitreise - Kartenwerke (18991231, source)
+- dimensions: &id562
+    Time:
+      default: '18981231'
+      values: ['18981231']
+  name: ch.swisstopo.zeitreihen_18981231
+  sources: [ch.swisstopo.zeitreihen_18981231_cache_out]
+  title: Zeitreise - Kartenwerke (18981231)
+- dimensions: *id562
+  name: ch.swisstopo.zeitreihen_18981231_source
+  sources: [ch.swisstopo.zeitreihen_18981231_cache]
+  title: Zeitreise - Kartenwerke (18981231, source)
+- dimensions: &id563
+    Time:
+      default: '18971231'
+      values: ['18971231']
+  name: ch.swisstopo.zeitreihen_18971231
+  sources: [ch.swisstopo.zeitreihen_18971231_cache_out]
+  title: Zeitreise - Kartenwerke (18971231)
+- dimensions: *id563
+  name: ch.swisstopo.zeitreihen_18971231_source
+  sources: [ch.swisstopo.zeitreihen_18971231_cache]
+  title: Zeitreise - Kartenwerke (18971231, source)
+- dimensions: &id564
+    Time:
+      default: '18961231'
+      values: ['18961231']
+  name: ch.swisstopo.zeitreihen_18961231
+  sources: [ch.swisstopo.zeitreihen_18961231_cache_out]
+  title: Zeitreise - Kartenwerke (18961231)
+- dimensions: *id564
+  name: ch.swisstopo.zeitreihen_18961231_source
+  sources: [ch.swisstopo.zeitreihen_18961231_cache]
+  title: Zeitreise - Kartenwerke (18961231, source)
+- dimensions: &id565
+    Time:
+      default: '18951231'
+      values: ['18951231']
+  name: ch.swisstopo.zeitreihen_18951231
+  sources: [ch.swisstopo.zeitreihen_18951231_cache_out]
+  title: Zeitreise - Kartenwerke (18951231)
+- dimensions: *id565
+  name: ch.swisstopo.zeitreihen_18951231_source
+  sources: [ch.swisstopo.zeitreihen_18951231_cache]
+  title: Zeitreise - Kartenwerke (18951231, source)
+- dimensions: &id566
+    Time:
+      default: '18941231'
+      values: ['18941231']
+  name: ch.swisstopo.zeitreihen_18941231
+  sources: [ch.swisstopo.zeitreihen_18941231_cache_out]
+  title: Zeitreise - Kartenwerke (18941231)
+- dimensions: *id566
+  name: ch.swisstopo.zeitreihen_18941231_source
+  sources: [ch.swisstopo.zeitreihen_18941231_cache]
+  title: Zeitreise - Kartenwerke (18941231, source)
+- dimensions: &id567
+    Time:
+      default: '18931231'
+      values: ['18931231']
+  name: ch.swisstopo.zeitreihen_18931231
+  sources: [ch.swisstopo.zeitreihen_18931231_cache_out]
+  title: Zeitreise - Kartenwerke (18931231)
+- dimensions: *id567
+  name: ch.swisstopo.zeitreihen_18931231_source
+  sources: [ch.swisstopo.zeitreihen_18931231_cache]
+  title: Zeitreise - Kartenwerke (18931231, source)
+- dimensions: &id568
+    Time:
+      default: '18921231'
+      values: ['18921231']
+  name: ch.swisstopo.zeitreihen_18921231
+  sources: [ch.swisstopo.zeitreihen_18921231_cache_out]
+  title: Zeitreise - Kartenwerke (18921231)
+- dimensions: *id568
+  name: ch.swisstopo.zeitreihen_18921231_source
+  sources: [ch.swisstopo.zeitreihen_18921231_cache]
+  title: Zeitreise - Kartenwerke (18921231, source)
+- dimensions: &id569
+    Time:
+      default: '18911231'
+      values: ['18911231']
+  name: ch.swisstopo.zeitreihen_18911231
+  sources: [ch.swisstopo.zeitreihen_18911231_cache_out]
+  title: Zeitreise - Kartenwerke (18911231)
+- dimensions: *id569
+  name: ch.swisstopo.zeitreihen_18911231_source
+  sources: [ch.swisstopo.zeitreihen_18911231_cache]
+  title: Zeitreise - Kartenwerke (18911231, source)
+- dimensions: &id570
+    Time:
+      default: '18901231'
+      values: ['18901231']
+  name: ch.swisstopo.zeitreihen_18901231
+  sources: [ch.swisstopo.zeitreihen_18901231_cache_out]
+  title: Zeitreise - Kartenwerke (18901231)
+- dimensions: *id570
+  name: ch.swisstopo.zeitreihen_18901231_source
+  sources: [ch.swisstopo.zeitreihen_18901231_cache]
+  title: Zeitreise - Kartenwerke (18901231, source)
+- dimensions: &id571
+    Time:
+      default: '18891231'
+      values: ['18891231']
+  name: ch.swisstopo.zeitreihen_18891231
+  sources: [ch.swisstopo.zeitreihen_18891231_cache_out]
+  title: Zeitreise - Kartenwerke (18891231)
+- dimensions: *id571
+  name: ch.swisstopo.zeitreihen_18891231_source
+  sources: [ch.swisstopo.zeitreihen_18891231_cache]
+  title: Zeitreise - Kartenwerke (18891231, source)
+- dimensions: &id572
+    Time:
+      default: '18881231'
+      values: ['18881231']
+  name: ch.swisstopo.zeitreihen_18881231
+  sources: [ch.swisstopo.zeitreihen_18881231_cache_out]
+  title: Zeitreise - Kartenwerke (18881231)
+- dimensions: *id572
+  name: ch.swisstopo.zeitreihen_18881231_source
+  sources: [ch.swisstopo.zeitreihen_18881231_cache]
+  title: Zeitreise - Kartenwerke (18881231, source)
+- dimensions: &id573
+    Time:
+      default: '18871231'
+      values: ['18871231']
+  name: ch.swisstopo.zeitreihen_18871231
+  sources: [ch.swisstopo.zeitreihen_18871231_cache_out]
+  title: Zeitreise - Kartenwerke (18871231)
+- dimensions: *id573
+  name: ch.swisstopo.zeitreihen_18871231_source
+  sources: [ch.swisstopo.zeitreihen_18871231_cache]
+  title: Zeitreise - Kartenwerke (18871231, source)
+- dimensions: &id574
+    Time:
+      default: '18861231'
+      values: ['18861231']
+  name: ch.swisstopo.zeitreihen_18861231
+  sources: [ch.swisstopo.zeitreihen_18861231_cache_out]
+  title: Zeitreise - Kartenwerke (18861231)
+- dimensions: *id574
+  name: ch.swisstopo.zeitreihen_18861231_source
+  sources: [ch.swisstopo.zeitreihen_18861231_cache]
+  title: Zeitreise - Kartenwerke (18861231, source)
+- dimensions: &id575
+    Time:
+      default: '18851231'
+      values: ['18851231']
+  name: ch.swisstopo.zeitreihen_18851231
+  sources: [ch.swisstopo.zeitreihen_18851231_cache_out]
+  title: Zeitreise - Kartenwerke (18851231)
+- dimensions: *id575
+  name: ch.swisstopo.zeitreihen_18851231_source
+  sources: [ch.swisstopo.zeitreihen_18851231_cache]
+  title: Zeitreise - Kartenwerke (18851231, source)
+- dimensions: &id576
+    Time:
+      default: '18841231'
+      values: ['18841231']
+  name: ch.swisstopo.zeitreihen_18841231
+  sources: [ch.swisstopo.zeitreihen_18841231_cache_out]
+  title: Zeitreise - Kartenwerke (18841231)
+- dimensions: *id576
+  name: ch.swisstopo.zeitreihen_18841231_source
+  sources: [ch.swisstopo.zeitreihen_18841231_cache]
+  title: Zeitreise - Kartenwerke (18841231, source)
+- dimensions: &id577
+    Time:
+      default: '18831231'
+      values: ['18831231']
+  name: ch.swisstopo.zeitreihen_18831231
+  sources: [ch.swisstopo.zeitreihen_18831231_cache_out]
+  title: Zeitreise - Kartenwerke (18831231)
+- dimensions: *id577
+  name: ch.swisstopo.zeitreihen_18831231_source
+  sources: [ch.swisstopo.zeitreihen_18831231_cache]
+  title: Zeitreise - Kartenwerke (18831231, source)
+- dimensions: &id578
+    Time:
+      default: '18821231'
+      values: ['18821231']
+  name: ch.swisstopo.zeitreihen_18821231
+  sources: [ch.swisstopo.zeitreihen_18821231_cache_out]
+  title: Zeitreise - Kartenwerke (18821231)
+- dimensions: *id578
+  name: ch.swisstopo.zeitreihen_18821231_source
+  sources: [ch.swisstopo.zeitreihen_18821231_cache]
+  title: Zeitreise - Kartenwerke (18821231, source)
+- dimensions: &id579
+    Time:
+      default: '18811231'
+      values: ['18811231']
+  name: ch.swisstopo.zeitreihen_18811231
+  sources: [ch.swisstopo.zeitreihen_18811231_cache_out]
+  title: Zeitreise - Kartenwerke (18811231)
+- dimensions: *id579
+  name: ch.swisstopo.zeitreihen_18811231_source
+  sources: [ch.swisstopo.zeitreihen_18811231_cache]
+  title: Zeitreise - Kartenwerke (18811231, source)
+- dimensions: &id580
+    Time:
+      default: '18801231'
+      values: ['18801231']
+  name: ch.swisstopo.zeitreihen_18801231
+  sources: [ch.swisstopo.zeitreihen_18801231_cache_out]
+  title: Zeitreise - Kartenwerke (18801231)
+- dimensions: *id580
+  name: ch.swisstopo.zeitreihen_18801231_source
+  sources: [ch.swisstopo.zeitreihen_18801231_cache]
+  title: Zeitreise - Kartenwerke (18801231, source)
+- dimensions: &id581
+    Time:
+      default: '18791231'
+      values: ['18791231']
+  name: ch.swisstopo.zeitreihen_18791231
+  sources: [ch.swisstopo.zeitreihen_18791231_cache_out]
+  title: Zeitreise - Kartenwerke (18791231)
+- dimensions: *id581
+  name: ch.swisstopo.zeitreihen_18791231_source
+  sources: [ch.swisstopo.zeitreihen_18791231_cache]
+  title: Zeitreise - Kartenwerke (18791231, source)
+- dimensions: &id582
+    Time:
+      default: '18781231'
+      values: ['18781231']
+  name: ch.swisstopo.zeitreihen_18781231
+  sources: [ch.swisstopo.zeitreihen_18781231_cache_out]
+  title: Zeitreise - Kartenwerke (18781231)
+- dimensions: *id582
+  name: ch.swisstopo.zeitreihen_18781231_source
+  sources: [ch.swisstopo.zeitreihen_18781231_cache]
+  title: Zeitreise - Kartenwerke (18781231, source)
+- dimensions: &id583
+    Time:
+      default: '18771231'
+      values: ['18771231']
+  name: ch.swisstopo.zeitreihen_18771231
+  sources: [ch.swisstopo.zeitreihen_18771231_cache_out]
+  title: Zeitreise - Kartenwerke (18771231)
+- dimensions: *id583
+  name: ch.swisstopo.zeitreihen_18771231_source
+  sources: [ch.swisstopo.zeitreihen_18771231_cache]
+  title: Zeitreise - Kartenwerke (18771231, source)
+- dimensions: &id584
+    Time:
+      default: '18761231'
+      values: ['18761231']
+  name: ch.swisstopo.zeitreihen_18761231
+  sources: [ch.swisstopo.zeitreihen_18761231_cache_out]
+  title: Zeitreise - Kartenwerke (18761231)
+- dimensions: *id584
+  name: ch.swisstopo.zeitreihen_18761231_source
+  sources: [ch.swisstopo.zeitreihen_18761231_cache]
+  title: Zeitreise - Kartenwerke (18761231, source)
+- dimensions: &id585
+    Time:
+      default: '18751231'
+      values: ['18751231']
+  name: ch.swisstopo.zeitreihen_18751231
+  sources: [ch.swisstopo.zeitreihen_18751231_cache_out]
+  title: Zeitreise - Kartenwerke (18751231)
+- dimensions: *id585
+  name: ch.swisstopo.zeitreihen_18751231_source
+  sources: [ch.swisstopo.zeitreihen_18751231_cache]
+  title: Zeitreise - Kartenwerke (18751231, source)
+- dimensions: &id586
+    Time:
+      default: '18741231'
+      values: ['18741231']
+  name: ch.swisstopo.zeitreihen_18741231
+  sources: [ch.swisstopo.zeitreihen_18741231_cache_out]
+  title: Zeitreise - Kartenwerke (18741231)
+- dimensions: *id586
+  name: ch.swisstopo.zeitreihen_18741231_source
+  sources: [ch.swisstopo.zeitreihen_18741231_cache]
+  title: Zeitreise - Kartenwerke (18741231, source)
+- dimensions: &id587
+    Time:
+      default: '18731231'
+      values: ['18731231']
+  name: ch.swisstopo.zeitreihen_18731231
+  sources: [ch.swisstopo.zeitreihen_18731231_cache_out]
+  title: Zeitreise - Kartenwerke (18731231)
+- dimensions: *id587
+  name: ch.swisstopo.zeitreihen_18731231_source
+  sources: [ch.swisstopo.zeitreihen_18731231_cache]
+  title: Zeitreise - Kartenwerke (18731231, source)
+- dimensions: &id588
+    Time:
+      default: '18721231'
+      values: ['18721231']
+  name: ch.swisstopo.zeitreihen_18721231
+  sources: [ch.swisstopo.zeitreihen_18721231_cache_out]
+  title: Zeitreise - Kartenwerke (18721231)
+- dimensions: *id588
+  name: ch.swisstopo.zeitreihen_18721231_source
+  sources: [ch.swisstopo.zeitreihen_18721231_cache]
+  title: Zeitreise - Kartenwerke (18721231, source)
+- dimensions: &id589
+    Time:
+      default: '18711231'
+      values: ['18711231']
+  name: ch.swisstopo.zeitreihen_18711231
+  sources: [ch.swisstopo.zeitreihen_18711231_cache_out]
+  title: Zeitreise - Kartenwerke (18711231)
+- dimensions: *id589
+  name: ch.swisstopo.zeitreihen_18711231_source
+  sources: [ch.swisstopo.zeitreihen_18711231_cache]
+  title: Zeitreise - Kartenwerke (18711231, source)
+- dimensions: &id590
+    Time:
+      default: '18701231'
+      values: ['18701231']
+  name: ch.swisstopo.zeitreihen_18701231
+  sources: [ch.swisstopo.zeitreihen_18701231_cache_out]
+  title: Zeitreise - Kartenwerke (18701231)
+- dimensions: *id590
+  name: ch.swisstopo.zeitreihen_18701231_source
+  sources: [ch.swisstopo.zeitreihen_18701231_cache]
+  title: Zeitreise - Kartenwerke (18701231, source)
+- dimensions: &id591
+    Time:
+      default: '18691231'
+      values: ['18691231']
+  name: ch.swisstopo.zeitreihen_18691231
+  sources: [ch.swisstopo.zeitreihen_18691231_cache_out]
+  title: Zeitreise - Kartenwerke (18691231)
+- dimensions: *id591
+  name: ch.swisstopo.zeitreihen_18691231_source
+  sources: [ch.swisstopo.zeitreihen_18691231_cache]
+  title: Zeitreise - Kartenwerke (18691231, source)
+- dimensions: &id592
+    Time:
+      default: '18681231'
+      values: ['18681231']
+  name: ch.swisstopo.zeitreihen_18681231
+  sources: [ch.swisstopo.zeitreihen_18681231_cache_out]
+  title: Zeitreise - Kartenwerke (18681231)
+- dimensions: *id592
+  name: ch.swisstopo.zeitreihen_18681231_source
+  sources: [ch.swisstopo.zeitreihen_18681231_cache]
+  title: Zeitreise - Kartenwerke (18681231, source)
+- dimensions: &id593
+    Time:
+      default: '18671231'
+      values: ['18671231']
+  name: ch.swisstopo.zeitreihen_18671231
+  sources: [ch.swisstopo.zeitreihen_18671231_cache_out]
+  title: Zeitreise - Kartenwerke (18671231)
+- dimensions: *id593
+  name: ch.swisstopo.zeitreihen_18671231_source
+  sources: [ch.swisstopo.zeitreihen_18671231_cache]
+  title: Zeitreise - Kartenwerke (18671231, source)
+- dimensions: &id594
+    Time:
+      default: '18661231'
+      values: ['18661231']
+  name: ch.swisstopo.zeitreihen_18661231
+  sources: [ch.swisstopo.zeitreihen_18661231_cache_out]
+  title: Zeitreise - Kartenwerke (18661231)
+- dimensions: *id594
+  name: ch.swisstopo.zeitreihen_18661231_source
+  sources: [ch.swisstopo.zeitreihen_18661231_cache]
+  title: Zeitreise - Kartenwerke (18661231, source)
+- dimensions: &id595
+    Time:
+      default: '18651231'
+      values: ['18651231']
+  name: ch.swisstopo.zeitreihen_18651231
+  sources: [ch.swisstopo.zeitreihen_18651231_cache_out]
+  title: Zeitreise - Kartenwerke (18651231)
+- dimensions: *id595
+  name: ch.swisstopo.zeitreihen_18651231_source
+  sources: [ch.swisstopo.zeitreihen_18651231_cache]
+  title: Zeitreise - Kartenwerke (18651231, source)
+- dimensions: &id596
+    Time:
+      default: '18641231'
+      values: ['18641231']
+  name: ch.swisstopo.zeitreihen_18641231
+  sources: [ch.swisstopo.zeitreihen_18641231_cache_out]
+  title: Zeitreise - Kartenwerke (18641231)
+- dimensions: *id596
+  name: ch.swisstopo.zeitreihen_18641231_source
+  sources: [ch.swisstopo.zeitreihen_18641231_cache]
+  title: Zeitreise - Kartenwerke (18641231, source)
+- dimensions: &id597
+    Time:
+      default: '18631231'
+      values: ['18631231']
+  name: ch.swisstopo.zeitreihen_18631231
+  sources: [ch.swisstopo.zeitreihen_18631231_cache_out]
+  title: Zeitreise - Kartenwerke (18631231)
+- dimensions: *id597
+  name: ch.swisstopo.zeitreihen_18631231_source
+  sources: [ch.swisstopo.zeitreihen_18631231_cache]
+  title: Zeitreise - Kartenwerke (18631231, source)
+- dimensions: &id598
+    Time:
+      default: '18621231'
+      values: ['18621231']
+  name: ch.swisstopo.zeitreihen_18621231
+  sources: [ch.swisstopo.zeitreihen_18621231_cache_out]
+  title: Zeitreise - Kartenwerke (18621231)
+- dimensions: *id598
+  name: ch.swisstopo.zeitreihen_18621231_source
+  sources: [ch.swisstopo.zeitreihen_18621231_cache]
+  title: Zeitreise - Kartenwerke (18621231, source)
+- dimensions: &id599
+    Time:
+      default: '18611231'
+      values: ['18611231']
+  name: ch.swisstopo.zeitreihen_18611231
+  sources: [ch.swisstopo.zeitreihen_18611231_cache_out]
+  title: Zeitreise - Kartenwerke (18611231)
+- dimensions: *id599
+  name: ch.swisstopo.zeitreihen_18611231_source
+  sources: [ch.swisstopo.zeitreihen_18611231_cache]
+  title: Zeitreise - Kartenwerke (18611231, source)
+- dimensions: &id600
+    Time:
+      default: '18601231'
+      values: ['18601231']
+  name: ch.swisstopo.zeitreihen_18601231
+  sources: [ch.swisstopo.zeitreihen_18601231_cache_out]
+  title: Zeitreise - Kartenwerke (18601231)
+- dimensions: *id600
+  name: ch.swisstopo.zeitreihen_18601231_source
+  sources: [ch.swisstopo.zeitreihen_18601231_cache]
+  title: Zeitreise - Kartenwerke (18601231, source)
+- dimensions: &id601
+    Time:
+      default: '18591231'
+      values: ['18591231']
+  name: ch.swisstopo.zeitreihen_18591231
+  sources: [ch.swisstopo.zeitreihen_18591231_cache_out]
+  title: Zeitreise - Kartenwerke (18591231)
+- dimensions: *id601
+  name: ch.swisstopo.zeitreihen_18591231_source
+  sources: [ch.swisstopo.zeitreihen_18591231_cache]
+  title: Zeitreise - Kartenwerke (18591231, source)
+- dimensions: &id602
+    Time:
+      default: '18581231'
+      values: ['18581231']
+  name: ch.swisstopo.zeitreihen_18581231
+  sources: [ch.swisstopo.zeitreihen_18581231_cache_out]
+  title: Zeitreise - Kartenwerke (18581231)
+- dimensions: *id602
+  name: ch.swisstopo.zeitreihen_18581231_source
+  sources: [ch.swisstopo.zeitreihen_18581231_cache]
+  title: Zeitreise - Kartenwerke (18581231, source)
+- dimensions: &id603
+    Time:
+      default: '18571231'
+      values: ['18571231']
+  name: ch.swisstopo.zeitreihen_18571231
+  sources: [ch.swisstopo.zeitreihen_18571231_cache_out]
+  title: Zeitreise - Kartenwerke (18571231)
+- dimensions: *id603
+  name: ch.swisstopo.zeitreihen_18571231_source
+  sources: [ch.swisstopo.zeitreihen_18571231_cache]
+  title: Zeitreise - Kartenwerke (18571231, source)
+- dimensions: &id604
+    Time:
+      default: '18561231'
+      values: ['18561231']
+  name: ch.swisstopo.zeitreihen_18561231
+  sources: [ch.swisstopo.zeitreihen_18561231_cache_out]
+  title: Zeitreise - Kartenwerke (18561231)
+- dimensions: *id604
+  name: ch.swisstopo.zeitreihen_18561231_source
+  sources: [ch.swisstopo.zeitreihen_18561231_cache]
+  title: Zeitreise - Kartenwerke (18561231, source)
+- dimensions: &id605
+    Time:
+      default: '18551231'
+      values: ['18551231']
+  name: ch.swisstopo.zeitreihen_18551231
+  sources: [ch.swisstopo.zeitreihen_18551231_cache_out]
+  title: Zeitreise - Kartenwerke (18551231)
+- dimensions: *id605
+  name: ch.swisstopo.zeitreihen_18551231_source
+  sources: [ch.swisstopo.zeitreihen_18551231_cache]
+  title: Zeitreise - Kartenwerke (18551231, source)
+- dimensions: &id606
+    Time:
+      default: '18541231'
+      values: ['18541231']
+  name: ch.swisstopo.zeitreihen_18541231
+  sources: [ch.swisstopo.zeitreihen_18541231_cache_out]
+  title: Zeitreise - Kartenwerke (18541231)
+- dimensions: *id606
+  name: ch.swisstopo.zeitreihen_18541231_source
+  sources: [ch.swisstopo.zeitreihen_18541231_cache]
+  title: Zeitreise - Kartenwerke (18541231, source)
+- dimensions: &id607
+    Time:
+      default: '18531231'
+      values: ['18531231']
+  name: ch.swisstopo.zeitreihen_18531231
+  sources: [ch.swisstopo.zeitreihen_18531231_cache_out]
+  title: Zeitreise - Kartenwerke (18531231)
+- dimensions: *id607
+  name: ch.swisstopo.zeitreihen_18531231_source
+  sources: [ch.swisstopo.zeitreihen_18531231_cache]
+  title: Zeitreise - Kartenwerke (18531231, source)
+- dimensions: &id608
+    Time:
+      default: '18521231'
+      values: ['18521231']
+  name: ch.swisstopo.zeitreihen_18521231
+  sources: [ch.swisstopo.zeitreihen_18521231_cache_out]
+  title: Zeitreise - Kartenwerke (18521231)
+- dimensions: *id608
+  name: ch.swisstopo.zeitreihen_18521231_source
+  sources: [ch.swisstopo.zeitreihen_18521231_cache]
+  title: Zeitreise - Kartenwerke (18521231, source)
+- dimensions: &id609
+    Time:
+      default: '18511231'
+      values: ['18511231']
+  name: ch.swisstopo.zeitreihen_18511231
+  sources: [ch.swisstopo.zeitreihen_18511231_cache_out]
+  title: Zeitreise - Kartenwerke (18511231)
+- dimensions: *id609
+  name: ch.swisstopo.zeitreihen_18511231_source
+  sources: [ch.swisstopo.zeitreihen_18511231_cache]
+  title: Zeitreise - Kartenwerke (18511231, source)
+- dimensions: &id610
+    Time:
+      default: '18501231'
+      values: ['18501231']
+  name: ch.swisstopo.zeitreihen_18501231
+  sources: [ch.swisstopo.zeitreihen_18501231_cache_out]
+  title: Zeitreise - Kartenwerke (18501231)
+- dimensions: *id610
+  name: ch.swisstopo.zeitreihen_18501231_source
+  sources: [ch.swisstopo.zeitreihen_18501231_cache]
+  title: Zeitreise - Kartenwerke (18501231, source)
+- dimensions: &id611
+    Time:
+      default: '18491231'
+      values: ['18491231']
+  name: ch.swisstopo.zeitreihen_18491231
+  sources: [ch.swisstopo.zeitreihen_18491231_cache_out]
+  title: Zeitreise - Kartenwerke (18491231)
+- dimensions: *id611
+  name: ch.swisstopo.zeitreihen_18491231_source
+  sources: [ch.swisstopo.zeitreihen_18491231_cache]
+  title: Zeitreise - Kartenwerke (18491231, source)
+- dimensions: &id612
+    Time:
+      default: '18481231'
+      values: ['18481231']
+  name: ch.swisstopo.zeitreihen_18481231
+  sources: [ch.swisstopo.zeitreihen_18481231_cache_out]
+  title: Zeitreise - Kartenwerke (18481231)
+- dimensions: *id612
+  name: ch.swisstopo.zeitreihen_18481231_source
+  sources: [ch.swisstopo.zeitreihen_18481231_cache]
+  title: Zeitreise - Kartenwerke (18481231, source)
+- dimensions: &id613
+    Time:
+      default: '18471231'
+      values: ['18471231']
+  name: ch.swisstopo.zeitreihen_18471231
+  sources: [ch.swisstopo.zeitreihen_18471231_cache_out]
+  title: Zeitreise - Kartenwerke (18471231)
+- dimensions: *id613
+  name: ch.swisstopo.zeitreihen_18471231_source
+  sources: [ch.swisstopo.zeitreihen_18471231_cache]
+  title: Zeitreise - Kartenwerke (18471231, source)
+- dimensions: &id614
+    Time:
+      default: '18461231'
+      values: ['18461231']
+  name: ch.swisstopo.zeitreihen_18461231
+  sources: [ch.swisstopo.zeitreihen_18461231_cache_out]
+  title: Zeitreise - Kartenwerke (18461231)
+- dimensions: *id614
+  name: ch.swisstopo.zeitreihen_18461231_source
+  sources: [ch.swisstopo.zeitreihen_18461231_cache]
+  title: Zeitreise - Kartenwerke (18461231, source)
+- dimensions: &id615
+    Time:
+      default: '18451231'
+      values: ['18451231']
+  name: ch.swisstopo.zeitreihen_18451231
+  sources: [ch.swisstopo.zeitreihen_18451231_cache_out]
+  title: Zeitreise - Kartenwerke (18451231)
+- dimensions: *id615
+  name: ch.swisstopo.zeitreihen_18451231_source
+  sources: [ch.swisstopo.zeitreihen_18451231_cache]
+  title: Zeitreise - Kartenwerke (18451231, source)
+- dimensions: &id616
+    Time:
+      default: '18441231'
+      values: ['18441231']
+  name: ch.swisstopo.zeitreihen_18441231
+  sources: [ch.swisstopo.zeitreihen_18441231_cache_out]
+  title: Zeitreise - Kartenwerke (18441231)
+- dimensions: *id616
+  name: ch.swisstopo.zeitreihen_18441231_source
+  sources: [ch.swisstopo.zeitreihen_18441231_cache]
+  title: Zeitreise - Kartenwerke (18441231, source)
+- dimensions: &id617
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_100_20081218
+  sources: [ch.bafu.aquaprotect_100_20081218_cache_out]
+  title: "\xDCberschwemmung Aquaprotect 100 (20081218)"
+- dimensions: *id617
+  name: ch.bafu.aquaprotect_100
+  sources: [ch.bafu.aquaprotect_100_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 100 ('current')"
+- dimensions: *id617
+  name: ch.bafu.aquaprotect_100_20081218_source
+  sources: [ch.bafu.aquaprotect_100_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 100 (20081218, source)"
+- dimensions: &id618
+    Time:
+      default: '20111231'
+      values: ['20111231']
+  name: ch.are.beschaeftigtendichte_20111231
+  sources: [ch.are.beschaeftigtendichte_20111231_cache_out]
+  title: "Besch\xE4ftigtendichte (20111231)"
+- dimensions: *id618
+  name: ch.are.beschaeftigtendichte
+  sources: [ch.are.beschaeftigtendichte_20111231_cache]
+  title: "Besch\xE4ftigtendichte ('current')"
+- dimensions: *id618
+  name: ch.are.beschaeftigtendichte_20111231_source
+  sources: [ch.are.beschaeftigtendichte_20111231_cache]
+  title: "Besch\xE4ftigtendichte (20111231, source)"
+- dimensions: &id619
+    Time:
+      default: '20020101'
+      values: ['20020101']
+  name: ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101
+  sources: [ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_cache_out]
+  title: "Strukturg\xFCte Rechtes Umfeld (20020101)"
+- dimensions: *id619
+  name: ch.bafu.strukturguete-hochrhein_rechtesumfeld
+  sources: [ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_cache]
+  title: "Strukturg\xFCte Rechtes Umfeld ('current')"
+- dimensions: *id619
+  name: ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_source
+  sources: [ch.bafu.strukturguete-hochrhein_rechtesumfeld_20020101_cache]
+  title: "Strukturg\xFCte Rechtes Umfeld (20020101, source)"
+- dimensions: &id620
+    Time:
+      default: '20100831'
+      values: ['20100831']
+  name: ch.are.landschaftstypen_20100831
+  sources: [ch.are.landschaftstypen_20100831_cache_out]
+  title: Landschaftstypologie Schweiz (20100831)
+- dimensions: *id620
+  name: ch.are.landschaftstypen
+  sources: [ch.are.landschaftstypen_20100831_cache]
+  title: Landschaftstypologie Schweiz ('current')
+- dimensions: *id620
+  name: ch.are.landschaftstypen_20100831_source
+  sources: [ch.are.landschaftstypen_20100831_cache]
+  title: Landschaftstypologie Schweiz (20100831, source)
+- dimensions: &id621
+    Time:
+      default: '20131220'
+      values: ['20131220']
+  name: ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220
+  sources: [ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_cache_out]
+  title: Jagdbanngebiete AuLaV (20131220)
+- dimensions: *id621
+  name: ch.bafu.schutzgebiete-aulav_jagdbanngebiete
+  sources: [ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_cache]
+  title: Jagdbanngebiete AuLaV ('current')
+- dimensions: *id621
+  name: ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_source
+  sources: [ch.bafu.schutzgebiete-aulav_jagdbanngebiete_20131220_cache]
+  title: Jagdbanngebiete AuLaV (20131220, source)
+- dimensions: &id622
+    Time:
+      default: '20070116'
+      values: ['20070116']
+  name: ch.bfs.arealstatistik-hintergrund_20070116
+  sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache_out]
+  title: Vereinfachte Bodennutzung (20070116)
+- dimensions: *id622
+  name: ch.bfs.arealstatistik-hintergrund
+  sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
+  title: Vereinfachte Bodennutzung ('current')
+- dimensions: *id622
+  name: ch.bfs.arealstatistik-hintergrund_20070116_source
+  sources: [ch.bfs.arealstatistik-hintergrund_20070116_cache]
+  title: Vereinfachte Bodennutzung (20070116, source)
+- dimensions: &id623
+    Time:
+      default: '20120101'
+      values: ['20120101']
+  name: ch.are.bauzonen_20120101
+  sources: [ch.are.bauzonen_20120101_cache_out]
+  title: Bauzonen Schweiz (harmonisiert) (20120101)
+- dimensions: *id623
+  name: ch.are.bauzonen
+  sources: [ch.are.bauzonen_20120101_cache]
+  title: Bauzonen Schweiz (harmonisiert) ('current')
+- dimensions: *id623
+  name: ch.are.bauzonen_20120101_source
+  sources: [ch.are.bauzonen_20120101_cache]
+  title: Bauzonen Schweiz (harmonisiert) (20120101, source)
+- dimensions: &id624
+    Time:
+      default: '20030102'
+      values: ['20030102']
+  name: ch.bafu.gefahren-gefaehrdungszonen_20030102
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_20030102_cache_out]
+  title: Erdbebenzonen (20030102)
+- dimensions: *id624
+  name: ch.bafu.gefahren-gefaehrdungszonen
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_20030102_cache]
+  title: Erdbebenzonen ('current')
+- dimensions: *id624
+  name: ch.bafu.gefahren-gefaehrdungszonen_20030102_source
+  sources: [ch.bafu.gefahren-gefaehrdungszonen_20030102_cache]
+  title: Erdbebenzonen (20030102, source)
+- dimensions: &id625
+    Time:
+      default: '20140703'
+      values: ['20140703']
+  name: ch.swisstopo.treasurehunt_20140703
+  sources: [ch.swisstopo.treasurehunt_20140703_cache_out]
+  title: Schatzkarte (20140703)
+- dimensions: *id625
+  name: ch.swisstopo.treasurehunt
+  sources: [ch.swisstopo.treasurehunt_20140703_cache]
+  title: Schatzkarte ('current')
+- dimensions: *id625
+  name: ch.swisstopo.treasurehunt_20140703_source
+  sources: [ch.swisstopo.treasurehunt_20140703_cache]
+  title: Schatzkarte (20140703, source)
+- dimensions: &id626
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache_out]
+  title: Bindemittelindustrie 1965 (20060304)
+- dimensions: *id626
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache]
+  title: Bindemittelindustrie 1965 ('current')
+- dimensions: *id626
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1965_20060304_cache]
+  title: Bindemittelindustrie 1965 (20060304, source)
+- dimensions: &id627
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.bafu.hydrologie-niedrigwasserstatistik_20130101
+  sources: [ch.bafu.hydrologie-niedrigwasserstatistik_20130101_cache_out]
+  title: NQSTAT (20130101)
+- dimensions: *id627
+  name: ch.bafu.hydrologie-niedrigwasserstatistik
+  sources: [ch.bafu.hydrologie-niedrigwasserstatistik_20130101_cache]
+  title: NQSTAT ('current')
+- dimensions: *id627
+  name: ch.bafu.hydrologie-niedrigwasserstatistik_20130101_source
+  sources: [ch.bafu.hydrologie-niedrigwasserstatistik_20130101_cache]
+  title: NQSTAT (20130101, source)
+- dimensions: &id628
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_050_20081218
+  sources: [ch.bafu.aquaprotect_050_20081218_cache_out]
+  title: "\xDCberschwemmung Aquaprotect 50 (20081218)"
+- dimensions: *id628
+  name: ch.bafu.aquaprotect_050
+  sources: [ch.bafu.aquaprotect_050_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 50 ('current')"
+- dimensions: *id628
+  name: ch.bafu.aquaprotect_050_20081218_source
+  sources: [ch.bafu.aquaprotect_050_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 50 (20081218, source)"
+- dimensions: &id629
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.holzzuwachs_20100310
+  sources: [ch.bafu.holzzuwachs_20100310_cache_out]
+  title: Holzzuwachs (LFI) (20100310)
+- dimensions: *id629
+  name: ch.bafu.holzzuwachs
+  sources: [ch.bafu.holzzuwachs_20100310_cache]
+  title: Holzzuwachs (LFI) ('current')
+- dimensions: *id629
+  name: ch.bafu.holzzuwachs_20100310_source
+  sources: [ch.bafu.holzzuwachs_20100310_cache]
+  title: Holzzuwachs (LFI) (20100310, source)
+- dimensions: &id630
+    Time:
+      default: '20150326'
+      values: ['20150326']
+  name: ch.astra.unfaelle-personenschaeden_fahrraeder_20150326
+  sources: [ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_cache_out]
+  title: "Unf\xE4lle mit Fahrradbeteiligung (20150326)"
+- dimensions: *id630
+  name: ch.astra.unfaelle-personenschaeden_fahrraeder
+  sources: [ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_cache]
+  title: "Unf\xE4lle mit Fahrradbeteiligung ('current')"
+- dimensions: *id630
+  name: ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_source
+  sources: [ch.astra.unfaelle-personenschaeden_fahrraeder_20150326_cache]
+  title: "Unf\xE4lle mit Fahrradbeteiligung (20150326, source)"
+- dimensions: &id631
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-hangmuren_20060701
+  sources: [ch.bafu.silvaprotect-hangmuren_20060701_cache_out]
+  title: Hangmuren (20060701)
+- dimensions: *id631
+  name: ch.bafu.silvaprotect-hangmuren
+  sources: [ch.bafu.silvaprotect-hangmuren_20060701_cache]
+  title: Hangmuren ('current')
+- dimensions: *id631
+  name: ch.bafu.silvaprotect-hangmuren_20060701_source
+  sources: [ch.bafu.silvaprotect-hangmuren_20060701_cache]
+  title: Hangmuren (20060701, source)
+- dimensions: &id632
+    Time:
+      default: '20070101'
+      values: ['20070101']
+  name: ch.kantone.ivs-reg_loc_20070101
+  sources: [ch.kantone.ivs-reg_loc_20070101_cache_out]
+  title: IVS Kanton Bern (20070101)
+- dimensions: *id632
+  name: ch.kantone.ivs-reg_loc
+  sources: [ch.kantone.ivs-reg_loc_20070101_cache]
+  title: IVS Kanton Bern ('current')
+- dimensions: *id632
+  name: ch.kantone.ivs-reg_loc_20070101_source
+  sources: [ch.kantone.ivs-reg_loc_20070101_cache]
+  title: IVS Kanton Bern (20070101, source)
+- dimensions: &id633
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-murgang_20060701
+  sources: [ch.bafu.silvaprotect-murgang_20060701_cache_out]
+  title: Murgang (20060701)
+- dimensions: *id633
+  name: ch.bafu.silvaprotect-murgang
+  sources: [ch.bafu.silvaprotect-murgang_20060701_cache]
+  title: Murgang ('current')
+- dimensions: *id633
+  name: ch.bafu.silvaprotect-murgang_20060701_source
+  sources: [ch.bafu.silvaprotect-murgang_20060701_cache]
+  title: Murgang (20060701, source)
+- dimensions: &id634
+    Time:
+      default: '20090101'
+      values: ['20090101']
+  name: ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101
+  sources: [ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_cache_out]
+  title: NADUF (20090101)
+- dimensions: *id634
+  name: ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser
+  sources: [ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_cache]
+  title: NADUF ('current')
+- dimensions: *id634
+  name: ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_source
+  sources: [ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser_20090101_cache]
+  title: NADUF (20090101, source)
+- dimensions: &id635
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_cache_out]
+  title: "ARA-DB - Ausbaugr\xF6sse (EGW) (20140101)"
+- dimensions: *id635
+  name: ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_cache]
+  title: "ARA-DB - Ausbaugr\xF6sse (EGW) ('current')"
+- dimensions: *id635
+  name: ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_source
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_ausbaugroesse_20140101_cache]
+  title: "ARA-DB - Ausbaugr\xF6sse (EGW) (20140101, source)"
+- dimensions: &id636
+    Time:
+      default: '20120109'
+      values: ['20120109']
+  name: ch.bafu.schutzgebiete-biosphaerenreservate_20120109
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_20120109_cache_out]
+  title: "Biosph\xE4renreservate (20120109)"
+- dimensions: *id636
+  name: ch.bafu.schutzgebiete-biosphaerenreservate
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_20120109_cache]
+  title: "Biosph\xE4renreservate ('current')"
+- dimensions: *id636
+  name: ch.bafu.schutzgebiete-biosphaerenreservate_20120109_source
+  sources: [ch.bafu.schutzgebiete-biosphaerenreservate_20120109_cache]
+  title: "Biosph\xE4renreservate (20120109, source)"
+- dimensions: &id637
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_cache_out]
+  title: ARA-DB - Abwasserant. an Q347 (20140101)
+- dimensions: *id637
+  name: ch.bafu.gewaesserschutz-klaeranlagen_anteilq347
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_cache]
+  title: ARA-DB - Abwasserant. an Q347 ('current')
+- dimensions: *id637
+  name: ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_source
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_anteilq347_20140101_cache]
+  title: ARA-DB - Abwasserant. an Q347 (20140101, source)
+- dimensions: &id638
+    Time:
+      default: '20141231'
+      values: ['20141231']
+  name: ch.bag.zecken-fsme-faelle_20141231
+  sources: [ch.bag.zecken-fsme-faelle_20141231_cache_out]
+  title: "FSME - Lokale H\xE4ufungen (20141231)"
+- dimensions: *id638
+  name: ch.bag.zecken-fsme-faelle
+  sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
+  title: "FSME - Lokale H\xE4ufungen ('current')"
+- dimensions: *id638
+  name: ch.bag.zecken-fsme-faelle_20141231_source
+  sources: [ch.bag.zecken-fsme-faelle_20141231_cache]
+  title: "FSME - Lokale H\xE4ufungen (20141231, source)"
+- dimensions: &id639
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-gebaeude_20090401
+  sources: [ch.swisstopo.vec25-gebaeude_20090401_cache_out]
+  title: "Geb\xE4ude VECTOR25 (20090401)"
+- dimensions: *id639
+  name: ch.swisstopo.vec25-gebaeude
+  sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
+  title: "Geb\xE4ude VECTOR25 ('current')"
+- dimensions: *id639
+  name: ch.swisstopo.vec25-gebaeude_20090401_source
+  sources: [ch.swisstopo.vec25-gebaeude_20090401_cache]
+  title: "Geb\xE4ude VECTOR25 (20090401, source)"
+- dimensions: &id640
+    Time:
+      default: '20001231'
+      values: ['20001231']
+  name: ch.bafu.mittlere-abfluesse_20001231
+  sources: [ch.bafu.mittlere-abfluesse_20001231_cache_out]
+  title: "Mittlere Abfl\xFCsse (m\xB3/s) (20001231)"
+- dimensions: *id640
+  name: ch.bafu.mittlere-abfluesse
+  sources: [ch.bafu.mittlere-abfluesse_20001231_cache]
+  title: "Mittlere Abfl\xFCsse (m\xB3/s) ('current')"
+- dimensions: *id640
+  name: ch.bafu.mittlere-abfluesse_20001231_source
+  sources: [ch.bafu.mittlere-abfluesse_20001231_cache]
+  title: "Mittlere Abfl\xFCsse (m\xB3/s) (20001231, source)"
+- dimensions: &id641
+    Time:
+      default: '20130528'
+      values: ['20130528']
+  name: ch.bafu.fauna-wildtierkorridor_national_20130528
+  sources: [ch.bafu.fauna-wildtierkorridor_national_20130528_cache_out]
+  title: "Wildtierkorridore \xDCberregional (20130528)"
+- dimensions: *id641
+  name: ch.bafu.fauna-wildtierkorridor_national
+  sources: [ch.bafu.fauna-wildtierkorridor_national_20130528_cache]
+  title: "Wildtierkorridore \xDCberregional ('current')"
+- dimensions: *id641
+  name: ch.bafu.fauna-wildtierkorridor_national_20130528_source
+  sources: [ch.bafu.fauna-wildtierkorridor_national_20130528_cache]
+  title: "Wildtierkorridore \xDCberregional (20130528, source)"
+- dimensions: &id642
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101
+  sources: [ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_cache_out]
+  title: HUG-Messstationen (20130101)
+- dimensions: *id642
+  name: ch.bafu.hydrologie-untersuchungsgebiete_stationen
+  sources: [ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_cache]
+  title: HUG-Messstationen ('current')
+- dimensions: *id642
+  name: ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_source
+  sources: [ch.bafu.hydrologie-untersuchungsgebiete_stationen_20130101_cache]
+  title: HUG-Messstationen (20130101, source)
+- dimensions: &id643
+    Time:
+      default: '20040101'
+      values: ['20040101']
+  name: ch.bafu.hydrologischer-atlas_basisgebiete_20040101
+  sources: [ch.bafu.hydrologischer-atlas_basisgebiete_20040101_cache_out]
+  title: Basisgebiet (20040101)
+- dimensions: *id643
+  name: ch.bafu.hydrologischer-atlas_basisgebiete
+  sources: [ch.bafu.hydrologischer-atlas_basisgebiete_20040101_cache]
+  title: Basisgebiet ('current')
+- dimensions: *id643
+  name: ch.bafu.hydrologischer-atlas_basisgebiete_20040101_source
+  sources: [ch.bafu.hydrologischer-atlas_basisgebiete_20040101_cache]
+  title: Basisgebiet (20040101, source)
+- dimensions: &id644
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.swisstopo.vec200-miscellaneous_20150101
+  sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache_out]
+  title: Einzelobjekte VECTOR200 (20150101)
+- dimensions: *id644
+  name: ch.swisstopo.vec200-miscellaneous
+  sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
+  title: Einzelobjekte VECTOR200 ('current')
+- dimensions: *id644
+  name: ch.swisstopo.vec200-miscellaneous_20150101_source
+  sources: [ch.swisstopo.vec200-miscellaneous_20150101_cache]
+  title: Einzelobjekte VECTOR200 (20150101, source)
+- dimensions: &id645
+    Time:
+      default: '20080612'
+      values: ['20080612']
+  name: ch.bafu.flora-weltensutter_atlas_20080612
+  sources: [ch.bafu.flora-weltensutter_atlas_20080612_cache_out]
+  title: Atlas Welten&Sutter (20080612)
+- dimensions: *id645
+  name: ch.bafu.flora-weltensutter_atlas
+  sources: [ch.bafu.flora-weltensutter_atlas_20080612_cache]
+  title: Atlas Welten&Sutter ('current')
+- dimensions: *id645
+  name: ch.bafu.flora-weltensutter_atlas_20080612_source
+  sources: [ch.bafu.flora-weltensutter_atlas_20080612_cache]
+  title: Atlas Welten&Sutter (20080612, source)
+- dimensions: &id646
+    Time:
+      default: '20040302'
+      values: ['20040302']
+  name: ch.bafu.biogeographische_regionen_20040302
+  sources: [ch.bafu.biogeographische_regionen_20040302_cache_out]
+  title: Biogeographische Regionen (20040302)
+- dimensions: *id646
+  name: ch.bafu.biogeographische_regionen
+  sources: [ch.bafu.biogeographische_regionen_20040302_cache]
+  title: Biogeographische Regionen ('current')
+- dimensions: *id646
+  name: ch.bafu.biogeographische_regionen_20040302_source
+  sources: [ch.bafu.biogeographische_regionen_20040302_cache]
+  title: Biogeographische Regionen (20040302, source)
+- dimensions: &id647
+    Time:
+      default: '20130305'
+      values: ['20130305']
+  name: ch.bafu.naqua-grundwasser_nitrat_20130305
+  sources: [ch.bafu.naqua-grundwasser_nitrat_20130305_cache_out]
+  title: 'Grundwasser: Nitrat (20130305)'
+- dimensions: *id647
+  name: ch.bafu.naqua-grundwasser_nitrat
+  sources: [ch.bafu.naqua-grundwasser_nitrat_20130305_cache]
+  title: 'Grundwasser: Nitrat (''current'')'
+- dimensions: *id647
+  name: ch.bafu.naqua-grundwasser_nitrat_20130305_source
+  sources: [ch.bafu.naqua-grundwasser_nitrat_20130305_cache]
+  title: 'Grundwasser: Nitrat (20130305, source)'
+- dimensions: &id648
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-1985_20131121
+  sources: [ch.bfs.arealstatistik-1985_20131121_cache_out]
+  title: Arealstatistik 1979/85 NOAS04 (20131121)
+- dimensions: *id648
+  name: ch.bfs.arealstatistik-1985
+  sources: [ch.bfs.arealstatistik-1985_20131121_cache]
+  title: Arealstatistik 1979/85 NOAS04 ('current')
+- dimensions: *id648
+  name: ch.bfs.arealstatistik-1985_20131121_source
+  sources: [ch.bfs.arealstatistik-1985_20131121_cache]
+  title: Arealstatistik 1979/85 NOAS04 (20131121, source)
+- dimensions: &id649
+    Time:
+      default: '20030101'
+      values: ['20030101']
+  name: ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101
+  sources: [ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_cache_out]
+  title: HADES Atlasblatt 5.1.2 (20030101)
+- dimensions: *id649
+  name: ch.bafu.hydrologischer-atlas_kantonale-messstationen
+  sources: [ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_cache]
+  title: HADES Atlasblatt 5.1.2 ('current')
+- dimensions: *id649
+  name: ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_source
+  sources: [ch.bafu.hydrologischer-atlas_kantonale-messstationen_20030101_cache]
+  title: HADES Atlasblatt 5.1.2 (20030101, source)
+- dimensions: &id650
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.landesforstinventar-baumarten_20100310
+  sources: [ch.bafu.landesforstinventar-baumarten_20100310_cache_out]
+  title: Baumarten (LFI) (20100310)
+- dimensions: *id650
+  name: ch.bafu.landesforstinventar-baumarten
+  sources: [ch.bafu.landesforstinventar-baumarten_20100310_cache]
+  title: Baumarten (LFI) ('current')
+- dimensions: *id650
+  name: ch.bafu.landesforstinventar-baumarten_20100310_source
+  sources: [ch.bafu.landesforstinventar-baumarten_20100310_cache]
+  title: Baumarten (LFI) (20100310, source)
+- dimensions: &id651
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.belastung-personenverkehr-bahn_20121231
+  sources: [ch.are.belastung-personenverkehr-bahn_20121231_cache_out]
+  title: "Personenverkehr \xD6V (20121231)"
+- dimensions: *id651
+  name: ch.are.belastung-personenverkehr-bahn
+  sources: [ch.are.belastung-personenverkehr-bahn_20121231_cache]
+  title: "Personenverkehr \xD6V ('current')"
+- dimensions: *id651
+  name: ch.are.belastung-personenverkehr-bahn_20121231_source
+  sources: [ch.are.belastung-personenverkehr-bahn_20121231_cache]
+  title: "Personenverkehr \xD6V (20121231, source)"
+- dimensions: &id652
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.swisstopo.vec200-landcover-wald_20150101
+  sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache_out]
+  title: "Waldfl\xE4chen (20150101)"
+- dimensions: *id652
+  name: ch.swisstopo.vec200-landcover-wald
+  sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
+  title: "Waldfl\xE4chen ('current')"
+- dimensions: *id652
+  name: ch.swisstopo.vec200-landcover-wald_20150101_source
+  sources: [ch.swisstopo.vec200-landcover-wald_20150101_cache]
+  title: "Waldfl\xE4chen (20150101, source)"
+- dimensions: &id653
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.bafu.hydrologie-q347_20130101
+  sources: [ch.bafu.hydrologie-q347_20130101_cache_out]
+  title: Q347 (20130101)
+- dimensions: *id653
+  name: ch.bafu.hydrologie-q347
+  sources: [ch.bafu.hydrologie-q347_20130101_cache]
+  title: Q347 ('current')
+- dimensions: *id653
+  name: ch.bafu.hydrologie-q347_20130101_source
+  sources: [ch.bafu.hydrologie-q347_20130101_cache]
+  title: Q347 (20130101, source)
+- dimensions: &id654
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.swisstopo.vec200-transportation-strassennetz_20150101
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache_out]
+  title: Strassennetz VECTOR200 (20150101)
+- dimensions: *id654
+  name: ch.swisstopo.vec200-transportation-strassennetz
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
+  title: Strassennetz VECTOR200 ('current')
+- dimensions: *id654
+  name: ch.swisstopo.vec200-transportation-strassennetz_20150101_source
+  sources: [ch.swisstopo.vec200-transportation-strassennetz_20150101_cache]
+  title: Strassennetz VECTOR200 (20150101, source)
+- dimensions: &id655
+    Time:
+      default: '20080501'
+      values: ['20080501']
+  name: ch.bafu.silvaprotect-uebersarung_20080501
+  sources: [ch.bafu.silvaprotect-uebersarung_20080501_cache_out]
+  title: "\xDCbersarung (20080501)"
+- dimensions: *id655
+  name: ch.bafu.silvaprotect-uebersarung
+  sources: [ch.bafu.silvaprotect-uebersarung_20080501_cache]
+  title: "\xDCbersarung ('current')"
+- dimensions: *id655
+  name: ch.bafu.silvaprotect-uebersarung_20080501_source
+  sources: [ch.bafu.silvaprotect-uebersarung_20080501_cache]
+  title: "\xDCbersarung (20080501, source)"
+- dimensions: &id656
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache_out]
+  title: Bindemittelindustrie 1995 (20060304)
+- dimensions: *id656
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache]
+  title: Bindemittelindustrie 1995 ('current')
+- dimensions: *id656
+  name: ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-zementindustrie_1995_20060304_cache]
+  title: Bindemittelindustrie 1995 (20060304, source)
+- dimensions: &id657
+    Time:
+      default: '20151231'
+      values: ['20151231']
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache_out]
+  title: Landeskarte 1:500'000 | LK500 (20151231)
+- dimensions: *id657
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
+  title: Landeskarte 1:500'000 | LK500 ('current')
+- dimensions: *id657
+  name: ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_source
+  sources: [ch.swisstopo.pixelkarte-farbe-pk500.noscale_20151231_cache]
+  title: Landeskarte 1:500'000 | LK500 (20151231, source)
+- dimensions: &id658
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-strassennetz_20090401
+  sources: [ch.swisstopo.vec25-strassennetz_20090401_cache_out]
+  title: Strassennetz VECTOR25 (20090401)
+- dimensions: *id658
+  name: ch.swisstopo.vec25-strassennetz
+  sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
+  title: Strassennetz VECTOR25 ('current')
+- dimensions: *id658
+  name: ch.swisstopo.vec25-strassennetz_20090401_source
+  sources: [ch.swisstopo.vec25-strassennetz_20090401_cache]
+  title: Strassennetz VECTOR25 (20090401, source)
+- dimensions: &id659
+    Time:
+      default: '20090101'
+      values: ['20090101']
+  name: ch.bafu.feststoffe-geschiebemessnetz_20090101
+  sources: [ch.bafu.feststoffe-geschiebemessnetz_20090101_cache_out]
+  title: SOLID Bund, Geschiebe (20090101)
+- dimensions: *id659
+  name: ch.bafu.feststoffe-geschiebemessnetz
+  sources: [ch.bafu.feststoffe-geschiebemessnetz_20090101_cache]
+  title: SOLID Bund, Geschiebe ('current')
+- dimensions: *id659
+  name: ch.bafu.feststoffe-geschiebemessnetz_20090101_source
+  sources: [ch.bafu.feststoffe-geschiebemessnetz_20090101_cache]
+  title: SOLID Bund, Geschiebe (20090101, source)
+- dimensions: &id660
+    Time:
+      default: '20110829'
+      values: ['20110829']
+  name: ch.bafu.fischerei-aeschen_laichplaetze_20110829
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_20110829_cache_out]
+  title: "\xC4schen: Laichpl\xE4tze (20110829)"
+- dimensions: *id660
+  name: ch.bafu.fischerei-aeschen_laichplaetze
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_20110829_cache]
+  title: "\xC4schen: Laichpl\xE4tze ('current')"
+- dimensions: *id660
+  name: ch.bafu.fischerei-aeschen_laichplaetze_20110829_source
+  sources: [ch.bafu.fischerei-aeschen_laichplaetze_20110829_cache]
+  title: "\xC4schen: Laichpl\xE4tze (20110829, source)"
+- dimensions: &id661
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.bafu.gewaesserschutz-badewasserqualitaet_20140101
+  sources: [ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_cache_out]
+  title: "Badegew\xE4sserqualit\xE4t (20140101)"
+- dimensions: *id661
+  name: ch.bafu.gewaesserschutz-badewasserqualitaet
+  sources: [ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_cache]
+  title: "Badegew\xE4sserqualit\xE4t ('current')"
+- dimensions: *id661
+  name: ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_source
+  sources: [ch.bafu.gewaesserschutz-badewasserqualitaet_20140101_cache]
+  title: "Badegew\xE4sserqualit\xE4t (20140101, source)"
+- dimensions: &id662
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-eisenbahnnetz_20090401
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache_out]
+  title: Eisenbahnnetz VECTOR25 (20090401)
+- dimensions: *id662
+  name: ch.swisstopo.vec25-eisenbahnnetz
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
+  title: Eisenbahnnetz VECTOR25 ('current')
+- dimensions: *id662
+  name: ch.swisstopo.vec25-eisenbahnnetz_20090401_source
+  sources: [ch.swisstopo.vec25-eisenbahnnetz_20090401_cache]
+  title: Eisenbahnnetz VECTOR25 (20090401, source)
+- dimensions: &id663
+    Time:
+      default: '20040101'
+      values: ['20040101']
+  name: ch.bafu.wasser-entnahme_20040101
+  sources: [ch.bafu.wasser-entnahme_20040101_cache_out]
+  title: Wasserentnahme (20040101)
+- dimensions: *id663
+  name: ch.bafu.wasser-entnahme
+  sources: [ch.bafu.wasser-entnahme_20040101_cache]
+  title: Wasserentnahme ('current')
+- dimensions: *id663
+  name: ch.bafu.wasser-entnahme_20040101_source
+  sources: [ch.bafu.wasser-entnahme_20040101_cache]
+  title: Wasserentnahme (20040101, source)
+- dimensions: &id664
+    Time:
+      default: '20140314'
+      values: ['20140314']
+  name: ch.bafu.gefahren-baugrundklassen_20140314
+  sources: [ch.bafu.gefahren-baugrundklassen_20140314_cache_out]
+  title: Seismische Baugrundklassen (20140314)
+- dimensions: *id664
+  name: ch.bafu.gefahren-baugrundklassen
+  sources: [ch.bafu.gefahren-baugrundklassen_20140314_cache]
+  title: Seismische Baugrundklassen ('current')
+- dimensions: *id664
+  name: ch.bafu.gefahren-baugrundklassen_20140314_source
+  sources: [ch.bafu.gefahren-baugrundklassen_20140314_cache]
+  title: Seismische Baugrundklassen (20140314, source)
+- dimensions: &id665
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.holzvorrat_20100310
+  sources: [ch.bafu.holzvorrat_20100310_cache_out]
+  title: Holzvorrat (LFI) (20100310)
+- dimensions: *id665
+  name: ch.bafu.holzvorrat
+  sources: [ch.bafu.holzvorrat_20100310_cache]
+  title: Holzvorrat (LFI) ('current')
+- dimensions: *id665
+  name: ch.bafu.holzvorrat_20100310_source
+  sources: [ch.bafu.holzvorrat_20100310_cache]
+  title: Holzvorrat (LFI) (20100310, source)
+- dimensions: &id666
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache_out]
+  title: Industrieminerale (20060304)
+- dimensions: *id666
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache]
+  title: Industrieminerale ('current')
+- dimensions: *id666
+  name: ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_source
+  sources: [ch.swisstopo.geologie-rohstoffe-industrieminerale_20060304_cache]
+  title: Industrieminerale (20060304, source)
+- dimensions: &id667
+    Time:
+      default: '20150622'
+      values: ['20150622']
+  name: ch.bafu.waldreservate_20150622
+  sources: [ch.bafu.waldreservate_20150622_cache_out]
+  title: Waldreservate (20150622)
+- dimensions: *id667
+  name: ch.bafu.waldreservate
+  sources: [ch.bafu.waldreservate_20150622_cache]
+  title: Waldreservate ('current')
+- dimensions: *id667
+  name: ch.bafu.waldreservate_20150622_source
+  sources: [ch.bafu.waldreservate_20150622_cache]
+  title: Waldreservate (20150622, source)
+- dimensions: &id668
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.reisezeit-miv_20121231
+  sources: [ch.are.reisezeit-miv_20121231_cache_out]
+  title: Reisezeit zu Zentren MIV (20121231)
+- dimensions: *id668
+  name: ch.are.reisezeit-miv
+  sources: [ch.are.reisezeit-miv_20121231_cache]
+  title: Reisezeit zu Zentren MIV ('current')
+- dimensions: *id668
+  name: ch.are.reisezeit-miv_20121231_source
+  sources: [ch.are.reisezeit-miv_20121231_cache]
+  title: Reisezeit zu Zentren MIV (20121231, source)
+- dimensions: &id669
+    Time:
+      default: '19980101'
+      values: ['19980101']
+  name: ch.swisstopo.vec25-heckenbaeume_19980101
+  sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache_out]
+  title: "Hecken und B\xE4ume VECTOR25 (19980101)"
+- dimensions: *id669
+  name: ch.swisstopo.vec25-heckenbaeume
+  sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
+  title: "Hecken und B\xE4ume VECTOR25 ('current')"
+- dimensions: *id669
+  name: ch.swisstopo.vec25-heckenbaeume_19980101_source
+  sources: [ch.swisstopo.vec25-heckenbaeume_19980101_cache]
+  title: "Hecken und B\xE4ume VECTOR25 (19980101, source)"
+- dimensions: &id670
+    Time:
+      default: '20151231'
+      values: ['20151231']
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache_out]
+  title: Landeskarte 1:25'000 | LK25 (20151231)
+- dimensions: *id670
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
+  title: Landeskarte 1:25'000 | LK25 ('current')
+- dimensions: *id670
+  name: ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_source
+  sources: [ch.swisstopo.pixelkarte-farbe-pk25.noscale_20151231_cache]
+  title: Landeskarte 1:25'000 | LK25 (20151231, source)
+- dimensions: &id671
+    Time:
+      default: '20040101'
+      values: ['20040101']
+  name: ch.bafu.hydrologischer-atlas_flussgebiete_20040101
+  sources: [ch.bafu.hydrologischer-atlas_flussgebiete_20040101_cache_out]
+  title: Flussgebiet (20040101)
+- dimensions: *id671
+  name: ch.bafu.hydrologischer-atlas_flussgebiete
+  sources: [ch.bafu.hydrologischer-atlas_flussgebiete_20040101_cache]
+  title: Flussgebiet ('current')
+- dimensions: *id671
+  name: ch.bafu.hydrologischer-atlas_flussgebiete_20040101_source
+  sources: [ch.bafu.hydrologischer-atlas_flussgebiete_20040101_cache]
+  title: Flussgebiet (20040101, source)
+- dimensions: &id672
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-gewaessernetz_20090401
+  sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache_out]
+  title: "Gew\xE4ssernetz VECTOR25 (20090401)"
+- dimensions: *id672
+  name: ch.swisstopo.vec25-gewaessernetz
+  sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
+  title: "Gew\xE4ssernetz VECTOR25 ('current')"
+- dimensions: *id672
+  name: ch.swisstopo.vec25-gewaessernetz_20090401_source
+  sources: [ch.swisstopo.vec25-gewaessernetz_20090401_cache]
+  title: "Gew\xE4ssernetz VECTOR25 (20090401, source)"
+- dimensions: &id673
+    Time:
+      default: '20070731'
+      values: ['20070731']
+  name: ch.bafu.bundesinventare-flachmoore_regional_20070731
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_20070731_cache_out]
+  title: Flachmoore regional (20070731)
+- dimensions: *id673
+  name: ch.bafu.bundesinventare-flachmoore_regional
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_20070731_cache]
+  title: Flachmoore regional ('current')
+- dimensions: *id673
+  name: ch.bafu.bundesinventare-flachmoore_regional_20070731_source
+  sources: [ch.bafu.bundesinventare-flachmoore_regional_20070731_cache]
+  title: Flachmoore regional (20070731, source)
+- dimensions: &id674
+    Time:
+      default: '20070101'
+      values: ['20070101']
+  name: ch.bafu.vec25-gewaessernetz_2000_20070101
+  sources: [ch.bafu.vec25-gewaessernetz_2000_20070101_cache_out]
+  title: "Gew\xE4ssernetz 1:2 Mio. (20070101)"
+- dimensions: *id674
+  name: ch.bafu.vec25-gewaessernetz_2000
+  sources: [ch.bafu.vec25-gewaessernetz_2000_20070101_cache]
+  title: "Gew\xE4ssernetz 1:2 Mio. ('current')"
+- dimensions: *id674
+  name: ch.bafu.vec25-gewaessernetz_2000_20070101_source
+  sources: [ch.bafu.vec25-gewaessernetz_2000_20070101_cache]
+  title: "Gew\xE4ssernetz 1:2 Mio. (20070101, source)"
+- dimensions: &id675
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-sturz_20060701
+  sources: [ch.bafu.silvaprotect-sturz_20060701_cache_out]
+  title: Sturz (20060701)
+- dimensions: *id675
+  name: ch.bafu.silvaprotect-sturz
+  sources: [ch.bafu.silvaprotect-sturz_20060701_cache]
+  title: Sturz ('current')
+- dimensions: *id675
+  name: ch.bafu.silvaprotect-sturz_20060701_source
+  sources: [ch.bafu.silvaprotect-sturz_20060701_cache]
+  title: Sturz (20060701, source)
+- dimensions: &id676
+    Time:
+      default: '20070101'
+      values: ['20070101']
+  name: ch.bafu.vec25-seen_20070101
+  sources: [ch.bafu.vec25-seen_20070101_cache_out]
+  title: Seen (20070101)
+- dimensions: *id676
+  name: ch.bafu.vec25-seen
+  sources: [ch.bafu.vec25-seen_20070101_cache]
+  title: Seen ('current')
+- dimensions: *id676
+  name: ch.bafu.vec25-seen_20070101_source
+  sources: [ch.bafu.vec25-seen_20070101_cache]
+  title: Seen (20070101, source)
+- dimensions: &id677
+    Time:
+      default: '20110829'
+      values: ['20110829']
+  name: ch.bafu.fischerei-aeschen_larvenhabitate_20110829
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_20110829_cache_out]
+  title: "\xC4schen: Larvenhabitate (20110829)"
+- dimensions: *id677
+  name: ch.bafu.fischerei-aeschen_larvenhabitate
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_20110829_cache]
+  title: "\xC4schen: Larvenhabitate ('current')"
+- dimensions: *id677
+  name: ch.bafu.fischerei-aeschen_larvenhabitate_20110829_source
+  sources: [ch.bafu.fischerei-aeschen_larvenhabitate_20110829_cache]
+  title: "\xC4schen: Larvenhabitate (20110829, source)"
+- dimensions: &id678
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.are.agglomerationen_isolierte_staedte_20140101
+  sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache_out]
+  title: "Agglomerationen und isolierte St\xE4dte (20140101)"
+- dimensions: *id678
+  name: ch.are.agglomerationen_isolierte_staedte
+  sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache]
+  title: "Agglomerationen und isolierte St\xE4dte ('current')"
+- dimensions: *id678
+  name: ch.are.agglomerationen_isolierte_staedte_20140101_source
+  sources: [ch.are.agglomerationen_isolierte_staedte_20140101_cache]
+  title: "Agglomerationen und isolierte St\xE4dte (20140101, source)"
+- dimensions: &id679
+    Time:
+      default: '20130528'
+      values: ['20130528']
+  name: ch.bafu.fauna-vernetzungsachsen_national_20130528
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_20130528_cache_out]
+  title: Vernetzungssystem Wildtiere (20130528)
+- dimensions: *id679
+  name: ch.bafu.fauna-vernetzungsachsen_national
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_20130528_cache]
+  title: Vernetzungssystem Wildtiere ('current')
+- dimensions: *id679
+  name: ch.bafu.fauna-vernetzungsachsen_national_20130528_source
+  sources: [ch.bafu.fauna-vernetzungsachsen_national_20130528_cache]
+  title: Vernetzungssystem Wildtiere (20130528, source)
+- dimensions: &id680
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-primaerflaechen_20090401
+  sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache_out]
+  title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401)"
+- dimensions: *id680
+  name: ch.swisstopo.vec25-primaerflaechen
+  sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
+  title: "Prim\xE4rfl\xE4chen VECTOR25 ('current')"
+- dimensions: *id680
+  name: ch.swisstopo.vec25-primaerflaechen_20090401_source
+  sources: [ch.swisstopo.vec25-primaerflaechen_20090401_cache]
+  title: "Prim\xE4rfl\xE4chen VECTOR25 (20090401, source)"
+- dimensions: &id681
+    Time:
+      default: '20081218'
+      values: ['20081218']
+  name: ch.bafu.aquaprotect_500_20081218
+  sources: [ch.bafu.aquaprotect_500_20081218_cache_out]
+  title: "\xDCberschwemmung Aquaprotect 500 (20081218)"
+- dimensions: *id681
+  name: ch.bafu.aquaprotect_500
+  sources: [ch.bafu.aquaprotect_500_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 500 ('current')"
+- dimensions: *id681
+  name: ch.bafu.aquaprotect_500_20081218_source
+  sources: [ch.bafu.aquaprotect_500_20081218_cache]
+  title: "\xDCberschwemmung Aquaprotect 500 (20081218, source)"
+- dimensions: &id682
+    Time:
+      default: '20151231'
+      values: ['20151231']
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache_out]
+  title: Landeskarte 1:200'000 | LK200 (20151231)
+- dimensions: *id682
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
+  title: Landeskarte 1:200'000 | LK200 ('current')
+- dimensions: *id682
+  name: ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_source
+  sources: [ch.swisstopo.pixelkarte-farbe-pk200.noscale_20151231_cache]
+  title: Landeskarte 1:200'000 | LK200 (20151231, source)
+- dimensions: &id683
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.swisstopo.hangneigung-ueber_30_20130101
+  sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache_out]
+  title: "Hangneigungen ab 30\xB0 (20130101)"
+- dimensions: *id683
+  name: ch.swisstopo.hangneigung-ueber_30
+  sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache]
+  title: "Hangneigungen ab 30\xB0 ('current')"
+- dimensions: *id683
+  name: ch.swisstopo.hangneigung-ueber_30_20130101_source
+  sources: [ch.swisstopo.hangneigung-ueber_30_20130101_cache]
+  title: "Hangneigungen ab 30\xB0 (20130101, source)"
+- dimensions: &id684
+    Time:
+      default: '20150326'
+      values: ['20150326']
+  name: ch.astra.unfaelle-personenschaeden_getoetete_20150326
+  sources: [ch.astra.unfaelle-personenschaeden_getoetete_20150326_cache_out]
+  title: "Unf\xE4lle mit Get\xF6teten (20150326)"
+- dimensions: *id684
+  name: ch.astra.unfaelle-personenschaeden_getoetete
+  sources: [ch.astra.unfaelle-personenschaeden_getoetete_20150326_cache]
+  title: "Unf\xE4lle mit Get\xF6teten ('current')"
+- dimensions: *id684
+  name: ch.astra.unfaelle-personenschaeden_getoetete_20150326_source
+  sources: [ch.astra.unfaelle-personenschaeden_getoetete_20150326_cache]
+  title: "Unf\xE4lle mit Get\xF6teten (20150326, source)"
+- dimensions: &id685
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.belastung-gueterverkehr-strasse_20121231
+  sources: [ch.are.belastung-gueterverkehr-strasse_20121231_cache_out]
+  title: "G\xFCterverkehr Strasse (20121231)"
+- dimensions: *id685
+  name: ch.are.belastung-gueterverkehr-strasse
+  sources: [ch.are.belastung-gueterverkehr-strasse_20121231_cache]
+  title: "G\xFCterverkehr Strasse ('current')"
+- dimensions: *id685
+  name: ch.are.belastung-gueterverkehr-strasse_20121231_source
+  sources: [ch.are.belastung-gueterverkehr-strasse_20121231_cache]
+  title: "G\xFCterverkehr Strasse (20121231, source)"
+- dimensions: &id686
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_cache_out]
+  title: ARA-DB - Reinigungstyp (20140101)
+- dimensions: *id686
+  name: ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_cache]
+  title: ARA-DB - Reinigungstyp ('current')
+- dimensions: *id686
+  name: ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_source
+  sources: [ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp_20140101_cache]
+  title: ARA-DB - Reinigungstyp (20140101, source)
+- dimensions: &id687
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik-1997_20131121
+  sources: [ch.bfs.arealstatistik-1997_20131121_cache_out]
+  title: Arealstatistik 1992/97 NOAS04 (20131121)
+- dimensions: *id687
+  name: ch.bfs.arealstatistik-1997
+  sources: [ch.bfs.arealstatistik-1997_20131121_cache]
+  title: Arealstatistik 1992/97 NOAS04 ('current')
+- dimensions: *id687
+  name: ch.bfs.arealstatistik-1997_20131121_source
+  sources: [ch.bfs.arealstatistik-1997_20131121_cache]
+  title: Arealstatistik 1992/97 NOAS04 (20131121, source)
+- dimensions: &id688
+    Time:
+      default: '19920822'
+      values: ['19920822']
+  name: ch.bafu.flora-schwingrasen_19920822
+  sources: [ch.bafu.flora-schwingrasen_19920822_cache_out]
+  title: Schwingrasen (19920822)
+- dimensions: *id688
+  name: ch.bafu.flora-schwingrasen
+  sources: [ch.bafu.flora-schwingrasen_19920822_cache]
+  title: Schwingrasen ('current')
+- dimensions: *id688
+  name: ch.bafu.flora-schwingrasen_19920822_source
+  sources: [ch.bafu.flora-schwingrasen_19920822_cache]
+  title: Schwingrasen (19920822, source)
+- dimensions: &id689
+    Time:
+      default: '20131121'
+      values: ['20131121']
+  name: ch.bfs.arealstatistik_20131121
+  sources: [ch.bfs.arealstatistik_20131121_cache_out]
+  title: Arealstatistik 2004/09 NOAS04 (20131121)
+- dimensions: *id689
+  name: ch.bfs.arealstatistik
+  sources: [ch.bfs.arealstatistik_20131121_cache]
+  title: Arealstatistik 2004/09 NOAS04 ('current')
+- dimensions: *id689
+  name: ch.bfs.arealstatistik_20131121_source
+  sources: [ch.bfs.arealstatistik_20131121_cache]
+  title: Arealstatistik 2004/09 NOAS04 (20131121, source)
+- dimensions: &id690
+    Time:
+      default: '20151231'
+      values: ['20151231']
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache_out]
+  title: Landeskarte 1:100'000 | LK100 (20151231)
+- dimensions: *id690
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
+  title: Landeskarte 1:100'000 | LK100 ('current')
+- dimensions: *id690
+  name: ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_source
+  sources: [ch.swisstopo.pixelkarte-farbe-pk100.noscale_20151231_cache]
+  title: Landeskarte 1:100'000 | LK100 (20151231, source)
+- dimensions: &id691
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-anlagen_20090401
+  sources: [ch.swisstopo.vec25-anlagen_20090401_cache_out]
+  title: Anlagen VECTOR25 (20090401)
+- dimensions: *id691
+  name: ch.swisstopo.vec25-anlagen
+  sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
+  title: Anlagen VECTOR25 ('current')
+- dimensions: *id691
+  name: ch.swisstopo.vec25-anlagen_20090401_source
+  sources: [ch.swisstopo.vec25-anlagen_20090401_cache]
+  title: Anlagen VECTOR25 (20090401, source)
+- dimensions: &id692
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache_out]
+  title: "Steinbr\xFCche 1965 (20060304)"
+- dimensions: *id692
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache]
+  title: "Steinbr\xFCche 1965 ('current')"
+- dimensions: *id692
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1965_20060304_cache]
+  title: "Steinbr\xFCche 1965 (20060304, source)"
+- dimensions: &id693
+    Time:
+      default: '20110107'
+      values: ['20110107']
+  name: ch.bafu.fischerei-krebspest_20110107
+  sources: [ch.bafu.fischerei-krebspest_20110107_cache_out]
+  title: Krebspest (20110107)
+- dimensions: *id693
+  name: ch.bafu.fischerei-krebspest
+  sources: [ch.bafu.fischerei-krebspest_20110107_cache]
+  title: Krebspest ('current')
+- dimensions: *id693
+  name: ch.bafu.fischerei-krebspest_20110107_source
+  sources: [ch.bafu.fischerei-krebspest_20110107_cache]
+  title: Krebspest (20110107, source)
+- dimensions: &id694
+    Time:
+      default: '19821231'
+      values: ['19821231']
+  name: ch.nagra.aeromagnetische-karte_1500_19821231
+  sources: [ch.nagra.aeromagnetische-karte_1500_19821231_cache_out]
+  title: Aeromagnetik Aargau 1500 m 100 (19821231)
+- dimensions: *id694
+  name: ch.nagra.aeromagnetische-karte_1500
+  sources: [ch.nagra.aeromagnetische-karte_1500_19821231_cache]
+  title: Aeromagnetik Aargau 1500 m 100 ('current')
+- dimensions: *id694
+  name: ch.nagra.aeromagnetische-karte_1500_19821231_source
+  sources: [ch.nagra.aeromagnetische-karte_1500_19821231_cache]
+  title: Aeromagnetik Aargau 1500 m 100 (19821231, source)
+- dimensions: &id695
+    Time:
+      default: '20150326'
+      values: ['20150326']
+  name: ch.astra.unfaelle-personenschaeden_fussgaenger_20150326
+  sources: [ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_cache_out]
+  title: "Unf\xE4lle mit Fussg\xE4ngerbeteiligung (20150326)"
+- dimensions: *id695
+  name: ch.astra.unfaelle-personenschaeden_fussgaenger
+  sources: [ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_cache]
+  title: "Unf\xE4lle mit Fussg\xE4ngerbeteiligung ('current')"
+- dimensions: *id695
+  name: ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_source
+  sources: [ch.astra.unfaelle-personenschaeden_fussgaenger_20150326_cache]
+  title: "Unf\xE4lle mit Fussg\xE4ngerbeteiligung (20150326, source)"
+- dimensions: &id696
+    Time:
+      default: '20141126'
+      values: ['20141126']
+  name: ch.bazl.heliports-gebirgslandeplaetze_20141126
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_20141126_cache_out]
+  title: "Heliports/Gebirgslandepl\xE4tze (20141126)"
+- dimensions: *id696
+  name: ch.bazl.heliports-gebirgslandeplaetze
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_20141126_cache]
+  title: "Heliports/Gebirgslandepl\xE4tze ('current')"
+- dimensions: *id696
+  name: ch.bazl.heliports-gebirgslandeplaetze_20141126_source
+  sources: [ch.bazl.heliports-gebirgslandeplaetze_20141126_cache]
+  title: "Heliports/Gebirgslandepl\xE4tze (20141126, source)"
+- dimensions: &id697
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache_out]
+  title: "Steinbr\xFCche 1995 (20060304)"
+- dimensions: *id697
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache]
+  title: "Steinbr\xFCche 1995 ('current')"
+- dimensions: *id697
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1995_20060304_cache]
+  title: "Steinbr\xFCche 1995 (20060304, source)"
+- dimensions: &id698
+    Time:
+      default: '20151231'
+      values: ['20151231']
+  name: ch.swisstopo.swissimage-product_20151231
+  sources: [ch.swisstopo.swissimage-product_20151231_cache_out]
+  title: SWISSIMAGE (20151231)
+- dimensions: *id698
+  name: ch.swisstopo.swissimage-product
+  sources: [ch.swisstopo.swissimage-product_20151231_cache]
+  title: SWISSIMAGE ('current')
+- dimensions: *id698
+  name: ch.swisstopo.swissimage-product_20151231_source
+  sources: [ch.swisstopo.swissimage-product_20151231_cache]
+  title: SWISSIMAGE (20151231, source)
+- dimensions: &id699
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache_out]
+  title: Ziegeleien 1995 (20060304)
+- dimensions: *id699
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache]
+  title: Ziegeleien 1995 ('current')
+- dimensions: *id699
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1995_20060304_cache]
+  title: Ziegeleien 1995 (20060304, source)
+- dimensions: &id700
+    Time:
+      default: '20121201'
+      values: ['20121201']
+  name: ch.kantone.cadastralwebmap-farbe_20121201
+  sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache_out]
+  title: CadastralWebMap (20121201)
+- dimensions: *id700
+  name: ch.kantone.cadastralwebmap-farbe
+  sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
+  title: CadastralWebMap ('current')
+- dimensions: *id700
+  name: ch.kantone.cadastralwebmap-farbe_20121201_source
+  sources: [ch.kantone.cadastralwebmap-farbe_20121201_cache]
+  title: CadastralWebMap (20121201, source)
+- dimensions: &id701
+    Time:
+      default: '20050101'
+      values: ['20050101']
+  name: ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101
+  sources: [ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_cache_out]
+  title: HWGWP (20050101)
+- dimensions: *id701
+  name: ch.bafu.hydrologie-hochwassergrenzwertpegel
+  sources: [ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_cache]
+  title: HWGWP ('current')
+- dimensions: *id701
+  name: ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_source
+  sources: [ch.bafu.hydrologie-hochwassergrenzwertpegel_20050101_cache]
+  title: HWGWP (20050101, source)
+- dimensions: &id702
+    Time:
+      default: '20120829'
+      values: ['20120829']
+  name: ch.bazl.points-of-interest_20120829
+  sources: [ch.bazl.points-of-interest_20120829_cache_out]
+  title: Points of Interest (20120829)
+- dimensions: *id702
+  name: ch.bazl.points-of-interest
+  sources: [ch.bazl.points-of-interest_20120829_cache]
+  title: Points of Interest ('current')
+- dimensions: *id702
+  name: ch.bazl.points-of-interest_20120829_source
+  sources: [ch.bazl.points-of-interest_20120829_cache]
+  title: Points of Interest (20120829, source)
+- dimensions: &id703
+    Time:
+      default: '20040101'
+      values: ['20040101']
+  name: ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101
+  sources: [ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_cache_out]
+  title: Bilanzgebiet (20040101)
+- dimensions: *id703
+  name: ch.bafu.hydrologischer-atlas_bilanzgebiete
+  sources: [ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_cache]
+  title: Bilanzgebiet ('current')
+- dimensions: *id703
+  name: ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_source
+  sources: [ch.bafu.hydrologischer-atlas_bilanzgebiete_20040101_cache]
+  title: Bilanzgebiet (20040101, source)
+- dimensions: &id704
+    Time:
+      default: '20020101'
+      values: ['20020101']
+  name: ch.bafu.strukturguete-hochrhein_sohle_20020101
+  sources: [ch.bafu.strukturguete-hochrhein_sohle_20020101_cache_out]
+  title: "Strukturg\xFCte Sohle (20020101)"
+- dimensions: *id704
+  name: ch.bafu.strukturguete-hochrhein_sohle
+  sources: [ch.bafu.strukturguete-hochrhein_sohle_20020101_cache]
+  title: "Strukturg\xFCte Sohle ('current')"
+- dimensions: *id704
+  name: ch.bafu.strukturguete-hochrhein_sohle_20020101_source
+  sources: [ch.bafu.strukturguete-hochrhein_sohle_20020101_cache]
+  title: "Strukturg\xFCte Sohle (20020101, source)"
+- dimensions: &id705
+    Time:
+      default: '19641231'
+      values: ['19641231']
+  name: ch.swisstopo.geologie-generalkarte-ggk200_19641231
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache_out]
+  title: Geologische Generalkarte (19641231)
+- dimensions: *id705
+  name: ch.swisstopo.geologie-generalkarte-ggk200
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache]
+  title: Geologische Generalkarte ('current')
+- dimensions: *id705
+  name: ch.swisstopo.geologie-generalkarte-ggk200_19641231_source
+  sources: [ch.swisstopo.geologie-generalkarte-ggk200_19641231_cache]
+  title: Geologische Generalkarte (19641231, source)
+- dimensions: &id706
+    Time:
+      default: '20020101'
+      values: ['20020101']
+  name: ch.bafu.strukturguete-hochrhein_rechtesufer_20020101
+  sources: [ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_cache_out]
+  title: "Strukturg\xFCte Rechtes Ufer (20020101)"
+- dimensions: *id706
+  name: ch.bafu.strukturguete-hochrhein_rechtesufer
+  sources: [ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_cache]
+  title: "Strukturg\xFCte Rechtes Ufer ('current')"
+- dimensions: *id706
+  name: ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_source
+  sources: [ch.bafu.strukturguete-hochrhein_rechtesufer_20020101_cache]
+  title: "Strukturg\xFCte Rechtes Ufer (20020101, source)"
+- dimensions: &id707
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache_out]
+  title: Ziegeleien 1965 (20060304)
+- dimensions: *id707
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache]
+  title: Ziegeleien 1965 ('current')
+- dimensions: *id707
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1965_20060304_cache]
+  title: Ziegeleien 1965 (20060304, source)
+- dimensions: &id708
+    Time:
+      default: '20100310'
+      values: ['20100310']
+  name: ch.bafu.holznutzung_20100310
+  sources: [ch.bafu.holznutzung_20100310_cache_out]
+  title: "Holznutzung und Mortalit\xE4t (LFI) (20100310)"
+- dimensions: *id708
+  name: ch.bafu.holznutzung
+  sources: [ch.bafu.holznutzung_20100310_cache]
+  title: "Holznutzung und Mortalit\xE4t (LFI) ('current')"
+- dimensions: *id708
+  name: ch.bafu.holznutzung_20100310_source
+  sources: [ch.bafu.holznutzung_20100310_cache]
+  title: "Holznutzung und Mortalit\xE4t (LFI) (20100310, source)"
+- dimensions: &id709
+    Time:
+      default: '20150326'
+      values: ['20150326']
+  name: ch.astra.unfaelle-personenschaeden_motorraeder_20150326
+  sources: [ch.astra.unfaelle-personenschaeden_motorraeder_20150326_cache_out]
+  title: "Unf\xE4lle mit Motorradbeteiligung (20150326)"
+- dimensions: *id709
+  name: ch.astra.unfaelle-personenschaeden_motorraeder
+  sources: [ch.astra.unfaelle-personenschaeden_motorraeder_20150326_cache]
+  title: "Unf\xE4lle mit Motorradbeteiligung ('current')"
+- dimensions: *id709
+  name: ch.astra.unfaelle-personenschaeden_motorraeder_20150326_source
+  sources: [ch.astra.unfaelle-personenschaeden_motorraeder_20150326_cache]
+  title: "Unf\xE4lle mit Motorradbeteiligung (20150326, source)"
+- dimensions: &id710
+    Time:
+      default: '20001001'
+      values: ['20001001']
+  name: ch.bafu.waldschadenflaechen-lothar_20001001
+  sources: [ch.bafu.waldschadenflaechen-lothar_20001001_cache_out]
+  title: Sturmschaden Lothar (20001001)
+- dimensions: *id710
+  name: ch.bafu.waldschadenflaechen-lothar
+  sources: [ch.bafu.waldschadenflaechen-lothar_20001001_cache]
+  title: Sturmschaden Lothar ('current')
+- dimensions: *id710
+  name: ch.bafu.waldschadenflaechen-lothar_20001001_source
+  sources: [ch.bafu.waldschadenflaechen-lothar_20001001_cache]
+  title: Sturmschaden Lothar (20001001, source)
+- dimensions: &id711
+    Time:
+      default: '20110101'
+      values: ['20110101']
+  name: ch.bazl.landschaftsruhezonen_20110101
+  sources: [ch.bazl.landschaftsruhezonen_20110101_cache_out]
+  title: Landschaftsruhezonen Luftfahrt (20110101)
+- dimensions: *id711
+  name: ch.bazl.landschaftsruhezonen
+  sources: [ch.bazl.landschaftsruhezonen_20110101_cache]
+  title: Landschaftsruhezonen Luftfahrt ('current')
+- dimensions: *id711
+  name: ch.bazl.landschaftsruhezonen_20110101_source
+  sources: [ch.bazl.landschaftsruhezonen_20110101_cache]
+  title: Landschaftsruhezonen Luftfahrt (20110101, source)
+- dimensions: &id712
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache_out]
+  title: "Steinbr\xFCche 1915 (20060304)"
+- dimensions: *id712
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache]
+  title: "Steinbr\xFCche 1915 ('current')"
+- dimensions: *id712
+  name: ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-steinbrueche_1915_20060304_cache]
+  title: "Steinbr\xFCche 1915 (20060304, source)"
+- dimensions: &id713
+    Time:
+      default: '20060220'
+      values: ['20060220']
+  name: ch.bafu.fischerei-nasenlaichplaetze_20060220
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_20060220_cache_out]
+  title: "Nasenlaichpl\xE4tze (20060220)"
+- dimensions: *id713
+  name: ch.bafu.fischerei-nasenlaichplaetze
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_20060220_cache]
+  title: "Nasenlaichpl\xE4tze ('current')"
+- dimensions: *id713
+  name: ch.bafu.fischerei-nasenlaichplaetze_20060220_source
+  sources: [ch.bafu.fischerei-nasenlaichplaetze_20060220_cache]
+  title: "Nasenlaichpl\xE4tze (20060220, source)"
+- dimensions: &id714
+    Time:
+      default: '20150326'
+      values: ['20150326']
+  name: ch.astra.unfaelle-personenschaeden_alle_20150326
+  sources: [ch.astra.unfaelle-personenschaeden_alle_20150326_cache_out]
+  title: "Unf\xE4lle mit Personenschaden (20150326)"
+- dimensions: *id714
+  name: ch.astra.unfaelle-personenschaeden_alle
+  sources: [ch.astra.unfaelle-personenschaeden_alle_20150326_cache]
+  title: "Unf\xE4lle mit Personenschaden ('current')"
+- dimensions: *id714
+  name: ch.astra.unfaelle-personenschaeden_alle_20150326_source
+  sources: [ch.astra.unfaelle-personenschaeden_alle_20150326_cache]
+  title: "Unf\xE4lle mit Personenschaden (20150326, source)"
+- dimensions: &id715
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.reisezeit-oev_20121231
+  sources: [ch.are.reisezeit-oev_20121231_cache_out]
+  title: "Reisezeit zu Zentren \xD6V (20121231)"
+- dimensions: *id715
+  name: ch.are.reisezeit-oev
+  sources: [ch.are.reisezeit-oev_20121231_cache]
+  title: "Reisezeit zu Zentren \xD6V ('current')"
+- dimensions: *id715
+  name: ch.are.reisezeit-oev_20121231_source
+  sources: [ch.are.reisezeit-oev_20121231_cache]
+  title: "Reisezeit zu Zentren \xD6V (20121231, source)"
+- dimensions: &id716
+    Time:
+      default: '20130305'
+      values: ['20130305']
+  name: ch.bafu.naqua-grundwasser_psm_20130305
+  sources: [ch.bafu.naqua-grundwasser_psm_20130305_cache_out]
+  title: 'Grundwasser: Pestizide (20130305)'
+- dimensions: *id716
+  name: ch.bafu.naqua-grundwasser_psm
+  sources: [ch.bafu.naqua-grundwasser_psm_20130305_cache]
+  title: 'Grundwasser: Pestizide (''current'')'
+- dimensions: *id716
+  name: ch.bafu.naqua-grundwasser_psm_20130305_source
+  sources: [ch.bafu.naqua-grundwasser_psm_20130305_cache]
+  title: 'Grundwasser: Pestizide (20130305, source)'
+- dimensions: &id717
+    Time:
+      default: '20150101'
+      values: ['20150101']
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache_out]
+  title: "\xD6ffentlicher Verkehr VECTOR200 (20150101)"
+- dimensions: *id717
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
+  title: "\xD6ffentlicher Verkehr VECTOR200 ('current')"
+- dimensions: *id717
+  name: ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_source
+  sources: [ch.swisstopo.vec200-transportation-oeffentliche-verkehr_20150101_cache]
+  title: "\xD6ffentlicher Verkehr VECTOR200 (20150101, source)"
+- dimensions: &id718
+    Time:
+      default: '20070701'
+      values: ['20070701']
+  name: ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701
+  sources: [ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_cache_out]
+  title: Moorlandschaften AuLaV (20070701)
+- dimensions: *id718
+  name: ch.bafu.schutzgebiete-aulav_moorlandschaften
+  sources: [ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_cache]
+  title: Moorlandschaften AuLaV ('current')
+- dimensions: *id718
+  name: ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_source
+  sources: [ch.bafu.schutzgebiete-aulav_moorlandschaften_20070701_cache]
+  title: Moorlandschaften AuLaV (20070701, source)
+- dimensions: &id719
+    Time:
+      default: '20130101'
+      values: ['20130101']
+  name: ch.bafu.hydrologie-untersuchungsgebiete_20130101
+  sources: [ch.bafu.hydrologie-untersuchungsgebiete_20130101_cache_out]
+  title: HUG Hydro. Untersuchungsgebiete (20130101)
+- dimensions: *id719
+  name: ch.bafu.hydrologie-untersuchungsgebiete
+  sources: [ch.bafu.hydrologie-untersuchungsgebiete_20130101_cache]
+  title: HUG Hydro. Untersuchungsgebiete ('current')
+- dimensions: *id719
+  name: ch.bafu.hydrologie-untersuchungsgebiete_20130101_source
+  sources: [ch.bafu.hydrologie-untersuchungsgebiete_20130101_cache]
+  title: HUG Hydro. Untersuchungsgebiete (20130101, source)
+- dimensions: &id720
+    Time:
+      default: '20020101'
+      values: ['20020101']
+  name: ch.bafu.strukturguete-hochrhein_linkesufer_20020101
+  sources: [ch.bafu.strukturguete-hochrhein_linkesufer_20020101_cache_out]
+  title: "Strukturg\xFCte Linkes Ufer (20020101)"
+- dimensions: *id720
+  name: ch.bafu.strukturguete-hochrhein_linkesufer
+  sources: [ch.bafu.strukturguete-hochrhein_linkesufer_20020101_cache]
+  title: "Strukturg\xFCte Linkes Ufer ('current')"
+- dimensions: *id720
+  name: ch.bafu.strukturguete-hochrhein_linkesufer_20020101_source
+  sources: [ch.bafu.strukturguete-hochrhein_linkesufer_20020101_cache]
+  title: "Strukturg\xFCte Linkes Ufer (20020101, source)"
+- dimensions: &id721
+    Time:
+      default: '19821231'
+      values: ['19821231']
+  name: ch.nagra.aeromagnetische-karte_1100_19821231
+  sources: [ch.nagra.aeromagnetische-karte_1100_19821231_cache_out]
+  title: Aeromagnetik Aargau 1100 m 100 (19821231)
+- dimensions: *id721
+  name: ch.nagra.aeromagnetische-karte_1100
+  sources: [ch.nagra.aeromagnetische-karte_1100_19821231_cache]
+  title: Aeromagnetik Aargau 1100 m 100 ('current')
+- dimensions: *id721
+  name: ch.nagra.aeromagnetische-karte_1100_19821231_source
+  sources: [ch.nagra.aeromagnetische-karte_1100_19821231_cache]
+  title: Aeromagnetik Aargau 1100 m 100 (19821231, source)
+- dimensions: &id722
+    Time:
+      default: '20130305'
+      values: ['20130305']
+  name: ch.bafu.naqua-grundwasser_voc_20130305
+  sources: [ch.bafu.naqua-grundwasser_voc_20130305_cache_out]
+  title: 'Grundwasser: VOC (20130305)'
+- dimensions: *id722
+  name: ch.bafu.naqua-grundwasser_voc
+  sources: [ch.bafu.naqua-grundwasser_voc_20130305_cache]
+  title: 'Grundwasser: VOC (''current'')'
+- dimensions: *id722
+  name: ch.bafu.naqua-grundwasser_voc_20130305_source
+  sources: [ch.bafu.naqua-grundwasser_voc_20130305_cache]
+  title: 'Grundwasser: VOC (20130305, source)'
+- dimensions: &id723
+    Time:
+      default: '20110905'
+      values: ['20110905']
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_cache_out]
+  title: "\xC4schen: Verbreitungsgebiet (20110905)"
+- dimensions: *id723
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_cache]
+  title: "\xC4schen: Verbreitungsgebiet ('current')"
+- dimensions: *id723
+  name: ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_source
+  sources: [ch.bafu.fischerei-aeschen_verbreitungsgebiet_20110905_cache]
+  title: "\xC4schen: Verbreitungsgebiet (20110905, source)"
+- dimensions: &id724
+    Time:
+      default: '20090401'
+      values: ['20090401']
+  name: ch.swisstopo.vec25-uebrigerverkehr_20090401
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache_out]
+  title: "\xDCbriger Verkehr VECTOR25 (20090401)"
+- dimensions: *id724
+  name: ch.swisstopo.vec25-uebrigerverkehr
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
+  title: "\xDCbriger Verkehr VECTOR25 ('current')"
+- dimensions: *id724
+  name: ch.swisstopo.vec25-uebrigerverkehr_20090401_source
+  sources: [ch.swisstopo.vec25-uebrigerverkehr_20090401_cache]
+  title: "\xDCbriger Verkehr VECTOR25 (20090401, source)"
+- dimensions: &id725
+    Time:
+      default: '20140101'
+      values: ['20140101']
+  name: ch.bafu.wasserbau-vermessungsstrecken_20140101
+  sources: [ch.bafu.wasserbau-vermessungsstrecken_20140101_cache_out]
+  title: Vermessungsstrecken (20140101)
+- dimensions: *id725
+  name: ch.bafu.wasserbau-vermessungsstrecken
+  sources: [ch.bafu.wasserbau-vermessungsstrecken_20140101_cache]
+  title: Vermessungsstrecken ('current')
+- dimensions: *id725
+  name: ch.bafu.wasserbau-vermessungsstrecken_20140101_source
+  sources: [ch.bafu.wasserbau-vermessungsstrecken_20140101_cache]
+  title: Vermessungsstrecken (20140101, source)
+- dimensions: &id726
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.belastung-personenverkehr-strasse_20121231
+  sources: [ch.are.belastung-personenverkehr-strasse_20121231_cache_out]
+  title: Personenverkehr Strasse (20121231)
+- dimensions: *id726
+  name: ch.are.belastung-personenverkehr-strasse
+  sources: [ch.are.belastung-personenverkehr-strasse_20121231_cache]
+  title: Personenverkehr Strasse ('current')
+- dimensions: *id726
+  name: ch.are.belastung-personenverkehr-strasse_20121231_source
+  sources: [ch.are.belastung-personenverkehr-strasse_20121231_cache]
+  title: Personenverkehr Strasse (20121231, source)
+- dimensions: &id727
+    Time:
+      default: '19920115'
+      values: ['19920115']
+  name: ch.bafu.waldschadenflaechen-vivian_19920115
+  sources: [ch.bafu.waldschadenflaechen-vivian_19920115_cache_out]
+  title: Sturmschaden Vivian (19920115)
+- dimensions: *id727
+  name: ch.bafu.waldschadenflaechen-vivian
+  sources: [ch.bafu.waldschadenflaechen-vivian_19920115_cache]
+  title: Sturmschaden Vivian ('current')
+- dimensions: *id727
+  name: ch.bafu.waldschadenflaechen-vivian_19920115_source
+  sources: [ch.bafu.waldschadenflaechen-vivian_19920115_cache]
+  title: Sturmschaden Vivian (19920115, source)
+- dimensions: &id728
+    Time:
+      default: '20140314'
+      values: ['20140314']
+  name: ch.bafu.gefahren-spektral_20140314
+  sources: [ch.bafu.gefahren-spektral_20140314_cache_out]
+  title: Spektrale Mikrozonierung (20140314)
+- dimensions: *id728
+  name: ch.bafu.gefahren-spektral
+  sources: [ch.bafu.gefahren-spektral_20140314_cache]
+  title: Spektrale Mikrozonierung ('current')
+- dimensions: *id728
+  name: ch.bafu.gefahren-spektral_20140314_source
+  sources: [ch.bafu.gefahren-spektral_20140314_cache]
+  title: Spektrale Mikrozonierung (20140314, source)
+- dimensions: &id729
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache_out]
+  title: Ziegeleien 1907 (20060304)
+- dimensions: *id729
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache]
+  title: Ziegeleien 1907 ('current')
+- dimensions: *id729
+  name: ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_source
+  sources: [ch.swisstopo.geologie-geotechnik-ziegeleien_1907_20060304_cache]
+  title: Ziegeleien 1907 (20060304, source)
+- dimensions: &id730
+    Time:
+      default: '20090101'
+      values: ['20090101']
+  name: ch.bafu.hydrogeologie-uebersichtskarte_20090101
+  sources: [ch.bafu.hydrogeologie-uebersichtskarte_20090101_cache_out]
+  title: "\xDCbersichtskarte Hydrogeologie (20090101)"
+- dimensions: *id730
+  name: ch.bafu.hydrogeologie-uebersichtskarte
+  sources: [ch.bafu.hydrogeologie-uebersichtskarte_20090101_cache]
+  title: "\xDCbersichtskarte Hydrogeologie ('current')"
+- dimensions: *id730
+  name: ch.bafu.hydrogeologie-uebersichtskarte_20090101_source
+  sources: [ch.bafu.hydrogeologie-uebersichtskarte_20090101_cache]
+  title: "\xDCbersichtskarte Hydrogeologie (20090101, source)"
+- dimensions: &id731
+    Time:
+      default: '20121231'
+      values: ['20121231']
+  name: ch.are.bevoelkerungsdichte_20121231
+  sources: [ch.are.bevoelkerungsdichte_20121231_cache_out]
+  title: "Bev\xF6lkerungsdichte (20121231)"
+- dimensions: *id731
+  name: ch.are.bevoelkerungsdichte
+  sources: [ch.are.bevoelkerungsdichte_20121231_cache]
+  title: "Bev\xF6lkerungsdichte ('current')"
+- dimensions: *id731
+  name: ch.are.bevoelkerungsdichte_20121231_source
+  sources: [ch.are.bevoelkerungsdichte_20121231_cache]
+  title: "Bev\xF6lkerungsdichte (20121231, source)"
+- dimensions: &id732
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache_out]
+  title: Mineralische Energierohstoffe (20060304)
+- dimensions: *id732
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache]
+  title: Mineralische Energierohstoffe ('current')
+- dimensions: *id732
+  name: ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_source
+  sources: [ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas_20060304_cache]
+  title: Mineralische Energierohstoffe (20060304, source)
+- dimensions: &id733
+    Time:
+      default: '20110829'
+      values: ['20110829']
+  name: ch.bafu.fischerei-aeschen_kernzonen_20110829
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_20110829_cache_out]
+  title: "\xC4schen: Kernzonen (20110829)"
+- dimensions: *id733
+  name: ch.bafu.fischerei-aeschen_kernzonen
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_20110829_cache]
+  title: "\xC4schen: Kernzonen ('current')"
+- dimensions: *id733
+  name: ch.bafu.fischerei-aeschen_kernzonen_20110829_source
+  sources: [ch.bafu.fischerei-aeschen_kernzonen_20110829_cache]
+  title: "\xC4schen: Kernzonen (20110829, source)"
+- dimensions: &id734
+    Time:
+      default: '20060701'
+      values: ['20060701']
+  name: ch.bafu.silvaprotect-lawinen_20060701
+  sources: [ch.bafu.silvaprotect-lawinen_20060701_cache_out]
+  title: Lawinen (20060701)
+- dimensions: *id734
+  name: ch.bafu.silvaprotect-lawinen
+  sources: [ch.bafu.silvaprotect-lawinen_20060701_cache]
+  title: Lawinen ('current')
+- dimensions: *id734
+  name: ch.bafu.silvaprotect-lawinen_20060701_source
+  sources: [ch.bafu.silvaprotect-lawinen_20060701_cache]
+  title: Lawinen (20060701, source)
+- dimensions: &id735
+    Time:
+      default: '20140923'
+      values: ['20140923']
+  name: ch.bafu.schutzgebiete-luftfahrt_20140923
+  sources: [ch.bafu.schutzgebiete-luftfahrt_20140923_cache_out]
+  title: Schutzgebiete MIL (20140923)
+- dimensions: *id735
+  name: ch.bafu.schutzgebiete-luftfahrt
+  sources: [ch.bafu.schutzgebiete-luftfahrt_20140923_cache]
+  title: Schutzgebiete MIL ('current')
+- dimensions: *id735
+  name: ch.bafu.schutzgebiete-luftfahrt_20140923_source
+  sources: [ch.bafu.schutzgebiete-luftfahrt_20140923_cache]
+  title: Schutzgebiete MIL (20140923, source)
+- dimensions: &id736
+    Time:
+      default: '20060304'
+      values: ['20060304']
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen_20060304
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache_out]
+  title: Vererzungen (20060304)
+- dimensions: *id736
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache]
+  title: Vererzungen ('current')
+- dimensions: *id736
+  name: ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_source
+  sources: [ch.swisstopo.geologie-rohstoffe-vererzungen_20060304_cache]
+  title: Vererzungen (20060304, source)
+- dimensions: &id737
+    Time:
+      default: '20151231'
+      values: ['20151231']
+  name: ch.swisstopo.swissimage_20151231
+  sources: [ch.swisstopo.swissimage_20151231_cache_out]
+  title: SWISSIMAGE (20151231)
+- dimensions: *id737
+  name: ch.swisstopo.swissimage
+  sources: [ch.swisstopo.swissimage_20151231_cache]
+  title: SWISSIMAGE ('current')
+- dimensions: *id737
+  name: ch.swisstopo.swissimage_20151231_source
+  sources: [ch.swisstopo.swissimage_20151231_cache]
+  title: SWISSIMAGE (20151231, source)
+- dimensions: &id738
+    Time:
+      default: '20140620'
+      values: ['20140620']
+  name: ch.swisstopo.swissimage_20140620
+  sources: [ch.swisstopo.swissimage_20140620_cache_out]
+  title: SWISSIMAGE (20140620)
+- dimensions: *id738
+  name: ch.swisstopo.swissimage_20140620_source
+  sources: [ch.swisstopo.swissimage_20140620_cache]
+  title: SWISSIMAGE (20140620, source)
+- dimensions: &id739
+    Time:
+      default: '20131107'
+      values: ['20131107']
+  name: ch.swisstopo.swissimage_20131107
+  sources: [ch.swisstopo.swissimage_20131107_cache_out]
+  title: SWISSIMAGE (20131107)
+- dimensions: *id739
+  name: ch.swisstopo.swissimage_20131107_source
+  sources: [ch.swisstopo.swissimage_20131107_cache]
+  title: SWISSIMAGE (20131107, source)
+- dimensions: &id740
+    Time:
+      default: '20130916'
+      values: ['20130916']
+  name: ch.swisstopo.swissimage_20130916
+  sources: [ch.swisstopo.swissimage_20130916_cache_out]
+  title: SWISSIMAGE (20130916)
+- dimensions: *id740
+  name: ch.swisstopo.swissimage_20130916_source
+  sources: [ch.swisstopo.swissimage_20130916_cache]
+  title: SWISSIMAGE (20130916, source)
+- dimensions: &id741
+    Time:
+      default: '20130422'
+      values: ['20130422']
+  name: ch.swisstopo.swissimage_20130422
+  sources: [ch.swisstopo.swissimage_20130422_cache_out]
+  title: SWISSIMAGE (20130422)
+- dimensions: *id741
+  name: ch.swisstopo.swissimage_20130422_source
+  sources: [ch.swisstopo.swissimage_20130422_cache]
+  title: SWISSIMAGE (20130422, source)
+- dimensions: &id742
+    Time:
+      default: '20120809'
+      values: ['20120809']
+  name: ch.swisstopo.swissimage_20120809
+  sources: [ch.swisstopo.swissimage_20120809_cache_out]
+  title: SWISSIMAGE (20120809)
+- dimensions: *id742
+  name: ch.swisstopo.swissimage_20120809_source
+  sources: [ch.swisstopo.swissimage_20120809_cache]
+  title: SWISSIMAGE (20120809, source)
+- dimensions: &id743
+    Time:
+      default: '20120225'
+      values: ['20120225']
+  name: ch.swisstopo.swissimage_20120225
+  sources: [ch.swisstopo.swissimage_20120225_cache_out]
+  title: SWISSIMAGE (20120225)
+- dimensions: *id743
+  name: ch.swisstopo.swissimage_20120225_source
+  sources: [ch.swisstopo.swissimage_20120225_cache]
+  title: SWISSIMAGE (20120225, source)
+- dimensions: &id744
+    Time:
+      default: '20110914'
+      values: ['20110914']
+  name: ch.swisstopo.swissimage_20110914
+  sources: [ch.swisstopo.swissimage_20110914_cache_out]
+  title: SWISSIMAGE (20110914)
+- dimensions: *id744
+  name: ch.swisstopo.swissimage_20110914_source
+  sources: [ch.swisstopo.swissimage_20110914_cache]
+  title: SWISSIMAGE (20110914, source)
+- dimensions: &id745
+    Time:
+      default: '20110228'
+      values: ['20110228']
+  name: ch.swisstopo.swissimage_20110228
+  sources: [ch.swisstopo.swissimage_20110228_cache_out]
+  title: SWISSIMAGE (20110228)
+- dimensions: *id745
+  name: ch.swisstopo.swissimage_20110228_source
+  sources: [ch.swisstopo.swissimage_20110228_cache]
+  title: SWISSIMAGE (20110228, source)
+- dimensions: &id746
+    Time:
+      default: '20070701'
+      values: ['20070701']
+  name: ch.bafu.schutzgebiete-aulav_auen_20070701
+  sources: [ch.bafu.schutzgebiete-aulav_auen_20070701_cache_out]
+  title: Auengebiete AuLaV (20070701)
+- dimensions: *id746
+  name: ch.bafu.schutzgebiete-aulav_auen
+  sources: [ch.bafu.schutzgebiete-aulav_auen_20070701_cache]
+  title: Auengebiete AuLaV ('current')
+- dimensions: *id746
+  name: ch.bafu.schutzgebiete-aulav_auen_20070701_source
+  sources: [ch.bafu.schutzgebiete-aulav_auen_20070701_cache]
+  title: Auengebiete AuLaV (20070701, source)
 services:
   demo: null
   kml: null
-  tms: {origin: sw, use_grid_names: true}
+  tms: null
   wms:
     image_formats: [image/jpeg, image/png]
     md:

--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -139,7 +139,7 @@ for idx, layersConfig in enumerate(getLayersConfigs(topics=topics)):
             total_timestamps += len(timestamps)
             current_timestamp = timestamps[0]
             if bod_layer_id == 'ch.swisstopo.zeitreihen':
-                image_format = 'png'
+                image_format = 'jpeg'
             else:
                 image_format = layersConfig.arr_all_formats.split(',')[0]
             server_layer_name = bod_layer_id
@@ -166,7 +166,11 @@ for idx, layersConfig in enumerate(getLayersConfigs(topics=topics)):
                 # layer config: cache_out
                 layer = {'name': layer_name, 'title': "%s (%s)" % (title, timestamp), 'dimensions': dimensions, 'sources': [cache_name]}
 
-                cache = {"sources": [wmts_cache_name], "format": "image/%s" % image_format, "grids": grid_names, "disable_storage": True, "meta_size": [1, 1], "meta_buffer": 0}
+                if image_format == 'png':
+                    cache_format = 'image/png'
+                else:
+                    cache_format = 'image/%s' % image_format
+                cache = {"sources": [wmts_cache_name], "format": "%s" % cache_format, "grids": grid_names, "disable_storage": True, "meta_size": [1, 1], "meta_buffer": 0}
 
                 if '.swissimage' in wmts_cache_name:
                     cache["image"] = {"resampling_method": "bilinear"}

--- a/mapproxy/templates/mapproxy.tpl
+++ b/mapproxy/templates/mapproxy.tpl
@@ -3,9 +3,6 @@ services:
   demo:
   kml:
   tms:
-      origin: 'sw'
-      use_grid_names: true
-
   wmts:
      restful: true
      kvp: false
@@ -150,12 +147,10 @@ globals:
     concurrent_tile_creators: 32
   image:
       resampling_method: bicubic
-      # for 24bits PNG
-      paletted: false
+      # for 8bits PNG
+      paletted: true
       formats:
-         image/png:
-             mode: RGBA 
-             transparent: true
+         # override setting
          image/jpeg:
              mode: RGB 
              encoding_options:


### PR DESCRIPTION
Using PNG 8bits for Mapproxy. Unike Mapserver, it is not possible to fixed several type of PNGs in Mapproxy (i.e. '_image/png; mode=24bit_')

For zeitreiehen we have the have the following approach:
* Pre-generated (native LV03) are either _png_ (source, for Desktop) or _jpegpng_ (for web)
* Mapproxy are only _jpeg_ (we want light images and don't need transparency).


[Test branch](https://mf-chsdi3.dev.bgdi.ch/mom_mapproxy_fixes/mapproxy/)

Current PNG
===========

[Beispiel - Current](https://mf-chsdi3.prod.bgdi.ch/mapproxy/service?layers=ch.swisstopo.swisstlm3d-karte-farbe&format=image%2Fpng&service=WMS&version=1.3.0&request=GetMap&crs=CRS:84&bbox=7.41577148437501,46.702880859375,7.426757812499992,46.7138671875&width=512&height=512&styles=default&time=20150401)



OK: cadastre.png (512x512, 32-bit RGB+alpha, non-interlaced, 61.9%). 399565 bytes

Opting: Opting Output file size = 339180 bytes (60385 bytes = 15.11% decrease)


Optimized PNG
============

[Beispiel - Optimized](https://mf-chsdi3.dev.bgdi.ch/mom_mapproxy_fixes/mapproxy/service?layers=ch.swisstopo.swisstlm3d-karte-farbe&format=image/png&service=WMS&version=1.3.0&request=GetMap&crs=CRS:84&bbox=7.41577148437501,46.702880859375,7.426757812499992,46.7138671875&width=512&height=512&styles=default&time=20150401)

OK: cadastre_ltmom.png (512x512, 8-bit palette, non-interlaced, 69.5%). 79921     bytes

Opting: Output file size = 73902 bytes (6019 bytes = 7.53% decrease)