### PR TITLE
Show the same information in geocover layers tooltips:

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -1043,23 +1043,6 @@ register('ch.swisstopo.swissimage-product', SwissimageProduct)
 register_perimeter('ch.swisstopo.swissimage-product', SwissimageProductPerimeter)
 
 
-class GeolGeocoverMetadata(Base, Vector):
-    __tablename__ = 'kv_geocover'
-    __table_args__ = ({'schema': 'geol', 'autoload': False})
-    __template__ = 'templates/htmlpopup/geocover_metadata.mako'
-    __bodId__ = 'ch.swisstopo.geologie-geocover.metadata'
-    __label__ = 'nr'
-    id = Column('gid', Integer, primary_key=True)
-    nr = Column('nr', Text)
-    titel = Column('titel', Text)
-    basis = Column('basis', Text)
-    vektorisierung_jahr = Column('vektorisierung_jahr', Integer)
-    grat25 = Column('grat25', Text)
-    the_geom = Column(Geometry2D)
-
-register('ch.swisstopo.geologie-geocover.metadata', GeolGeocoverMetadata)
-
-
 class GeolGenKarteGGK200Meta(Base, Vector):
     __tablename__ = 'kv_ggk_pk'
     __table_args__ = ({'schema': 'geol', 'autoload': False, 'extend_existing': True})
@@ -2131,6 +2114,16 @@ register('ch.swisstopo.geologie-geocover', GeocoverPolygonAux2)
 register('ch.swisstopo.geologie-geocover', GeocoverPolygonMain)
 register('ch.swisstopo.geologie-geocover', GeocoverGridShop)
 register_perimeter('ch.swisstopo.geologie-geocover', GeocoverGridShop)
+
+
+class GeolGeocoverMetadata(Base, Geocover, ShopProductGroupClass, Vector):
+    __tablename__ = 'view_geocover_grid_shop'
+    __table_args__ = ({'schema': 'geol', 'autoload': False, 'extend_existing': True})
+    __bodId__ = 'ch.swisstopo.geologie-geocover.metadata'
+    __label__ = 'name_de'
+
+
+register('ch.swisstopo.geologie-geocover.metadata', GeolGeocoverMetadata)
 
 
 class Ga25Atlas:

--- a/chsdi/templates/htmlpopup/geocover_metadata.mako
+++ b/chsdi/templates/htmlpopup/geocover_metadata.mako
@@ -1,8 +1,0 @@
-<%inherit file="base.mako"/>
-
-<%def name="table_body(c, lang)">
-    <tr><td class="cell-left">${_('lab')}</td><td>${c['attributes']['nr']} -  ${c['attributes']['titel']}</td></tr> 
-    <tr><td class="cell-left">${_('vektorisierung_jahr')}</td><td>${int(c['attributes']['vektorisierung_jahr'])}</td></tr>
-    <tr><td class="cell-left">${_('basis')}</td>    <td>${c['attributes']['basis']}</td></tr>
-    <tr><td class="cell-left">${_('grat25')}</td>          <td>${c['attributes']['grat25']}</td></tr>
-</%def>


### PR DESCRIPTION
ch.swisstopo.geologie-geocover -> stopo_master.datenstand.toposhop_product
ch.swisstopo.geologie-geocover.metadata attribute datasource is not updated anymore, replaced with toposhop_product
[Testlink](https://mf-geoadmin3.dev.bgdi.ch/?topic=ech&api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fdev_ltclm_geocover_tooltip&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.geologie-geocover,ch.swisstopo.geologie-geocover.metadata&layers_opacity=0.75,0.75&X=181415.41&Y=679830.50&zoom=3)