### PR TITLE
Fix zope interface version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ WebOb==1.6.1
 WebTest==2.0.21
 toml
 lxml==2.3.0
+zope.interface==4.2.0


### PR DESCRIPTION
https://pypi.python.org/pypi/zope.interface

https://github.com/zopefoundation/zope.interface/issues/53

Today's release of zope.interface is crashing the app.
Therefore we're keeping zope.interface to an earlier version.
