### PR TITLE
update translation of haltestellen categories

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -122,57 +122,6 @@ msgstr "Haltestelle Bus"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Haltestelle Schiff"
 
-msgid "<i>Haltestellen Bus</i>"
-msgstr "Bus"
-
-msgid "<i>Haltestellen Bus_Tram</i>"
-msgstr "Bus, Tram"
-
-msgid "<i>Haltestellen Lift</i>"
-msgstr "Lift"
-
-msgid "<i>Haltestellen Luftseilbahn</i>"
-msgstr "Luftseilbahn"
-
-msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
-msgstr "Luftseilbahn, Zug"
-
-msgid "<i>Haltestellen Metro</i>"
-msgstr "Metro"
-
-msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
-msgstr "Reiner Betriebspunkt"
-
-msgid "<i>Haltestellen Schiff</i>"
-msgstr "Schiff"
-
-msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
-msgstr "Schiff, Zahnradbahn"
-
-msgid "<i>Haltestellen Standseilbahn</i>"
-msgstr "Standseilbahn"
-
-msgid "<i>Haltestellen Standseilbahn_Bus</i>"
-msgstr "Standseilbahn, Bus"
-
-msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
-msgstr "Standseilbahn, Luftseilbahn"
-
-msgid "<i>Haltestellen Standseilbahn_Zug</i>"
-msgstr "Standseilbahn, Zug"
-
-msgid "<i>Haltestellen Tram</i>"
-msgstr "Tram"
-
-msgid "<i>Haltestellen Zahnradbahn</i>"
-msgstr "Zahnradbahn"
-
-msgid "<i>Haltestellen Zug</i>"
-msgstr "Zug"
-
-msgid "<i>Haltestellen Zug_Tram</i>"
-msgstr "Zug, Tram"
-
 msgid "<i>Hauptgipfel</i>"
 msgstr "Hauptgipfel"
 
@@ -364,6 +313,75 @@ msgstr "Zollamt eingeschraenkt"
 
 msgid "<i>Zooareal</i>"
 msgstr "Zooareal"
+
+msgid "<i>haltestellen_aufzug</i>"
+msgstr "Lift"
+
+msgid "<i>haltestellen_bus</i>"
+msgstr "Bus"
+
+msgid "<i>haltestellen_bus_luftseilbahn</i>"
+msgstr "Bus, Luftseilbahn"
+
+msgid "<i>haltestellen_bus_schiff</i>"
+msgstr "Bus, Schiff"
+
+msgid "<i>haltestellen_bus_standseilbahn_tram</i>"
+msgstr "Bus, Standseilbahn, Tram"
+
+msgid "<i>haltestellen_bus_tram</i>"
+msgstr "Bus, Tram"
+
+msgid "<i>haltestellen_bus_tram_zug</i>"
+msgstr "Bus, Tram, Zug"
+
+msgid "<i>haltestellen_bus_zug</i>"
+msgstr "Bus, Zug"
+
+msgid "<i>haltestellen_luftseilbahn</i>"
+msgstr "Luftseilbahn"
+
+msgid "<i>haltestellen_luftseilbahn_zug</i>"
+msgstr "Luftseilbahn, Zug"
+
+msgid "<i>haltestellen_metro</i>"
+msgstr "Metro"
+
+msgid "<i>haltestellen_metro_zug</i>"
+msgstr "Metro, Zug"
+
+msgid "<i>haltestellen_schiff</i>"
+msgstr "Schiff"
+
+msgid "<i>haltestellen_schiff_zahnradbahn</i>"
+msgstr "Schiff, Zahnradbahn"
+
+msgid "<i>haltestellen_standseilbahn</i>"
+msgstr "Standseilbahn"
+
+msgid "<i>haltestellen_standseilbahn_bus</i>"
+msgstr "Standseilbahn, Bus"
+
+msgid "<i>haltestellen_standseilbahn_luftseilbahn</i>"
+msgstr "Standseilbahn, Luftseilbahn"
+
+msgid "<i>haltestellen_standseilbahn_zug</i>"
+msgstr "Standseilbahn, Zug"
+
+msgid "<i>haltestellen_tram</i>"
+msgstr "Tram"
+
+msgid "<i>haltestellen_tram_bus_zahnradbahn</i>"
+msgstr "Tram, Bus"
+
+msgid "<i>haltestellen_zahnradbahn</i>"
+msgstr "Zahnradbahn"
+
+msgid "<i>haltestellen_zug</i>"
+msgstr "Zug"
+
+msgid "<i>haltestellen_zug_tram</i>"
+msgstr "Zug, Tram"
 
 msgid "ABS_landesschwerenetz_type"
 msgstr "Absolutstation"

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -7506,53 +7506,71 @@ msgstr ""
 msgid "<i>Zooareal</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Bus</i>"
+msgid "<i>haltestellen_aufzug</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Bus_Tram</i>"
+msgid "<i>haltestellen_bus</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Lift</i>"
+msgid "<i>haltestellen_bus_luftseilbahn</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Luftseilbahn</i>"
+msgid "<i>haltestellen_bus_schiff</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
+msgid "<i>haltestellen_bus_standseilbahn_tram</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Metro</i>"
+msgid "<i>haltestellen_bus_tram</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
+msgid "<i>haltestellen_bus_tram_zug</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Schiff</i>"
+msgid "<i>haltestellen_bus_zug</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
+msgid "<i>haltestellen_luftseilbahn</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Standseilbahn_Bus</i>"
+msgid "<i>haltestellen_luftseilbahn_zug</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Standseilbahn</i>"
+msgid "<i>haltestellen_metro</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
+msgid "<i>haltestellen_metro_zug</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Standseilbahn_Zug</i>"
+msgid "<i>haltestellen_schiff</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Tram</i>"
+msgid "<i>haltestellen_schiff_zahnradbahn</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Zahnradbahn</i>"
+msgid "<i>haltestellen_standseilbahn_bus</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Zug</i>"
+msgid "<i>haltestellen_standseilbahn</i>"
 msgstr ""
 
-msgid "<i>Haltestellen Zug_Tram</i>"
+msgid "<i>haltestellen_standseilbahn_luftseilbahn</i>"
+msgstr ""
+
+msgid "<i>haltestellen_standseilbahn_zug</i>"
+msgstr ""
+
+msgid "<i>haltestellen_tram_bus_zahnradbahn</i>"
+msgstr ""
+
+msgid "<i>haltestellen_tram</i>"
+msgstr ""
+
+msgid "<i>haltestellen_zahnradbahn</i>"
+msgstr ""
+
+msgid "<i>haltestellen_zug</i>"
+msgstr ""
+
+msgid "<i>haltestellen_zug_tram</i>"
 msgstr ""

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -122,57 +122,6 @@ msgstr "Bus stop"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Ship stop"
 
-msgid "<i>Haltestellen Bus</i>"
-msgstr "Bus"
-
-msgid "<i>Haltestellen Bus_Tram</i>"
-msgstr "Bus, Tram"
-
-msgid "<i>Haltestellen Lift</i>"
-msgstr "Lift"
-
-msgid "<i>Haltestellen Luftseilbahn</i>"
-msgstr "Cablecar"
-
-msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
-msgstr "Cablecar, train"
-
-msgid "<i>Haltestellen Metro</i>"
-msgstr "Metro"
-
-msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
-msgstr "Simple operating point"
-
-msgid "<i>Haltestellen Schiff</i>"
-msgstr "Boat"
-
-msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
-msgstr "Boat, rack railway"
-
-msgid "<i>Haltestellen Standseilbahn</i>"
-msgstr "Funicular"
-
-msgid "<i>Haltestellen Standseilbahn_Bus</i>"
-msgstr "Funicular, bus"
-
-msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
-msgstr "Funicular, cableway"
-
-msgid "<i>Haltestellen Standseilbahn_Zug</i>"
-msgstr "Funicular, train"
-
-msgid "<i>Haltestellen Tram</i>"
-msgstr "Tram"
-
-msgid "<i>Haltestellen Zahnradbahn</i>"
-msgstr "Rack railway"
-
-msgid "<i>Haltestellen Zug</i>"
-msgstr "Train"
-
-msgid "<i>Haltestellen Zug_Tram</i>"
-msgstr "Train, tram"
-
 msgid "<i>Hauptgipfel</i>"
 msgstr "Main peak"
 
@@ -364,6 +313,75 @@ msgstr "Costume office restricted"
 
 msgid "<i>Zooareal</i>"
 msgstr "Zoo"
+
+msgid "<i>haltestellen_aufzug</i>"
+msgstr "Lift"
+
+msgid "<i>haltestellen_bus</i>"
+msgstr "Bus"
+
+msgid "<i>haltestellen_bus_luftseilbahn</i>"
+msgstr "Bus, cablecar"
+
+msgid "<i>haltestellen_bus_schiff</i>"
+msgstr "Bus, boat"
+
+msgid "<i>haltestellen_bus_standseilbahn_tram</i>"
+msgstr "Bus, funicular, tram"
+
+msgid "<i>haltestellen_bus_tram</i>"
+msgstr "Bus, tram"
+
+msgid "<i>haltestellen_bus_tram_zug</i>"
+msgstr "Bus, tram, train"
+
+msgid "<i>haltestellen_bus_zug</i>"
+msgstr "Bus, train"
+
+msgid "<i>haltestellen_luftseilbahn</i>"
+msgstr "Cablecar"
+
+msgid "<i>haltestellen_luftseilbahn_zug</i>"
+msgstr "Cablecar, train"
+
+msgid "<i>haltestellen_metro</i>"
+msgstr "Metro"
+
+msgid "<i>haltestellen_metro_zug</i>"
+msgstr "Metro, train"
+
+msgid "<i>haltestellen_schiff</i>"
+msgstr "Boat"
+
+msgid "<i>haltestellen_schiff_zahnradbahn</i>"
+msgstr "Boat, rack railway"
+
+msgid "<i>haltestellen_standseilbahn</i>"
+msgstr "Funicular"
+
+msgid "<i>haltestellen_standseilbahn_bus</i>"
+msgstr "Funicular, bus"
+
+msgid "<i>haltestellen_standseilbahn_luftseilbahn</i>"
+msgstr "Funicular, cableway"
+
+msgid "<i>haltestellen_standseilbahn_zug</i>"
+msgstr "Funicular, train"
+
+msgid "<i>haltestellen_tram</i>"
+msgstr "Tram"
+
+msgid "<i>haltestellen_tram_bus_zahnradbahn</i>"
+msgstr "Tram, bus"
+
+msgid "<i>haltestellen_zahnradbahn</i>"
+msgstr "Rack railway"
+
+msgid "<i>haltestellen_zug</i>"
+msgstr "Train"
+
+msgid "<i>haltestellen_zug_tram</i>"
+msgstr "Train, tram"
 
 msgid "ABS_landesschwerenetz_type"
 msgstr "absolute station"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -122,58 +122,6 @@ msgstr "Fermada da bus "
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Fermada da nav"
 
-msgid "<i>Haltestellen Bus</i>"
-msgstr "Bus"
-
-msgid "<i>Haltestellen Bus_Tram</i>"
-msgstr "Bus, tram"
-
-msgid "<i>Haltestellen Lift</i>"
-msgstr "Lift"
-
-msgid "<i>Haltestellen Luftseilbahn</i>"
-msgstr "Luftseilbahn"
-
-msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
-msgstr "Luftseilbahn, Zug"
-
-msgid "<i>Haltestellen Metro</i>"
-msgstr "Metro"
-
-msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
-msgstr "Reiner Betriebspunkt"
-
-msgid "<i>Haltestellen Schiff</i>"
-msgstr "Schiff"
-
-msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
-msgstr "Schiff, Zahnradbahn"
-
-msgid "<i>Haltestellen Standseilbahn</i>"
-msgstr "Standseilbahn"
-
-msgid "<i>Haltestellen Standseilbahn_Bus</i>"
-msgstr "Standseilbahn, Bus"
-
-msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
-msgstr "Standseilbahn, Luftseilbahn"
-
-msgid "<i>Haltestellen Standseilbahn_Zug</i>"
-msgstr "Standseilbahn, Zug"
-
-msgid "<i>Haltestellen Tram</i>"
-msgstr "Tram"
-
-msgid "<i>Haltestellen Zahnradbahn</i>"
-msgstr "Zahnradbahn
-"
-
-msgid "<i>Haltestellen Zug</i>"
-msgstr "Zug"
-
-msgid "<i>Haltestellen Zug_Tram</i>"
-msgstr "Zug, Tram"
-
 msgid "<i>Hauptgipfel</i>"
 msgstr "Piz principal"
 
@@ -365,6 +313,75 @@ msgstr "Uffizi da dazi  limità"
 
 msgid "<i>Zooareal</i>"
 msgstr "Zoo"
+
+msgid "<i>haltestellen_aufzug</i>"
+msgstr "Lift"
+
+msgid "<i>haltestellen_bus</i>"
+msgstr "Bus"
+
+msgid "<i>haltestellen_bus_luftseilbahn</i>"
+msgstr "Bus, Luftseilbahn"
+
+msgid "<i>haltestellen_bus_schiff</i>"
+msgstr "Bus, Schiff"
+
+msgid "<i>haltestellen_bus_standseilbahn_tram</i>"
+msgstr "Bus, Standseilbahn, Tram"
+
+msgid "<i>haltestellen_bus_tram</i>"
+msgstr "Bus, Tram"
+
+msgid "<i>haltestellen_bus_tram_zug</i>"
+msgstr "Bus, Tram, Zug"
+
+msgid "<i>haltestellen_bus_zug</i>"
+msgstr "Bus, Zug"
+
+msgid "<i>haltestellen_luftseilbahn</i>"
+msgstr "Luftseilbahn"
+
+msgid "<i>haltestellen_luftseilbahn_zug</i>"
+msgstr "Luftseilbahn, Zug"
+
+msgid "<i>haltestellen_metro</i>"
+msgstr "Metro"
+
+msgid "<i>haltestellen_metro_zug</i>"
+msgstr "Metro, Zug"
+
+msgid "<i>haltestellen_schiff</i>"
+msgstr "Schiff"
+
+msgid "<i>haltestellen_schiff_zahnradbahn</i>"
+msgstr "Schiff, Zahnradbahn"
+
+msgid "<i>haltestellen_standseilbahn</i>"
+msgstr "Standseilbahn"
+
+msgid "<i>haltestellen_standseilbahn_bus</i>"
+msgstr "Standseilbahn, Bus"
+
+msgid "<i>haltestellen_standseilbahn_luftseilbahn</i>"
+msgstr "Standseilbahn, Luftseilbahn"
+
+msgid "<i>haltestellen_standseilbahn_zug</i>"
+msgstr "Standseilbahn, Zug"
+
+msgid "<i>haltestellen_tram</i>"
+msgstr "Tram"
+
+msgid "<i>haltestellen_tram_bus_zahnradbahn</i>"
+msgstr "Tram, Bus"
+
+msgid "<i>haltestellen_zahnradbahn</i>"
+msgstr "Zahnradbahn"
+
+msgid "<i>haltestellen_zug</i>"
+msgstr "Zug"
+
+msgid "<i>haltestellen_zug_tram</i>"
+msgstr "Zug, Tram"
 
 msgid "ABS_landesschwerenetz_type"
 msgstr "Absolutstation"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -122,57 +122,6 @@ msgstr "Arrêt de bus"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Arrêt de bateau"
 
-msgid "<i>Haltestellen Bus</i>"
-msgstr "Bus"
-
-msgid "<i>Haltestellen Bus_Tram</i>"
-msgstr "Bus, Tram"
-
-msgid "<i>Haltestellen Lift</i>"
-msgstr "Ascenseur"
-
-msgid "<i>Haltestellen Luftseilbahn</i>"
-msgstr "Téléphérique"
-
-msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
-msgstr "Téléphérique, chemin de fer"
-
-msgid "<i>Haltestellen Metro</i>"
-msgstr "Métro"
-
-msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
-msgstr "Point d’exploitation simple"
-
-msgid "<i>Haltestellen Schiff</i>"
-msgstr "Bateau"
-
-msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
-msgstr "Bateau, chemin de fer à crémaillère"
-
-msgid "<i>Haltestellen Standseilbahn</i>"
-msgstr "Funiculaire"
-
-msgid "<i>Haltestellen Standseilbahn_Bus</i>"
-msgstr "Funiculaire, bus"
-
-msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
-msgstr "Funiculaire, téléphérique"
-
-msgid "<i>Haltestellen Standseilbahn_Zug</i>"
-msgstr "Funiculaire, chemin de fer"
-
-msgid "<i>Haltestellen Tram</i>"
-msgstr "Tram"
-
-msgid "<i>Haltestellen Zahnradbahn</i>"
-msgstr "Chemin de fer à crémaillère"
-
-msgid "<i>Haltestellen Zug</i>"
-msgstr "Chemin de fer"
-
-msgid "<i>Haltestellen Zug_Tram</i>"
-msgstr "Chemin de ter, tram"
-
 msgid "<i>Hauptgipfel</i>"
 msgstr "Sommet principal"
 
@@ -364,6 +313,75 @@ msgstr "Bureau de douane restreint"
 
 msgid "<i>Zooareal</i>"
 msgstr "Zoo"
+
+msgid "<i>haltestellen_aufzug</i>"
+msgstr "Ascenseur"
+
+msgid "<i>haltestellen_bus</i>"
+msgstr "Bus"
+
+msgid "<i>haltestellen_bus_luftseilbahn</i>"
+msgstr "Bus, téléphérique"
+
+msgid "<i>haltestellen_bus_schiff</i>"
+msgstr "Bus, bateau"
+
+msgid "<i>haltestellen_bus_standseilbahn_tram</i>"
+msgstr "Bus, funiculaire, tram"
+
+msgid "<i>haltestellen_bus_tram</i>"
+msgstr "Bus, tram"
+
+msgid "<i>haltestellen_bus_tram_zug</i>"
+msgstr "Bus, tram, chemin de fer"
+
+msgid "<i>haltestellen_bus_zug</i>"
+msgstr "Bus, chemin de fer"
+
+msgid "<i>haltestellen_luftseilbahn</i>"
+msgstr "Téléphérique"
+
+msgid "<i>haltestellen_luftseilbahn_zug</i>"
+msgstr "Téléphérique, chemin de fer"
+
+msgid "<i>haltestellen_metro</i>"
+msgstr "Métro"
+
+msgid "<i>haltestellen_metro_zug</i>"
+msgstr "Métro, chemin de fer"
+
+msgid "<i>haltestellen_schiff</i>"
+msgstr "Bateau"
+
+msgid "<i>haltestellen_schiff_zahnradbahn</i>"
+msgstr "Bateau, chemin de fer à crémaillère"
+
+msgid "<i>haltestellen_standseilbahn</i>"
+msgstr "Funiculaire"
+
+msgid "<i>haltestellen_standseilbahn_bus</i>"
+msgstr "Funiculaire, bus"
+
+msgid "<i>haltestellen_standseilbahn_luftseilbahn</i>"
+msgstr "Funiculaire, téléphérique"
+
+msgid "<i>haltestellen_standseilbahn_zug</i>"
+msgstr "Funiculaire, chemin de fer"
+
+msgid "<i>haltestellen_tram</i>"
+msgstr "Tram"
+
+msgid "<i>haltestellen_tram_bus_zahnradbahn</i>"
+msgstr "Tram, bus"
+
+msgid "<i>haltestellen_zahnradbahn</i>"
+msgstr "Chemin de fer à crémaillère"
+
+msgid "<i>haltestellen_zug</i>"
+msgstr "Chemin de fer"
+
+msgid "<i>haltestellen_zug_tram</i>"
+msgstr "Chemin de fer, tram"
 
 msgid "ABS_landesschwerenetz_type"
 msgstr "station absolue"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -122,57 +122,6 @@ msgstr "Fermata del bus"
 msgid "<i>Haltestelle Schiff</i>"
 msgstr "Fermata del battello"
 
-msgid "<i>Haltestellen Bus</i>"
-msgstr "Autobus"
-
-msgid "<i>Haltestellen Bus_Tram</i>"
-msgstr "Autobus, tram"
-
-msgid "<i>Haltestellen Lift</i>"
-msgstr "Ascensore"
-
-msgid "<i>Haltestellen Luftseilbahn</i>"
-msgstr "Funivia"
-
-msgid "<i>Haltestellen Luftseilbahn_Zug</i>"
-msgstr "Funivia, ferrovia"
-
-msgid "<i>Haltestellen Metro</i>"
-msgstr "Metropolitana"
-
-msgid "<i>Haltestellen Reiner Betriebspunkt</i>"
-msgstr "Punto operativo semplice"
-
-msgid "<i>Haltestellen Schiff</i>"
-msgstr "Battello"
-
-msgid "<i>Haltestellen Schiff_Zahnradbahn</i>"
-msgstr "Battello e ferrovia a cremagliera"
-
-msgid "<i>Haltestellen Standseilbahn</i>"
-msgstr "Funicolare"
-
-msgid "<i>Haltestellen Standseilbahn_Bus</i>"
-msgstr "Funicolare, autobus"
-
-msgid "<i>Haltestellen Standseilbahn_Luftseilbahn</i>"
-msgstr "Funicolare, funivia"
-
-msgid "<i>Haltestellen Standseilbahn_Zug</i>"
-msgstr "Funicolare, ferrovia"
-
-msgid "<i>Haltestellen Tram</i>"
-msgstr "Tram"
-
-msgid "<i>Haltestellen Zahnradbahn</i>"
-msgstr "Ferrovia a cremagliera"
-
-msgid "<i>Haltestellen Zug</i>"
-msgstr "Ferrovia"
-
-msgid "<i>Haltestellen Zug_Tram</i>"
-msgstr "Ferrovia, tram"
-
 msgid "<i>Hauptgipfel</i>"
 msgstr "Cima principale"
 
@@ -364,6 +313,75 @@ msgstr "Ufficio doganale limitato"
 
 msgid "<i>Zooareal</i>"
 msgstr "Zoo"
+
+msgid "<i>haltestellen_aufzug</i>"
+msgstr "Ascenseur"
+
+msgid "<i>haltestellen_bus</i>"
+msgstr "Autobus"
+
+msgid "<i>haltestellen_bus_luftseilbahn</i>"
+msgstr "Autobus, funivia"
+
+msgid "<i>haltestellen_bus_schiff</i>"
+msgstr "Autobus, fattello"
+
+msgid "<i>haltestellen_bus_standseilbahn_tram</i>"
+msgstr "Autobus, funicolare, tram"
+
+msgid "<i>haltestellen_bus_tram</i>"
+msgstr "Autobus, tram"
+
+msgid "<i>haltestellen_bus_tram_zug</i>"
+msgstr "Autobus, tram, ferrovia"
+
+msgid "<i>haltestellen_bus_zug</i>"
+msgstr "Autobus, ferrovia"
+
+msgid "<i>haltestellen_luftseilbahn</i>"
+msgstr "Funivia"
+
+msgid "<i>haltestellen_luftseilbahn_zug</i>"
+msgstr "Funivia, ferrovia"
+
+msgid "<i>haltestellen_metro</i>"
+msgstr "Metropolitana"
+
+msgid "<i>haltestellen_metro_zug</i>"
+msgstr "Metropolitana, ferrovia"
+
+msgid "<i>haltestellen_schiff</i>"
+msgstr "Battello"
+
+msgid "<i>haltestellen_schiff_zahnradbahn</i>"
+msgstr "Battello e ferrovia a cremagliera"
+
+msgid "<i>haltestellen_standseilbahn</i>"
+msgstr "Funicolare"
+
+msgid "<i>haltestellen_standseilbahn_bus</i>"
+msgstr "Funicolare, autobus"
+
+msgid "<i>haltestellen_standseilbahn_luftseilbahn</i>"
+msgstr "Funicolare, funivia"
+
+msgid "<i>haltestellen_standseilbahn_zug</i>"
+msgstr "Funicolare, ferrovia"
+
+msgid "<i>haltestellen_tram</i>"
+msgstr "Tram"
+
+msgid "<i>haltestellen_tram_bus_zahnradbahn</i>"
+msgstr "Tram, autobus"
+
+msgid "<i>haltestellen_zahnradbahn</i>"
+msgstr "Ferrovia a cremagliera"
+
+msgid "<i>haltestellen_zug</i>"
+msgstr "Ferrovia"
+
+msgid "<i>haltestellen_zug_tram</i>"
+msgstr "Ferrovia, tram"
 
 msgid "ABS_landesschwerenetz_type"
 msgstr "station absolue"


### PR DESCRIPTION
due to a data update we have to update the translation of haltestellen categories, 
is updating https://github.com/geoadmin/mf-chsdi3/pull/1768

should be deployed together with: https://github.com/geoadmin/service-sphinxsearch/pull/245

