### PR TITLE
correct link to wms in legend

### DIFF
--- a/chsdi/templates/legend.mako
+++ b/chsdi/templates/legend.mako
@@ -38,6 +38,10 @@
       legend_url_pdf = False
   legend_url = host + '/static/images/legends/' + c['layerBodId'] + '_' + lang + '.png'
   times = c['attributes']['dataStatus'] if 'dataStatus' in c['attributes'] else '-'
+
+  wms_urls = str(c['attributes']['wmsUrlResource'])
+  wms_url = wms_urls.split(' ', 1)[0] 
+
 %>
 <div class="legend-container">
 <div class="legend-header">
@@ -108,7 +112,7 @@
     <tr>
       <td>${_('WMS Dienst')}</td>
 % if 'wmsUrlResource' in c['attributes']:
-      <td><a href="${c['attributes']['wmsUrlResource']}" target="new">${_('wms_resource_text')}</a></td>
+      <td><a href="${wms_url}" target="new">${_('wms_resource_text')}</a></td>
 % else:
       <td>-</td>
 % endif

--- a/chsdi/templates/legend.mako
+++ b/chsdi/templates/legend.mako
@@ -39,8 +39,9 @@
   legend_url = host + '/static/images/legends/' + c['layerBodId'] + '_' + lang + '.png'
   times = c['attributes']['dataStatus'] if 'dataStatus' in c['attributes'] else '-'
 
-  wms_urls = str(c['attributes']['wmsUrlResource'])
-  wms_url = wms_urls.split(' ', 1)[0] 
+  if 'wmsUrlResource' in c['attributes']:
+      wms_urls = c['attributes']['wmsUrlResource']
+      wms_url = wms_urls.split(' ', 1)[0]
 
 %>
 <div class="legend-container">


### PR DESCRIPTION
linked to issue https://github.com/geoadmin/mf-geoadmin3/issues/3218.
Assuming that the link has to redirect to the public wms (always the first in the table, as far as I know),
I adapted the legend template so that it redirects to this link. Here is a [test link](http://mf-chsdi3.dev.bgdi.ch/frr_wms_link_legend/rest/services/all/MapServer/ch.bafu.moose/legend?lang=fr).
But is this how it is supposed to be? Should the user be able to redirect to the swisstopo wms for example?