### PR TITLE
Treat distributed indices in sphinx search tests

### DIFF
--- a/chsdi/tests/integration/test_layers.py
+++ b/chsdi/tests/integration/test_layers.py
@@ -89,11 +89,13 @@ class LayersChecker(object):
         models = models_from_name(layer)
         assert (models is not None and len(models) > 0), layer
         model = models[0]
-        query = self.session.query(model.primary_key_column())
         expectedStatus = 200
-        # we expect 404 errors for searchable layers without any data
-        if query.first() is None:
-            expectedStatus = 404
+        # Special treatment for non-distributed sphinx indices (single model)
+        if len(models) == 1:
+            query = self.session.query(model.primary_key_column())
+            # we expect 404 errors for searchable layers without any data (no sphinx index)
+            if query.first() is None:
+                expectedStatus = 404
 
         # If it fails here, it most probably means given layer does not have sphinx index available
         link = '/rest/services/all/SearchServer?features=' + layer + '&bbox=600818.7808825106,197290.49919797093,601161.2808825106,197587.99919797093&type=featuresearch&searchText=dummy'


### PR DESCRIPTION
Latests failures on jenkins jobs are cause by a layer which consists of multiple models. This case is covered by a distributed index in sphinxsearch.

There's a difference in how sphinxsearch treats indices with no content (no data). For single indices, the index is not created at all (even when defined in the config) and completely ignored. For distributed indices, the sub-indices are always created, even though neither of the contains any data. From the point of view of the service this means that a) single indices with no data will return 404 (as no sphinx index is found) but b) distributed indices with no data will return 200, even though there's no data.

This PR tries to address this by checking for 404 only for single indices.

It's probably not the optimal solution, but I think follows the KISS rule for now.