### PR TITLE
Get remote datenstand from geojson

### DIFF
--- a/chsdi/templates/legend.mako
+++ b/chsdi/templates/legend.mako
@@ -113,7 +113,9 @@
     </tr>
     <tr>
       <td>${_('Datenstand')}</td>
-% if times:
+% if legend['datenstand']:
+      <td>${legend['datenstand']}</td>
+% elif times:
   % if len(times) == 4:
       <td>${times}</td>
   % elif len(times) == 6:


### PR DESCRIPTION
I tried to make as impact less as I could.
See:
https://github.com/geoadmin/mf-geoadmin3/issues/2366

We could test this function which would in turn test the existence of the geojson and the timestamp field but I would need to add it in the e2e tests I think. do you agree?