### PR TITLE
Fix usage of assertRaises in unit tests

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -294,7 +294,7 @@ def parse_box2d(stringBox2D):
 
 def is_box2d(box2D):
     # Bottom left to top right only
-    if box2D[0] > box2D[2] or box2D[1] > box2D[3] or len(box2D) != 4:
+    if len(box2D) != 4 or box2D[0] > box2D[2] or box2D[1] > box2D[3]:
         raise ValueError('Invalid box2D.')
     return True
 

--- a/chsdi/tests/functional/test_helpers.py
+++ b/chsdi/tests/functional/test_helpers.py
@@ -206,7 +206,7 @@ class Test_Helpers(unittest.TestCase):
         testval = 5
         result = float_raise_nan(testval)
         self.assertEqual(result, 5.0)
-        self.assertRaises('ValueError')
+        self.assertRaises(ValueError, float_raise_nan, 'no_number')
 
     def test_parse_box2d(self):
         strBox2d = 'BOX(1.1 2.2,3.3 4.4)'
@@ -224,10 +224,9 @@ class Test_Helpers(unittest.TestCase):
 
     def test_center_from_box2d_wrong(self):
         box2d = [10.1, 2.2, 3.3, 6.6]
-        try:
-            center_from_box2d(box2d)
-        except ValueError as e:
-            self.assertRaises(e)
+        self.assertRaises(ValueError, center_from_box2d, box2d)
+        box2d = [1.1, 2.2, 3.3]
+        self.assertRaises(ValueError, center_from_box2d, box2d)
 
     def test_format_scale(self):
         scale = 50000


### PR DESCRIPTION
Currently, these tests don't run at all (they
do nothing)

See official documentation
https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertRaises

@loicgasser We discussed this once. Please review.