### PR TITLE
Add plConfig parameter to topics

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -389,6 +389,7 @@ class Topics(Base):
     backgroundLayers = Column('background_layers', postgresql.ARRAY(Text))
     showCatalog = Column('show_catalog', Boolean)
     staging = Column('staging', Text)
+    plconf = Column('permalink_configuration', Text)
 
 
 class Catalog(Base):

--- a/chsdi/tests/integration/test_topics.py
+++ b/chsdi/tests/integration/test_topics.py
@@ -16,6 +16,7 @@ class TestTopicsListingView(TestsBase):
             self.assertTrue('selectedLayers' in topic)
             self.assertTrue('defaultBackground' in topic)
             self.assertTrue('activatedLayers' in topic)
+            self.assertTrue('plConfig' in topic)
 
     def test_topics_with_cb(self):
         resp = self.testapp.get('/rest/services', params={'callback': 'cb'}, status=200)

--- a/chsdi/views/topics.py
+++ b/chsdi/views/topics.py
@@ -19,6 +19,7 @@ def topics(request):
         'defaultBackground': q.defaultBackground,
         'backgroundLayers': q.backgroundLayers,
         'selectedLayers': q.selectedLayers,
-        'activatedLayers': q.activatedLayers
+        'activatedLayers': q.activatedLayers,
+        'plConfig': q.plconf
     } for q in query]
     return {'topics': results}


### PR DESCRIPTION
This is the back-end part for https://github.com/geoadmin/mf-geoadmin3/issues/3031

It exposes the new plConfig parameter to the topics service. The bod is ready and deployed to dev. A PR with testlink is coming in mf-geoadmin3 project.