### PR TITLE
GetCapabilities open for everybody. Adapt test

### DIFF
--- a/chsdi/tests/e2e/test_wmtscapabilities_auth.py
+++ b/chsdi/tests/e2e/test_wmtscapabilities_auth.py
@@ -31,14 +31,16 @@ class TestWmtsGetTileAuth(TestsBase):
         assert (resp.status_code == code), 'Called Url: ' + url + ' [referer: ' + str(referer) + '] with return code: ' + str(resp.status_code)
 
     def test_bad_referer_get_capabilties(self):
-        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.mp.BAD_REFERER, 403)
+        # Get Cap is open for all
+        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.mp.BAD_REFERER, 200)
 
     def test_bad_referer_get_tile(self):
         for path in self.paths:
             self.check_status_code(self.mp.mapproxy_url + path, self.mp.BAD_REFERER, 403)
 
     def test_no_referer_get_capabilties(self):
-        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', None, 403)
+        # Get Cap is open for all
+        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', None, 200)
 
     def test_no_referer_get_tile(self):
         for path in self.paths:


### PR DESCRIPTION
We adapted the varnish configuratoin to free up getCapabilites document for everybody.

Therefore, we need to adapt our varnish tests. This PR does it.

Self-merge.