### PR TITLE
Remove matrixSet from WGS layers

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -103,10 +103,12 @@ class LayersConfig(Base):
                     config['label'] = translate(val)
                 elif k == 'attribution':
                     config[k] = translate(val)
-                elif k == 'matrixSet' and self.__dict__['srid'] != '4326':
-                    config['resolutions'] = self._getResolutionsFromMatrixSet(
-                        val
-                    )
+                elif k == 'matrixSet':
+                    if self.__dict__['srid'] != '4326':
+                        config['resolutions'] = \
+                            self._getResolutionsFromMatrixSet(
+                                val
+                            )
                 else:
                     config[k] = val
 


### PR DESCRIPTION
This is a small fix, just noticed matrixSet appeared in the layersConfig for _3d layers (e.g. in WGS84)
Even if it doesn't break anything it's better to remove it.