### PR TITLE
set the right zoomlevel for lk25 and lk50 backlinks from zeitreise la…

### DIFF
--- a/chsdi/templates/historicalmaps/viewer.mako
+++ b/chsdi/templates/historicalmaps/viewer.mako
@@ -18,6 +18,13 @@
   title += ': ' + pageTitle
   loaderUrl = h.make_agnostic(route_url('ga_api', request))
 
+  if c.get('title') == 'kartenwerk_lk25':
+      zoomlevel = 8
+  elif c.get('title') == 'kartenwerk_lk50':
+      zoomlevel = 7
+  else:
+      zoomlevel = 6
+
   if c.get('width') is None or c.get('height') is None:
       wh = h.imagesize_from_metafile(tileUrlBasePath, bildnummer)
       width = c.get('width') or wh[0]
@@ -26,8 +33,8 @@
       width = c.get('width')
       height = c.get('height')
 
-  geoadminUrl = "//%s/?layers=%s&zoom=6&Y=%s&X=%s&time=%s" % (
-      request.registry.settings['geoadminhost'], layerBodId, center[0], center[1], release_year)
+  geoadminUrl = "//%s/?layers=%s&zoom=%s&Y=%s&X=%s&time=%s" % (
+      request.registry.settings['geoadminhost'], layerBodId, zoomlevel, center[0], center[1], release_year)
 %>
 
 <!DOCTYPE html>


### PR DESCRIPTION
…yer tooltip

proposed solution for https://github.com/geoadmin/mf-chsdi3/issues/2142

[Testlink ](https://mf-geoadmin3.dev.bgdi.ch/?topic=ech&lang=de&bgLayer=ch.swisstopo.swissimage&api_url=dev_ltclm_lk25_lk50_fullres&X=128527.50&Y=630625.00&zoom=8&layers=ch.swisstopo.zeitreihen&layers_timestamp=19951231&time=1995)