### PR TITLE
Ensure that empty categories have an empty list

### DIFF
--- a/chsdi/views/catalog.py
+++ b/chsdi/views/catalog.py
@@ -45,6 +45,8 @@ def tree_data(G, root, attrs, meta):
             c = add_children(child, G)
             if c:
                 d[children] = c
+            elif d['category'] != 'layer':
+                d[children] = []
             children_.append(d)
             if ('orderKey' in d):
                 order_key = lambda x: x['orderKey']


### PR DESCRIPTION
With this PR we ensure that children is always defined at the category level. (used in geoadmin to determine whether a leaf is a layer or a category)

[Test Link](https://mf-geoadmin3.dev.bgdi.ch/?api_url=gal_empty_list&topic=sachplan)

@mariokeusen Is it normal to have empty categories in prod?

Otherwise please change sachplan topic and change the staging of the categories
PS Infrastructure routes (SIN)
PS Militaire (PSM)

to test (the layers associated to the categories should be set to test as well, they are in test in the catalog only)