### PR TITLE
Improve search ranking

### DIFF
--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -149,6 +149,13 @@ class TestSearchServiceView(TestsBase):
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json['results'][1]['attrs']['detail'], 'rhonesandstrasse 16a 3900 brig 6002 brig-glis ch vs')
 
+    def test_search_ranking(self):
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': 'gstaad', 'type': 'locations'}, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'gstaad')
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': 'gstaad 10', 'type': 'locations'}, status=200)
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'gstaadstrasse 10 3792 saanen 843 saanen ch be')
+
     def test_search_features_identify(self):
         params = {'searchText': 'vd 446', 'type': 'featuresearch', 'bbox': '551306.5625,167918.328125,551754.125,168514.625', 'features': 'ch.astra.ivs-reg_loc'}
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -299,7 +299,7 @@ class Search(SearchValidation):
                 '%s "%s"~5'  % (fields, preNonDigit),
                 '%s "%s"'    % (fields, infNonDigit),
                 '%s "^%s"'   % (fields, infNonDigit),
-                '%s "%s"~5'  % (fields, infNonDigit),
+                '%s "%s"~5'  % (fields, infNonDigit)
             ]
 
         if hasDigit:
@@ -337,8 +337,8 @@ class Search(SearchValidation):
             'gg25': 2,
             'district': 3,
             'kantone': 4,
-            'gazetteer': 5,  # Not used, also 6
-            'address': 7,
+            'gazetteer': 5,  # Not used, also 7
+            'address': 6,
             'parcel': 10
         }
         buildRanksList = lambda x: origin2Rank[x]

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -275,36 +275,47 @@ class Search(SearchValidation):
         return transformCoordinate(wkt, 21781, 4326)
 
     def _query_fields(self, fields):
-        exact_nondigit_prefix_digit = lambda x: ''.join((x, '*')) if x.isdigit() else x
-        prefix_nondigit_exact_digit = lambda x: x if x.isdigit() else ''.join((x, '*'))
-        prefix_match_all = lambda x: ''.join((x, '*'))
-        infix_nondigit_prefix_digit = lambda x: ''.join((x, '*')) if x.isdigit() else ''.join(('*', x, '*'))
+        # 10a, 10b needs to be interpreted as digit
+        q = []
+        isdigit = lambda x: bool(re.match('^[0-9]', x))
+        hasDigit = bool(len([x for x in self.searchText if isdigit(x)]) > 0)
+        hasNonDigit = bool(len([x for x in self.searchText if not isdigit(x)]) > 0)
 
-        exactAll = ' '.join(self.searchText)
-        exactNonDigitPreDigit = ' '.join(
-            map(exact_nondigit_prefix_digit, self.searchText))
-        preNonDigitExactDigit = ' '.join(
-            map(prefix_nondigit_exact_digit, self.searchText))
-        preNonDigitPreDigit = ' '.join(
-            map(prefix_match_all, self.searchText))
-        infNonDigitPreDigit = ' '.join(
-            map(infix_nondigit_prefix_digit, self.searchText))
+        prefix_non_digit = lambda x: x if isdigit(x) else ''.join((x, '*'))
+        infix_non_digit = lambda x: x if isdigit(x) else ''.join(('*', x, '*'))
 
-        finalQuery = ' | '.join((
-            '%s "^%s"' % (fields, exactAll),
-            '%s "%s"' % (fields, exactAll),
-            '%s "%s"~5' % (fields, exactAll),
-            '%s "%s"' % (fields, exactNonDigitPreDigit),
-            '%s "%s"~5' % (fields, exactNonDigitPreDigit),
-            '%s "%s"' % (fields, preNonDigitExactDigit),
-            '%s "%s"~5' % (fields, preNonDigitExactDigit),
-            '%s "^%s"' % (fields, preNonDigitPreDigit),
-            '%s "%s"' % (fields, preNonDigitPreDigit),
-            '%s "%s"~5' % (fields, preNonDigitPreDigit),
-            '%s "%s"' % (fields, infNonDigitPreDigit),
-            '%s "%s"~5' % (fields, infNonDigitPreDigit)
-        ))
+        if hasNonDigit:
+            exactAll = ' '.join(self.searchText)
+            preNonDigit = ' '.join([prefix_non_digit(w) for w in self.searchText])
+            infNonDigit = ' '.join([infix_non_digit(w) for w in self.searchText])
+            q = [
+                '%s "%s"'    % (fields, exactAll),
+                '%s "^%s"'   % (fields, exactAll),
+                '%s "%s$"'   % (fields, exactAll),
+                '%s "^%s$"'  % (fields, exactAll),
+                '%s "%s"~5'  % (fields, exactAll),
+                '%s "%s"'    % (fields, preNonDigit),
+                '%s "^%s"'   % (fields, preNonDigit),
+                '%s "%s"~5'  % (fields, preNonDigit),
+                '%s "%s"'    % (fields, infNonDigit),
+                '%s "^%s"'   % (fields, infNonDigit),
+                '%s "%s"~5'  % (fields, infNonDigit),
+            ]
 
+        if hasDigit:
+            prefix_digit = lambda x: x if not isdigit(x) else ''.join((x, '*'))
+            prefix_all = lambda x: ''.join((x, '*'))
+            preDigit = ' '.join([prefix_digit(w) for w in self.searchText])
+            preNonDigitAndPreDigit = ' '.join([prefix_all(w) for w in self.searchText])
+            infNonDigitAndPreDigit = ' '.join([prefix_digit(infix_non_digit(w)) for w in self.searchText])
+            q = q + [
+                '%s "%s"'   % (fields, preDigit),
+                '%s "^%s"'  % (fields, preDigit),
+                '%s "%s"'   % (fields, preNonDigitAndPreDigit),
+                '%s "%s"~5' % (fields, preNonDigitAndPreDigit),
+                '%s "%s"'   % (fields, infNonDigitAndPreDigit)
+            ]
+        finalQuery = ' | '.join(q)
         return finalQuery
 
     def _origin_to_layerbodid(self, origin):
@@ -326,8 +337,8 @@ class Search(SearchValidation):
             'gg25': 2,
             'district': 3,
             'kantone': 4,
-            'gazetteer': 5,
-            'address': 6,
+            'gazetteer': 5,  # Not used, also 6
+            'address': 7,
             'parcel': 10
         }
         buildRanksList = lambda x: origin2Rank[x]


### PR DESCRIPTION
This PR improves the ranking of the search.

Before we were building queries were some patterns would be repeated several times when

1. we only had digits
2. we only had non-digits

This would sometimes lead to strange ranking results.

We now test if the search pattern contains `digit` and `non-digit` words before building the query.

This is intended to work with https://github.com/geoadmin/service-sphinxsearch/pull/292

(indice have already been rotated in dev)
https://github.com/geoadmin/service-sphinxsearch/pull/292

[Test Link new dev](http://map.geo.admin.ch?api_url=//mf-chsdi3.dev.bgdi.ch/gal_search_ranking)


Note that it is significantly slower on dev.

To compare with previous behaviour on dev 

[Test Link previous dev also](http://map.geo.admin.ch?env=dev)