### PR TITLE
Many KMZ are not served with the right 'content-Type'

### DIFF
--- a/chsdi/views/ogcproxy.py
+++ b/chsdi/views/ogcproxy.py
@@ -54,7 +54,8 @@ class OgcProxy:
         #  All content types are allowed
         if "content-type" in resp:
             ct = resp["content-type"]
-            if resp["content-type"] == "application/vnd.google-earth.kmz":
+            if ct == "application/vnd.google-earth.kmz" or \
+                    (ct == "application/octet-stream" and resp["content-location"].endswith(".kmz")):
                 zipfile = None
                 try:
                     zipurl = urlopen(url)


### PR DESCRIPTION
Be more relaxed on content-type if file extension matches
Did expect `application/vnd.google-earth.kmz`, but `application/octet-stream` may also work, has the vast majority of client are not able to set correctly this information.


Three examples, same data:

1/ Correct _Content-Type_ --> OK
https://s.geo.admin.ch/6e7d5fe9a6


2/ Incorrect _Content-Type_  --> KMZ not loaded

https://map.geo.admin.ch/?lang=fr&layers=KML%7C%7Chttps%3A%2F%2Fpublic.geo.admin.ch%2Fwascha%2Fwascha.kmz&layers_visibility=true


3/ With this PR (mom_kmz)
Incorrect _Content-Type_, but _.kmz_

https://map.geo.admin.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fmom_kmz&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=KML%7C%7Chttps:%2F%2Fpublic.geo.admin.ch%2Fwascha%2Fwascha.kmz

