### PR TITLE
fix no link data in tooltips

### DIFF
--- a/chsdi/templates/htmlpopup/projflughafenanlagen.mako
+++ b/chsdi/templates/htmlpopup/projflughafenanlagen.mako
@@ -15,5 +15,9 @@
     <tr><td class="cell-left">${_('modif_validfrom')}</td>            <td>${c['attributes']['validfrom'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('durationofeffect')}</td>           <td>${c['attributes']['durationofeffect'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('descriptionText')}</td>            <td>${c['attributes']['description'] or '-'}</td></tr>
+%if c['attributes']['weblink_ref']:
     <tr><td class="cell-left">${_('legalregulationlink')}</td>        <td><a target="_blank" href="${c['attributes']['weblink_ref']}">${_('legalregulationlink') or '-'}</a></td></tr>
+% else:
+    <tr><td class="cell-left">${_('legalregulationlink')}</td>        <td> - </td></tr>
+%endif
 </%def>

--- a/chsdi/templates/htmlpopup/sgt_facilities.mako
+++ b/chsdi/templates/htmlpopup/sgt_facilities.mako
@@ -14,8 +14,8 @@
 	<tr><td class="cell-left">${_('tt_sachplan_facility_anlagestatus')}</td>      <td>${c['attributes'][facstatus_text] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>    <td>${h.parse_date_string(c['attributes']['validfrom'])}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>               <td>${c['attributes']['description'] or '-'}</td></tr>
-% if 'web' in c['attributes']:
-    <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                <td><a href="${c['attributes']['web'] or '-'}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
+% if c['attributes']['web']:
+    <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                <td><a href="${c['attributes']['web']}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
 % else:
     <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                <td> - </td></tr>
 %endif

--- a/chsdi/templates/htmlpopup/sgt_planning.mako
+++ b/chsdi/templates/htmlpopup/sgt_planning.mako
@@ -20,8 +20,8 @@
     <tr><td class="cell-left">${_('tt_sachplan_planning_von')}</td>           <td>${h.parse_date_string(c['attributes']['validfrom'])}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_planning_bis')}</td>           <td>${h.parse_date_string(c['attributes']['validuntil'])}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>           <td>${c['attributes']['description'] or '-'}</td></tr>
-% if 'web' in c['attributes']:
-    <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>            <td><a href="${c['attributes']['web'] or '-'}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
+% if c['attributes']['web']:
+    <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>            <td><a href="${c['attributes']['web']}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
 % else:
     <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>            <td> - </td></tr>
 %endif

--- a/chsdi/templates/htmlpopup/sif_facilities.mako
+++ b/chsdi/templates/htmlpopup/sif_facilities.mako
@@ -20,8 +20,8 @@
     <tr><td class="cell-left">${_('tt_sachplan_facility_anlagestatus')}</td>          <td>${c['attributes'][facstatus_text] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>        <td>${datefrom or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>                   <td>${c['attributes'][description_text] or '-'}</td></tr>
-% if 'doc_web' in c['attributes']:
-    <tr><td class="cell-left">${_('ch.bav.sachplan-infrastruktur-schiene_anhorung.doc_title')}</td>                    <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
+% if c['attributes']['doc_web']:
+    <tr><td class="cell-left">${_('ch.bav.sachplan-infrastruktur-schiene_anhorung.doc_title')}</td>                    <td><a href="${c['attributes']['doc_web']}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
 % else:
     <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                    <td> - </td></tr>
 %endif

--- a/chsdi/templates/htmlpopup/sif_planning.mako
+++ b/chsdi/templates/htmlpopup/sif_planning.mako
@@ -29,10 +29,10 @@ endif
       <td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>
       <td>${datefrom or '-'}</td>
     </tr>
-% if 'doc_web' in c['attributes']:
+% if c['attributes']['doc_web']:
     <tr>
       <td class="cell-left">${_('ch.bav.sachplan-infrastruktur-schiene_anhorung.doc_title')}</td>
-      <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
+      <td><a href="${c['attributes']['doc_web']}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
 % else:
     <tr>
       <td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>

--- a/chsdi/templates/htmlpopup/sil_facilities.mako
+++ b/chsdi/templates/htmlpopup/sil_facilities.mako
@@ -15,9 +15,9 @@
     <tr><td class="cell-left">${_('tt_sachplan_facility_anlagestatus')}</td>          <td>${c['attributes'][facstatus_text] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>        <td>${c['attributes']['validfrom'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>                   <td>${c['attributes'][description_text] or '-'}</td></tr>
-% if 'document_web' in c['attributes']:
-    <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                    <td><a href="${c['attributes']['document_web'] or '-'}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
-% else:
+%  if c['attributes']['document_web']:
+     <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                   <td><a href="${c['attributes']['document_web']}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
+%else:
     <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                    <td> - </td></tr>
 %endif
 </%def>

--- a/chsdi/templates/htmlpopup/sil_planning.mako
+++ b/chsdi/templates/htmlpopup/sil_planning.mako
@@ -39,10 +39,10 @@
       <td class="cell-left">${_('tt_sachplan_beschreibung')}</td>
       <td>${c['attributes'][description_text] or '-'}</td>
     </tr>
-% if 'document_web' in c['attributes']:
+% if c['attributes']['document_web']:
     <tr>
       <td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>
-      <td><a href="${c['attributes']['document_web'] or '-'}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
+      <td><a href="${c['attributes']['document_web']}" target="_blank">${_('tt_sachplan_objektblatt')}</a></td></tr>
 % else:
     <tr>
       <td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>

--- a/chsdi/templates/htmlpopup/sis_facilities.mako
+++ b/chsdi/templates/htmlpopup/sis_facilities.mako
@@ -20,8 +20,8 @@
     <tr><td class="cell-left">${_('tt_sachplan_facility_anlagestatus')}</td>          <td>${c['attributes'][facstatus_text] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>        <td>${datefrom or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>                   <td>${c['attributes'][description_text] or '-'}</td></tr>
-% if 'doc_web' in c['attributes']:
-    <tr><td class="cell-left">${_(doc_title)}</td>                    <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
+% if c['attributes']['doc_web']:
+    <tr><td class="cell-left">${_(doc_title)}</td>                    <td><a href="${c['attributes']['doc_web']}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
 % else:
     <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>                    <td> - </td></tr>
 %endif

--- a/chsdi/templates/htmlpopup/sis_planning.mako
+++ b/chsdi/templates/htmlpopup/sis_planning.mako
@@ -49,10 +49,10 @@ endif
       <td class="cell-left">${_('tt_sachplan_beschreibung')}</td>
       <td>${c['attributes'][description_text] or '-'}</td>
     </tr>
-% if 'doc_web' in c['attributes']:
+% if c['attributes']['doc_web']:
     <tr>
       <td class="cell-left">${_(doc_title)}</td>
-      <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
+      <td><a href="${c['attributes']['doc_web']}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
 % else:
     <tr>
       <td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>

--- a/chsdi/templates/htmlpopup/suel_facilities.mako
+++ b/chsdi/templates/htmlpopup/suel_facilities.mako
@@ -18,8 +18,8 @@
     <tr><td class="cell-left">${_('tt_sachplan_facility_anlagestatus')}</td>    <td>${c['attributes'][facstatus_text] or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_facility_beschlussdatum')}</td>  <td>${datefrom or '-'}</td></tr>
     <tr><td class="cell-left">${_('tt_sachplan_beschreibung')}</td>             <td>${c['attributes'][description_text] or '-' | n}</td></tr>
-% if 'doc_web' in c['attributes']:
-    <tr><td class="cell-left">${_(doc_title)}</td>                              <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
+% if c['attributes']['doc_web']:
+    <tr><td class="cell-left">${_(doc_title)}</td>                              <td><a href="${c['attributes']['doc_web']}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
 % else:
     <tr><td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>              <td> - </td></tr>
 %endif

--- a/chsdi/templates/htmlpopup/suel_planning.mako
+++ b/chsdi/templates/htmlpopup/suel_planning.mako
@@ -49,10 +49,10 @@ endif
       <td class="cell-left">${_('tt_sachplan_beschreibung')}</td>
       <td>${c['attributes'][description_text] or '-' | n}</td>
     </tr>
-% if 'doc_web' in c['attributes']:
+% if c['attributes']['doc_web']:
     <tr>
       <td class="cell-left">${_(doc_title)}</td>
-      <td><a href="${c['attributes']['doc_web'] or '-'}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
+      <td><a href="${c['attributes']['doc_web']}" target="_blank">${c['attributes']['doc_title'] or '-'}</a></td></tr>
 % else:
     <tr>
       <td class="cell-left">${_('tt_sachplan_weitereinfo')}</td>


### PR DESCRIPTION
This PR is to fix the wrong link that was created in the tooltip when no link was given in the data.
[test link](https://mf-geoadmin3.dev.bgdi.ch/src/?api_url=frr_more_info_link&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-grau&layers=ch.bazl.sachplan-infrastruktur-luftfahrt_kraft,ch.bfe.sachplan-geologie-tiefenlager,ch.bav.sachplan-infrastruktur-schifffahrt_kraft,ch.bav.sachplan-infrastruktur-schiene_kraft,ch.bfe.sachplan-uebertragungsleitungen_kraft,ch.bazl.projektierungszonen-flughafenanlagen&X=224457.76&Y=661903.94&zoom=2&layers_opacity=1,0.75,1,1,1,0.75&layers_visibility=true,false,false,false,false,false)