### PR TITLE
Remove auth decorator from ogcproxy

### DIFF
--- a/chsdi/tests/integration/test_ogcproxy.py
+++ b/chsdi/tests/integration/test_ogcproxy.py
@@ -9,10 +9,6 @@ class TestOGCproxyView(TestsBase):
         super(TestOGCproxyView, self).setUp()
         self.headers = {'X-SearchServer-Authorized': 'true'}
 
-    def test_proxy_forbidden(self):
-        params = {'url': 'http://www.geo.admin.ch/'}
-        self.testapp.get('/ogcproxy', params=params, status=403)
-
     def test_proxy_authorized(self):
         params = {'url': 'http://www.geo.admin.ch/'}
         resp = self.testapp.get('/ogcproxy', params=params, headers=self.headers, status=200)

--- a/chsdi/views/ogcproxy.py
+++ b/chsdi/views/ogcproxy.py
@@ -8,8 +8,6 @@ from pyramid.view import view_config
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPBadGateway, HTTPNotAcceptable
 from pyramid.response import Response
-from chsdi.lib.decorators import requires_authorization
-
 
 from StringIO import StringIO
 from urllib import urlopen
@@ -28,7 +26,6 @@ class OgcProxy:
     def __init__(self, request):
         self.request = request
 
-    @requires_authorization()
     @view_config(route_name='ogcproxy')
     def ogcproxy(self):
 


### PR DESCRIPTION
Since we had double check, at varnish level and application level.

Genereal rule is to check everything at varnish level, except where we need a more fined solution (e.g. removing geometries, which has to be done by the service).