### PR TITLE
Change regex in ogcproxy to catch the encoding correctly

### DIFF
--- a/chsdi/views/ogcproxy.py
+++ b/chsdi/views/ogcproxy.py
@@ -72,7 +72,7 @@ class OgcProxy:
             raise HTTPNotAcceptable()
 
         if content.find('encoding=') > 0:
-            m = re.search("encoding=\"(.*?)\\\"", content)
+            m = re.search("encoding=[\\\"|\"|\'](.*?)[\\\"|\"|\']", content)
             doc_encoding = m.group(1)
             if doc_encoding.lower() != DEFAULT_ENCODING:
                 try:


### PR DESCRIPTION
Fix https://github.com/geoadmin/mf-geoadmin3/issues/3032

[Before](http://api3.geo.admin.ch/ogcproxy?url=https%3A%2F%2Fgist.githubusercontent.com%2Fdavidoesch%2F2d3fa44b076b06449645%2Fraw%2F9ff3431141f17e37349e38939b34924e03b4a0e8%2FPatrouilledesGlaciersPOI.kml)

[After](http://mf-chsdi3.dev.bgdi.ch/fix_3032/ogcproxy?url=https%3A%2F%2Fgist.githubusercontent.com%2Fdavidoesch%2F2d3fa44b076b06449645%2Fraw%2F9ff3431141f17e37349e38939b34924e03b4a0e8%2FPatrouilledesGlaciersPOI.kml)