### PR TITLE
Raise error on big geoms

### DIFF
--- a/chsdi/lib/exceptions.py
+++ b/chsdi/lib/exceptions.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+import pyramid.httpexceptions as exc
+
+
+class HTTPBandwidthLimited(exc.HTTPServerError):
+    code = 509
+    title = 'Bandwidth Limit Exceeded'

--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -5,8 +5,8 @@ import geojson
 import datetime
 import decimal
 from sys import maxsize
-import pyramid.httpexceptions as exc
 from pyramid.threadlocal import get_current_registry
+from chsdi.lib.exceptions import HTTPBandwidthLimited
 from shapely.geometry import asShape
 from shapely.geometry import box
 from sqlalchemy.sql import func
@@ -50,11 +50,6 @@ def getToleranceMeters(imageDisplay, mapExtent, tolerance):
     return 0.0
 
 
-class HTTPBandwidtLimited(exc.HTTPServerError):
-    code = 509
-    title = 'Bandwidth Limit Exceeded'
-
-
 class Vector(GeoInterface):
     __minscale__ = 0
     __maxscale__ = maxsize
@@ -80,7 +75,7 @@ class Vector(GeoInterface):
                         geom = self._shape
                     elif val is not None:
                         if len(val.data) > 1000000:
-                            raise HTTPBandwidtLimited('Feature ID %s: is too large' % self.id)
+                            raise HTTPBandwidthLimited('Feature ID %s: is too large' % self.id)
                         geom = to_shape(val)
                 elif not col.foreign_keys and not isinstance(col.type, Geometry):
                     properties[p.key] = val

--- a/chsdi/tests/integration/test_identify_service.py
+++ b/chsdi/tests/integration/test_identify_service.py
@@ -98,11 +98,8 @@ class TestIdentifyService(TestsBase):
     def test_identify_valid(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertIn('results', resp.json)
-        self.assertIn('attributes', resp.json['results'][0])
-        self.assertIn('geometry', resp.json['results'][0])
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=509)
+        self.assertEqual(resp.content_type, 'text/plain')
 
     def test_identify_valid_on_grid(self):
         params = {'geometry': '555000,171125', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryPoint',
@@ -137,18 +134,15 @@ class TestIdentifyService(TestsBase):
     def test_identify_valid_topic_all(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertIn('attributes', resp.json['results'][0])
-        self.assertIn('geometry', resp.json['results'][0])
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=509)
+        self.assertEqual(resp.content_type, 'text/plain')
 
     def test_identify_valid_with_callback(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all',
-                  'callback': 'cb'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
-        self.assertEqual(resp.content_type, 'text/javascript')
-        resp.mustcontain('cb({')
+                  'callback': 'cb_'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=509)
+        self.assertEqual(resp.content_type, 'text/plain')
 
     def test_identify_with_geojson(self):
         params = {'geometry': '600000,200000,631000,210000', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',

--- a/chsdi/tests/integration/test_layers.py
+++ b/chsdi/tests/integration/test_layers.py
@@ -136,7 +136,7 @@ class LayersChecker(object):
         assert featureId is not None, 'No feature was found in table %s for layer %s' % (
             schema + '.' + model.__tablename__, layerId)
         pythonType = primaryKeyColumn.type.python_type
-        assert type(featureId) == pythonType, 'Expected %s; Got: %s; For layer %s and GeoTable %s' % (
+        assert isinstance(featureId, pythonType), 'Expected %s; Got: %s; For layer %s and GeoTable %s' % (
             pythonType, type(featureId), layerId, schema + '.' + model.__tablename__)
 
 

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -24,6 +24,7 @@ from chsdi.lib.validation.find import FindServiceValidation
 from chsdi.lib.validation.identify import IdentifyServiceValidation
 from chsdi.lib.validation.geometryservice import GeometryServiceValidation
 from chsdi.lib.helpers import format_query, decompress_gzipped_string, center_from_box2d
+from chsdi.lib.exceptions import HTTPBandwidthLimited
 from chsdi.lib.filters import full_text_search
 from chsdi.models.clientdata_dynamodb import get_bucket
 from chsdi.models import (
@@ -707,7 +708,10 @@ def _process_feature(feature, params):
             f = feature.__esrijson_interface__
         return f
 
-    if params.returnGeometry and not has_long_geometry(feature):
+    if has_long_geometry(feature):
+        raise HTTPBandwidthLimited('Feature ID %s: is too large' % feature.id)
+
+    if params.returnGeometry:
         # Filter out this layer individually, disregarding of the global returnGeometry
         # setting
         if not params.varnish_authorized and \


### PR DESCRIPTION
Rather than silently removing geomtries, we inform the client why we can't provide this geometry.

Related to https://github.com/geoadmin/mf-chsdi3/issues/2178