### PR TITLE
Translation update from geocat

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -3441,7 +3441,7 @@ msgid "ch.bafu.wasser-teileinzugsgebiete_40"
 msgstr "Teileinzugsgebiete 40km2"
 
 msgid "ch.bafu.wasser-vorfluter"
-msgstr "Ablussregimetyp"
+msgstr "Abflussregimetyp"
 
 msgid "ch.bafu.wasserbau-querprofilmarken"
 msgstr "Querprofilmarke"


### PR DESCRIPTION
Typo error in the alternative title in German of layer ch.bafu.wasser-vorfluter