### PR TITLE
Add tilematrixes down to 20 for epsg:4326

### DIFF
--- a/chsdi/templates/wmtscapabilities/TileMatrixSet_4326.mako
+++ b/chsdi/templates/wmtscapabilities/TileMatrixSet_4326.mako
@@ -124,8 +124,8 @@
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>16384</MatrixWidth>
+        <MatrixHeight>8192</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>14</ows:Identifier>
@@ -133,8 +133,8 @@
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>32768</MatrixWidth>
+        <MatrixHeight>16384</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>15</ows:Identifier>
@@ -142,8 +142,8 @@
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>65536</MatrixWidth>
+        <MatrixHeight>32768</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>16</ows:Identifier>
@@ -151,8 +151,8 @@
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>131072</MatrixWidth>
+        <MatrixHeight>65536</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>17</ows:Identifier>
@@ -160,8 +160,8 @@
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>262144</MatrixWidth>
+        <MatrixHeight>131072</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>18</ows:Identifier>
@@ -169,8 +169,8 @@
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>524288</MatrixWidth>
+        <MatrixHeight>262144</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>19</ows:Identifier>
@@ -178,16 +178,16 @@
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>1048576</MatrixWidth>
+        <MatrixHeight>524288</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>20</ows:Identifier>
-        <ScaleDenominator>268.6903412724137</ScaleDenominator>
+        <ScaleDenominator>266.591197981223</ScaleDenominator>
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
+        <MatrixWidth>2097152</MatrixWidth>
+        <MatrixHeight>1048576</MatrixHeight>
       </TileMatrix>
  </TileMatrixSet>

--- a/chsdi/templates/wmtscapabilities/TileMatrixSet_4326.mako
+++ b/chsdi/templates/wmtscapabilities/TileMatrixSet_4326.mako
@@ -20,33 +20,6 @@
         <MatrixHeight>2</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>10</ows:Identifier>
-        <ScaleDenominator>272989.3867327723315839</ScaleDenominator>
-        <TopLeftCorner>90 -180</TopLeftCorner>
-        <TileWidth>256</TileWidth>
-        <TileHeight>256</TileHeight>
-        <MatrixWidth>2048</MatrixWidth>
-        <MatrixHeight>1024</MatrixHeight>
-      </TileMatrix>
-      <TileMatrix>
-        <ows:Identifier>11</ows:Identifier>
-        <ScaleDenominator>136494.6933663861657919</ScaleDenominator>
-        <TopLeftCorner>90 -180</TopLeftCorner>
-        <TileWidth>256</TileWidth>
-        <TileHeight>256</TileHeight>
-        <MatrixWidth>4096</MatrixWidth>
-        <MatrixHeight>2048</MatrixHeight>
-      </TileMatrix>
-      <TileMatrix>
-        <ows:Identifier>12</ows:Identifier>
-        <ScaleDenominator>68247.3466831930828960</ScaleDenominator>
-        <TopLeftCorner>90 -180</TopLeftCorner>
-        <TileWidth>256</TileWidth>
-        <TileHeight>256</TileHeight>
-        <MatrixWidth>8192</MatrixWidth>
-        <MatrixHeight>4096</MatrixHeight>
-      </TileMatrix>
-      <TileMatrix>
         <ows:Identifier>02</ows:Identifier>
         <ScaleDenominator>69885283.0035897168854717</ScaleDenominator>
         <TopLeftCorner>90 -180</TopLeftCorner>
@@ -117,5 +90,104 @@
         <TileHeight>256</TileHeight>
         <MatrixWidth>1024</MatrixWidth>
         <MatrixHeight>512</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>10</ows:Identifier>
+        <ScaleDenominator>272989.3867327723315839</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2048</MatrixWidth>
+        <MatrixHeight>1024</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>11</ows:Identifier>
+        <ScaleDenominator>136494.6933663861657919</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4096</MatrixWidth>
+        <MatrixHeight>2048</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>12</ows:Identifier>
+        <ScaleDenominator>68247.3466831930828960</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>13</ows:Identifier>
+        <ScaleDenominator>34123.67334159654</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>14</ows:Identifier>
+        <ScaleDenominator>17061.83667079827</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>15</ows:Identifier>
+        <ScaleDenominator>8530.918335399136</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>16</ows:Identifier>
+        <ScaleDenominator>4265.459167699568</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>17</ows:Identifier>
+        <ScaleDenominator>2132.729583849784</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>18</ows:Identifier>
+        <ScaleDenominator>1066.364791924892</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>19</ows:Identifier>
+        <ScaleDenominator>533.182395962446</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>20</ows:Identifier>
+        <ScaleDenominator>268.6903412724137</ScaleDenominator>
+        <TopLeftCorner>90 -180</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
       </TileMatrix>
  </TileMatrixSet>


### PR DESCRIPTION
Démo [GetCapabilities](http://mf-chsdi3.dev.bgdi.ch/mom_4326_tilematrixset/EPSG/4326/1.0.0/WMTSCapabilities.xml)

Integrated in [ArcGisOnline](http://www.arcgis.com/home/webmap/viewer.html?webmap=bdf240d7ba424329a1ee49bc7c04d582)

ArcGis REST JS [API integration](http://codepen.io/procrastinatio/full/b65a6267e8ff6e9a1942adaed8cfb988/)

See https://github.com/geoadmin/service-mapproxy/issues/42

:bomb: Must be merge/deployed togehther with https://github.com/geoadmin/service-mapproxy/pull/41