### PR TITLE
Deactivating not needed services on clusters

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -275,3 +275,12 @@ interpreted-options = app_version = __import__('time').strftime('%s')
                       apache_entry_path = '' if options.get('apache_base_path') == 'main' else ('/' + options.get('apache_base_path'))
 extends = vars
 
+
+[removeconfig]
+recipe = collective.recipe.cmd
+on_install = true
+on_update = true
+cmds =
+    if [ -f "${buildout:directory}/apache/tomcat-print.conf" ]; then rm "${buildout:directory}/apache/tomcat-print.conf"; fi &&
+    if [ -f "${buildout:directory}/apache/mapproxy.conf" ]; then rm "${buildout:directory}/apache/mapproxy.conf"; fi
+

--- a/buildout_prod.cfg
+++ b/buildout_prod.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends = buildout.cfg
 
+
 [vars]
 # urls
 api_url = //api3.geo.admin.ch

--- a/buildout_prod_api.cfg
+++ b/buildout_prod_api.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends = buildout_prod.cfg
+parts += removeconfig
+parts -=  mapproxy
+          print-config
+          print-war
+
+

--- a/buildout_prod_varia.cfg
+++ b/buildout_prod_varia.cfg
@@ -1,0 +1,7 @@
+[buildout]
+extends = buildout_prod.cfg
+parts -=po2mo
+        validate-py
+        doc
+        node-modules
+        lessc

--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -24,10 +24,13 @@ int = ip-10-220-6-155.eu-west-1.compute.internal,
       ip-10-220-5-202.eu-west-1.compute.internal
 
 # mf0p
-prod = ip-10-220-4-152.eu-west-1.compute.internal,
-       ip-10-220-5-219.eu-west-1.compute.internal,
-       ip-10-220-5-225.eu-west-1.compute.internal,
+prod_api = ip-10-220-4-152.eu-west-1.compute.internal,
+       ip-10-220-5-219.eu-west-1.compute.internal
+
+prod_varia = ip-10-220-5-225.eu-west-1.compute.internal,
        ip-10-220-6-184.eu-west-1.compute.internal
+
+prod = %(prod_api)s, %(prod_varia)s
 
 # bakom demo instance dec 2014
 demo = ip-10-220-5-69.eu-west-1.compute.internal

--- a/deploysnapshot.sh
+++ b/deploysnapshot.sh
@@ -6,7 +6,7 @@ T="$(date +%s)"
 set -o errexit
 
 # Check if snapshot parameter is supplied and there are 2 parameters
-if [ "$2" != "int" ] && [ "$2" != "prod" ] && [ "$2" != "demo" ]
+if [ "$2" != "int" ] && [ "$2" != "prod" ] && [ "$2" != "demo" ] && [ "$2" != "prod_api" ] && [ "$2" != "prod_varia" ]
 then
   echo "Error: Please specify 1) snapshot directoy and 2) target."
   exit 1
@@ -28,7 +28,7 @@ then
       ./nose_run.sh -i
     fi
 
-    if [ "$2" == "prod" ]
+    if [ "$2" == "prod" ] ||  [ "$2" == "prod_api" ] ||  [ "$2" == "prod_varia" ] 
     then
       echo "Running nose tests with production cluster in $SNAPSHOTDIR"
       ./nose_run.sh -p


### PR DESCRIPTION
We have currently two mf-chsdi3 clusters:
* For API3, services
* For Mapproxy, profile/height and print

The goal is to deactivate services that do not need to run on a specific cluster (trying solve, or at least isolate #1599 and #1638)

Two new targets are defined `prod_api`and `prod_varia`, while `prod`is retained.

