### PR TITLE
Enable querying of null and not null values

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -165,7 +165,7 @@ def format_query(model, value):
                 match.group(2),
                 match.group(3),
                 match.group(4).replace(u'\\', u'\\\\')
-                              .replace(u'\'', u'\\\'')
+                              .replace(u'\'', u"\''")
                               .replace(u'_', u'\\_'),
                 match.group(5)
             ))
@@ -181,7 +181,11 @@ def format_query(model, value):
             res.append(val)
         return res
 
-    extractMatches = lambda x: x[0] if x[0] != '' else x[1]
+    def extractMatches(x):
+        for v in x:
+            if v != '':
+                return v
+        return v
 
     def getOperator(values):
         supportedOperators = [' and ', ' or ']
@@ -193,10 +197,12 @@ def format_query(model, value):
             return operator
         return ''
 
-    regEx = r'(\w+\s(?:ilike|not ilike)\s(?:\'%)[^\'%]+(?:%\'))|(\w+\s(?:=|\!=|>=|<=|>|<)\s[^\s]+)'
+    regEx = r'(\w+\s(?:ilike|not ilike)\s(?:\'%)[^\%]+(?:%\'))|(\w+\s(?:=|\!=|>=|<=|>|<)\s[^\s]+)|(\w+\s(?:is null|is not null))'
 
     try:
         values = map(extractMatches, re.findall(regEx, value))
+        if len(values) == 0:
+            return None
         operator = getOperator(values)
         values = map(escapeSQL, values)
         values = replacePropByColumnName(model, values)

--- a/chsdi/tests/integration/test_mapservice.py
+++ b/chsdi/tests/integration/test_mapservice.py
@@ -201,6 +201,16 @@ class TestMapServiceView(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
+    def test_identify_query_null(self):
+        params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp', 'where': 'andere_stoffe is null'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+
+    def test_identify_query_not_null(self):
+        params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp', 'where': 'andere_stoffe is not null'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+
     def test_identify_query_number(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'maxheightagl > 210'}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
@@ -236,14 +246,18 @@ class TestMapServiceView(TestsBase):
                   'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'obstacletype = \'Antenna\''}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
+        self.assertGreater(len(resp.json['results']), 0)
 
     def test_identify_query_escape_quote(self):
-        params = {'geometryFormat': 'geojson', 'lang': 'en', 'layers': 'all:ch.bafu.hydrologie-wassertemperaturmessstationen', 'time': '2013', 'where': 'name ilike \'%Broye-Payerne, Caserne d\'aviation%\''}
+        params = {'geometryFormat': 'geojson', 'lang': 'en', 'layers': 'all:ch.bafu.hydrologie-wassertemperaturmessstationen',
+                  'time': '2013', 'where': "name ilike \'%Broye-Payerne, Caserne d'aviation%\' or name ilike \'%Aare-Bern, Schönau%\'"}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
+        self.assertGreater(len(resp.json['results']), 0)
 
     def test_identify_query_offset(self):
-        params = {'layers': 'all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill', 'returnGeometry': 'false', 'timeInstant': '2015', 'where': 'gemname ilike \'%a%\''}
+        params = {'layers': 'all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill', 'returnGeometry': 'false', 'timeInstant': '2015',
+                  'where': 'gemname ilike \'%a%\''}
         resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         params.update({'offset': '2'})
         resp2 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
@@ -255,7 +269,8 @@ class TestMapServiceView(TestsBase):
         self.assertEqual(resp1.json['results'][5]['featureId'], resp3.json['results'][0]['featureId'])
 
     def test_identify_bbox_offset(self):
-        params = {'layers': 'all:ch.bazl.luftfahrthindernis', 'timeInstant': '2015', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryEnvelope', 'geometry': '573788,93220,750288,192720',
+        params = {'layers': 'all:ch.bazl.luftfahrthindernis', 'timeInstant': '2015', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryEnvelope',
+                  'geometry': '573788,93220,750288,192720',
                   'imageDisplay': '1920,778,96', 'mapExtent': '107788,-5279,1067788,383720', 'tolerance': '0'}
         resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         params.update({'offset': '2'})
@@ -274,7 +289,8 @@ class TestMapServiceView(TestsBase):
 
     def test_identify_result_limit(self):
         # Assure not more than 201 results are returned
-        params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}', 'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
+        params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
+                  'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '10', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register'}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
@@ -282,7 +298,8 @@ class TestMapServiceView(TestsBase):
 
     def test_identify_limit_parameter(self):
         # No limit parameters
-        params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}', 'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
+        params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
+                  'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '10', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register'}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')


### PR DESCRIPTION
This is the first part of https://github.com/geoadmin/mf-geoadmin3/issues/2013

[Test link null](http://mf-chsdi3.dev.bgdi.ch/gal_query_null/rest/services/all/MapServer/identify?geometryFormat=geojson&lang=en&layers=all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp&timeInstant=2014&where=andere_stoffe+is+null)
[Test link not null](http://mf-chsdi3.dev.bgdi.ch/gal_query_null/rest/services/all/MapServer/identify?geometryFormat=geojson&lang=en&layers=all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp&timeInstant=2014&where=andere_stoffe+is+not+null)

@oterral Can you take care of the front-end part?
And also fix the bug where the second condition doesn't provide the button for the suggestions?
See screen shot for condition 2:
![suggestions_missing_cond2](https://cloud.githubusercontent.com/assets/3306154/13141347/270ace60-d637-11e5-806b-c177c148eb57.png)
After that I think we can remove the `(beta)` in the title of this tool.

Empty strings should be set to null in DB as this is the purpose of null values.

FYI: This can be merged safely even if the front-end part has not been adapted yet.