### PR TITLE
s_map_number instead of pk_product in model id

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -174,6 +174,7 @@ class GravimetrischerAtlasMetadata (Base, ShopProductClass, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __tablename__ = 'view_gridstand_gravimetrie_atlas_metadata_shop'
     __bodId__ = 'ch.swisstopo.geologie-gravimetrischer_atlas.metadata'
+    id = Column('s_map_number', Integer, primary_key=True)
 
 
 register('ch.swisstopo.geologie-gravimetrischer_atlas.metadata', GravimetrischerAtlasMetadata)
@@ -215,6 +216,7 @@ class StrassenKarte200Metadata(Base, ShopProductClass, Vector):
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __tablename__ = 'view_gridstand_stk200'
     __bodId__ = 'ch.swisstopo.stk200-papierkarte.metadata'
+    id = Column('s_map_number', Integer, primary_key=True)
 
 register('ch.swisstopo.stk200-papierkarte.metadata', StrassenKarte200Metadata)
 

--- a/chsdi/templates/htmlpopup/shop_product.mako
+++ b/chsdi/templates/htmlpopup/shop_product.mako
@@ -7,7 +7,14 @@
     lang = lang if lang in ('fr','it','en') else 'de'
     fid = str(c['featureId'])
     webDavHost = request.registry.settings['webdav_host']
-    image = webDavHost + '/swisstopoproducts/250/' + fid + '.jpg'
+    if layer == 'ch.swisstopo.geologie-gravimetrischer_atlas.metadata':
+        img_id = 'GRAV-DRG' + fid
+    elif layer == 'ch.swisstopo.stk200-papierkarte.metadata':
+        img_id = 'Strassenkarte' + fid
+    else:
+        img_id = fid
+
+    image = webDavHost + '/swisstopoproducts/250/' + img_id + '.jpg'
     if 'pk_product' not in c['attributes']:
         if h.resource_exists(image):
             image_exists = True


### PR DESCRIPTION
This PR replaces the feature id of two layers:
ch.swisstopo.stk200-papierkarte.metadata
ch.swisstopo.geologie-gravimetrischer_atlas.metadata
so that it corresponds to puzzle's mapping for the price service. The configuration is not ready on their side for ch.swisstopo.geologie-gravimetrischer_atlas.metadata yet, so the fix cannot be tested yet for this layer.
Here is a [test link] (https://mf-geoadmin3.dev.bgdi.ch/?api_url=frr_grav_stk_shop_id&topic=ech&lang=fr&X=174493.42&Y=665168.86&zoom=1&bgLayer=ch.swisstopo.swissimage&layers=ch.swisstopo.stk200-papierkarte.metadata,ch.swisstopo.geologie-gravimetrischer_atlas.metadata&layers_visibility=true,false)