### PR TITLE
Adapt mapproxy tests to new autoscale backends

### DIFF
--- a/buildout_ci.cfg
+++ b/buildout_ci.cfg
@@ -5,7 +5,7 @@ extends = buildout_dev.cfg
 # urls
 api_url = //mf-chsdi3.ci.bgdi.ch
 host = mf-chsdi3.ci.bgdi.ch
-mapproxyhost = mf-chsdi3.ci.bgdi.ch
+mapproxyhost = wmts20.dev.bgdi.ch
 # geomadmin
 geoadminhost = mf-geoadmin3.ci.bgdi.ch
 # On ci, we use staging prod!

--- a/buildout_dev.cfg
+++ b/buildout_dev.cfg
@@ -17,7 +17,7 @@ sphinxhost = service-sphinxsearch.dev.bgdi.ch
 # wms
 wmshost = wms-bgdi.dev.bgdi.ch
 # mapproxy
-mapproxyhost = mf-chsdi3.dev.bgdi.ch
+mapproxyhost = wmts20.dev.bgdi.ch
 # staging of geodata
 geodata_staging = test
 # deploy target

--- a/buildout_int.cfg
+++ b/buildout_int.cfg
@@ -14,7 +14,7 @@ sphinxhost = service-sphinxsearch.int.bgdi.ch
 # wms
 wmshost = wms-bgdi.int.bgdi.ch
 # mapproxy
-mapproxyhost = mf-chsdi3.int.bgdi.ch
+mapproxyhost = wmts20.int.bgdi.ch
 # Geodata staging
 geodata_staging= prod
 # deploy target

--- a/buildout_prod.cfg
+++ b/buildout_prod.cfg
@@ -14,7 +14,7 @@ db_staging = prod
 # wms
 wmshost = wms.geo.admin.ch
 # mapproxy
-mapproxyhost = wmts10.geo.admin.ch
+mapproxyhost = wmts20.geo.admin.ch
 # robots file
 robots_file = robots_prod.txt
 # deploy target

--- a/chsdi/tests/e2e/__init__.py
+++ b/chsdi/tests/e2e/__init__.py
@@ -13,7 +13,8 @@ class MapProxyTestsBase(object):
         try:
             os.environ["http_proxy"] = registry.settings['http_proxy']
             apache_entry_path = registry.settings['apache_entry_path']
-            self.mapproxy_url = "http://" + registry.settings['mapproxyhost'] + apache_entry_path
+            self.mapproxy_url = "http://" + registry.settings['mapproxyhost'] + '/'
+            self.host_url = "http://" + registry.settings['host'] + apache_entry_path
         except KeyError as e:
             raise e
         self.BAD_REFERER = 'http://foo.ch'

--- a/chsdi/tests/e2e/test_wmtscapabilities_auth.py
+++ b/chsdi/tests/e2e/test_wmtscapabilities_auth.py
@@ -32,7 +32,7 @@ class TestWmtsGetTileAuth(TestsBase):
 
     def test_bad_referer_get_capabilties(self):
         # Get Cap is open for all
-        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.mp.BAD_REFERER, 200)
+        self.check_status_code(self.mp.host_url + '/1.0.0/WMTSCapabilities.xml', self.mp.BAD_REFERER, 200)
 
     def test_bad_referer_get_tile(self):
         for path in self.paths:
@@ -40,14 +40,14 @@ class TestWmtsGetTileAuth(TestsBase):
 
     def test_no_referer_get_capabilties(self):
         # Get Cap is open for all
-        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', None, 200)
+        self.check_status_code(self.mp.host_url + '/1.0.0/WMTSCapabilities.xml', None, 200)
 
     def test_no_referer_get_tile(self):
         for path in self.paths:
             self.check_status_code(self.mp.mapproxy_url + path, None, 403)
 
     def test_good_referer_get_capabilties(self):
-        self.check_status_code(self.mp.mapproxy_url + '/1.0.0/WMTSCapabilities.xml', self.mp.GOOD_REFERER, 200)
+        self.check_status_code(self.mp.host_url + '/1.0.0/WMTSCapabilities.xml', self.mp.GOOD_REFERER, 200)
 
     def test_good_referer_get_tile(self):
         for path in self.paths:

--- a/chsdi/tests/e2e/test_wmtsgettile.py
+++ b/chsdi/tests/e2e/test_wmtsgettile.py
@@ -21,6 +21,11 @@ MAPPROXY_URLS = [
     'wmts12.geo.admin.ch',
     'wmts13.geo.admin.ch',
     'wmts14.geo.admin.ch',
+    'wmts20.geo.admin.ch',
+    'wmts21.geo.admin.ch',
+    'wmts22.geo.admin.ch',
+    'wmts23.geo.admin.ch',
+    'wmts24.geo.admin.ch',
 ]
 
 
@@ -87,7 +92,7 @@ class TileChecker(MapProxyTestsBase):
 
         if epsg in tiles.keys():
             capabilities_name = "WMTSCapabilities.EPSG.%d.xml" % epsg if epsg != 21781 else "WMTSCapabilities.xml"
-            resp = requests.get(self.mapproxy_url + '/1.0.0/%s' % capabilities_name, params={'_id': self.hash()},
+            resp = requests.get(self.host_url + '/1.0.0/%s' % capabilities_name, params={'_id': self.hash()},
                                 headers=HEADER_RESULTS[0]['Header'])
 
             root = etree.fromstring(resp.content)

--- a/chsdi/views/wmtscapabilities.py
+++ b/chsdi/views/wmtscapabilities.py
@@ -65,15 +65,11 @@ class WMTSCapabilites(MapNameValidation):
             'X-Forwarded-Proto',
             self.request.scheme)
         staging = self.request.registry.settings['geodata_staging']
-        host = self.request.headers.get(
-            'X-Forwarded-Host', self.request.host)
         mapproxyHost = self.request.registry.settings['mapproxyhost']
-        apache_base_path = self.request.registry.settings['apache_base_path']
-        apache_entry_point = '/' if (apache_base_path == 'main' or 'localhost' in host) else '/' + apache_base_path
 
         # Default ressource
         s3_url = sanitize_url("%s://wmts.geo.admin.ch/" % scheme)
-        mapproxy_url = sanitize_url("%s://%s%s/" % (scheme, mapproxyHost, apache_entry_point))
+        mapproxy_url = sanitize_url("%s://%s/" % (scheme, mapproxyHost))
         onlineressources = {'mapproxy': mapproxy_url, 's3': s3_url}
 
         layers_query = self.request.db.query(self.models['GetCap'])


### PR DESCRIPTION
This adapts the test urls for mapproxy related tests. It also assures that the wmts getcapabilities contain the correct urls for the re-projected tiles (using the wmts20.[dev|int].bgdi.ch addresses for dev and int and wmts20.geo.admin.ch for prod.