### PR TITLE
Fix cadastral webmap link tests

### DIFF
--- a/chsdi/tests/e2e/test_links.py
+++ b/chsdi/tests/e2e/test_links.py
@@ -11,7 +11,7 @@ class TestLinks(TestsBase):
         headers = {
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.68 Safari/537.36'
         }
-        for i in range(23):
+        for i in range(1, 27):
             response = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/%d/htmlPopup' % i, status=200)
 
             soup = response.html


### PR DESCRIPTION
This is to fix failing nightly tests of the cadastral webmap links.