### PR TITLE
visualize '-' if no pdf in gisgeol tooltips

### DIFF
--- a/chsdi/templates/htmlpopup/gisgeol.mako
+++ b/chsdi/templates/htmlpopup/gisgeol.mako
@@ -39,6 +39,11 @@
           </td>
     </tr>
     % else:
+          <td class="cell-left">${_('pdf_url')}</td>
+          <td> -
+          </td>
+    </tr>
+
         % if (c['attributes']['copy_avail']) == 'free' and (c['attributes']['view_avail']) == 'free':
                 <tr><td class="cell-left">${_('gisgeol_auskunft')}</td>
           <td>


### PR DESCRIPTION
trivial. Shows the pdf tooltip line with a "-" if no pdf list