### PR TITLE
Adapt deployment

### DIFF
--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -21,7 +21,10 @@ content = Include /var/www/vhosts/mf-chsdi3/private/chsdi/apache/*.conf
 [remote_hosts]
 # mf0i
 int = ip-10-220-6-119.eu-west-1.compute.internal,
-      ip-10-220-6-105.eu-west-1.compute.internal
+      ip-10-220-6-41.eu-west-1.compute.internal,
+      ip-10-220-6-105.eu-west-1.compute.internal,
+      ip-10-220-6-208.eu-west-1.compute.internal
+
 
 # mf0 --> vpc_mf0_legacy_prod and vpc_mf0_prod
 prod = ip-10-220-5-86.eu-west-1.compute.internal,

--- a/deploy/hooks/post-restore
+++ b/deploy/hooks/post-restore
@@ -12,4 +12,25 @@ if [ -x /usr/bin/puppet ]; then
     sudo /usr/bin/puppet agent --enable
 fi
 
-exit 0
+# We should check if apache is running and return error if it's not
+sleep 5
+sudo /etc/init.d/apache2 status
+
+apache_rc=$?
+
+if [ $apache_rc -ne 0 ]; then
+
+  echo "-----------Deploy Error----------"
+  echo "Apache is not running on the deployed instance. Aborting deployment. Please check  instance"
+  echo "-----------End of Deploy Error----------"
+
+else
+
+  # We wait to assure that varnishes had time to detect running apache again
+  # before we deploy to next instance
+  echo "Waiting 70 seconds before continuing. Give varnish time to rediscover this instance..."
+  sleep 70
+
+fi
+
+exit $apache_rc


### PR DESCRIPTION
This PR adds 2 new integration target machines.

It also assures that we don't have the 'varnish looses back-ends' effect described in comments in https://github.com/geoadmin/mf-geoadmin3/pull/3200 during the deploy.

We had this since forever, but it never really mattered because deployment was so slow. Now with a) make instead of buildout and b) reduced transfer of files to targets because of removed .git repository, we are much faster. This started to show the bad effect on deployment:

![image](https://cloud.githubusercontent.com/assets/2572317/13792003/0c55b7e2-eaf0-11e5-856f-a6aea928b3c9.png)
