### PR TITLE
Add deploy no print target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,8 @@ help:
 	@echo "- deploydev          Deploys master to dev (SNAPSHOT=true to also create a snapshot)"
 	@echo "- deployint          Deploys a snapshot to integration (SNAPSHOT=201512021146)"
 	@echo "- deployprod         Deploys a snapshot to production (SNAPSHOT=201512021146)"
+	@echo "- deployintnoprint   Deploys a snapshot to integration without print and profile"
+	@echo "- deployprodnoprint  Deploys a snapshot to production without print and profile"
 	@echo "- clean              Remove generated files"
 	@echo "- cleanall           Remove all the build artefacts"
 	@echo
@@ -268,9 +270,17 @@ deploydev:
 deployint:
 	scripts/deploysnapshot.sh $(SNAPSHOT) int $(NO_TESTS) $(DEPLOYCONFIG)
 
+.PHONY: deployintnoprint
+deployintnoprint:
+	scripts/deploysnapshot.sh $(SNAPSHOT) int_no_print $(NO_TESTS) $(DEPLOYCONFIG)
+
 .PHONY: deployprod
 deployprod:
 	scripts/deploysnapshot.sh $(SNAPSHOT) prod $(NO_TESTS) $(DEPLOYCONFIG)
+
+.PHONY: deployprodnoprint
+deployprodnoprint:
+	scripts/deploysnapshot.sh $(SNAPSHOT) prod_no_print $(NO_TESTS) $(DEPLOYCONFIG)
 
 .PHONY: deploydemo
 deploydemo:

--- a/README.md
+++ b/README.md
@@ -84,9 +84,17 @@ desired target. For integration, do
 
 `make deployint SNAPSHOT=201512011411`
 
+the same deploy command is available to ommit the update on the print and profile instances using:
+
+`make deployintnoprint SNAPSHOT=201512011411`
+
 This will run the full nose tests **from inside the 201512011411 snapshot directory** against the **integration db cluster**. Only if these tests are successfull, the snapshot is deployed to the integration cluster.
 
 `make deployprod SNAPSHOT=201512011411`
+
+the same deploy command is available to ommit the update on the print and profile instances using:
+
+`make deployprodnoprint SNAPSHOT=201512011411`
 
 This will do the corresponding thing for prod (tests will be run **against prod backends**)
 The same is valid for demo too:

--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -25,12 +25,17 @@ int = ip-10-220-6-221.eu-west-1.compute.internal,
       ip-10-220-6-105.eu-west-1.compute.internal,
       ip-10-220-6-208.eu-west-1.compute.internal
 
+int_no_print = ip-10-220-6-221.eu-west-1.compute.internal,
+               ip-10-220-6-41.eu-west-1.compute.internal
 
 # mf0 --> vpc_mf0_legacy_prod and vpc_mf0_prod
-prod = ip-10-220-5-86.eu-west-1.compute.internal,
-       ip-10-220-6-138.eu-west-1.compute.internal,
-       ip-10-220-5-201.eu-west-1.compute.internal,
-       ip-10-220-6-126.eu-west-1.compute.internal
+prod = ip-10-220-5-201.eu-west-1.compute.internal,
+       ip-10-220-6-126.eu-west-1.compute.internal,
+       ip-10-220-5-86.eu-west-1.compute.internal,
+       ip-10-220-6-138.eu-west-1.compute.internal
+
+prod_no_print = ip-10-220-5-201.eu-west-1.compute.internal,
+                ip-10-220-6-126.eu-west-1.compute.internal
 
 # bakom demo instance dec 2014
 demo = ip-10-220-5-174.eu-west-1.compute.internal

--- a/deploy/hooks/post-restore-code
+++ b/deploy/hooks/post-restore-code
@@ -22,6 +22,14 @@ elif [[ -f rc_$TARGET ]]; then
   source rc_$TARGET
   make templates
   make printwar APACHE_BASE_PATH=main
+elif [[ "$TARGET" == "int_no_print" ]]; then
+  make clean
+  source rc_int
+  make templates
+elif [[ "$TARGET" == "prod_no_print" ]]; then
+  make clean
+  source rc_prod
+  make templates
 fi
 
 exit $?

--- a/scripts/deploysnapshot.sh
+++ b/scripts/deploysnapshot.sh
@@ -5,12 +5,16 @@ T="$(date +%s)"
 #bail out on any error
 set -o errexit
 
-# Check if snapshot parameter is supplied and there are 2 parameters
-if [ "$2" != "int" ] && [ "$2" != "prod" ] && [ "$2" != "demo" ]
-then
+contains () {
+  local e;
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
   echo "Error: Please specify 1) snapshot directoy and 2) target."
   exit 1
-fi
+}
+
+# Check if snapshot parameter is supplied and there are 2 parameters
+VALID_TARGETS=("int int_no_print prod prod_no_print demo")
+contains $2 $VALID_TARGETS
 
 SNAPSHOTDIR=/var/www/vhosts/mf-chsdi3/private/snapshots/$1
 
@@ -23,13 +27,13 @@ cd $SNAPSHOTDIR_CODE
 # Run nose tests with target cluster db
 if [ -z $3 ] || [ $3 != "notests" ]
 then
-    if [ "$2" == "int" ]
+    if [[ "$2" == "int" ]] || [[ "$2" == "int_no_print" ]]
     then
       echo "Running nose tests with integration cluster in $SNAPSHOTDIR"
       scripts/nose_run.sh -i
     fi
 
-    if [ "$2" == "prod" ]
+    if [[ "$2" == "prod" ]] || [[ "$2" == "prod_no_print" ]]
     then
       echo "Running nose tests with production cluster in $SNAPSHOTDIR"
       scripts/nose_run.sh -p


### PR DESCRIPTION
@gjn as discussed
The PR adds the possibility to deploy the app only on the 2 main instances (without print and profile).

The motivation is that we don't really to update the print or profile function that often (a couple of times a year) but we always deploy on all 4 instances.

To test this PR try:

```
make deployintnoprint SNAPSHOT=201606011317 DEPLOYCONFIG=from_current_directory
```

We'll gain quite a bit pf time this way.

```
make deployint
```

still deploys the snapshot on all 4 instances.