### PR TITLE
Updating example and doc for new WMTS source

### DIFF
--- a/chsdi/static/doc/examples/cadastralwebmap.html
+++ b/chsdi/static/doc/examples/cadastralwebmap.html
@@ -40,6 +40,7 @@
       </div>
     </div>
     <script src="../loader.js" type="text/javascript"></script> 
+    <script src="utils.js" type="text/javascript"></script>
     <script src="cadastralwebmap.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/cadastralwebmap.js
+++ b/chsdi/static/doc/examples/cadastralwebmap.js
@@ -1,9 +1,3 @@
-function qualifyURL(url) {
-  var a = document.createElement('a');
-  a.href = url;
-  return  a.cloneNode(false).href.replace('api3', 'wmts10');
-}
-
 var attributions = [
   new ol.Attribution({
     html: '<a href="http://www.geo.admin.ch/internet/geoportal/en/home.html">' +
@@ -21,7 +15,7 @@ var wmtsCadastre = new ol.layer.Tile({
     layer: 'ch.kantone.cadastralwebmap-farbe',
     crossOrigin: 'anonymous',
     attributions: attributions,
-    url: qualifyURL('..') + '1.0.0/{Layer}/default/current/21781/{TileMatrix}/{TileCol}/{TileRow}.png',
+    url: getWMTSSource() + '/1.0.0/{Layer}/default/current/21781/{TileMatrix}/{TileCol}/{TileRow}.png',
     tileGrid: new ol.tilegrid.WMTS({
       origin: [420000, 350000],
       resolutions: resolutions,

--- a/chsdi/static/doc/examples/ol3_lv95.html
+++ b/chsdi/static/doc/examples/ol3_lv95.html
@@ -39,6 +39,7 @@
     <script src="/static/js/jquery-2.0.3.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
     <script src="../loader.js" type="text/javascript"></script> 
+    <script src="utils.js" type="text/javascript"></script>
     <script src="ol3_lv95.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/ol3_lv95.js
+++ b/chsdi/static/doc/examples/ol3_lv95.js
@@ -8,12 +8,6 @@ var projection = ol.proj.get('EPSG:2056');
 projection.setExtent(extent);
 
 
-function qualifyURL(url) {
-    var a = document.createElement('a');
-    a.href = url;
-    return a.cloneNode(false).href;
-}
-
 var matrixIds = [];
 for (var i = 0; i < RESOLUTIONS.length; i++) {
     matrixIds.push(i);
@@ -34,7 +28,7 @@ var wmtsSource = function(layer, options) {
             html: '<a target="new" href="http://www.swisstopo.admin.ch/' +
                 'internet/swisstopo/en/home.html">swisstopo</a>'
         })],
-        url: (qualifyURL('..') + '1.0.0/{Layer}/default/' +
+        url: (getWMTSSource() + '/1.0.0/{Layer}/default/' +
             timestamp + '/2056/' +
             '{TileMatrix}/{TileCol}/{TileRow}.').replace('http:', location.protocol) + extension,
         tileGrid: tileGrid,

--- a/chsdi/static/doc/examples/ol3_lv95_all.html
+++ b/chsdi/static/doc/examples/ol3_lv95_all.html
@@ -39,6 +39,7 @@
     <script src="/static/js/jquery-2.0.3.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
     <script src="../loader.js" type="text/javascript"></script> 
+    <script src="utils.js" type="text/javascript"></script>
     <script src="ol3_lv95_all.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/ol3_lv95_all.js
+++ b/chsdi/static/doc/examples/ol3_lv95_all.js
@@ -12,7 +12,7 @@ var lang = getUrlParameter('lang') || 'en';
 var layer = getUrlParameter('layer') || 'ch.swisstopo.pixelkarte-farbe_wmts';
 var timestamp = getUrlParameter('timestamp') || 20140520;
 var format = getUrlParameter('format') || 'jpeg';
-var raw_url = getUrlParameter('base_url') || qualifyURL('..');
+var raw_url = getUrlParameter('base_url') || getWMTSSource();
 
 var BASE_URL = raw_url.replace(/\/+$/, "")
 
@@ -52,7 +52,7 @@ var cadastralCfg = {
 };
 
 $.ajax({
-    url: BASE_URL + "/rest/services/api/MapServer/layersConfig?lang=" + lang
+    url: qualifyURL('..') +  "rest/services/api/MapServer/layersConfig?lang=" + lang
 }).done(function(data) {
     var content = '';
     var layer_nb = 0;

--- a/chsdi/static/doc/examples/ol3_mercator.html
+++ b/chsdi/static/doc/examples/ol3_mercator.html
@@ -38,6 +38,7 @@
      <script src="/static/js/jquery-2.0.3.min.js"></script>
      <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
     <script src="../loader.js" type="text/javascript"></script> 
+    <script src="utils.js" type="text/javascript"></script>
     <script src="ol3_mercator.js" type="text/javascript"></script>
   </body>
 </html>

--- a/chsdi/static/doc/examples/ol3_mercator.js
+++ b/chsdi/static/doc/examples/ol3_mercator.js
@@ -1,9 +1,3 @@
-function qualifyURL(url) {
-  var a = document.createElement('a');
-  a.href = url;
-  return a.cloneNode(false).href;
-}
-
 // Reprojected WMTS layer from map.geo.admin.ch
 
 var createLayer = function(layername, timestamp) {
@@ -15,7 +9,7 @@ var createLayer = function(layername, timestamp) {
                  'internet/swisstopo/en/home.html">swisstopo</a>'
            })
          ],
-         url: qualifyURL('..') + '1.0.0/' + layername + '/default/' + timestamp + '/3857/{z}/{x}/{y}.jpeg'
+         url: getWMTSSource() + '/1.0.0/' + layername + '/default/' + timestamp + '/3857/{z}/{x}/{y}.jpeg'
        })
    });
 }

--- a/chsdi/static/doc/examples/utils.js
+++ b/chsdi/static/doc/examples/utils.js
@@ -1,0 +1,14 @@
+
+var WMTS = {'mf-chsdi3.dev.bgdi.ch': '//wmts20.dev.bgdi.ch',
+            'mf-chsdi3.int.bgdi.ch': '//wmts20.int.bgdi.ch',
+            'api3.geo.admin.ch': '//wmts10.geo.admin.ch'
+            }
+function getWMTSSource() {
+    var hostname = location.host;
+    var hostnames = Object.keys(WMTS);
+    if (hostnames.indexOf(hostname) > -1) {
+        return  WMTS[hostname];
+    } else {
+        return WMTS['api3.geo.admin.ch'];
+    }
+}

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -2,6 +2,7 @@
 
   <head>
     <link href="../_static/custom.css" rel="stylesheet" type="text/css" />
+    <script src="../examples/utils.js"></script>
   </head>
 
 
@@ -747,9 +748,9 @@ GetCapabilities
 
 The GetCapabilites document provides informations about the service, along with layer description, both in german and french.
 
-`http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml <../1.0.0/WMTSCapabilities.xml>`_ 
+`http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml <https://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml>`_ 
 
-`http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr <../1.0.0/WMTSCapabilities.xml?lang=fr>`_ 
+`http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr <https://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml?lang=fr>`_ 
 
 Parameters
 **********
@@ -860,13 +861,13 @@ Beside, the **LV03** projection, the same tiles are offered in four other *tilem
 These projections are:
 
 * Plate-Carrée WGS1984 (EPSG:4326)
-    `http://wmts10.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml <../EPSG/4326/1.0.0/WMTSCapabilities.xml>`_
+    `http://wmts10.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml>`_
 * Plate-Carrée ETRS89 (EPSG:4258)
-    `http://wmts10.geo.admin.ch/EPSG/4258/1.0.0/WMTSCapabilities.xml <../EPSG/4258/1.0.0/WMTSCapabilities.xml>`_
+    `http://wmts10.geo.admin.ch/EPSG/4258/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/4258/1.0.0/WMTSCapabilities.xml>`_
 * LV95/CH1903+ (EPSG:2056)
-    `http://wmts10.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml <../EPSG/2056/1.0.0/WMTSCapabilities.xml>`_ 
+    `http://wmts10.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml>`_ 
 * WGS84/Pseudo-Mercator (EPSG:3857, as used in OSM, Bing, Google Map)
-    `http://wmts10.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml <../EPSG/3857/1.0.0/WMTSCapabilities.xml>`_
+    `http://wmts10.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml>`_
 
 
 Note:
@@ -888,9 +889,9 @@ Note:
 
 Example
 *******
-* At tile: `http://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/3857/9/266/180.jpeg <../1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/3857/9/266/180.jpeg>`_
+* At tile: `http://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/3857/9/266/180.jpeg <https://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/3857/9/266/180.jpeg>`_
 
-.. image:: http://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/3857/9/266/180.jpeg
+.. image:: https://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/20140520/3857/9/266/180.jpeg
 
 * An OpenLayers3 application using the `pseudo-Mercator projection <../examples/ol3_mercator.html>`_ 
 * An OpenLayers3 example showing the `Cadastralwebmap as WMTS <../examples/cadastralwebmap.html>`_ 
@@ -1025,3 +1026,18 @@ Response syntax
         label: "RE"
       }
   ]
+
+
+.. raw:: html
+
+    <script>
+    var hostname = getWMTSSource();
+
+        var l = document.links;
+        for(var i=0; i<l.length; i++) {
+            var href = l[i].href;
+            if (href.indexOf('wmts10') > -1) {
+                 l[i].href = href.replace(/^https:\/\/wmts10\.geo\.admin\.ch/, hostname);
+            }
+        }
+   </script>


### PR DESCRIPTION
All examples and doc should use the corresponding staging source, and only `wmts10.geo.admin.ch`on `prod` (no `api3.geo.admin.ch`anymore)

Démo
* [Examples](http://mf-chsdi3.dev.bgdi.ch/mom_wmts_quelle/api/examples.html)
* [Doc](http://mf-chsdi3.dev.bgdi.ch/mom_wmts_quelle/services/sdiservices.html#wmts)