### PR TITLE
Adapted releasenotes to reflect old ga3 snapshot

### DIFF
--- a/chsdi/static/doc/source/releasenotes/index.rst
+++ b/chsdi/static/doc/source/releasenotes/index.rst
@@ -31,9 +31,6 @@ API & applications
 
 `MAP <//map.geo.admin.ch>`__
 '''''''''''''''''''''''''''''
-- New topic 'Cadastre'
-- WMS Import now supports non-LV03 coordinate system WMS Services
-- Layer Manager now allows the rearranging of layers via Drag and Drop
 - Bug Fixes
 - `Full changelog <https://github.com/geoadmin/mf-geoadmin3/compare/r_160217...r_160302>`__
 


### PR DESCRIPTION
Because we have prolbems with new version of mf-geoadmin3, we will re-deploy the old snapshot.

Data will be updated.