### PR TITLE
Fixing station board tests

### DIFF
--- a/chsdi/tests/integration/test_stationboard.py
+++ b/chsdi/tests/integration/test_stationboard.py
@@ -30,12 +30,6 @@ class TestStationboard(TestsBase):
         resp = self.testapp.get('/stationboard/stops/8501120', params=params, status=400)
         resp.mustcontain('The limit parameter must be an integer')
 
-    def test_stationboard_max_limit(self):
-        params = {'limit': '50'}
-        resp = self.testapp.get('/stationboard/stops/8501120', params=params, status=200)
-        self.assertTrue(resp.content_type == 'application/json')
-        self.assertTrue(len(resp.json) == 20)
-
     def test_available_destinations(self):
         resp = self.testapp.get('/stationboard/stops/8500109/destinations', status=200)
         self.assertTrue(resp.content_type == 'application/json')


### PR DESCRIPTION
The test failed now (result was 19 and not 20), so it seems that it's not a stable test. (which could be because we update the data on a regular basis.

@pfanguin @loicgasser Could a re-add a more stable test. (Also, the limit parameter is not really tested because we test not if 50 is the limit here).