### PR TITLE
[WIP] Add 3config support in layers configuration service

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -86,29 +86,29 @@ class LayersConfig(Base):
     geojsonUrlit = Column('geojson_url_it', Text)
     geojsonUrlrm = Column('geojson_url_rm', Text)
     geojsonUrlen = Column('geojson_url_en', Text)
+    config3d = Column('fk_config3d', Boolean)
+    srid = Column('srid', Text)
 
     def layerConfig(self, params):
         config = {}
         translate = params.translate
-        excludedAttrs = ('geojsonUrlde', 'geojsonUrlfr', 'geojsonUrlit', 'geojsonUrlrm', 'geojsonUrlen')
         wmsHost = params.request.registry.settings['wmshost']
         for k in self.__dict__.keys():
-            if not k.startswith("_") and k not in excludedAttrs and \
-                self.__dict__[k] is not None and \
-                    k not in ('staging'):
+            val = self.__dict__[k]
+            if not k.startswith("_") and not k.startswith('geojsonUrl') and \
+                    val is not None and k not in ('staging', 'srid'):
                 if k == 'maps':
-                    config['topics'] = self.__dict__[k]
+                    config['topics'] = val
                 elif k == 'layerBodId':
-                    config['label'] = translate(self.__dict__[k])
+                    config['label'] = translate(val)
                 elif k == 'attribution':
-                    config[k] = translate(self.__dict__[k])
-                elif k == 'matrixSet':
-                    if self.__dict__[k] != '21781_26':
-                        config['resolutions'] = self._getResolutionsFromMatrixSet(
-                            self.__dict__[k]
-                        )
+                    config[k] = translate(val)
+                elif k == 'matrixSet' and self.__dict__['srid'] != '4326':
+                    config['resolutions'] = self._getResolutionsFromMatrixSet(
+                        val
+                    )
                 else:
-                    config[k] = self.__dict__[k]
+                    config[k] = val
 
         layerStaging = self.__dict__['staging']
         if config['type'] == 'wmts':

--- a/chsdi/static/doc/source/api/faq/index.rst
+++ b/chsdi/static/doc/source/api/faq/index.rst
@@ -81,6 +81,7 @@ Here is a list of all the freely accessible layers:
    <script type="text/javascript">
 
    function init() {
+       var suffix3d = '_3d';
        $.getJSON( "../../rest/services/api/MapServer/layersConfig", function( data ) {
           var myInnerHtml_queryable = "<br><table border=\"0\">";
           var myInnerHtml_searchable =  "<br><table border=\"0\">";
@@ -88,7 +89,7 @@ Here is a list of all the freely accessible layers:
           var counterQueryable = 1;
           var counterSearchable = 1;
           for (var layer in layers_api) {
-            if (!layers_api[layer].parentLayerId) {
+            if (!layers_api[layer].parentLayerId && layer.indexOf(suffix3d, layer.length - suffix3d.length) == -1) {
               if (layers_api[layer].queryable) {
                 myInnerHtml_queryable += '<tr><td>' + counterQueryable + '</td><td><a href="http://map3.geo.admin.ch/?layers=' +
                   layer + '" target="new"> ' + layer + '</a>&nbsp('+layers_api[layer].label+')</td></tr>';
@@ -117,7 +118,7 @@ Here is a list of all the freely accessible layers:
              layers_notfree.push({'layerBodId': 'ch.swisstopo.swissimage'});
              for (var i = 0; i < layers_notfree.length; i++) {
                 var nflayer = layers_notfree[i];
-                if (layers_api[nflayer.layerBodId] &&
+                if (layers_api[nflayer.layerBodId] && layer.indexOf(suffix3d, layer.length - suffix3d.length) == -1 &&
                     !layers_api[nflayer.layerBodId].parentLayerId) {
                     myInnerHtml_notfree += '<tr><td>' + counterNotFree + '</td><td><a href="http://map3.geo.admin.ch/?layers=' +
                       nflayer.layerBodId + '" target="new"> ' + nflayer.layerBodId + '</a>&nbsp('+layers_api[nflayer.layerBodId].label+')</td></tr>';
@@ -135,7 +136,7 @@ Here is a list of all the freely accessible layers:
              var counterFree = 1;
              for (var i = 0; i < layers_free.length; i++) {
                 var flayer = layers_free[i];
-                if (layers_api[flayer.layerBodId] &&
+                if (layers_api[flayer.layerBodId] && layer.indexOf(suffix3d, layer.length - suffix3d.length) == -1 &&
                    !layers_api[flayer.layerBodId].parentLayerId) {
                     myInnerHtml_free += '<tr><td>' + counterFree + '</td><td><a href="http://map3.geo.admin.ch/?layers=' +
                       flayer.layerBodId + '" target="new"> ' + flayer.layerBodId + '</a>&nbsp('+layers_api[flayer.layerBodId].label+')</td></tr>';

--- a/chsdi/tests/integration/test_layers.py
+++ b/chsdi/tests/integration/test_layers.py
@@ -39,7 +39,8 @@ class LayersChecker(object):
         valNone = None
         query = self.session.query(distinct(LayersConfig.layerBodId)) \
             .filter(LayersConfig.staging == self.staging) \
-            .filter(LayersConfig.parentLayerId == valNone)
+            .filter(LayersConfig.parentLayerId == valNone) \
+            .filter(LayersConfig.srid != '4326')
         if queryable is not None:
             query = query.filter(LayersConfig.queryable == queryable)
         if hasLegend is not None:


### PR DESCRIPTION
@gjn @ltclm (I am using a tem DB and table)
Explicit behaviour:
A 3d config parameter is defined -> use the config for the imagery layer as is (don't extend 2D config)
(Issue with subLayers where we would need to use 2 layers proxy for one layer in WGS84)

Implicit behaviour (nothing in layersconfig):
For WMTS: use MapProxy
For WMS: use CRS=EPSG:4326

Note that I am using the final names and timestamps getting rid of the `.3d` in the `serverLayerName`.

As discussed `opaque` and `has3dMetadata` will remain hardcoded in the mf-geoadmin3 as it will only affect a set of predefined layers. We'll get rid of `extent`.

So you should 4 new layers (which are only proxies similarly to what we have with `_wmts` and `_wms`:
- ch.swisstopo.pixelkarte-farbe_3d (serverLayerName: ch.swisstopo.pixelkarte-farbe)
- ch.swisstopo.pixelkarte-grau_3d (serverLayerName: ch.swisstopo.pixelkarte-grau)
- ch.swisstopo.zeitreihen_3d (serverLayerName: ch.swisstopo.zeitreihen)
- ch.swisstopo.swissimage-product_3d ...

I will copy all the image tiles to the correct address once this has been validated and adapt the code in mf-geoadmin3.

Changes in DB:
In tileset we have now new `tile_matrix_set_id` (e.g. 4326) Note that I did not add all the timestamps for zeitreiheihen. (for testing purposes, in general we want to be able to have a set of different timestamps per `CRS`.

In layers config table: I added 2 new columns
`config3d`
`srid` -> in order to group the layers in tileset using the projection.

Of course I needed to adapt the layers config view where all the magic happens.
Add new entries in tileset, dataset and layers_js.

[Test Link](http://mf-chsdi3.dev.bgdi.ch/gal_3d_layersconf/rest/services/ech/MapServer/layersConfig)