### PR TITLE
Order by distance when limit is set to 1

### DIFF
--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -209,9 +209,10 @@ class Vector(GeoInterface):
     by selected clients only.
     '''
     @classmethod
-    def order_by_distance(cls, geometry, geometryType, imageDisplay, mapExtent, tolerance):
+    def order_by_distance(cls, geometry, geometryType, imageDisplay, mapExtent, tolerance, limit):
         toleranceMeters = getToleranceMeters(imageDisplay, mapExtent, tolerance)
-        if toleranceMeters <= 250.0:
+        # If limit is equal to 1 we have to be accurate
+        if toleranceMeters <= 250.0 or limit == 1:
             geom = esriRest2Shapely(geometry)
             wkbGeometry = WKBElement(buffer(geom.wkb), 21781)
             geomColumn = cls.geometry_column()

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -469,6 +469,10 @@ def _get_features_for_filters(params, layerBodIds, maxFeatures=None, where=None)
     a feature. '''
     for layer in layerBodIds:
         layerBodId, models = next(layer.iteritems())
+        # Determine the limit
+        limits = [x for x in [maxFeatures, params.limit] if x is not None]
+        flimit = min(limits) if len(limits) > 0 else None
+
         if where is not None:
             vectorLayer = []
             for model in models:
@@ -506,7 +510,8 @@ def _get_features_for_filters(params, layerBodIds, maxFeatures=None, where=None)
                             params.geometryType,
                             params.imageDisplay,
                             params.mapExtent,
-                            params.tolerance
+                            params.tolerance,
+                            flimit
                         )
                     query = query.order_by(ordering) if ordering is not None else query
                     query = query.filter(geomFilter)
@@ -521,8 +526,6 @@ def _get_features_for_filters(params, layerBodIds, maxFeatures=None, where=None)
                         timeInstantColumn == timeInstant)
 
             # Add limit
-            limits = [x for x in [maxFeatures, params.limit] if x is not None]
-            flimit = min(limits) if len(limits) > 0 else None
             query = query.limit(flimit) if flimit is not None else query
 
             # Add offset


### PR DESCRIPTION
Fix: as part of https://github.com/geoadmin/mf-geoadmin3/issues/3382

We limited the search radius at 250 meters for stability/performance reasons when ordering by distance.

But when it is combined with limit 1, it returns inaccurate results because the order is not respected anymore.
Here we assume than we the limit is set to 1, we must order by distance to get an accurate result.

@oterral Can you add `order=distance` in geoadmin for shop layers (e.g. when we use limit 1)?