### PR TITLE
Do not build on int,prod

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -179,7 +179,7 @@ source-directory = .
 exclude-directories = buildout node_modules
 interpreted-options = app_version = __import__('time').strftime('%s')
                       apache_entry_path = '' if options.get('apache_base_path') == 'main' else ('/' + options.get('apache_base_path'))
-                      git_branch = __import__('subprocess').check_output(['git', 'rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']).rstrip()
+                      git_branch = __import__('subprocess').check_output(['cat', 'buildout/.last-git-branch']) if __import__('os').path.exists('buildout/.git-last-branch') else __import__('subprocess').check_output(['git', 'rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']).rstrip()
                       branch_staging = 'test' if options.get('deploy_target') == 'dev' else 'integration'
 
 extends = vars

--- a/deploy/hooks/post-restore-code
+++ b/deploy/hooks/post-restore-code
@@ -13,9 +13,7 @@ cd $CODE_DIR
 ##python bootstrap.py --distribute --version 1.5.2 > /dev/null
 
 if [ -f buildout_$TARGET.cfg ]; then
-    buildout/bin/buildout -c buildout_$TARGET.cfg
-else
-    buildout/bin/buildout
+    buildout/bin/buildout -c buildout_$TARGET.cfg install print-config print-war
 fi
 
 if [[ $CODE_DIR == */branch/* ]]; then

--- a/deploydev.sh
+++ b/deploydev.sh
@@ -49,6 +49,7 @@ if [ $CREATE_SNAPSHOT == 'true' ]; then
   cd $SNAPSHOTDIR/chsdi3/code/chsdi3/
   git describe --tags --abbrev=0 > .last-release
   git log -1 --pretty=format:"%h - %an, %ar : %s" > .last-commit-ref
+  git rev-parse --symbolic-full-name --abbrev-ref HEAD > .last-git-branch
   rm -rf .git*
 else
   echo "NO Snapshot created. Specify '-s' parameter got create snapshot."

--- a/deploysnapshot.sh
+++ b/deploysnapshot.sh
@@ -19,22 +19,27 @@ cwd=$(pwd)
 # Go into snapshot directory to run nose-tests
 cd $SNAPSHOTDIR/chsdi3/code/chsdi3
 
-# Run nose tests with target cluster db
-if [ -z $3 ] || [ $3 != "notests" ]
+if [ "$2" == "int" ]
 then
-    if [ "$2" == "int" ]
-    then
-      echo "Running nose tests with integration cluster in $SNAPSHOTDIR"
-      ./nose_run.sh -i
-    fi
+  if [ -z $3 ] || [ $3 != "notests" ]
+  then
+    echo "Running nose tests with integration cluster in $SNAPSHOTDIR"
+    ./nose_run.sh -i
+  fi
+  buildout/bin/buildout -c buildout_int.cfg
+elif [ "$2" == "prod" ]
+then
+  if [ -z $3 ] || [ $3 != "notests" ]
+  then
+    echo "Running nose tests with production cluster in $SNAPSHOTDIR"
+    ./nose_run.sh -p
+  fi
+  buildout/bin/buildout -c buildout_prod.cfg
+fi
 
-    if [ "$2" == "prod" ]
-    then
-      echo "Running nose tests with production cluster in $SNAPSHOTDIR"
-      ./nose_run.sh -p
-    fi
-else
-    echo "You have disabled nosetests!"
+if [ -z $3 == "notests" ]
+then
+  echo "You have disabled the tests"
 fi
 
 # back to working directory for the deploy command


### PR DESCRIPTION
This PR does 2 things
1. We don't build on int and prod instances anymore when deploying the main project to int or prod
2. We avoid invoking git in snapshot directory by using the `.last-git-branch` file generated during deploydev

@gjn this is untested as I know you're currently deploying and it something to test on master

We could take the same approach in geoadmin if this is proven to be successful.