### PR TITLE
Add order by distance parameter to identify

### DIFF
--- a/chsdi/lib/validation/mapservice.py
+++ b/chsdi/lib/validation/mapservice.py
@@ -34,6 +34,8 @@ class MapServiceValidation(MapNameValidation):
             'esriGeometryPolygon',
             'esriGeometryEnvelope'
         )
+        self._limit = None
+        self._order = None
 
     @property
     def where(self):
@@ -94,6 +96,14 @@ class MapServiceValidation(MapNameValidation):
     @property
     def offset(self):
         return self._offset
+
+    @property
+    def limit(self):
+        return self._limit
+
+    @property
+    def order(self):
+        return self._order
 
     @where.setter
     def where(self, value):
@@ -235,3 +245,20 @@ class MapServiceValidation(MapNameValidation):
                 raise HTTPBadRequest('Please provide an integer as an offset parameter')
             else:
                 self._offset = int(value)
+
+    @limit.setter
+    def limit(self, value):
+        if value is not None:
+            if value.isdigit() and int(value) >= 0:
+                self._limit = int(value)
+            else:
+                raise HTTPBadRequest('Please provide a positive integer for the parameter limit')
+
+    @order.setter
+    def order(self, value):
+        if value is not None:
+            if value != 'distance':
+                raise HTTPBadRequest('Please provide a valid order parameter')
+            if self.geometry is None:
+                raise HTTPBadRequest('The order value can only be used together with a geometry.')
+            self._order = value


### PR DESCRIPTION
@AFoletti this is a PR for your solarenergie branch. We need this to optimize the sonnendach application.

This PR adds 2 new parameters to identify requests, which will both be undocumented:

a) `limit` to be able to limit result set. Currently, all results up to 200 are returned. With this parameter, we can now specify a lower limit. Note that in any case, never more that 200 features are returned.

b) `order` to be able to sort result according to distance to request point. You have to specify `order=distance` for it to have any effect. There's an internal security guard (see comments) that should assure that not too many results need to be ordered, as this could potentially impact the db heavily.

@loicgasser I'll merge this directly into Ambrogios branch but would be glad if you could review it.