### PR TITLE
Fix rarely failing varnish tests

### DIFF
--- a/chsdi/tests/e2e/test_varnish.py
+++ b/chsdi/tests/e2e/test_varnish.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import os
-import random
 import requests
+import time
 from chsdi.tests.integration import TestsBase
 
 from chsdi.tests.integration.test_file_storage import VALID_KML, NOT_WELL_FORMED_KML
@@ -19,7 +19,7 @@ class TestVarnish(TestsBase):
         return os.urandom(bits / 8).encode('hex')
 
     def timestamp(self):
-        return random.randrange(20140101, 20141001)
+        return int(round(time.time() * 1000.0))
 
     def setUp(self):
         super(TestVarnish, self).setUp()


### PR DESCRIPTION
I hope that this will fix the 1-in-2 failing tests we currently have. The timestamp used can conicide with an previous timestamp and giving back wrong results (contain geometry if used with timestamp of previous request that had correct referer).

Note that this probably fixes the sometimes failing tests, but we have a general problem with this
service and the caching mechanism that needs to be adressed.

I'll open an issue for that and auto-merge this fix.