### PR TITLE
Replace httplib with requests in link tests

### DIFF
--- a/chsdi/tests/e2e/test_links.py
+++ b/chsdi/tests/e2e/test_links.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import httplib2
+import requests
 
 from chsdi.tests.integration import TestsBase
 
@@ -8,12 +8,14 @@ from chsdi.tests.integration import TestsBase
 class TestLinks(TestsBase):
 
     def test_external_links(self):
-        h = httplib2.Http(timeout=10)
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.68 Safari/537.36'
+        }
         for i in range(23):
             response = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/%d/htmlPopup' % i, status=200)
 
             soup = response.html
             for a in soup.findAll('a'):
                 link = a.get('href')
-                resp, content = h.request(link, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.68 Safari/537.36'})
-                self.assertTrue(resp.status == 200, link)
+                r = requests.get(link, timeout=10, headers=headers)
+                self.assertTrue(r.status_code == 200, link)


### PR DESCRIPTION
Because https://github.com/geoadmin/mf-chsdi3/pull/1789/files doesn't work with urllib2, so we replace it with requests, and suddenly it works.

@procrastinatio Please review/merge asap as it fixes broken test in master.