### PR TITLE
Add missing host in url

### DIFF
--- a/chsdi/templates/htmlpopup/kantone.ivs-reg_loc.mako
+++ b/chsdi/templates/htmlpopup/kantone.ivs-reg_loc.mako
@@ -61,7 +61,7 @@
                 ${_('ivs_nat_abschnitt')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/it/${PDF_Level_3}.pdf" target="_blank">${PDF_Level_3_Name}</a><br />
             % endif
         % else:
-            ${_('ivs_nat_strecke')}: <a href="/kogis_web/downloads/ivs/beschr/de/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
+            ${_('ivs_nat_strecke')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/de/${PDF_Level_1}.pdf" target="_blank">${PDF_Level_1_Name}</a><br />
             % if PDF_Level_2_exist <> '00':
                 ${_('ivs_nat_linienfuehrung')}: <a href="${webDavHost}/kogis_web/downloads/ivs/beschr/de/${PDF_Level_2}.pdf" target="_blank">${PDF_Level_2_Name}</a><br />
             % endif
@@ -80,5 +80,4 @@
         % endif
     % endif
     </td></tr>
-
 </%def>


### PR DESCRIPTION
When you click on a ivs segment, the link to the PDF in the tooltip is wrong (only in DE, RM and EN).
The hostname was missing on the url link

Test Link : 
https://mf-geoadmin3.dev.bgdi.ch/ltalp/src/?X=170558.21&Y=624313.40&zoom=7&lang=de&topic=ivs&bgLayer=voidLayer&layers=ch.kantone.ivs-reg_loc&catalogNodes=340,341,358,361&layers_opacity=0.75