### PR TITLE
[WIP] Pseudo static file for layersConfig

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -35,6 +35,11 @@ RedirectMatch permanent ^${apache_entry_path}/iipimage/(.*)$ ${apache_entry_path
 # Redirect no-slash target to slashed version
 RedirectMatch ^${apache_entry_path}$ ${apache_entry_path}/
 
+
+# Makes layersConfig looks like a real file
+RewriteRule ^${apache_entry_path}/(rest/services/all/MapServer/layersConfig)\.(de|fr|en|it|rm)\.json ${apache_entry_path}/$1?lang=$2 [PT]
+RewriteRule ^${apache_entry_path}/[0-9]+/(rest/services/all/MapServer/layersConfig)\.(de|fr|en|it|rm)\.json ${apache_entry_path}/$1?lang=$2 [E=${apache_base_path}setyearcache:true,PT]
+
 # If URI has numbers at the start, we cache a year
 # This allows a client to create their own cache and
 # update at his discretion
@@ -52,6 +57,7 @@ RewriteRule ^${apache_entry_path}/robots.txt ${apache_entry_path}/static/${robot
 <LocationMatch ^${apache_entry_path}/static/(robots.txt|robots_prod.txt)>
     Header set Content-type "text/plain"
 </LocationMatch>
+
 
 # WMTS Capabilities
 RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities\.xml$ ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml [PT,NC,QSA,L]

--- a/chsdi/tests/e2e/test_apache.py
+++ b/chsdi/tests/e2e/test_apache.py
@@ -1,0 +1,23 @@
+
+import requests
+
+from pyramid.paster import get_app
+
+app = get_app('development.ini')
+
+
+try:
+    api_url = "http:" + app.registry.settings['api_url']
+except KeyError as e:
+    api_url = 'http://api.geo.admin.ch'
+
+
+def test_layersConfig():
+
+    for lang in ('de', 'fr', 'it', 'rm', 'en'):
+        resp = requests.get(api_url + '/rest/services/all/MapServer/layersConfig?lang={}'.format(lang))
+        ori = resp.json()
+        resp = requests.get(api_url + '/rest/services/all/MapServer/layersConfig.{}.json'.format(lang))
+        static = resp.json()
+
+        assert static == ori


### PR DESCRIPTION
In order to put geoadmin in S3, we need a `layersConfig` service which behave like a file, i.e. instead of [layersconfig?lang=rm](http://mf-chsdi3.dev.bgdi.ch/mom_layersconfig_lang/rest/services/all/MapServer/layersConfig?lang=rm) the service may be requested as [layersConfig.rm](http://mf-chsdi3.dev.bgdi.ch/mom_layersconfig_lang/rest/services/all/MapServer/layersConfig.rm.json).

Unfortunately, the whole localize buisiness in pyramid is done at a very early stage (before routing in this respect), and is hard to overcome. `mod_rewrite`can do the trick, 

See https://github.com/geoadmin/mf-geoadmin3/issues/3092 for rational behing this PR

Note: `.rm` is stopped by BIT proxy 

This PR is only adding some functionalities, not changing anything existing.