### PR TITLE
Adapt links and translations for new CMS

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -1863,7 +1863,7 @@ msgid "ch.babs.kulturgueter.zkob"
 msgstr "Beschreibung"
 
 msgid "ch.babs.url"
-msgstr "http://www.bevoelkerungsschutz.admin.ch/internet/bs/de/home/das_babs.html"
+msgstr "http://www.babs.admin.ch/de/home.html"
 
 msgid "ch.bafu"
 msgstr "BAFU"
@@ -3561,7 +3561,7 @@ msgid "ch.bakom.uplink50"
 msgstr "Upload ≥ 50 Mbit/s"
 
 msgid "ch.bakom.url"
-msgstr "http://www.bakom.admin.ch/index.html"
+msgstr "https://www.bakom.admin.ch/bakom/de/home.html"
 
 msgid "ch.bakom.verfuegbarkeit-hdtv"
 msgstr "HDTV-Verfügbarkeit Festnetz"
@@ -3909,7 +3909,7 @@ msgid "ch.bazl.sicherheitszonenplan"
 msgstr "Sicherheitszonenplan"
 
 msgid "ch.bazl.url"
-msgstr "http://www.bazl.admin.ch/index.html?lang=de"
+msgstr "https://www.bazl.admin.ch/bazl/de/home.html"
 
 msgid "ch.bfe"
 msgstr "BFE"
@@ -4329,7 +4329,7 @@ msgid "ch.ensi"
 msgstr "ENSI"
 
 msgid "ch.ensi.url"
-msgstr "http://www.ensi.ch/de/"
+msgstr "https://www.ensi.ch/de/"
 
 msgid "ch.ensi.zonenplan-notfallschutz-kernanlagen"
 msgstr "Zonenpläne für den Notfallschutz"
@@ -4338,7 +4338,7 @@ msgid "ch.kanton.av"
 msgstr "Amtliche Vermessung Schweiz / FL"
 
 msgid "ch.kanton.av.url"
-msgstr "http://www.cadastre.ch/internet/cadastre/de/home/products/webmap/cwm.html"
+msgstr "http://www.cadastre.ch/internet/kataster/de/home/services/service/wms/cwm.html"
 
 msgid "ch.kantone.cadastralwebmap-farbe"
 msgstr "CadastralWebMap"
@@ -5583,7 +5583,7 @@ msgid "ch.swisstopo.treasurehunt"
 msgstr "Schatzkarte"
 
 msgid "ch.swisstopo.url"
-msgstr "http://www.swisstopo.admin.ch/internet/swisstopo/de/home.html"
+msgstr "https://www.swisstopo.admin.ch/de/home.html"
 
 msgid "ch.swisstopo.vec200-adminboundaries-protectedarea"
 msgstr "Schutzgebiete VECTOR200"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -1863,7 +1863,7 @@ msgid "ch.babs.kulturgueter.zkob"
 msgstr "Description"
 
 msgid "ch.babs.url"
-msgstr "http://www.bevoelkerungsschutz.admin.ch/internet/bs/en/home/das_babs.html"
+msgstr "http://www.babs.admin.ch/de/home.html"
 
 msgid "ch.bafu"
 msgstr "FOEN"
@@ -3561,7 +3561,7 @@ msgid "ch.bakom.uplink50"
 msgstr "Upload ≥ 50 Mbit/s"
 
 msgid "ch.bakom.url"
-msgstr "http://www.bakom.admin.ch/index.html"
+msgstr "https://www.bakom.admin.ch/bakom/en/homepage.html"
 
 msgid "ch.bakom.verfuegbarkeit-hdtv"
 msgstr "Availability HDTV fixed netw."
@@ -3909,7 +3909,7 @@ msgid "ch.bazl.sicherheitszonenplan"
 msgstr "Safety zone plan"
 
 msgid "ch.bazl.url"
-msgstr "http://www.bazl.admin.ch/index.html?lang=en"
+msgstr "https://www.bazl.admin.ch/bazl/en/home.html"
 
 msgid "ch.bfe"
 msgstr "SFOE"
@@ -4329,7 +4329,7 @@ msgid "ch.ensi"
 msgstr "ENSI"
 
 msgid "ch.ensi.url"
-msgstr "http://www.ensi.ch/en/"
+msgstr "https://www.ensi.ch/en/?noredirect=en_US"
 
 msgid "ch.ensi.zonenplan-notfallschutz-kernanlagen"
 msgstr "Plans for Emergency protection"
@@ -4338,7 +4338,7 @@ msgid "ch.kanton.av"
 msgstr "Cadastral Surveying Switzerland / FL"
 
 msgid "ch.kanton.av.url"
-msgstr "http://www.cadastre.ch/internet/cadastre/de/home/products/webmap/cwm.html"
+msgstr "http://www.cadastre.ch/internet/kataster/en/home/services/service/wms/cwm.html"
 
 msgid "ch.kantone.cadastralwebmap-farbe"
 msgstr "CadastralWebMap"
@@ -5583,7 +5583,7 @@ msgid "ch.swisstopo.treasurehunt"
 msgstr "Treasurehunt"
 
 msgid "ch.swisstopo.url"
-msgstr "http://www.swisstopo.admin.ch/internet/swisstopo/en/home.html"
+msgstr "https://www.swisstopo.admin.ch/en/home.html"
 
 msgid "ch.swisstopo.vec200-adminboundaries-protectedarea"
 msgstr "Protected Areas VECTOR200"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -1863,7 +1863,7 @@ msgid "ch.babs.kulturgueter.zkob"
 msgstr "Beschreibung"
 
 msgid "ch.babs.url"
-msgstr "http://www.bevoelkerungsschutz.admin.ch/internet/bs/de/home/das_babs.html"
+msgstr "http://www.babs.admin.ch/de/home.html"
 
 msgid "ch.bafu"
 msgstr "BAFU"
@@ -3561,7 +3561,7 @@ msgid "ch.bakom.uplink50"
 msgstr "Upload ≥ 50 Mbit/s"
 
 msgid "ch.bakom.url"
-msgstr "http://www.bakom.admin.ch/index.html"
+msgstr "https://www.bakom.admin.ch/bakom/de/home.html"
 
 msgid "ch.bakom.verfuegbarkeit-hdtv"
 msgstr "Disponibladad HDTV rait fixa"
@@ -3909,7 +3909,7 @@ msgid "ch.bazl.sicherheitszonenplan"
 msgstr "Plan da zonas da segirezza"
 
 msgid "ch.bazl.url"
-msgstr "http://www.bazl.admin.ch/index.html?lang=rm"
+msgstr "https://www.bazl.admin.ch/bazl/de/home.html"
 
 msgid "ch.bfe"
 msgstr "BFE"
@@ -4329,7 +4329,7 @@ msgid "ch.ensi"
 msgstr "ENSI"
 
 msgid "ch.ensi.url"
-msgstr "http://www.ensi.ch/de/"
+msgstr "https://www.ensi.ch/de/"
 
 msgid "ch.ensi.zonenplan-notfallschutz-kernanlagen"
 msgstr "Plans da las zonas d'urgenza"
@@ -4338,7 +4338,7 @@ msgid "ch.kanton.av"
 msgstr "Mesiraziun uffiziala svizra / FL"
 
 msgid "ch.kanton.av.url"
-msgstr "http://www.cadastre.ch/internet/cadastre/de/home/products/webmap/cwm.html"
+msgstr "http://www.cadastre.ch/internet/kataster/de/home/services/service/wms/cwm.html"
 
 msgid "ch.kantone.cadastralwebmap-farbe"
 msgstr "CadastralWebMap"
@@ -5583,7 +5583,7 @@ msgid "ch.swisstopo.treasurehunt"
 msgstr "Schatzkarte"
 
 msgid "ch.swisstopo.url"
-msgstr "http://www.swisstopo.admin.ch/internet/swisstopo/de/home.html"
+msgstr "https://www.swisstopo.admin.ch/de/home.html"
 
 msgid "ch.swisstopo.vec200-adminboundaries-protectedarea"
 msgstr "Territoris protegids VECTOR200"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -1863,7 +1863,7 @@ msgid "ch.babs.kulturgueter.zkob"
 msgstr "Description"
 
 msgid "ch.babs.url"
-msgstr "http://www.bevoelkerungsschutz.admin.ch/internet/bs/fr/home/das_babs.html"
+msgstr "http://www.babs.admin.ch/fr/home.html"
 
 msgid "ch.bafu"
 msgstr "OFEV"
@@ -3561,7 +3561,7 @@ msgid "ch.bakom.uplink50"
 msgstr "Liaison ≥ 50 Mbit/s ascendante"
 
 msgid "ch.bakom.url"
-msgstr "http://www.bakom.admin.ch/index.html"
+msgstr "https://www.bakom.admin.ch/bakom/fr/page-daccueil.html"
 
 msgid "ch.bakom.verfuegbarkeit-hdtv"
 msgstr "Disponibilité HDTV réseau fixe"
@@ -3909,7 +3909,7 @@ msgid "ch.bazl.sicherheitszonenplan"
 msgstr "Plan de la zone de sécurité"
 
 msgid "ch.bazl.url"
-msgstr "http://www.bazl.admin.ch/index.html?lang=fr"
+msgstr "https://www.bazl.admin.ch/bazl/fr/home.html"
 
 msgid "ch.bfe"
 msgstr "OFEN"
@@ -4329,7 +4329,7 @@ msgid "ch.ensi"
 msgstr "IFSN"
 
 msgid "ch.ensi.url"
-msgstr "http://www.ensi.ch/fr/"
+msgstr "https://www.ensi.ch/fr/?noredirect=fr_FR"
 
 msgid "ch.ensi.zonenplan-notfallschutz-kernanlagen"
 msgstr "Plans des zones d’urgence"
@@ -4338,7 +4338,7 @@ msgid "ch.kanton.av"
 msgstr "Mensuration officielle suisse / FL"
 
 msgid "ch.kanton.av.url"
-msgstr "http://www.cadastre.ch/internet/cadastre/fr/home/products/webmap/cwm.html"
+msgstr "http://www.cadastre.ch/internet/kataster/fr/home/services/service/wms/cwm.html"
 
 msgid "ch.kantone.cadastralwebmap-farbe"
 msgstr "CadastralWebMap"
@@ -5583,7 +5583,7 @@ msgid "ch.swisstopo.treasurehunt"
 msgstr "Carte-tresor"
 
 msgid "ch.swisstopo.url"
-msgstr "http://www.swisstopo.admin.ch/internet/swisstopo/fr/home.html"
+msgstr "https://www.swisstopo.admin.ch/fr/home.html"
 
 msgid "ch.swisstopo.vec200-adminboundaries-protectedarea"
 msgstr "Sites protégés VECTOR200"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -1863,7 +1863,7 @@ msgid "ch.babs.kulturgueter.zkob"
 msgstr "Description"
 
 msgid "ch.babs.url"
-msgstr "http://www.bevoelkerungsschutz.admin.ch/internet/bs/it/home/das_babs.html"
+msgstr "http://www.babs.admin.ch/it/home.html"
 
 msgid "ch.bafu"
 msgstr "UFAM"
@@ -3561,7 +3561,7 @@ msgid "ch.bakom.uplink50"
 msgstr "Upload ≥50 Mbit/s"
 
 msgid "ch.bakom.url"
-msgstr "http://www.bakom.admin.ch/index.html"
+msgstr "https://www.bakom.admin.ch/bakom/it/pagina-iniziale.html"
 
 msgid "ch.bakom.verfuegbarkeit-hdtv"
 msgstr "Disponibilità TV HD rete fissa"
@@ -3909,7 +3909,7 @@ msgid "ch.bazl.sicherheitszonenplan"
 msgstr "Piano delle zone di sicurezza"
 
 msgid "ch.bazl.url"
-msgstr "http://www.bazl.admin.ch/index.html?lang=it"
+msgstr "https://www.bazl.admin.ch/bazl/it/home.html"
 
 msgid "ch.bfe"
 msgstr "UFE"
@@ -4329,7 +4329,7 @@ msgid "ch.ensi"
 msgstr "IFSN"
 
 msgid "ch.ensi.url"
-msgstr "http://www.ensi.ch/it/"
+msgstr "https://www.ensi.ch/it/?noredirect=it_IT"
 
 msgid "ch.ensi.zonenplan-notfallschutz-kernanlagen"
 msgstr "Piani delle zone d'urgenza"
@@ -4338,7 +4338,7 @@ msgid "ch.kanton.av"
 msgstr "Misurazione ufficiale svizzera / FL"
 
 msgid "ch.kanton.av.url"
-msgstr "http://www.cadastre.ch/internet/cadastre/it/home/products/webmap/cwm.html"
+msgstr "http://www.cadastre.ch/internet/kataster/it/home/services/service/wms/cwm.html"
 
 msgid "ch.kantone.cadastralwebmap-farbe"
 msgstr "CadastralWebMap"
@@ -5583,7 +5583,7 @@ msgid "ch.swisstopo.treasurehunt"
 msgstr "Mappa-Tesoro"
 
 msgid "ch.swisstopo.url"
-msgstr "http://www.swisstopo.admin.ch/internet/swisstopo/it/home.html"
+msgstr "https://www.swisstopo.admin.ch/it/home.html"
 
 msgid "ch.swisstopo.vec200-adminboundaries-protectedarea"
 msgstr "Siti protetti VECTOR200"

--- a/chsdi/static/doc/source/api/faq/index.rst
+++ b/chsdi/static/doc/source/api/faq/index.rst
@@ -22,7 +22,7 @@ The GeoAdmin API provides also :ref:`rest_services`
 Who can use the GeoAdmin API ?
 ******************************
 
-The GeoAdmin API terms of use are accessible here: `Terms of Use <http://www.geo.admin.ch/internet/geoportal/de/home/services/geoservices/display_services/api_services/order_form.html>`_
+The GeoAdmin API terms of use are accessible here: `Terms of Use <https://www.geo.admin.ch/de/geo-services/geo-services/portrayal-services-web-mapping/programming-interface-api/order_form.html>`_
 
 What is the license of the GeoAdmin API ?
 *****************************************
@@ -57,7 +57,7 @@ Feel free to use it and ask all the questions you want.
 Which layers are available ?
 ****************************
 
-Some layers can’t be freely used. These layers are accessible by the way of `swisstopo web access - WMTS documentation <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/services/web_services/webaccess.html>`_
+Some layers can’t be freely used. These layers are accessible by the way of `swisstopo web access - WMTS documentation <https://www.swisstopo.ch/webaccess>`_
 
 The list below includes the layers that require a swisstopo web acesss:
 
@@ -160,7 +160,7 @@ The help pages of http://map.geo.admin.ch is accessible here: http://help.geo.ad
 Can I use http://localhost to test my developments ?
 ****************************************************
 
-Yes, localhost can be used to test the developments. In all cases, you have to follow the `Terms of Use <http://www.geo.admin.ch/internet/geoportal/de/home/services/geoservices/display_services/api_services/order_form.html>`_.
+Yes, localhost can be used to test the developments. In all cases, you have to follow the `Terms of Use <https://www.geo.admin.ch/de/geo-services/geo-services/portrayal-services-web-mapping/programming-interface-api/order_form.html>`_.
 
 Where can I get information about OWSChecker ?
 **********************************************

--- a/chsdi/static/doc/source/api/quickstart.rst
+++ b/chsdi/static/doc/source/api/quickstart.rst
@@ -9,7 +9,7 @@ API Quick start
 
 .. note::
 
-  The GeoAdmin API and all GeoAdmin services can be used in both HTTP and HTTPS contexts. Though most layers are freely accessible, a `swisstopo web access <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/services/web_services/webaccess.html>`_ is required for some of them. For a list of all available layers and their accessibility please refer to the `FAQ <faq/index.html#which-layers-are-available>`_.
+  The GeoAdmin API and all GeoAdmin services can be used in both HTTP and HTTPS contexts. Though most layers are freely accessible, a `swisstopo web access <https://www.swisstopo.ch/webaccess>`_ is required for some of them. For a list of all available layers and their accessibility please refer to the `FAQ <faq/index.html#which-layers-are-available>`_.
 
 .. raw:: html
 

--- a/chsdi/static/doc/source/api/terms_of_use.rst
+++ b/chsdi/static/doc/source/api/terms_of_use.rst
@@ -11,5 +11,5 @@ Terms of use
 ============
 
 .. note::
-    The GeoAdmin API terms of use are accessible here: `Terms of Use <http://www.geo.admin.ch/internet/geoportal/de/home/services/geoservices/display_services/api_services/order_form.html>`_
+    The GeoAdmin API terms of use are accessible here: `Terms of Use <https://www.geo.admin.ch/de/geo-services/geo-services/portrayal-services-web-mapping/programming-interface-api/order_form.html>`_
 

--- a/chsdi/static/doc/source/index.rst
+++ b/chsdi/static/doc/source/index.rst
@@ -64,7 +64,7 @@ Use the GeoAdmin API Forum to ask questions: http://groups.google.com/group/geoa
 
 
 .. warning::
-    The GeoAdmin API and all GeoAdmin services can be used in both HTTP and HTTPS contexts. Though most layers are freely accessible, a `swisstopo web access <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/services/web_services/webaccess.html>`_ is required for some of them. For a list of all available layers and their accessibility please refer to the `FAQ <api/faq/index.html#which-layers-are-available>`_.
+    The GeoAdmin API and all GeoAdmin services can be used in both HTTP and HTTPS contexts. Though most layers are freely accessible, a `swisstopo web access <https://www.swisstopo.ch/webaccess>`_ is required for some of them. For a list of all available layers and their accessibility please refer to the `FAQ <api/faq/index.html#which-layers-are-available>`_.
 
 
 API
@@ -98,7 +98,7 @@ Terms of use
    api/terms_of_use
 
 .. note::
-    The GeoAdmin API terms of use are accessible here: `Terms of Use <http://www.geo.admin.ch/internet/geoportal/de/home/services/geoservices/display_services/api_services/order_form.html>`_
+    The GeoAdmin API terms of use are accessible here: `Terms of Use <https://www.geo.admin.ch/de/geo-services/geo-services/portrayal-services-web-mapping/programming-interface-api/order_form.html>`_
 
 .. About Geoadmin API section
 
@@ -106,4 +106,4 @@ Terms of use
    :maxdepth: 1
    :hidden:
 
-   About Geoadmin API <http://www.geo.admin.ch/internet/geoportal/en/home/geoadmin.html>
+   About Geoadmin API <https://www.geo.admin.ch/>

--- a/chsdi/static/doc/source/releasenotes/index.rst
+++ b/chsdi/static/doc/source/releasenotes/index.rst
@@ -2366,7 +2366,7 @@ API & applications
 
 - Udpate documentation to include description of output parameters in services
 - Lubis tooltips and viewer now contains backlink to object in map
-- Add reverse geoconding on locations. Note: this service needs registering. `Read our terms <http://www.geo.admin.ch/internet/geoportal/de/home/services/geoservices/display_services/api_services/order_form.html>`__.
+- Add reverse geoconding on locations. Note: this service needs registering. `Read our terms <https://www.geo.admin.ch/de/geo-services/geo-services/portrayal-services-web-mapping/programming-interface-api/order_form.html>`__.
 - `Full changelog <https://github.com/geoadmin/mf-chsdi3/compare/rel_140702...r_140717>`__
 
 `MAP <//map.geo.admin.ch>`__

--- a/chsdi/static/doc/source/services/owschecker/user_guide.rst
+++ b/chsdi/static/doc/source/services/owschecker/user_guide.rst
@@ -41,7 +41,7 @@ The eCH-0056 Checker can be used via a HTML form and as a web service.
 -------------
 The HTML form is available at the following address:
 
- * http://www.geo.admin.ch/internet/geoportal/de/home/services/geoservices/ech0056.html
+ * https://www.geo.admin.ch/de/geo-dienstleistungen/geodienste/pruefdienste.html
 
 The form inputs are:
 

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -149,12 +149,12 @@ Here is a description of the data one can find in the above response.
 
   - **wmsResource**: the WMS resource of the layer
   - **scaleLimit**: the scale at which the layer is valid
-  - **inspireUpperAbstract**: the abstract of the `INSPIRE <http://www.geo.admin.ch/internet/geoportal/en/home/geoadmin/mission/inspire.html>`_ category (first level)
-  - **inprireName**: the name of the `INSPIRE <http://www.geo.admin.ch/internet/geoportal/en/home/geoadmin/mission/inspire.html>`_ category
+  - **inspireUpperAbstract**: the abstract of the `INSPIRE <https://www.geo.admin.ch/en/geo-information-switzerland/geodata-index-inspire.html>`_ category (first level)
+  - **inprireName**: the name of the `INSPIRE <https://www.geo.admin.ch/en/geo-information-switzerland/geodata-index-inspire.html>`_ category
   - **urlDetails**: link to the official details page
   - **bundCollectionNumber**: the collection number
   - **dataOwner**: the data owner
-  - **inprieAbstract**: the abstract of the `INSPIRE <http://www.geo.admin.ch/internet/geoportal/en/home/geoadmin/mission/inspire.html>`_ category the layer belongs to
+  - **inprieAbstract**: the abstract of the `INSPIRE <https://www.geo.admin.ch/en/geo-information-switzerland/geodata-index-inspire.html>`_ category the layer belongs to
   - **absctract**: the layer absctract
   - **wmsContactAbbreviation**: the abbreviation contact for the WMS resource
   - **downloadUrl**: the link where the data can be downloaded
@@ -162,7 +162,7 @@ Here is a description of the data one can find in the above response.
   - **wmsContactName**: the contact name for the WMS resource
   - **dataStatus**: the date of the latest data update
   - **bundCollectionName**: the collection name
-  - **inspireUpperName**: the name of the `INSPIRE <http://www.geo.admin.ch/internet/geoportal/en/home/geoadmin/mission/inspire.html>`_ category (first level)
+  - **inspireUpperName**: the name of the `INSPIRE <https://www.geo.admin.ch/en/geo-information-switzerland/geodata-index-inspire.html>`_ category (first level)
   - **urlApplication**: the application where this layer is published
   - **tileInfo**: WMTS general information in json format. Note that this section is always identical and is not tied to a particular "map" like in ESRI specifications.
 
@@ -499,7 +499,7 @@ The search service is separated in 3 various categories or types:
 * The **location search** which is composed of the following geocoded locations:
 
   * Cantons, Cities and communes
-  * All names as printed on the national map (`SwissNames <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/landscape/toponymy.html>`_)
+  * All names as printed on the national map (`SwissNames <https://shop.swisstopo.admin.ch/de/products/landscape/names3D>`_)
   * The districts
   * The ZIP codes
   * The addresses (!! the Swiss cantons only allow websites of the federal government to use the addresses search service !!)
@@ -650,7 +650,7 @@ Height
 ------
 
 This service allows to obtain elevation information for a point. **Note: this service is not freely accessible (fee required).** `Please Contact us <mailto:geodata@swisstopo.ch>`_
-See `Height models <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/height.html>`_ for more details about data used by this service.
+See `Height models <https://shop.swisstopo.admin.ch/de/products/height_models/alti3D>`_ for more details about data used by this service.
 
 URL
 ***
@@ -690,7 +690,7 @@ Profile
 -------
 
 This service allows to obtain elevation information for a polyline in CSV format. **Note: this service is not freely accessible (fee required).** `Please Contact us <mailto:geodata@swisstopo.ch>`_
-See `Height models <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/height.html>`_ for more details about data used by this service.
+See `Height models <https://shop.swisstopo.admin.ch/de/products/height_models/alti3D>`_ for more details about data used by this service.
 
 URL
 ***
@@ -738,7 +738,7 @@ WMTS
 
 A RESTFul implementation of the `WMTS <http://www.opengeospatial.org/standards/wmts>`_ `OGC <http://www.opengeospatial.org/>`_ standard.
 For detailed information, see `WMTS OGC standard <http://www.opengeospatial.org/standards/wmts>`_
-In order to have access to the WMTS, you require a `swisstopo web access - WMTS documentation <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/services/web_services/webaccess.html>`_, 
+In order to have access to the WMTS, you require a `swisstopo web access - WMTS documentation <https://www.swisstopo.ch/webaccess>`_, 
 despite the fact that most layers are free to use. See :ref:`available_layers` for a list of all available layers.
 
 
@@ -889,7 +889,7 @@ Note:
 * Reprojected tiles are generated *on-the-fly* with `MapProxy <http://mapproxy.org>`_. If you plan to heavily use this service, please
   inform us in advance.
 * *MapProxy* uses the `Proj.4 <http://trac.osgeo.org/proj/>`_ library internaly to transform between datum, except for the reframe from  
-  **LV03/MN03** tiles which is *NTv2* grid based (`CHENyx06 <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/software/products/chenyx06.html>`_)
+  **LV03/MN03** tiles which is *NTv2* grid based (`CHENyx06 <https://www.swisstopo.admin.ch/en/knowledge-facts/surveying-geodesy/reference-frames/local.html>`_)
 * Source for these reprojected tiles are the *native* **LV03/MN03** ones. The only exception is *ch.kantone.cadastralwebmap-farbe* that uses a WMS service as its source.
 * Note that all layers are available at all scales. You have to check for which **tileMatrixSets** a particuliar layer is defined. Your WMTS client may either stretch the
   tiles from the last available level or display nothing.
@@ -985,7 +985,7 @@ Terrain Service
 
 A RESTFul implementation of "`Cesium <http://cesiumjs.org/>`_" `Quantized Mesh <https://github.com/AnalyticalGraphicsInc/quantized-mesh>`_ terrain service.
 Terrain tiles are served according to the `Tile Map Service (TMS) <http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification>`_ layout and global-geodetic profile.
-In order to access the terrain tiles, you require a `swisstopo web access - WMTS documentation <http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/services/web_services/webaccess.html>`_.
+In order to access the terrain tiles, you require a `swisstopo web access - WMTS documentation <https://www.swisstopo.ch/webaccess>`_.
 
 URL
 ***


### PR DESCRIPTION
This updates the translations and adapts wrong CMS links. Also, it fixes https://github.com/geoadmin/mf-geoadmin3/issues/3390

[Testlink Doc](https://mf-chsdi3.dev.bgdi.ch/gjn_trans)
[Front End Test](https://mf-geoadmin3.dev.bgdi.ch/gjn_attribution/?api_url=gjn_trans&api_env=dev&lang=en&topic=swisstopo&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung,ch.bazl.sachplan-infrastruktur-luftfahrt_kraft&layers_opacity=0.75,1&X=226481.36&Y=659634.32&zoom=0)