### PR TITLE
Adding retry logic when testing external links

### DIFF
--- a/chsdi/tests/e2e/test_links.py
+++ b/chsdi/tests/e2e/test_links.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import requests
+from urlparse import urlparse
+
 
 from chsdi.tests.integration import TestsBase
+
+MAX_RETRIES = 3
+TIMEOUT = 10
 
 
 class TestLinks(TestsBase):
@@ -11,11 +16,18 @@ class TestLinks(TestsBase):
         headers = {
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.68 Safari/537.36'
         }
+
         for i in range(1, 27):
             response = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/%d/htmlPopup' % i, status=200)
 
             soup = response.html
             for a in soup.findAll('a'):
                 link = a.get('href')
-                r = requests.get(link, timeout=10, headers=headers)
+                s = requests.Session()
+                a = requests.adapters.HTTPAdapter(max_retries=MAX_RETRIES)
+                scheme, netloc, path, params, query, fragment = urlparse(link)
+                scheme = scheme if scheme in ['http', 'https'] else 'http'
+                s.mount('%s://' % scheme, a)
+
+                r = s.get(link, timeout=TIMEOUT, headers=headers)
                 self.assertEqual(r.status_code, 200, link)


### PR DESCRIPTION
Trying to avoid timeout errors when testing external links (See https://jenkins.prod.bgdi.ch/job/cadastral_portal_links/540)