### PR TITLE
Workaround to avoid dupplicate error between apache and wsgi

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -13,9 +13,14 @@ RewriteEngine on
 ExpiresActive on
 
 # Enabling CORS
-Header set Access-Control-Allow-Origin "*"
 Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS"
 Header always set Access-Control-Allow-Headers "x-requested-with, Content-Type, origin, authorization, accept, client-security-token"
+
+# Mapproxy is adding its own CORS headers. 'Set' should be enought, but is not.
+<LocationMatch "^${apache_entry_path}/(?!1\.0\.0)">
+    Header set Access-Control-Allow-Origin "*"
+</LocationMatch>
+
 
 
 AddOutputFilterByType DEFLATE text/css


### PR DESCRIPTION
Mapproxy 1.8 is setting it's own CORS headers. Normally we would expected headers set by WSGI application to be available to apache, but it looks like it is broken in old mod_wsgi module.

So we have to found a way not to set the _Access-control-allow-origin_ for requests handled by Mapproxy.

Testing is not easy as about 30 vhosts are setting carefully this header.

