### PR TITLE
Pdf as attachment for IE greater than 10

### DIFF
--- a/apache/tomcat-print.conf.in
+++ b/apache/tomcat-print.conf.in
@@ -16,7 +16,7 @@ AliasMatch ^${apache_entry_path}/print(proxy)?/(\-multi)?([0-9]+\.pdf\.printout)
   # overriding what set by the print server
   SetEnvIf Request_URI "\.pdf$" PDF=pdf
   SetEnvIf User-Agent .*MSIE.* IE=1
-  SetEnvIf User-Agent .*MSIE 10.* IE10=1
+  SetEnvIf User-Agent .*MSIE 1[0-9]+.* IE10=1
 
   Header set Content-Disposition "inline" env=IE
   Header set Content-Type "application/octet-stream" env=PDF

--- a/buildout_ltmom.cfg
+++ b/buildout_ltmom.cfg
@@ -1,5 +1,6 @@
 [buildout]
 extends = buildout_user_base.cfg
+#parts += print-war
 
 [vars]
 apache_base_path = ltmom
@@ -7,6 +8,7 @@ api_url = //mf-chsdi3.dev.bgdi.ch/ltmom
 host = mf-chsdi3.dev.bgdi.ch
 geoadminhost = mf-geoadmin3.dev.bgdi.ch/ltmom
 server_port = 9001
+#print_war = ltmom
 
 
 [modwsgi]


### PR DESCRIPTION
Adding IE 11 (and greater) to the IE list that should handling PDF as PDF attachment.

Should fix https://github.com/geoadmin/mf-chsdi3/issues/1721