### PR TITLE
translate gazetteer swissnames3d categories

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -17,6 +17,303 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 0.9.5\n"
 
+msgid "<i>Abwasserreinigungsareal</i>"
+msgstr "Abwasserreinigungsareal"
+
+msgid "<i>Alpiner Gipfel</i>"
+msgstr "Alpiner Gipfel"
+
+msgid "<i>Ausfahrt</i>"
+msgstr "Ausfahrt"
+
+msgid "<i>Aussichtspunkt</i>"
+msgstr "Aussichtspunkt"
+
+msgid "<i>Autofaehre</i>"
+msgstr "Autofaehre"
+
+msgid "<i>Bildstock</i>"
+msgstr "Bildstock"
+
+msgid "<i>Bobbahn</i>"
+msgstr "Bobbahn"
+
+msgid "<i>Brunnen</i>"
+msgstr "Brunnen"
+
+msgid "<i>Campingplatzareal</i>"
+msgstr "Campingplatzareal"
+
+msgid "<i>Denkmal</i>"
+msgstr "Denkmal"
+
+msgid "<i>Deponieareal</i>"
+msgstr "Deponieareal"
+
+msgid "<i>Ein- und Ausfahrt</i>"
+msgstr "Ein- und Ausfahrt"
+
+msgid "<i>Erratischer Block</i>"
+msgstr "Erratischer Block"
+
+msgid "<i>Felsblock</i>"
+msgstr "Felsblock"
+
+msgid "<i>Felskopf</i>"
+msgstr "Felskopf"
+
+msgid "<i>Fliessgewaesser</i>"
+msgstr "Fliessgewaesser"
+
+msgid "<i>Flugfeldareal</i>"
+msgstr "Flugfeldareal"
+
+msgid "<i>Flughafenareal</i>"
+msgstr "Flughafenareal"
+
+msgid "<i>Flugplatzareal</i>"
+msgstr "Flugplatzareal"
+
+msgid "<i>Flurname swisstopo</i>"
+msgstr "Flurname swisstopo"
+
+msgid "<i>Freizeitanlagenareal</i>"
+msgstr "Freizeitanlagenareal"
+
+msgid "<i>Friedhof</i>"
+msgstr "Friedhof"
+
+msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Gebaeude Einzelhaus"
+
+msgid "<i>Gebiet</i>"
+msgstr "Gebiet"
+
+msgid "<i>Gipfel</i>"
+msgstr "Gipfel"
+
+msgid "<i>Gletscher</i>"
+msgstr "Gletscher"
+
+msgid "<i>Golfplatzareal</i>"
+msgstr "Golfplatzareal"
+
+msgid "<i>Gondelbahn</i>"
+msgstr "Gondelbahn"
+
+msgid "<i>Graben</i>"
+msgstr "Graben"
+
+msgid "<i>Grat</i>"
+msgstr "Grat"
+
+msgid "<i>Grossregion</i>"
+msgstr "Grossregion"
+
+msgid "<i>Grotte, Hoehle</i>"
+msgstr "Grotte, Hoehle"
+
+msgid "<i>Haltestelle Bahn</i>"
+msgstr "Haltestelle Bahn"
+
+msgid "<i>Haltestelle Bus</i>"
+msgstr "Haltestelle Bus"
+
+msgid "<i>Haltestelle Schiff</i>"
+msgstr "Haltestelle Schiff"
+
+msgid "<i>Hauptgipfel</i>"
+msgstr "Hauptgipfel"
+
+msgid "<i>Haupthuegel</i>"
+msgstr "Haupthuegel"
+
+msgid "<i>Haupttal</i>"
+msgstr "Haupttal"
+
+msgid "<i>Heliport</i>"
+msgstr "Heliport"
+
+msgid "<i>Historisches Areal</i>"
+msgstr "Historisches Areal"
+
+msgid "<i>Huegel</i>"
+msgstr "Huegel"
+
+msgid "<i>Huegelzug</i>"
+msgstr "Huegelzug"
+
+msgid "<i>Kapelle</i>"
+msgstr "Kapelle"
+
+msgid "<i>Kehrichtverbrennungsareal</i>"
+msgstr "Kehrichtverbrennungsareal"
+
+msgid "<i>Kleinbahn</i>"
+msgstr "Kleinbahn"
+
+msgid "<i>Klosterareal</i>"
+msgstr "Klosterareal"
+
+msgid "<i>Kraftwerkareal</i>"
+msgstr "Kraftwerkareal"
+
+msgid "<i>Landesgrenzstein</i>"
+msgstr "Landesgrenzstein"
+
+msgid "<i>Landschaftsname</i>"
+msgstr "Landschaftsname"
+
+msgid "<i>Lokalname swisstopo</i>"
+msgstr "Lokalname swisstopo"
+
+msgid "<i>Luftseilbahn</i>"
+msgstr "Luftseilbahn"
+
+msgid "<i>Massiv</i>"
+msgstr "Massiv"
+
+msgid "<i>Massnahmenvollzugsanstaltsareal</i>"
+msgstr "Massnahmenvollzugsanstaltsareal"
+
+msgid "<i>Messeareal</i>"
+msgstr "Messeareal"
+
+msgid "<i>Normalspur</i>"
+msgstr "Normalspur"
+
+msgid "<i>Oeffentliches Parkareal</i>"
+msgstr "Oeffentliches Parkareal"
+
+msgid "<i>Oeffentliches Parkplatzareal</i>"
+msgstr "Oeffentliches Parkplatzareal"
+
+msgid "<i>Offenes Gebaeude</i>"
+msgstr "Offenes Gebaeude"
+
+msgid "<i>Ort</i>"
+msgstr "Ort"
+
+msgid "<i>Ortsteil</i>"
+msgstr "Ortsteil"
+
+msgid "<i>Pass</i>"
+msgstr "Pass"
+
+msgid "<i>Personenfaehre mit Seil</i>"
+msgstr "Personenfaehre mit Seil"
+
+msgid "<i>Personenfaehre ohne Seil</i>"
+msgstr "Personenfaehre ohne Seil"
+
+msgid "<i>Pferderennbahnareal</i>"
+msgstr "Pferderennbahnareal"
+
+msgid "<i>Quartier</i>"
+msgstr "Quartier"
+
+msgid "<i>Quartierteil</i>"
+msgstr "Quartierteil"
+
+msgid "<i>Quelle</i>"
+msgstr "Quelle"
+
+msgid "<i>Rastplatzareal</i>"
+msgstr "Rastplatzareal"
+
+msgid "<i>Rodelbahn</i>"
+msgstr "Rodelbahn"
+
+msgid "<i>Sakrales Gebaeude</i>"
+msgstr "Sakrales Gebaeude"
+
+msgid "<i>Schmalspur</i>"
+msgstr "Schmalspur"
+
+msgid "<i>Schul- und Hochschulareal</i>"
+msgstr "Schul- und Hochschulareal"
+
+msgid "<i>Schwimmbadareal</i>"
+msgstr "Schwimmbadareal"
+
+msgid "<i>See</i>"
+msgstr "See"
+
+msgid "<i>Seeinsel</i>"
+msgstr "Seeinsel"
+
+msgid "<i>Seeteil</i>"
+msgstr "Seeteil"
+
+msgid "<i>Sesselbahn</i>"
+msgstr "Sesselbahn"
+
+msgid "<i>Skilift</i>"
+msgstr "Skilift"
+
+msgid "<i>Skisprungschanze</i>"
+msgstr "Skisprungschanze"
+
+msgid "<i>Spitalareal</i>"
+msgstr "Spitalareal"
+
+msgid "<i>Sportplatzareal</i>"
+msgstr "Sportplatzareal"
+
+msgid "<i>Standplatzareal</i>"
+msgstr "Standplatzareal"
+
+msgid "<i>Staudamm</i>"
+msgstr "Staudamm"
+
+msgid "<i>Staumauer</i>"
+msgstr "Staumauer"
+
+msgid "<i>Strasse</i>"
+msgstr "Strasse"
+
+msgid "<i>Strassenpass</i>"
+msgstr "Strassenpass"
+
+msgid "<i>Tal</i>"
+msgstr "Tal"
+
+msgid "<i>Transportseil</i>"
+msgstr "Transportseil"
+
+msgid "<i>Truppenuebungsplatz</i>"
+msgstr "Truppenuebungsplatz"
+
+msgid "<i>Turm</i>"
+msgstr "Turm"
+
+msgid "<i>Uebrige Bahnen</i>"
+msgstr "Uebrige Bahnen"
+
+msgid "<i>Unterwerkareal</i>"
+msgstr "Unterwerkareal"
+
+msgid "<i>Verzweigung</i>"
+msgstr "Verzweigung"
+
+msgid "<i>Wasserfall</i>"
+msgstr "Wasserfall"
+
+msgid "<i>Wehr</i>"
+msgstr "Wehr"
+
+msgid "<i>Zollamt 24h 24h</i>"
+msgstr "Zollamt 24h 24h"
+
+msgid "<i>Zollamt 24h eingeschraenkt</i>"
+msgstr "Zollamt 24h eingeschraenkt"
+
+msgid "<i>Zollamt eingeschraenkt</i>"
+msgstr "Zollamt eingeschraenkt"
+
+msgid "<i>Zooareal</i>"
+msgstr "Zooareal"
+
 msgid "ABS_landesschwerenetz_type"
 msgstr "Absolutstation"
 

--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -122,6 +122,57 @@ msgstr "Haltestelle Bus"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Haltestelle Schiff"
 
+msgid "<i>Haltestellen Bus</i>"
+msgstr "Bus"
+
+msgid "<i>Haltestellen Bus_Tram</i>"
+msgstr "Bus, Tram"
+
+msgid "<i>Haltestellen Lift</i>"
+msgstr "Lift"
+
+msgid "<i>Haltestellen Luftseilbahn</i>"
+msgstr "Luftseilbahn"
+
+msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
+msgstr "Luftseilbahn, Zug"
+
+msgid "<i>Haltestellen Metro</i>"
+msgstr "Metro"
+
+msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
+msgstr "Reiner Betriebspunkt"
+
+msgid "<i>Haltestellen Schiff</i>"
+msgstr "Schiff"
+
+msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
+msgstr "Schiff, Zahnradbahn"
+
+msgid "<i>Haltestellen Standseilbahn</i>"
+msgstr "Standseilbahn"
+
+msgid "<i>Haltestellen Standseilbahn_Bus</i>"
+msgstr "Standseilbahn, Bus"
+
+msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
+msgstr "Standseilbahn, Luftseilbahn"
+
+msgid "<i>Haltestellen Standseilbahn_Zug</i>"
+msgstr "Standseilbahn, Zug"
+
+msgid "<i>Haltestellen Tram</i>"
+msgstr "Tram"
+
+msgid "<i>Haltestellen Zahnradbahn</i>"
+msgstr "Zahnradbahn"
+
+msgid "<i>Haltestellen Zug</i>"
+msgstr "Zug"
+
+msgid "<i>Haltestellen Zug_Tram</i>"
+msgstr "Zug, Tram"
+
 msgid "<i>Hauptgipfel</i>"
 msgstr "Hauptgipfel"
 

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -7505,3 +7505,54 @@ msgstr ""
 
 msgid "<i>Zooareal</i>"
 msgstr ""
+
+msgid "<i>Haltestellen Bus</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Bus_Tram</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Lift</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Luftseilbahn</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Metro</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Schiff</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Standseilbahn_Bus</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Standseilbahn</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Standseilbahn_Zug</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Tram</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Zahnradbahn</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Zug</i>"
+msgstr ""
+
+msgid "<i>Haltestellen Zug_Tram</i>"
+msgstr ""

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -7208,3 +7208,300 @@ msgstr ""
 
 msgid "tt_lubis_schraegaufnahmen_y"
 msgstr ""
+
+msgid "<i>Abwasserreinigungsareal</i>"
+msgstr ""
+
+msgid "<i>Alpiner Gipfel</i>"
+msgstr ""
+
+msgid "<i>Ausfahrt</i>"
+msgstr ""
+
+msgid "<i>Aussichtspunkt</i>"
+msgstr ""
+
+msgid "<i>Autofaehre</i>"
+msgstr ""
+
+msgid "<i>Bildstock</i>"
+msgstr ""
+
+msgid "<i>Bobbahn</i>"
+msgstr ""
+
+msgid "<i>Brunnen</i>"
+msgstr ""
+
+msgid "<i>Campingplatzareal</i>"
+msgstr ""
+
+msgid "<i>Denkmal</i>"
+msgstr ""
+
+msgid "<i>Deponieareal</i>"
+msgstr ""
+
+msgid "<i>Ein- und Ausfahrt</i>"
+msgstr ""
+
+msgid "<i>Erratischer Block</i>"
+msgstr ""
+
+msgid "<i>Felsblock</i>"
+msgstr ""
+
+msgid "<i>Felskopf</i>"
+msgstr ""
+
+msgid "<i>Fliessgewaesser</i>"
+msgstr ""
+
+msgid "<i>Flugfeldareal</i>"
+msgstr ""
+
+msgid "<i>Flughafenareal</i>"
+msgstr ""
+
+msgid "<i>Flugplatzareal</i>"
+msgstr ""
+
+msgid "<i>Flurname swisstopo</i>"
+msgstr ""
+
+msgid "<i>Freizeitanlagenareal</i>"
+msgstr ""
+
+msgid "<i>Friedhof</i>"
+msgstr ""
+
+msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr ""
+
+msgid "<i>Gebiet</i>"
+msgstr ""
+
+msgid "<i>Gipfel</i>"
+msgstr ""
+
+msgid "<i>Gletscher</i>"
+msgstr ""
+
+msgid "<i>Golfplatzareal</i>"
+msgstr ""
+
+msgid "<i>Gondelbahn</i>"
+msgstr ""
+
+msgid "<i>Graben</i>"
+msgstr ""
+
+msgid "<i>Grat</i>"
+msgstr ""
+
+msgid "<i>Grossregion</i>"
+msgstr ""
+
+msgid "<i>Grotte, Hoehle</i>"
+msgstr ""
+
+msgid "<i>Haltestelle Bahn</i>"
+msgstr ""
+
+msgid "<i>Haltestelle Bus</i>"
+msgstr ""
+
+msgid "<i>Haltestelle Schiff</i>"
+msgstr ""
+
+msgid "<i>Hauptgipfel</i>"
+msgstr ""
+
+msgid "<i>Haupthuegel</i>"
+msgstr ""
+
+msgid "<i>Haupttal</i>"
+msgstr ""
+
+msgid "<i>Heliport</i>"
+msgstr ""
+
+msgid "<i>Historisches Areal</i>"
+msgstr ""
+
+msgid "<i>Huegel</i>"
+msgstr ""
+
+msgid "<i>Huegelzug</i>"
+msgstr ""
+
+msgid "<i>Kapelle</i>"
+msgstr ""
+
+msgid "<i>Kehrichtverbrennungsareal</i>"
+msgstr ""
+
+msgid "<i>Kleinbahn</i>"
+msgstr ""
+
+msgid "<i>Klosterareal</i>"
+msgstr ""
+
+msgid "<i>Kraftwerkareal</i>"
+msgstr ""
+
+msgid "<i>Landesgrenzstein</i>"
+msgstr ""
+
+msgid "<i>Landschaftsname</i>"
+msgstr ""
+
+msgid "<i>Lokalname swisstopo</i>"
+msgstr ""
+
+msgid "<i>Luftseilbahn</i>"
+msgstr ""
+
+msgid "<i>Massiv</i>"
+msgstr ""
+
+msgid "<i>Massnahmenvollzugsanstaltsareal</i>"
+msgstr ""
+
+msgid "<i>Messeareal</i>"
+msgstr ""
+
+msgid "<i>Normalspur</i>"
+msgstr ""
+
+msgid "<i>Oeffentliches Parkareal</i>"
+msgstr ""
+
+msgid "<i>Oeffentliches Parkplatzareal</i>"
+msgstr ""
+
+msgid "<i>Offenes Gebaeude</i>"
+msgstr ""
+
+msgid "<i>Ort</i>"
+msgstr ""
+
+msgid "<i>Ortsteil</i>"
+msgstr ""
+
+msgid "<i>Pass</i>"
+msgstr ""
+
+msgid "<i>Personenfaehre mit Seil</i>"
+msgstr ""
+
+msgid "<i>Personenfaehre ohne Seil</i>"
+msgstr ""
+
+msgid "<i>Pferderennbahnareal</i>"
+msgstr ""
+
+msgid "<i>Quartier</i>"
+msgstr ""
+
+msgid "<i>Quartierteil</i>"
+msgstr ""
+
+msgid "<i>Quelle</i>"
+msgstr ""
+
+msgid "<i>Rastplatzareal</i>"
+msgstr ""
+
+msgid "<i>Rodelbahn</i>"
+msgstr ""
+
+msgid "<i>Sakrales Gebaeude</i>"
+msgstr ""
+
+msgid "<i>Schmalspur</i>"
+msgstr ""
+
+msgid "<i>Schul- und Hochschulareal</i>"
+msgstr ""
+
+msgid "<i>Schwimmbadareal</i>"
+msgstr ""
+
+msgid "<i>See</i>"
+msgstr ""
+
+msgid "<i>Seeinsel</i>"
+msgstr ""
+
+msgid "<i>Seeteil</i>"
+msgstr ""
+
+msgid "<i>Sesselbahn</i>"
+msgstr ""
+
+msgid "<i>Skilift</i>"
+msgstr ""
+
+msgid "<i>Skisprungschanze</i>"
+msgstr ""
+
+msgid "<i>Spitalareal</i>"
+msgstr ""
+
+msgid "<i>Sportplatzareal</i>"
+msgstr ""
+
+msgid "<i>Standplatzareal</i>"
+msgstr ""
+
+msgid "<i>Staudamm</i>"
+msgstr ""
+
+msgid "<i>Staumauer</i>"
+msgstr ""
+
+msgid "<i>Strasse</i>"
+msgstr ""
+
+msgid "<i>Strassenpass</i>"
+msgstr ""
+
+msgid "<i>Tal</i>"
+msgstr ""
+
+msgid "<i>Transportseil</i>"
+msgstr ""
+
+msgid "<i>Truppenuebungsplatz</i>"
+msgstr ""
+
+msgid "<i>Turm</i>"
+msgstr ""
+
+msgid "<i>Uebrige Bahnen</i>"
+msgstr ""
+
+msgid "<i>Unterwerkareal</i>"
+msgstr ""
+
+msgid "<i>Verzweigung</i>"
+msgstr ""
+
+msgid "<i>Wasserfall</i>"
+msgstr ""
+
+msgid "<i>Wehr</i>"
+msgstr ""
+
+msgid "<i>Zollamt 24h 24h</i>"
+msgstr ""
+
+msgid "<i>Zollamt 24h eingeschraenkt</i>"
+msgstr ""
+
+msgid "<i>Zollamt eingeschraenkt</i>"
+msgstr ""
+
+msgid "<i>Zooareal</i>"
+msgstr ""

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -17,6 +17,303 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 0.9.5\n"
 
+msgid "<i>Abwasserreinigungsareal</i>"
+msgstr "Wastewater treatment plant   "
+
+msgid "<i>Alpiner Gipfel</i>"
+msgstr "Alpin peak"
+
+msgid "<i>Ausfahrt</i>"
+msgstr "Exit"
+
+msgid "<i>Aussichtspunkt</i>"
+msgstr "Viewpoint"
+
+msgid "<i>Autofaehre</i>"
+msgstr "Car ferry"
+
+msgid "<i>Bildstock</i>"
+msgstr "Oratory"
+
+msgid "<i>Bobbahn</i>"
+msgstr "Bob run"
+
+msgid "<i>Brunnen</i>"
+msgstr "Fountain"
+
+msgid "<i>Campingplatzareal</i>"
+msgstr "Campground"
+
+msgid "<i>Denkmal</i>"
+msgstr "Monument"
+
+msgid "<i>Deponieareal</i>"
+msgstr "Waste disposal"
+
+msgid "<i>Ein- und Ausfahrt</i>"
+msgstr "Entrance and exit"
+
+msgid "<i>Erratischer Block</i>"
+msgstr "Erratic block"
+
+msgid "<i>Felsblock</i>"
+msgstr "Cliff-block"
+
+msgid "<i>Felskopf</i>"
+msgstr "Rocky head"
+
+msgid "<i>Fliessgewaesser</i>"
+msgstr "Water course"
+
+msgid "<i>Flugfeldareal</i>"
+msgstr "Airfield"
+
+msgid "<i>Flughafenareal</i>"
+msgstr "Airport"
+
+msgid "<i>Flugplatzareal</i>"
+msgstr "Aerodrom"
+
+msgid "<i>Flurname swisstopo</i>"
+msgstr "Named location swisstopo"
+
+msgid "<i>Freizeitanlagenareal</i>"
+msgstr "Leisure park"
+
+msgid "<i>Friedhof</i>"
+msgstr "Cemetery"
+
+msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Building"
+
+msgid "<i>Gebiet</i>"
+msgstr "Territory"
+
+msgid "<i>Gipfel</i>"
+msgstr "Peak"
+
+msgid "<i>Gletscher</i>"
+msgstr "Glacier"
+
+msgid "<i>Golfplatzareal</i>"
+msgstr "Golf course"
+
+msgid "<i>Gondelbahn</i>"
+msgstr "Gondola lift"
+
+msgid "<i>Graben</i>"
+msgstr "Ditch"
+
+msgid "<i>Grat</i>"
+msgstr "Crest"
+
+msgid "<i>Grossregion</i>"
+msgstr "Main Region"
+
+msgid "<i>Grotte, Hoehle</i>"
+msgstr "Cave"
+
+msgid "<i>Haltestelle Bahn</i>"
+msgstr "Railway stop"
+
+msgid "<i>Haltestelle Bus</i>"
+msgstr "Bus stop"
+
+msgid "<i>Haltestelle Schiff</i>"
+msgstr "Ship stop"
+
+msgid "<i>Hauptgipfel</i>"
+msgstr "Main peak"
+
+msgid "<i>Haupthuegel</i>"
+msgstr "Main hill"
+
+msgid "<i>Haupttal</i>"
+msgstr "Main Valley"
+
+msgid "<i>Heliport</i>"
+msgstr "Heliport"
+
+msgid "<i>Historisches Areal</i>"
+msgstr "Historical area"
+
+msgid "<i>Huegel</i>"
+msgstr "Hill"
+
+msgid "<i>Huegelzug</i>"
+msgstr "Hill range"
+
+msgid "<i>Kapelle</i>"
+msgstr "Chapel"
+
+msgid "<i>Kehrichtverbrennungsareal</i>"
+msgstr "Waste incineration plant"
+
+msgid "<i>Kleinbahn</i>"
+msgstr "Small Train"
+
+msgid "<i>Klosterareal</i>"
+msgstr "Cloister area"
+
+msgid "<i>Kraftwerkareal</i>"
+msgstr "Power plant"
+
+msgid "<i>Landesgrenzstein</i>"
+msgstr "Boundary mark"
+
+msgid "<i>Landschaftsname</i>"
+msgstr "Landscape Name"
+
+msgid "<i>Lokalname swisstopo</i>"
+msgstr "Local name"
+
+msgid "<i>Luftseilbahn</i>"
+msgstr "Cable car"
+
+msgid "<i>Massiv</i>"
+msgstr "Massif"
+
+msgid "<i>Massnahmenvollzugsanstaltsareal</i>"
+msgstr "Prison"
+
+msgid "<i>Messeareal</i>"
+msgstr "Fairground"
+
+msgid "<i>Normalspur</i>"
+msgstr "Standard railway track"
+
+msgid "<i>Oeffentliches Parkareal</i>"
+msgstr "Public Parc"
+
+msgid "<i>Oeffentliches Parkplatzareal</i>"
+msgstr "Public parking ground"
+
+msgid "<i>Offenes Gebaeude</i>"
+msgstr "Open building"
+
+msgid "<i>Ort</i>"
+msgstr "Populated Place"
+
+msgid "<i>Ortsteil</i>"
+msgstr "Part of a populated place"
+
+msgid "<i>Pass</i>"
+msgstr "Pass"
+
+msgid "<i>Personenfaehre mit Seil</i>"
+msgstr "Foot ferry with rope"
+
+msgid "<i>Personenfaehre ohne Seil</i>"
+msgstr "Foot ferry without rope"
+
+msgid "<i>Pferderennbahnareal</i>"
+msgstr "Race course"
+
+msgid "<i>Quartier</i>"
+msgstr "Ward"
+
+msgid "<i>Quartierteil</i>"
+msgstr "Part of a ward"
+
+msgid "<i>Quelle</i>"
+msgstr "Spring"
+
+msgid "<i>Rastplatzareal</i>"
+msgstr "Rest area"
+
+msgid "<i>Rodelbahn</i>"
+msgstr "Toboggan run"
+
+msgid "<i>Sakrales Gebaeude</i>"
+msgstr "Sacred building"
+
+msgid "<i>Schmalspur</i>"
+msgstr "Narrow railway track"
+
+msgid "<i>Schul- und Hochschulareal</i>"
+msgstr "School"
+
+msgid "<i>Schwimmbadareal</i>"
+msgstr "Swimming pool"
+
+msgid "<i>See</i>"
+msgstr "Lake"
+
+msgid "<i>Seeinsel</i>"
+msgstr "Island on a lake"
+
+msgid "<i>Seeteil</i>"
+msgstr "Lake part"
+
+msgid "<i>Sesselbahn</i>"
+msgstr "Chair lift"
+
+msgid "<i>Skilift</i>"
+msgstr "Ski Lift"
+
+msgid "<i>Skisprungschanze</i>"
+msgstr "Ski jump"
+
+msgid "<i>Spitalareal</i>"
+msgstr "Hospital"
+
+msgid "<i>Sportplatzareal</i>"
+msgstr "Sport field"
+
+msgid "<i>Standplatzareal</i>"
+msgstr "Area with fixed mobil-homes"
+
+msgid "<i>Staudamm</i>"
+msgstr "Dyke"
+
+msgid "<i>Staumauer</i>"
+msgstr "Dam"
+
+msgid "<i>Strasse</i>"
+msgstr "Road"
+
+msgid "<i>Strassenpass</i>"
+msgstr "Roadpass"
+
+msgid "<i>Tal</i>"
+msgstr "Valley"
+
+msgid "<i>Transportseil</i>"
+msgstr "Ropeway for goods"
+
+msgid "<i>Truppenuebungsplatz</i>"
+msgstr "Military training ground"
+
+msgid "<i>Turm</i>"
+msgstr "Tower"
+
+msgid "<i>Uebrige Bahnen</i>"
+msgstr "Other transport"
+
+msgid "<i>Unterwerkareal</i>"
+msgstr "Substation"
+
+msgid "<i>Verzweigung</i>"
+msgstr "Interchange"
+
+msgid "<i>Wasserfall</i>"
+msgstr "Waterfall"
+
+msgid "<i>Wehr</i>"
+msgstr "Lock"
+
+msgid "<i>Zollamt 24h 24h</i>"
+msgstr "Costume office 24h 24h"
+
+msgid "<i>Zollamt 24h eingeschraenkt</i>"
+msgstr "Costume office 24h restricted"
+
+msgid "<i>Zollamt eingeschraenkt</i>"
+msgstr "Costume office restricted"
+
+msgid "<i>Zooareal</i>"
+msgstr "Zoo"
+
 msgid "ABS_landesschwerenetz_type"
 msgstr "absolute station"
 

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -122,6 +122,57 @@ msgstr "Bus stop"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Ship stop"
 
+msgid "<i>Haltestellen Bus</i>"
+msgstr "Bus"
+
+msgid "<i>Haltestellen Bus_Tram</i>"
+msgstr "Bus, Tram"
+
+msgid "<i>Haltestellen Lift</i>"
+msgstr "Lift"
+
+msgid "<i>Haltestellen Luftseilbahn</i>"
+msgstr "Cablecar"
+
+msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
+msgstr "Cablecar, train"
+
+msgid "<i>Haltestellen Metro</i>"
+msgstr "Metro"
+
+msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
+msgstr "Simple operating point"
+
+msgid "<i>Haltestellen Schiff</i>"
+msgstr "Boat"
+
+msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
+msgstr "Boat, rack railway"
+
+msgid "<i>Haltestellen Standseilbahn</i>"
+msgstr "Funicular"
+
+msgid "<i>Haltestellen Standseilbahn_Bus</i>"
+msgstr "Funicular, bus"
+
+msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
+msgstr "Funicular, cableway"
+
+msgid "<i>Haltestellen Standseilbahn_Zug</i>"
+msgstr "Funicular, train"
+
+msgid "<i>Haltestellen Tram</i>"
+msgstr "Tram"
+
+msgid "<i>Haltestellen Zahnradbahn</i>"
+msgstr "Rack railway"
+
+msgid "<i>Haltestellen Zug</i>"
+msgstr "Train"
+
+msgid "<i>Haltestellen Zug_Tram</i>"
+msgstr "Train, tram"
+
 msgid "<i>Hauptgipfel</i>"
 msgstr "Main peak"
 

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -122,6 +122,58 @@ msgstr "Fermada da bus "
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Fermada da nav"
 
+msgid "<i>Haltestellen Bus</i>"
+msgstr "Bus"
+
+msgid "<i>Haltestellen Bus_Tram</i>"
+msgstr "Bus, tram"
+
+msgid "<i>Haltestellen Lift</i>"
+msgstr "Lift"
+
+msgid "<i>Haltestellen Luftseilbahn</i>"
+msgstr "Luftseilbahn"
+
+msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
+msgstr "Luftseilbahn, Zug"
+
+msgid "<i>Haltestellen Metro</i>"
+msgstr "Metro"
+
+msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
+msgstr "Reiner Betriebspunkt"
+
+msgid "<i>Haltestellen Schiff</i>"
+msgstr "Schiff"
+
+msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
+msgstr "Schiff, Zahnradbahn"
+
+msgid "<i>Haltestellen Standseilbahn</i>"
+msgstr "Standseilbahn"
+
+msgid "<i>Haltestellen Standseilbahn_Bus</i>"
+msgstr "Standseilbahn, Bus"
+
+msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
+msgstr "Standseilbahn, Luftseilbahn"
+
+msgid "<i>Haltestellen Standseilbahn_Zug</i>"
+msgstr "Standseilbahn, Zug"
+
+msgid "<i>Haltestellen Tram</i>"
+msgstr "Tram"
+
+msgid "<i>Haltestellen Zahnradbahn</i>"
+msgstr "Zahnradbahn
+"
+
+msgid "<i>Haltestellen Zug</i>"
+msgstr "Zug"
+
+msgid "<i>Haltestellen Zug_Tram</i>"
+msgstr "Zug, Tram"
+
 msgid "<i>Hauptgipfel</i>"
 msgstr "Piz principal"
 

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -17,6 +17,303 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 0.9.5\n"
 
+msgid "<i>Abwasserreinigungsareal</i>"
+msgstr "Serenera"
+
+msgid "<i>Alpiner Gipfel</i>"
+msgstr "Piz alpin"
+
+msgid "<i>Ausfahrt</i>"
+msgstr "Sortida "
+
+msgid "<i>Aussichtspunkt</i>"
+msgstr "Punct panoramic"
+
+msgid "<i>Autofaehre</i>"
+msgstr "Navetta per autos"
+
+msgid "<i>Bildstock</i>"
+msgstr "Sontget "
+
+msgid "<i>Bobbahn</i>"
+msgstr "Bobera"
+
+msgid "<i>Brunnen</i>"
+msgstr "Funtauna "
+
+msgid "<i>Campingplatzareal</i>"
+msgstr "Plazza da campar"
+
+msgid "<i>Denkmal</i>"
+msgstr "Monument "
+
+msgid "<i>Deponieareal</i>"
+msgstr "Deponia"
+
+msgid "<i>Ein- und Ausfahrt</i>"
+msgstr "Entrada e sortida"
+
+msgid "<i>Erratischer Block</i>"
+msgstr "Bloc erratic"
+
+msgid "<i>Felsblock</i>"
+msgstr "Crappun "
+
+msgid "<i>Felskopf</i>"
+msgstr "Grugn "
+
+msgid "<i>Fliessgewaesser</i>"
+msgstr "Currents"
+
+msgid "<i>Flugfeldareal</i>"
+msgstr "Champ d'aviaziun"
+
+msgid "<i>Flughafenareal</i>"
+msgstr "Eroport"
+
+msgid "<i>Flugplatzareal</i>"
+msgstr "Plazza aviatica"
+
+msgid "<i>Flurname swisstopo</i>"
+msgstr "Num da cultira swisstopo"
+
+msgid "<i>Freizeitanlagenareal</i>"
+msgstr "Implant da temp liber"
+
+msgid "<i>Friedhof</i>"
+msgstr "Santeri "
+
+msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Edifizi "
+
+msgid "<i>Gebiet</i>"
+msgstr "Territori "
+
+msgid "<i>Gipfel</i>"
+msgstr "Piz"
+
+msgid "<i>Gletscher</i>"
+msgstr "Glatscher "
+
+msgid "<i>Golfplatzareal</i>"
+msgstr "Plazza da golf"
+
+msgid "<i>Gondelbahn</i>"
+msgstr "Telecabina"
+
+msgid "<i>Graben</i>"
+msgstr "Foss"
+
+msgid "<i>Grat</i>"
+msgstr "Cresta "
+
+msgid "<i>Grossregion</i>"
+msgstr "Territori principal"
+
+msgid "<i>Grotte, Hoehle</i>"
+msgstr "Grotta "
+
+msgid "<i>Haltestelle Bahn</i>"
+msgstr "Fermada da viafier"
+
+msgid "<i>Haltestelle Bus</i>"
+msgstr "Fermada da bus "
+
+msgid "<i>Haltestelle Schiff</i>"
+msgstr "Fermada da nav"
+
+msgid "<i>Hauptgipfel</i>"
+msgstr "Piz principal"
+
+msgid "<i>Haupthuegel</i>"
+msgstr "Collina principal"
+
+msgid "<i>Haupttal</i>"
+msgstr "Val principala"
+
+msgid "<i>Heliport</i>"
+msgstr "Champ d'aviaziun per helicopter"
+
+msgid "<i>Historisches Areal</i>"
+msgstr "Areal istoric "
+
+msgid "<i>Huegel</i>"
+msgstr "Collina"
+
+msgid "<i>Huegelzug</i>"
+msgstr "Chadaina da collinas "
+
+msgid "<i>Kapelle</i>"
+msgstr "Chaplutta "
+
+msgid "<i>Kehrichtverbrennungsareal</i>"
+msgstr "Implant per arder rument "
+
+msgid "<i>Kleinbahn</i>"
+msgstr "Viafier a binaris stretgs"
+
+msgid "<i>Klosterareal</i>"
+msgstr "Convent "
+
+msgid "<i>Kraftwerkareal</i>"
+msgstr "Implant electric"
+
+msgid "<i>Landesgrenzstein</i>"
+msgstr "Crap da cunfin naziunal"
+
+msgid "<i>Landschaftsname</i>"
+msgstr "Regiun "
+
+msgid "<i>Lokalname swisstopo</i>"
+msgstr "Num local swisstopo"
+
+msgid "<i>Luftseilbahn</i>"
+msgstr "Pendiculara"
+
+msgid "<i>Massiv</i>"
+msgstr "Massiv "
+
+msgid "<i>Massnahmenvollzugsanstaltsareal</i>"
+msgstr "Praschun "
+
+msgid "<i>Messeareal</i>"
+msgstr "Fiera"
+
+msgid "<i>Normalspur</i>"
+msgstr "Binari normal"
+
+msgid "<i>Oeffentliches Parkareal</i>"
+msgstr "Parc public"
+
+msgid "<i>Oeffentliches Parkplatzareal</i>"
+msgstr "Parcadi public"
+
+msgid "<i>Offenes Gebaeude</i>"
+msgstr "Edifizi avert"
+
+msgid "<i>Ort</i>"
+msgstr "Lieu "
+
+msgid "<i>Ortsteil</i>"
+msgstr "Part da la vischnanca"
+
+msgid "<i>Pass</i>"
+msgstr "Pass"
+
+msgid "<i>Personenfaehre mit Seil</i>"
+msgstr "Navetta cun corda"
+
+msgid "<i>Personenfaehre ohne Seil</i>"
+msgstr "Navetta senza corda"
+
+msgid "<i>Pferderennbahnareal</i>"
+msgstr "Ippodrom"
+
+msgid "<i>Quartier</i>"
+msgstr "Quartier "
+
+msgid "<i>Quartierteil</i>"
+msgstr "Part di quartier "
+
+msgid "<i>Quelle</i>"
+msgstr "Funtauna "
+
+msgid "<i>Rastplatzareal</i>"
+msgstr "Pausadi "
+
+msgid "<i>Rodelbahn</i>"
+msgstr "Via da scarsolar"
+
+msgid "<i>Sakrales Gebaeude</i>"
+msgstr "Edifizi sacrala"
+
+msgid "<i>Schmalspur</i>"
+msgstr "Binari stretg"
+
+msgid "<i>Schul- und Hochschulareal</i>"
+msgstr "Scola"
+
+msgid "<i>Schwimmbadareal</i>"
+msgstr "Bogn "
+
+msgid "<i>See</i>"
+msgstr "Lai"
+
+msgid "<i>Seeinsel</i>"
+msgstr "Insla di lai"
+
+msgid "<i>Seeteil</i>"
+msgstr "Part di lai"
+
+msgid "<i>Sesselbahn</i>"
+msgstr "Sutgera "
+
+msgid "<i>Skilift</i>"
+msgstr "Runal"
+
+msgid "<i>Skisprungschanze</i>"
+msgstr "Schanza sigl cun skis"
+
+msgid "<i>Spitalareal</i>"
+msgstr "Ospital "
+
+msgid "<i>Sportplatzareal</i>"
+msgstr "Plazza da sport "
+
+msgid "<i>Standplatzareal</i>"
+msgstr "Lieu da staziunament "
+
+msgid "<i>Staudamm</i>"
+msgstr "Mir da serra"
+
+msgid "<i>Staumauer</i>"
+msgstr "Mir da fermada "
+
+msgid "<i>Strasse</i>"
+msgstr "Strada"
+
+msgid "<i>Strassenpass</i>"
+msgstr "Pass stradal "
+
+msgid "<i>Tal</i>"
+msgstr "Val"
+
+msgid "<i>Transportseil</i>"
+msgstr "Corda da transport"
+
+msgid "<i>Truppenuebungsplatz</i>"
+msgstr "Plazza da exercizi da truppa"
+
+msgid "<i>Turm</i>"
+msgstr "Tur"
+
+msgid "<i>Uebrige Bahnen</i>"
+msgstr "Ulteriurs  vials"
+
+msgid "<i>Unterwerkareal</i>"
+msgstr "Sutstaziun "
+
+msgid "<i>Verzweigung</i>"
+msgstr "Diromaziun "
+
+msgid "<i>Wasserfall</i>"
+msgstr "Cascada "
+
+msgid "<i>Wehr</i>"
+msgstr "Rempar idraulic "
+
+msgid "<i>Zollamt 24h 24h</i>"
+msgstr "Uffizi da dazi 24h 24h"
+
+msgid "<i>Zollamt 24h eingeschraenkt</i>"
+msgstr "Uffizi da dazi 24h limità"
+
+msgid "<i>Zollamt eingeschraenkt</i>"
+msgstr "Uffizi da dazi  limità"
+
+msgid "<i>Zooareal</i>"
+msgstr "Zoo"
+
 msgid "ABS_landesschwerenetz_type"
 msgstr "Absolutstation"
 

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -122,6 +122,57 @@ msgstr "Arrêt de bus"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Arrêt de bateau"
 
+msgid "<i>Haltestellen Bus</i>"
+msgstr "Bus"
+
+msgid "<i>Haltestellen Bus_Tram</i>"
+msgstr "Bus, Tram"
+
+msgid "<i>Haltestellen Lift</i>"
+msgstr "Ascenseur"
+
+msgid "<i>Haltestellen Luftseilbahn</i>"
+msgstr "Téléphérique"
+
+msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
+msgstr "Téléphérique, chemin de fer"
+
+msgid "<i>Haltestellen Metro</i>"
+msgstr "Métro"
+
+msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
+msgstr "Point d’exploitation simple"
+
+msgid "<i>Haltestellen Schiff</i>"
+msgstr "Bateau"
+
+msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
+msgstr "Bateau, chemin de fer à crémaillère"
+
+msgid "<i>Haltestellen Standseilbahn</i>"
+msgstr "Funiculaire"
+
+msgid "<i>Haltestellen Standseilbahn_Bus</i>"
+msgstr "Funiculaire, bus"
+
+msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
+msgstr "Funiculaire, téléphérique"
+
+msgid "<i>Haltestellen Standseilbahn_Zug</i>"
+msgstr "Funiculaire, chemin de fer"
+
+msgid "<i>Haltestellen Tram</i>"
+msgstr "Tram"
+
+msgid "<i>Haltestellen Zahnradbahn</i>"
+msgstr "Chemin de fer à crémaillère"
+
+msgid "<i>Haltestellen Zug</i>"
+msgstr "Chemin de fer"
+
+msgid "<i>Haltestellen Zug_Tram</i>"
+msgstr "Chemin de ter, tram"
+
 msgid "<i>Hauptgipfel</i>"
 msgstr "Sommet principal"
 

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -17,6 +17,303 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 0.9.5\n"
 
+msgid "<i>Abwasserreinigungsareal</i>"
+msgstr "Station d'épuration des eaux usées"
+
+msgid "<i>Alpiner Gipfel</i>"
+msgstr "Sommet alpin"
+
+msgid "<i>Ausfahrt</i>"
+msgstr "Sortie"
+
+msgid "<i>Aussichtspunkt</i>"
+msgstr "Point de vue "
+
+msgid "<i>Autofaehre</i>"
+msgstr "Bac pour véhicule"
+
+msgid "<i>Bildstock</i>"
+msgstr "Oratoire"
+
+msgid "<i>Bobbahn</i>"
+msgstr "Piste de bob"
+
+msgid "<i>Brunnen</i>"
+msgstr "Fontaine"
+
+msgid "<i>Campingplatzareal</i>"
+msgstr "Terrain de camping"
+
+msgid "<i>Denkmal</i>"
+msgstr "Mémorial"
+
+msgid "<i>Deponieareal</i>"
+msgstr "Décharge"
+
+msgid "<i>Ein- und Ausfahrt</i>"
+msgstr "Entrée et sortie"
+
+msgid "<i>Erratischer Block</i>"
+msgstr "Bloc erratique"
+
+msgid "<i>Felsblock</i>"
+msgstr "Bloc de rocher"
+
+msgid "<i>Felskopf</i>"
+msgstr "Tête de rocher"
+
+msgid "<i>Fliessgewaesser</i>"
+msgstr "Cours d’eau"
+
+msgid "<i>Flugfeldareal</i>"
+msgstr "Champ d'aviation"
+
+msgid "<i>Flughafenareal</i>"
+msgstr "Aéroport"
+
+msgid "<i>Flugplatzareal</i>"
+msgstr "Aérodrome"
+
+msgid "<i>Flurname swisstopo</i>"
+msgstr "Lieu-dit swisstopo"
+
+msgid "<i>Freizeitanlagenareal</i>"
+msgstr "Parc de loisir "
+
+msgid "<i>Friedhof</i>"
+msgstr "Cimetière"
+
+msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Bâtiment"
+
+msgid "<i>Gebiet</i>"
+msgstr "Territoire"
+
+msgid "<i>Gipfel</i>"
+msgstr "Sommet"
+
+msgid "<i>Gletscher</i>"
+msgstr "Glacier"
+
+msgid "<i>Golfplatzareal</i>"
+msgstr "Terrain de golf"
+
+msgid "<i>Gondelbahn</i>"
+msgstr "Télécabine"
+
+msgid "<i>Graben</i>"
+msgstr "Fossé"
+
+msgid "<i>Grat</i>"
+msgstr "Crête"
+
+msgid "<i>Grossregion</i>"
+msgstr "Grande région"
+
+msgid "<i>Grotte, Hoehle</i>"
+msgstr "Grotte"
+
+msgid "<i>Haltestelle Bahn</i>"
+msgstr "Arrêt de chemin de fer"
+
+msgid "<i>Haltestelle Bus</i>"
+msgstr "Arrêt de bus"
+
+msgid "<i>Haltestelle Schiff</i>"
+msgstr "Arrêt de bateau"
+
+msgid "<i>Hauptgipfel</i>"
+msgstr "Sommet principal"
+
+msgid "<i>Haupthuegel</i>"
+msgstr "Colline principale"
+
+msgid "<i>Haupttal</i>"
+msgstr "Vallée majeur"
+
+msgid "<i>Heliport</i>"
+msgstr "Héliport"
+
+msgid "<i>Historisches Areal</i>"
+msgstr "Site historique"
+
+msgid "<i>Huegel</i>"
+msgstr "Colline"
+
+msgid "<i>Huegelzug</i>"
+msgstr "Groupe de collines"
+
+msgid "<i>Kapelle</i>"
+msgstr "Chapelle"
+
+msgid "<i>Kehrichtverbrennungsareal</i>"
+msgstr "Usine d'incinération des déchets"
+
+msgid "<i>Kleinbahn</i>"
+msgstr "Petit train"
+
+msgid "<i>Klosterareal</i>"
+msgstr "Site de couvent"
+
+msgid "<i>Kraftwerkareal</i>"
+msgstr "Centrale électrique"
+
+msgid "<i>Landesgrenzstein</i>"
+msgstr "Borne de frontière"
+
+msgid "<i>Landschaftsname</i>"
+msgstr "Paysage"
+
+msgid "<i>Lokalname swisstopo</i>"
+msgstr "Nom local swisstopo"
+
+msgid "<i>Luftseilbahn</i>"
+msgstr "Téléphérique"
+
+msgid "<i>Massiv</i>"
+msgstr "Massif"
+
+msgid "<i>Massnahmenvollzugsanstaltsareal</i>"
+msgstr "Etablissement d'exécution des peines."
+
+msgid "<i>Messeareal</i>"
+msgstr "Zone d'exposition"
+
+msgid "<i>Normalspur</i>"
+msgstr "Voie normale"
+
+msgid "<i>Oeffentliches Parkareal</i>"
+msgstr "Parc public"
+
+msgid "<i>Oeffentliches Parkplatzareal</i>"
+msgstr "Place de stationnement publique"
+
+msgid "<i>Offenes Gebaeude</i>"
+msgstr "Bâtiment ouvert"
+
+msgid "<i>Ort</i>"
+msgstr "Lieu"
+
+msgid "<i>Ortsteil</i>"
+msgstr "Partie de lieu"
+
+msgid "<i>Pass</i>"
+msgstr "Col"
+
+msgid "<i>Personenfaehre mit Seil</i>"
+msgstr "Bac avec corde"
+
+msgid "<i>Personenfaehre ohne Seil</i>"
+msgstr "Bac sans corde"
+
+msgid "<i>Pferderennbahnareal</i>"
+msgstr "Hippodrome"
+
+msgid "<i>Quartier</i>"
+msgstr "Quartier"
+
+msgid "<i>Quartierteil</i>"
+msgstr "Partie de quartier"
+
+msgid "<i>Quelle</i>"
+msgstr "Source"
+
+msgid "<i>Rastplatzareal</i>"
+msgstr "Aire de repos"
+
+msgid "<i>Rodelbahn</i>"
+msgstr "Piste de luge"
+
+msgid "<i>Sakrales Gebaeude</i>"
+msgstr "Bâtiment religieux"
+
+msgid "<i>Schmalspur</i>"
+msgstr "Voie étroite"
+
+msgid "<i>Schul- und Hochschulareal</i>"
+msgstr "Ecole"
+
+msgid "<i>Schwimmbadareal</i>"
+msgstr "Piscine"
+
+msgid "<i>See</i>"
+msgstr "Lac"
+
+msgid "<i>Seeinsel</i>"
+msgstr "Ile de lac"
+
+msgid "<i>Seeteil</i>"
+msgstr "Partie de lac"
+
+msgid "<i>Sesselbahn</i>"
+msgstr "Télésiège"
+
+msgid "<i>Skilift</i>"
+msgstr "Skilift"
+
+msgid "<i>Skisprungschanze</i>"
+msgstr "Tremplin de saut à ski"
+
+msgid "<i>Spitalareal</i>"
+msgstr "Hôpital"
+
+msgid "<i>Sportplatzareal</i>"
+msgstr "Terrain de sport"
+
+msgid "<i>Standplatzareal</i>"
+msgstr "Aire avec mobile-homes fixes"
+
+msgid "<i>Staudamm</i>"
+msgstr "Digue de retenue d'eau"
+
+msgid "<i>Staumauer</i>"
+msgstr "Barrage"
+
+msgid "<i>Strasse</i>"
+msgstr "Route"
+
+msgid "<i>Strassenpass</i>"
+msgstr "Col routier"
+
+msgid "<i>Tal</i>"
+msgstr "Vallée"
+
+msgid "<i>Transportseil</i>"
+msgstr "Téléphérique pour matériel"
+
+msgid "<i>Truppenuebungsplatz</i>"
+msgstr "Place d'entraînement militaire"
+
+msgid "<i>Turm</i>"
+msgstr "Tour"
+
+msgid "<i>Uebrige Bahnen</i>"
+msgstr "Autres moyens de transport"
+
+msgid "<i>Unterwerkareal</i>"
+msgstr "Station de transformation électrique"
+
+msgid "<i>Verzweigung</i>"
+msgstr "Echangeur"
+
+msgid "<i>Wasserfall</i>"
+msgstr "Chute d'eau"
+
+msgid "<i>Wehr</i>"
+msgstr "Ecluse"
+
+msgid "<i>Zollamt 24h 24h</i>"
+msgstr "Bureau de douane  24h 24h"
+
+msgid "<i>Zollamt 24h eingeschraenkt</i>"
+msgstr "Bureau de douane 24h restreint"
+
+msgid "<i>Zollamt eingeschraenkt</i>"
+msgstr "Bureau de douane restreint"
+
+msgid "<i>Zooareal</i>"
+msgstr "Zoo"
+
 msgid "ABS_landesschwerenetz_type"
 msgstr "station absolue"
 

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -122,6 +122,57 @@ msgstr "Fermata del bus"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Fermata del battello"
 
+msgid "<i>Haltestellen Bus</i>"
+msgstr "Autobus"
+
+msgid "<i>Haltestellen Bus_Tram</i>"
+msgstr "Autobus, tram"
+
+msgid "<i>Haltestellen Lift</i>"
+msgstr "Ascensore"
+
+msgid "<i>Haltestellen Luftseilbahn</i>"
+msgstr "Funivia"
+
+msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
+msgstr "Funivia, ferrovia"
+
+msgid "<i>Haltestellen Metro</i>"
+msgstr "Metropolitana"
+
+msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
+msgstr "Punto operativo semplice"
+
+msgid "<i>Haltestellen Schiff</i>"
+msgstr "Battello"
+
+msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
+msgstr "Battello e ferrovia a cremagliera"
+
+msgid "<i>Haltestellen Standseilbahn</i>"
+msgstr "Funicolare"
+
+msgid "<i>Haltestellen Standseilbahn_Bus</i>"
+msgstr "Funicolare, autobus"
+
+msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
+msgstr "Funicolare, funivia"
+
+msgid "<i>Haltestellen Standseilbahn_Zug</i>"
+msgstr "Funicolare, ferrovia"
+
+msgid "<i>Haltestellen Tram</i>"
+msgstr "Tram"
+
+msgid "<i>Haltestellen Zahnradbahn</i>"
+msgstr "Ferrovia a cremagliera"
+
+msgid "<i>Haltestellen Zug</i>"
+msgstr "Ferrovia"
+
+msgid "<i>Haltestellen Zug_Tram</i>"
+msgstr "Ferrovia, tram"
+
 msgid "<i>Hauptgipfel</i>"
 msgstr "Cima principale"
 

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -17,6 +17,303 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 0.9.5\n"
 
+msgid "<i>Abwasserreinigungsareal</i>"
+msgstr "Depuratore"
+
+msgid "<i>Alpiner Gipfel</i>"
+msgstr "Cima alpina"
+
+msgid "<i>Ausfahrt</i>"
+msgstr "Uscita"
+
+msgid "<i>Aussichtspunkt</i>"
+msgstr "Punto panoramico"
+
+msgid "<i>Autofaehre</i>"
+msgstr "Traghetto"
+
+msgid "<i>Bildstock</i>"
+msgstr "Oratorio"
+
+msgid "<i>Bobbahn</i>"
+msgstr "Pista da bob"
+
+msgid "<i>Brunnen</i>"
+msgstr "Fontana"
+
+msgid "<i>Campingplatzareal</i>"
+msgstr "Campeggio"
+
+msgid "<i>Denkmal</i>"
+msgstr "Memoriale"
+
+msgid "<i>Deponieareal</i>"
+msgstr "Discarica"
+
+msgid "<i>Ein- und Ausfahrt</i>"
+msgstr "Entrata e uscita"
+
+msgid "<i>Erratischer Block</i>"
+msgstr "Blocco erratico"
+
+msgid "<i>Felsblock</i>"
+msgstr "Masso di roccia"
+
+msgid "<i>Felskopf</i>"
+msgstr "Sperone di roccia"
+
+msgid "<i>Fliessgewaesser</i>"
+msgstr "Corso d'acqua"
+
+msgid "<i>Flugfeldareal</i>"
+msgstr "Campi d'aviazione"
+
+msgid "<i>Flughafenareal</i>"
+msgstr "Aereoporto"
+
+msgid "<i>Flugplatzareal</i>"
+msgstr "Aerodromo"
+
+msgid "<i>Flurname swisstopo</i>"
+msgstr "Nomi di zone"
+
+msgid "<i>Freizeitanlagenareal</i>"
+msgstr "Parco giochi"
+
+msgid "<i>Friedhof</i>"
+msgstr "Cimitero"
+
+msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Edificio"
+
+msgid "<i>Gebiet</i>"
+msgstr "Territorio"
+
+msgid "<i>Gipfel</i>"
+msgstr "Cima"
+
+msgid "<i>Gletscher</i>"
+msgstr "Ghiacciaio"
+
+msgid "<i>Golfplatzareal</i>"
+msgstr "Campo da golf"
+
+msgid "<i>Gondelbahn</i>"
+msgstr "Telecabina"
+
+msgid "<i>Graben</i>"
+msgstr "Fossato"
+
+msgid "<i>Grat</i>"
+msgstr "Cresta"
+
+msgid "<i>Grossregion</i>"
+msgstr "Grande regione"
+
+msgid "<i>Grotte, Hoehle</i>"
+msgstr "Grotta"
+
+msgid "<i>Haltestelle Bahn</i>"
+msgstr "Fermata del treno"
+
+msgid "<i>Haltestelle Bus</i>"
+msgstr "Fermata del bus"
+
+msgid "<i>Haltestelle Schiff</i>"
+msgstr "Fermata del battello"
+
+msgid "<i>Hauptgipfel</i>"
+msgstr "Cima principale"
+
+msgid "<i>Haupthuegel</i>"
+msgstr "Collina principale"
+
+msgid "<i>Haupttal</i>"
+msgstr "Valle maggiore"
+
+msgid "<i>Heliport</i>"
+msgstr "Eliporto"
+
+msgid "<i>Historisches Areal</i>"
+msgstr "Sito storico"
+
+msgid "<i>Huegel</i>"
+msgstr "Collina "
+
+msgid "<i>Huegelzug</i>"
+msgstr "Gruppo di colline"
+
+msgid "<i>Kapelle</i>"
+msgstr "Cappella"
+
+msgid "<i>Kehrichtverbrennungsareal</i>"
+msgstr "Inceneritore"
+
+msgid "<i>Kleinbahn</i>"
+msgstr "Piccolo treno"
+
+msgid "<i>Klosterareal</i>"
+msgstr "Convento"
+
+msgid "<i>Kraftwerkareal</i>"
+msgstr "Centrale elettrica"
+
+msgid "<i>Landesgrenzstein</i>"
+msgstr "Cippo di confine"
+
+msgid "<i>Landschaftsname</i>"
+msgstr "Regione"
+
+msgid "<i>Lokalname swisstopo</i>"
+msgstr "Nome locale swisstopo"
+
+msgid "<i>Luftseilbahn</i>"
+msgstr "Teleferica"
+
+msgid "<i>Massiv</i>"
+msgstr "Massiccio"
+
+msgid "<i>Massnahmenvollzugsanstaltsareal</i>"
+msgstr "Carcere"
+
+msgid "<i>Messeareal</i>"
+msgstr "Fiera"
+
+msgid "<i>Normalspur</i>"
+msgstr "Ferrovia a scartamento normale"
+
+msgid "<i>Oeffentliches Parkareal</i>"
+msgstr "Parco pubblico"
+
+msgid "<i>Oeffentliches Parkplatzareal</i>"
+msgstr "Parcheggio pubblico"
+
+msgid "<i>Offenes Gebaeude</i>"
+msgstr "Edificio aperto"
+
+msgid "<i>Ort</i>"
+msgstr "Luogo"
+
+msgid "<i>Ortsteil</i>"
+msgstr "Quartiere"
+
+msgid "<i>Pass</i>"
+msgstr "Colle"
+
+msgid "<i>Personenfaehre mit Seil</i>"
+msgstr "Traghetto passeggeri a corda"
+
+msgid "<i>Personenfaehre ohne Seil</i>"
+msgstr "Traghetto passeggeri senza corda "
+
+msgid "<i>Pferderennbahnareal</i>"
+msgstr "Ippodromo"
+
+msgid "<i>Quartier</i>"
+msgstr "Quartiere"
+
+msgid "<i>Quartierteil</i>"
+msgstr "Parte di quartiere"
+
+msgid "<i>Quelle</i>"
+msgstr "Fonte"
+
+msgid "<i>Rastplatzareal</i>"
+msgstr "Area di servizio"
+
+msgid "<i>Rodelbahn</i>"
+msgstr "Pista da slitta"
+
+msgid "<i>Sakrales Gebaeude</i>"
+msgstr "Edificio religioso"
+
+msgid "<i>Schmalspur</i>"
+msgstr "Ferrovia a scartamento ridotto"
+
+msgid "<i>Schul- und Hochschulareal</i>"
+msgstr "Scuola"
+
+msgid "<i>Schwimmbadareal</i>"
+msgstr "Piscina"
+
+msgid "<i>See</i>"
+msgstr "lago"
+
+msgid "<i>Seeinsel</i>"
+msgstr "Isola di lago"
+
+msgid "<i>Seeteil</i>"
+msgstr "Parte di lago"
+
+msgid "<i>Sesselbahn</i>"
+msgstr "Seggiovia"
+
+msgid "<i>Skilift</i>"
+msgstr "Sciovia"
+
+msgid "<i>Skisprungschanze</i>"
+msgstr "Trampolino da salto con gli sci"
+
+msgid "<i>Spitalareal</i>"
+msgstr "Ospedale"
+
+msgid "<i>Sportplatzareal</i>"
+msgstr "Campo da sport"
+
+msgid "<i>Standplatzareal</i>"
+msgstr "Zona di stazionamento camper"
+
+msgid "<i>Staudamm</i>"
+msgstr "Diga di ritenzione idrica"
+
+msgid "<i>Staumauer</i>"
+msgstr "Diga"
+
+msgid "<i>Strasse</i>"
+msgstr "Strada"
+
+msgid "<i>Strassenpass</i>"
+msgstr "Passo"
+
+msgid "<i>Tal</i>"
+msgstr "Valle"
+
+msgid "<i>Transportseil</i>"
+msgstr "Teleferica per materiale"
+
+msgid "<i>Truppenuebungsplatz</i>"
+msgstr "Pizza d'armi"
+
+msgid "<i>Turm</i>"
+msgstr "Torre"
+
+msgid "<i>Uebrige Bahnen</i>"
+msgstr "Altri mezzi di trasporto"
+
+msgid "<i>Unterwerkareal</i>"
+msgstr "Stazione di trasformazione elettrica"
+
+msgid "<i>Verzweigung</i>"
+msgstr "Svincolo"
+
+msgid "<i>Wasserfall</i>"
+msgstr "Cascata"
+
+msgid "<i>Wehr</i>"
+msgstr "Chiusa"
+
+msgid "<i>Zollamt 24h 24h</i>"
+msgstr "Ufficio doganale 24h 24h"
+
+msgid "<i>Zollamt 24h eingeschraenkt</i>"
+msgstr "Ufficio doganale 24h limitato"
+
+msgid "<i>Zollamt eingeschraenkt</i>"
+msgstr "Ufficio doganale limitato"
+
+msgid "<i>Zooareal</i>"
+msgstr "Zoo"
+
 msgid "ABS_landesschwerenetz_type"
 msgstr "station absolue"
 

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -73,6 +73,11 @@ class Search(SearchValidation):
             )
             # swiss search
             self._swiss_search()
+            # translate some gazetteer categories from swissnames3 tagged with <i>...</i> in the label attribute of the response
+            for key, value in enumerate(self.results['results']):
+                translation = re.search(r'.*(<i>[\s\S]*?<\/i>).*', value['attrs']['label']) or False
+                if translation:
+                    self.results['results'][key]['attrs']['label'] = value['attrs']['label'].replace(translation.group(1), '<i>%s</i>' % str(self.request.translate(translation.group(1)).encode('utf-8')))
         return self.results
 
     def _fuzzy_search(self, searchTextFinal):


### PR DESCRIPTION
this pull request will add the translation of the swissnames tlm object categories.
there are some lines of code who will translate ``<i>...</i>`` from the label attribute of the swisssearch result.
@gjn please review this part, it is for sure not the best solution.