### PR TITLE
Assure .git directory exists when installing secrets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,7 @@ requirements.txt:
 
 .venv/bin/git-secrets: .venv
 	@echo "${GREEN}Installing git secrets${RESET}";
+	if [ ! -d ".git" ]; then git init; fi
 	rm -rf .venv/git-secrets
 	git clone https://github.com/awslabs/git-secrets .venv/git-secrets
 	cd .venv/git-secrets && make install PREFIX=..


### PR DESCRIPTION
https://github.com/geoadmin/mf-chsdi3/pull/2061 installed git secrets. It assumed that a .git repository is actually present. When we are creating a snapshot for the deploy, we are removing the .git directory. Thus, a new make will break because the git secrets installation fails.

This PR makes sure that the git secrets installation does not fail by creating the .git directory when it doesn't exist.

Quick self-merge because I want to deploy to integration.