### PR TITLE
Correct documentation for iframe example

### DIFF
--- a/chsdi/static/doc/source/api/examples.rst
+++ b/chsdi/static/doc/source/api/examples.rst
@@ -83,7 +83,7 @@ GeoAdmin iframe examples
       link: 'http://openlayers.org/en/v3.6.0/examples/',
       cat: 2 
     }, {
-      label: 'Communication between a KML layer in iframe and the parent window',
+      label: 'Communication between a GeoJSON layer in iframe and the parent window',
       codepen: 'yOBzqM',
       cat: 3
     }];


### PR DESCRIPTION
The documentation is wrong in that the codepen exampled linked to does not contain a kml, but a GeoJSON layer.

The kml support is not yet implemented and under discussion here: https://github.com/geoadmin/mf-geoadmin3/pull/3199

@loicgasser Would be happy for a quick review.