### PR TITLE
Scale dependent filtering early enough

### DIFF
--- a/chsdi/models/__init__.py
+++ b/chsdi/models/__init__.py
@@ -44,6 +44,22 @@ def register_oereb(name, klass):
     oerebmap.setdefault(name, []).append(klass)
 
 
+def min_resolution(m):
+    return m.__minresolution__ if hasattr(m, '__minresolution__') else 0.0
+
+
+def max_resolution(m):
+    return m.__maxresolution__ if hasattr(m, '__maxresolution__') else float('inf')
+
+
+def min_scale(m):
+    return m.__minscale__ if hasattr(m, '__minscale__') else 0.0
+
+
+def max_scale(m):
+    return m.__maxscale__ if hasattr(m, '__maxscale__') else float('inf')
+
+
 def perimeter_models_from_bodid(bodId):
     perimeter_models = perimetermap.get(bodId)
     if perimeter_models is None:
@@ -51,30 +67,21 @@ def perimeter_models_from_bodid(bodId):
     return perimeter_models
 
 
-def oereb_models_from_bodid(bodId):
-    return oerebmap.get(bodId)
+def oereb_models_from_bodid(bodId, scale=None):
+    models = oerebmap.get(bodId)
+    if scale is not None:
+        models = [m for m in models if scale < max_scale(m) and scale >= min_scale(m)]
+    return models
 
 
-def models_from_bodid(bodId, scale=None):
+def models_from_bodid(bodId, scale=None, resolution=None):
     models = bodmap.get(bodId)
-    if scale and models:
-        filteredModels = []
-        for m in models:
-            hasMinScale = hasattr(m, '__minscale__')
-            hasMaxScale = hasattr(m, '__maxscale__')
-            if hasMinScale and hasMaxScale:
-                if m.__minscale__ < scale and m.__maxscale__ > scale:
-                    filteredModels.append(m)
-            elif hasMinScale:
-                if m.__minscale__ < scale:
-                    filteredModels.append(m)
-            elif hasMaxScale:
-                if m.__maxscale__ > scale:
-                    filteredModels.append(m)
-        if len(filteredModels) > 0:
-            return filteredModels
-    else:
-        return models
+    if models:
+        if scale is not None:
+            models = [m for m in models if scale < max_scale(m) and scale >= min_scale(m)]
+        elif resolution is not None:
+            models = [m for m in models if resolution < max_resolution(m) and resolution >= min_resolution(m)]
+    return models
 
 
 def queryable_models_from_bodid(bodId, searchField):

--- a/chsdi/tests/integration/test_identify_service.py
+++ b/chsdi/tests/integration/test_identify_service.py
@@ -418,6 +418,20 @@ class TestIdentifyService(TestsBase):
         params.update({'limit': 'a'})
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
 
+    def test_identify_quer_spatial_filters_scale_dep(self):
+        params = {'layers': 'all:ch.bav.haltestellen-oev',
+                  'geometry': '643952.5,164121.24999999997',
+                  'geometryFormat': 'geojson',
+                  'geometryType': 'esriGeometryEnvelope',
+                  'imageDisplay': '1641,867,96',
+                  'mapExtent': '533750,136249.99999999994,550250,174249.99999999997',
+                  'tolerance': '5',
+                  'where': 'name ilike \'%dietikon%\''
+                  }
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(len(resp.json['results']), 0)
+
     def test_identify_order_by_distance(self):
         params = {'layers': 'all:ch.bfs.gebaeude_wohnungs_register',
                   'geometry': '643952.5,164121.24999999997',


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-chsdi3/issues/2225

The combination of a spatial filter, attribute filter and scale dependent layer would fail as the models where not filtered early enough .

[Test link](map.geo.admin.ch?api_url=//mf-chsdi3.dev.bgdi.ch/gal_res_management?layers=ch.bav.haltestellen-oev)
