### PR TITLE
Look for available serachField on all models [ltfoa_solarenergie_daecher]

### DIFF
--- a/chsdi/models/__init__.py
+++ b/chsdi/models/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import engine_from_config
+from sqlalchemy import engine_from_config, Column
 
 
 dbs = ['are', 'bafu', 'bak', 'bod', 'dritte', 'edi', 'evd', 'kogis', 'stopo', 'uvek', 'vbs', 'zeitreihen', 'lubis']
@@ -38,26 +38,20 @@ def register_oereb(name, klass):
     oerebmap.setdefault(name, []).append(klass)
 
 
-def models_from_bodid(bodId):
-    if bodId in bodmap:
-        return bodmap[bodId]
-    else:
-        return None
-
-
 def oereb_models_from_bodid(bodId):
-    if bodId in oerebmap:
-        return oerebmap[bodId]
-    else:
-        return None
+    return oerebmap.get(bodId)
 
 
-def models_from_name(name):
-    models = models_from_bodid(name)
+def models_from_bodid(bodId):
+    return bodmap.get(bodId)
+
+
+def queryable_models_from_bodid(bodId, searchField):
+    models = models_from_bodid(bodId)
     if models is not None:
-        return models
-    else:
-        return None
+        models = [m for m in models if isinstance(m.get_column_by_property_name(searchField), Column)]
+        if len(models) > 0:
+            return models
 
 
 def get_models_attributes_keys(models, lang, attributeOnly):

--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -4,7 +4,7 @@ from sqlalchemy import Column, Text, Integer, Boolean
 from sqlalchemy.dialects import postgresql
 
 from chsdi.lib.helpers import make_agnostic
-from chsdi.models import bases, models_from_name, get_models_attributes_keys
+from chsdi.models import bases, models_from_bodid, get_models_attributes_keys
 
 Base = bases['bod']
 
@@ -130,7 +130,7 @@ class LayersConfig(Base):
             config['attributionUrl'] = translate(self.__dict__['attribution'] + '.url')
 
         # adding __queryable_attributes__ if they have them
-        models = models_from_name(self.layerBodId)
+        models = models_from_bodid(self.layerBodId)
         if models is not None:
             queryable_attributes = get_models_attributes_keys(models, params.lang, True)
             if len(queryable_attributes) > 0:

--- a/chsdi/tests/integration/test_layers.py
+++ b/chsdi/tests/integration/test_layers.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql.expression import func
 
 from chsdi.models.bod import LayersConfig
-from chsdi.models import models_from_name
+from chsdi.models import models_from_bodid
 
 
 class LayersChecker(object):
@@ -53,7 +53,7 @@ class LayersChecker(object):
 
     def ilayersWithFeatures(self):
         for layer in self.ilayers(queryable=True):
-            models = models_from_name(layer)
+            models = models_from_bodid(layer)
             assert (models is not None and len(models) > 0), layer
             model = models[0]
             query = self.session.query(model.primary_key_column())
@@ -87,7 +87,7 @@ class LayersChecker(object):
             assert ((layer + '_' + lang) in legendImages), layer + '_' + lang
 
     def checkSearch(self, layer):
-        models = models_from_name(layer)
+        models = models_from_bodid(layer)
         assert (models is not None and len(models) > 0), layer
         model = models[0]
         expectedStatus = 200

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -16,7 +16,7 @@ from sqlalchemy import text
 from chsdi.lib.validation.mapservice import MapServiceValidation
 from chsdi.lib.helpers import format_query
 from chsdi.lib.filters import full_text_search
-from chsdi.models import models_from_name, oereb_models_from_bodid
+from chsdi.models import models_from_bodid, queryable_models_from_bodid, oereb_models_from_bodid
 from chsdi.models.bod import OerebMetadata, get_bod_model
 from chsdi.views.layers import get_layer, get_layers_metadata_for_params
 from chsdi.models.vector import Geometry
@@ -253,9 +253,9 @@ def _identify(request):
     else:
         layerIds = params.layers
     models = [
-        models_from_name(layerId) for
+        models_from_bodid(layerId) for
         layerId in layerIds
-        if models_from_name(layerId) is not None
+        if models_from_bodid(layerId) is not None
     ]
     if models is None:
         raise exc.HTTPBadRequest('No GeoTable was found for %s' % ' '.join(layerIds))
@@ -294,7 +294,7 @@ def _get_features(params, extended=False):
     ''' Returns exactly one feature or raises
     an excpetion '''
     featureIds = params.featureIds.split(',')
-    models = models_from_name(params.layerId)
+    models = models_from_bodid(params.layerId)
     if models is None:
         raise exc.HTTPBadRequest('No Vector Table was found for %s' % params.layerId)
 
@@ -414,7 +414,7 @@ def _attributes(request):
     attributesValues = []
     params = _get_attributes_params(request)
 
-    models = models_from_name(params.layerId)
+    models = models_from_bodid(params.layerId)
 
     if models is None:
         raise exc.HTTPBadRequest('No Vector Table was found for %s' % params.layerId)
@@ -450,16 +450,15 @@ def _find(request):
     if params.searchText is None:
         raise exc.HTTPBadRequest('Please provide a searchText')
 
-    models = models_from_name(params.layer)
+    models = queryable_models_from_bodid(params.layer, params.searchField)
     features = []
-    findColumn = lambda x: (x, x.get_column_by_property_name(params.searchField))
     if models is None:
-        raise exc.HTTPBadRequest('No Vector Table was found for %s' % params.layer)
+        raise exc.HTTPBadRequest(
+            'No Vector Table was found for %s for searchField %s' % (params.layer, params.searchField))
+
     for model in models:
-        vectorModel, searchColumn = findColumn(model)
-        if searchColumn is None:
-            raise exc.HTTPBadRequest('Please provide an existing searchField')
-        query = request.db.query(vectorModel)
+        searchColumn = model.get_column_by_property_name(params.searchField)
+        query = request.db.query(model)
         if params.contains:
             query = full_text_search(
                 query,
@@ -543,7 +542,7 @@ def releases(request):
     # on specially sorted views. We add the _meta part to the given
     # layer name
     # Note that only zeitreihen is currently supported for this service
-    models = models_from_name(params.layer + '_meta')
+    models = models_from_bodid(params.layer + '_meta')
     if models is None:
         raise exc.HTTPBadRequest('No Vector Table was found for %s' % params.layer)
 

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -12,7 +12,7 @@ import pyramid.httpexceptions as exc
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from chsdi.lib.validation.mapservice import MapServiceValidation
-from chsdi.models import models_from_name, get_models_attributes_keys
+from chsdi.models import models_from_bodid, get_models_attributes_keys
 from chsdi.models.bod import LayersConfig, get_bod_model, computeHeader
 from chsdi.lib.filters import full_text_search, filter_by_geodata_staging, filter_by_map_name
 
@@ -116,7 +116,7 @@ def feature_attributes(request):
     attributes of vector layers. '''
     params = LayersParams(request)
     layerId = request.matchdict.get('layerId')
-    models = models_from_name(layerId)
+    models = models_from_bodid(layerId)
     # Models for the same layer have the same attributes
     if models is None:
         raise exc.HTTPBadRequest('No Vector Table was found for %s' % layerId)


### PR DESCRIPTION
One layer can have several models and sometimes only some of those models have the so called `queryable` properties. This PR takes this fact into account.
 
@AFoletti 
I see that you're using a view `view_solarenergie_daecher_gs` which is probably huge!
A find operation is quite demanding if we cannot make use of the indices. Any chance we might have a real table for that?

For `df_uid`: Do we need other queries than an excat match? Otherwise I would say we don't need it in the find because it's also the `primary key` and `GET Feature` would be more approriate.

