### PR TITLE
Queryable attributes fixes

### DIFF
--- a/buildout_ltfoa.cfg
+++ b/buildout_ltfoa.cfg
@@ -6,7 +6,7 @@ apache_base_path = ltfoa
 api_url = //mf-chsdi3.dev.bgdi.ch/ltfoa
 host = mf-chsdi3.dev.bgdi.ch
 geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltfoa
-server_port = 9004
+server_port = 9055
 
 [modwsgi]
 config-file = ${buildout:directory}/development.ini

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -156,7 +156,7 @@ def format_query(model, value):
     '''
     def escapeSQL(value):
         if u'ilike' in value:
-            match = re.search(r'([a-z]+\s)(ilike|not ilike)(\s\'%)(.*)(%\')', value)
+            match = re.search(r'([\w]+\s)(ilike|not ilike)(\s\'%)(.*)(%\')', value)
             where = u''.join((
                 match.group(1).replace(u'\'', u'E\''),
                 match.group(2),

--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -3077,6 +3077,9 @@ msgstr "BFE"
 msgid "ch.bfe.abgeltung-wasserkraftnutzung"
 msgstr "Verzicht Wasserkraftnutzung"
 
+msgid "ch.bfe.abgeltung-wasserkraftnutzung.name"
+msgstr "Name"
+
 msgid "ch.bfe.energieforschung"
 msgstr "Cleantech-Projekte"
 
@@ -3161,6 +3164,15 @@ msgstr "SP Geologische Tiefenlager"
 msgid "ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung"
 msgstr "SP Geologische Tiefenlager: t.D."
 
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_de"
+msgstr "Anlage"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_fr"
+msgstr "Anlage"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_it"
+msgstr "Anlage"
+
 msgid "ch.bfe.sachplan-uebertragungsleitungen_anhoerung"
 msgstr "SÜL Anhörung"
 
@@ -3214,6 +3226,12 @@ msgstr "Statistik Wasserkraft"
 
 msgid "ch.bfe.stauanlagen-bundesaufsicht"
 msgstr "Stauanlagen"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damname"
+msgstr "Name"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damtype_de"
+msgstr "Sperrentyp"
 
 msgid "ch.bfe.url"
 msgstr "http://www.bfe.admin.ch/index.html?lang=de"
@@ -3633,12 +3651,11 @@ msgstr "Einteilung geol. Generalkarte 200"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.autor"
 msgstr "Autor(en)"
 
-#. TODO
-msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-msgstr "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.jahr"
 msgstr "Publikationsjahr"
+
+msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.nr"
+msgstr "Kartenblatt"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.titel"
 msgstr "Titel"
@@ -6143,12 +6160,6 @@ msgstr "Ende Schutzverpflichtung"
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_endprotectioncommitment"
 msgstr "Ende Schutzverpflichtung"
 
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Name"
-
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Name"
-
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_objectnumber"
 msgstr "Objektnummer"
 
@@ -6304,12 +6315,6 @@ msgstr "Sperrenhöhe"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damheight"
 msgstr "Sperrenhöhe"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Name"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Name"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damtype"
 msgstr "Sperrentyp"

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -58,6 +58,24 @@ msgstr ""
 msgid "ch.pronatura.waldreservate.gisteilobjekt"
 msgstr ""
 
+msgid "ch.bfe.abgeltung-wasserkraftnutzung.name"
+msgstr ""
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damname"
+msgstr ""
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damtype_de"
+msgstr ""
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_de"
+msgstr ""
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_fr"
+msgstr ""
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_it"
+msgstr ""
+
 msgid "ch.bafu.waldreservate.gisteilobjekt"
 msgstr ""
 
@@ -3894,9 +3912,6 @@ msgstr ""
 msgid "bet_traegerverein"
 msgstr ""
 
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr ""
-
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_endprotectioncommitment"
 msgstr ""
 
@@ -3937,9 +3952,6 @@ msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_crestlevel"
 msgstr ""
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damheight"
-msgstr ""
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
 msgstr ""
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damtype"
@@ -4287,9 +4299,6 @@ msgstr ""
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_endprotectioncommitment"
 msgstr ""
 
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr ""
-
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_objectnumber"
 msgstr ""
 
@@ -4429,9 +4438,6 @@ msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_crestlevel"
 msgstr ""
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damheight"
-msgstr ""
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
 msgstr ""
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damtype_de"
@@ -7014,7 +7020,7 @@ msgstr ""
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.autor"
 msgstr ""
 
-msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
+msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.nr"
 msgstr ""
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.jahr"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -2948,9 +2948,8 @@ msgstr "More information"
 msgid "ch.bav.sachplan-infrastruktur-schiene_kraft.facname_de"
 msgstr "Facility"
 
-#. TODO
 msgid "ch.bav.sachplan-infrastruktur-schiene_kraft.facname_fr"
-msgstr "ch.bav.sachplan-infrastruktur-schiene_kraft.facname_fr"
+msgstr "Facility"
 
 msgid "ch.bav.sachplan-infrastruktur-schiene_kraft.facname_it"
 msgstr "Facility"
@@ -3078,6 +3077,9 @@ msgstr "SFOE"
 msgid "ch.bfe.abgeltung-wasserkraftnutzung"
 msgstr "Abandonment of hydropower"
 
+msgid "ch.bfe.abgeltung-wasserkraftnutzung.name"
+msgstr "Name"
+
 msgid "ch.bfe.energieforschung"
 msgstr "Cleantech projects"
 
@@ -3162,6 +3164,15 @@ msgstr "SP Deep Geol. Repositories"
 msgid "ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung"
 msgstr "SP Deep Geol.Repositories: T.p."
 
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_de"
+msgstr "Facility"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_fr"
+msgstr "Facility"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_it"
+msgstr "Facility"
+
 msgid "ch.bfe.sachplan-uebertragungsleitungen_anhoerung"
 msgstr "SÜL Anhörung"
 
@@ -3215,6 +3226,12 @@ msgstr "Hydropower statistics"
 
 msgid "ch.bfe.stauanlagen-bundesaufsicht"
 msgstr "Dam"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damname"
+msgstr "Name"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damtype_de"
+msgstr "Dam Type"
 
 msgid "ch.bfe.url"
 msgstr "http://www.bfe.admin.ch/index.html?lang=en"
@@ -3634,12 +3651,11 @@ msgstr "Division General Geol. Map 200"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.autor"
 msgstr "Author(s)"
 
-#. TODO
-msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-msgstr "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.jahr"
 msgstr "Year of publication"
+
+msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.nr"
+msgstr "Sheet number"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.titel"
 msgstr "Map title"
@@ -4395,9 +4411,8 @@ msgstr "Copyright & data protection"
 msgid "disclaimer url"
 msgstr "http://www.geo.admin.ch/internet/geoportal/en/home/geoadmin/contact.html#copyright"
 
-#. TODO
 msgid "district"
-msgstr "district"
+msgstr "Bezirk"
 
 msgid "doccreation_date"
 msgstr "Dokumentsdatum"
@@ -6145,12 +6160,6 @@ msgstr "Ende Schutzverpflichtung"
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_endprotectioncommitment"
 msgstr "Ende Schutzverpflichtung"
 
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Name"
-
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Name"
-
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_objectnumber"
 msgstr "Objektnummer"
 
@@ -6306,12 +6315,6 @@ msgstr "Dam Height"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damheight"
 msgstr "Dam Height"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Name"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Name"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damtype"
 msgstr "Dam Type"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -3077,6 +3077,9 @@ msgstr "BFE"
 msgid "ch.bfe.abgeltung-wasserkraftnutzung"
 msgstr "Renunzia a forza idraulica"
 
+msgid "ch.bfe.abgeltung-wasserkraftnutzung.name"
+msgstr "Name"
+
 msgid "ch.bfe.energieforschung"
 msgstr "Cleantech-Projekte"
 
@@ -3161,6 +3164,15 @@ msgstr "PS Deposits geologics profunds"
 msgid "ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung"
 msgstr "PS Deposits geol. profunds: p.t."
 
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_de"
+msgstr "Anlage"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_fr"
+msgstr "Anlage"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_it"
+msgstr "Anlage"
+
 msgid "ch.bfe.sachplan-uebertragungsleitungen_anhoerung"
 msgstr "SÜL Anhörung"
 
@@ -3214,6 +3226,12 @@ msgstr "Statistica implants idraulics"
 
 msgid "ch.bfe.stauanlagen-bundesaufsicht"
 msgstr "Stabiliments d'accumulaziun"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damname"
+msgstr "Name"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damtype_de"
+msgstr "Sperrentyp"
 
 msgid "ch.bfe.url"
 msgstr "http://www.bfe.admin.ch/index.html?lang=de"
@@ -3633,12 +3651,11 @@ msgstr "Einteilung geol. Generalkarte 200"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.autor"
 msgstr "Autor(en)"
 
-#. TODO
-msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-msgstr "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.jahr"
 msgstr "Publikationsjahr"
+
+msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.nr"
+msgstr "Kartenblatt"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.titel"
 msgstr "Titel"
@@ -6143,12 +6160,6 @@ msgstr "Ende Schutzverpflichtung"
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_endprotectioncommitment"
 msgstr "Ende Schutzverpflichtung"
 
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Name"
-
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Name"
-
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_objectnumber"
 msgstr "Objektnummer"
 
@@ -6304,12 +6315,6 @@ msgstr "Sperrenhöhe"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damheight"
 msgstr "Sperrenhöhe"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Name"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Name"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damtype"
 msgstr "Sperrentyp"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -3077,6 +3077,9 @@ msgstr "OFEN"
 msgid "ch.bfe.abgeltung-wasserkraftnutzung"
 msgstr "Renonciation force hydraulique"
 
+msgid "ch.bfe.abgeltung-wasserkraftnutzung.name"
+msgstr "Nom"
+
 msgid "ch.bfe.energieforschung"
 msgstr "Projets cleantech"
 
@@ -3161,6 +3164,15 @@ msgstr "PS Dépôts couches géol. profondes"
 msgid "ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung"
 msgstr "PS dépôts couches géol.prof.: p.t."
 
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_de"
+msgstr "Installation"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_fr"
+msgstr "Installation"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_it"
+msgstr "Installation"
+
 msgid "ch.bfe.sachplan-uebertragungsleitungen_anhoerung"
 msgstr "PSE consultation"
 
@@ -3214,6 +3226,12 @@ msgstr "Statistique hydroélectricité"
 
 msgid "ch.bfe.stauanlagen-bundesaufsicht"
 msgstr "Ouvrages d’accumulation"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damname"
+msgstr "Nom"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damtype_de"
+msgstr "Type de barrage"
 
 msgid "ch.bfe.url"
 msgstr "http://www.bfe.admin.ch/index.html?lang=fr"
@@ -3633,12 +3651,11 @@ msgstr "Découpage carte géol. générale 200"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.autor"
 msgstr "Auteur(s)"
 
-#. TODO
-msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-msgstr "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.jahr"
 msgstr "Année de publication"
+
+msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.nr"
+msgstr "Nombre de la feuille"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.titel"
 msgstr "Nom de feuille"
@@ -6143,12 +6160,6 @@ msgstr "Fin de l'obligation de protection"
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_endprotectioncommitment"
 msgstr "Fin de l'obligation de protection"
 
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Nom"
-
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Nom"
-
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_objectnumber"
 msgstr "Numéro d'objet"
 
@@ -6304,12 +6315,6 @@ msgstr "Hauteur du barrage"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damheight"
 msgstr "Hauteur du barrage"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Nom"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Nom"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damtype"
 msgstr "Type de barrage"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -3077,6 +3077,9 @@ msgstr "UFE"
 msgid "ch.bfe.abgeltung-wasserkraftnutzung"
 msgstr "Abbandono dell'idroelettricitá"
 
+msgid "ch.bfe.abgeltung-wasserkraftnutzung.name"
+msgstr "Nom"
+
 msgid "ch.bfe.energieforschung"
 msgstr "Progetti Cleantech"
 
@@ -3161,6 +3164,15 @@ msgstr "PS Depositi strati geol. profondi"
 msgid "ch.bfe.sachplan-geologie-tiefenlager-thematische-darstellung"
 msgstr "PS depositi strati geol.prof.: p.t."
 
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_de"
+msgstr "Installazione"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_fr"
+msgstr "Installazione"
+
+msgid "ch.bfe.sachplan-geologie-tiefenlager.facname_it"
+msgstr "Installazione"
+
 msgid "ch.bfe.sachplan-uebertragungsleitungen_anhoerung"
 msgstr "PSE consultazione"
 
@@ -3214,6 +3226,12 @@ msgstr "Statistica idroelettricitá"
 
 msgid "ch.bfe.stauanlagen-bundesaufsicht"
 msgstr "Impianti di sbarramento"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damname"
+msgstr "Nome"
+
+msgid "ch.bfe.stauanlagen-bundesaufsicht.damtype_de"
+msgstr "Tipo dell'opera di sbarramento"
 
 msgid "ch.bfe.url"
 msgstr "http://www.bfe.admin.ch/index.html?lang=it"
@@ -3633,12 +3651,11 @@ msgstr "Divisione carta geol. generale 200"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.autor"
 msgstr "Autori"
 
-#. TODO
-msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-msgstr "ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.jahr"
 msgstr "L'anno di edizione"
+
+msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.nr"
+msgstr "numero di carta"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.metadata.titel"
 msgstr "Titolo"
@@ -6143,12 +6160,6 @@ msgstr "Fin de l'obligation de protection"
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_endprotectioncommitment"
 msgstr "Fin de l'obligation de protection"
 
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Nom"
-
-msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_name"
-msgstr "Nom"
-
 msgid "tt_ch.bfe.abgeltung-wasserkraftnutzung_objectnumber"
 msgstr "Numéro d'objet"
 
@@ -6304,12 +6315,6 @@ msgstr "Altezza dell'opera di sbarramento"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damheight"
 msgstr "Altezza dell'opera di sbarramento"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Nome"
-
-msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damname"
-msgstr "Nome"
 
 msgid "tt_ch.bfe.stauanlagen-bundesaufsicht_damtype"
 msgstr "Tipo dell'opera di sbarramento"

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -746,6 +746,7 @@ class GeolGenKarteGGK200Meta(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False, 'extend_existing': True})
     __template__ = 'templates/htmlpopup/generalkarte_ggk200.metadata.mako'
     __bodId__ = 'ch.swisstopo.geologie-generalkarte-ggk200.metadata'
+    __queryable_attributes__ = ['titel', 'jahr', 'author', 'nr']
     __label__ = 'prod_id'
     id = Column('gid', Text, primary_key=True)
     nr = Column('nr', Integer)

--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -383,6 +383,7 @@ class ABGELTUNGWASSERKRAFTNUTZUNG(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/abgeltungwasserkraftnutzung.mako'
     __bodId__ = 'ch.bfe.abgeltung-wasserkraftnutzung'
+    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('objectnumber', Integer, primary_key=True)
     the_geom = Column(Geometry(geometry_type='GEOMETRY',
@@ -493,6 +494,7 @@ class ENERGIEFORSCHUNG(Base, Vector):
     __template__ = 'templates/htmlpopup/energieforschung.mako'
     __bodId__ = 'ch.bfe.energieforschung'
     __extended_info__ = True
+    __queryable_attributes__ = ['projektnummer', 'titel']
     __label__ = 'titel'
     id = Column('bgdi_id', Integer, primary_key=True)
     titel = Column('titel', Text)
@@ -565,6 +567,7 @@ class STAUANLAGENBUNDESAUFSICHT(Base, Vector):
     __template__ = 'templates/htmlpopup/stauanlagenbundesaufsicht.mako'
     __bodId__ = 'ch.bfe.stauanlagen-bundesaufsicht'
     __extended_info__ = True
+    __queryable_attributes__ = ['damname', 'damtype_de']
     __label__ = 'damname'
     id = Column('dam_stabil_id', Integer, primary_key=True)
     the_geom = Column(Geometry(geometry_type='GEOMETRY',
@@ -830,6 +833,7 @@ class sgt_facilities(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/sgt_facilities.mako'
     __bodId__ = 'ch.bfe.sachplan-geologie-tiefenlager'
+    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Integer, primary_key=True)
@@ -862,6 +866,7 @@ class sgt_planning(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/sgt_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-geologie-tiefenlager'
+    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Text, primary_key=True)
@@ -898,6 +903,7 @@ class sgt_planning_raster(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/sgt_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-geologie-tiefenlager'
+    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Integer, primary_key=True)

--- a/chsdi/templates/htmlpopup/abgeltungwasserkraftnutzung.mako
+++ b/chsdi/templates/htmlpopup/abgeltungwasserkraftnutzung.mako
@@ -2,7 +2,7 @@
 
 <%def name="table_body(c, lang)">
 <% c['stable_id'] = True %>
-    <tr><td class="cell-left">${_('tt_ch.bfe.abgeltung-wasserkraftnutzung_name')}</td>                        <td>${c['attributes']['name']}</td></tr>
+    <tr><td class="cell-left">${_('ch.bfe.abgeltung-wasserkraftnutzung.name')}</td>                        <td>${c['attributes']['name']}</td></tr>
     <tr><td class="cell-left">${_('tt_ch.bfe.abgeltung-wasserkraftnutzung_objectnumber')}</td>                <td>${c['featureId'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_ch.bfe.abgeltung-wasserkraftnutzung_area')}</td>                        <td>${c['attributes']['area'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_ch.bfe.abgeltung-wasserkraftnutzung_perimeter')}</td>                   <td>${c['attributes']['perimeter'] or '-'}</td></tr>

--- a/chsdi/templates/htmlpopup/generalkarte_ggk200.metadata.mako
+++ b/chsdi/templates/htmlpopup/generalkarte_ggk200.metadata.mako
@@ -2,7 +2,7 @@
 
 <%def name="table_body(c, lang)">
     <% c['stable_id'] = True %>
-	<tr><td class="cell-left">${_('ch.swisstopo.geologie-generalkarte-ggk200.metadata.ggk_nr')}</td> <td>${c['attributes']['nr'] or '-'}</td></tr>
+	<tr><td class="cell-left">${_('ch.swisstopo.geologie-generalkarte-ggk200.metadata.nr')}</td> <td>${c['attributes']['nr'] or '-'}</td></tr>
 	<tr><td class="cell-left">${_('ch.swisstopo.geologie-generalkarte-ggk200.metadata.titel')}</td> <td>${c['attributes']['titel'] or '-'}</td></tr>
 	<tr><td class="cell-left">${_('ch.swisstopo.geologie-generalkarte-ggk200.metadata.autor')}</td> <td>${c['attributes']['autor'].replace('&dagger;',u"\u2020")}</td></tr>
 	<tr><td class="cell-left">${_('ch.swisstopo.geologie-generalkarte-ggk200.metadata.jahr')}</td> <td>${c['attributes']['jahr'] or '-'}</td></tr>

--- a/chsdi/templates/htmlpopup/gisgeol.mako
+++ b/chsdi/templates/htmlpopup/gisgeol.mako
@@ -12,7 +12,7 @@
     def br(text):
         return text.replace('\n', markupsafe.Markup('<br />'))
 %>
-    <tr><td class="cell-left">${_('sgd_nr')}</td><td>${c['attributes']['sgd_nr']}</td></tr>
+    <tr><td class="cell-left">${_('ch.swisstopo.geologie-gisgeol-flaechen-100to1000km2.sgd_nr')}</td><td>${c['attributes']['sgd_nr']}</td></tr>
     <tr><td class="cell-left">${_('original_document_id')}</td><td>${c['attributes']['orig_id']}</td></tr>
     <tr><td class="cell-left">${_('title')}</td><td>${c['attributes']['title'] | br}</td></tr>
     <tr><td class="cell-left">${_('author')}</td><td>${c['attributes']['author'] | br}</td></tr>

--- a/chsdi/templates/htmlpopup/stauanlagenbundesaufsicht.mako
+++ b/chsdi/templates/htmlpopup/stauanlagenbundesaufsicht.mako
@@ -7,7 +7,7 @@
     lang = lang if lang != 'it' else 'fr'
     damtype = 'damtype_%s' % lang
 %>
-    <tr><td class="cell-left">${_('tt_ch.bfe.stauanlagen-bundesaufsicht_damname')}</td>           <td>${c['attributes']['damname']}</td></tr>
+    <tr><td class="cell-left">${_('ch.bfe.stauanlagen-bundesaufsicht.damname')}</td>           <td>${c['attributes']['damname']}</td></tr>
     <tr><td class="cell-left">${_('tt_ch.bfe.stauanlagen-bundesaufsicht_damtype')}</td>           <td>${c['attributes'][damtype] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_ch.bfe.stauanlagen-bundesaufsicht_damheight')}</td>         <td>${int(c['attributes']['damheight']) or '-'}&nbsp;m</td></tr>
     <tr><td class="cell-left">${_('tt_ch.bfe.stauanlagen-bundesaufsicht_crestlevel')}</td>        <td>${int(c['attributes']['crestlevel']) or '-'}&nbsp;${_('abk_meter_ueber_meer')}</td></tr>


### PR DESCRIPTION
This PR fixes several problems with queryable attributes:
- some missing translations are added
- some missing queryable attributes are added
- makos and translations are adapted in oder to use the automatically generated msg_id
- a nasty regexp error, resulting in a 400 in several layers, is fixed