### PR TITLE
Add identifier to htmlpopup

### DIFF
--- a/chsdi/templates/htmlpopup/base.mako
+++ b/chsdi/templates/htmlpopup/base.mako
@@ -53,7 +53,7 @@
 <body>
   <div class="chsdi-htmlpopup-container">
 % else:
-  <div class="htmlpopup-container">
+  <div id="${c['layerBodId']}#${c['featureId']}" class="htmlpopup-container">
 % endif
   <div class="htmlpopup-header">
     <span>${c['fullName']}</span> (${c['attribution']})


### PR DESCRIPTION
Needed for  highlight in geoadmin tooltip

[Test](https://mf-chsdi3.dev.bgdi.ch/teo_id/rest/services/ech/MapServer/ch.bafu.biogeographische_regionen/6/htmlPopup?coord=600250,198375&imageDisplay=1862,621,96&lang=fr&mapExtent=395750,132125,861250,287375)