### PR TITLE
Fix tests and remove :all test for identify

### DIFF
--- a/chsdi/tests/integration/test_identify_service.py
+++ b/chsdi/tests/integration/test_identify_service.py
@@ -97,7 +97,7 @@ class TestIdentifyService(TestsBase):
 
     def test_identify_valid(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
-                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
+                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all:ch.swisstopo.fixpunkte-agnes'}
         resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
@@ -131,18 +131,18 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
         resp.mustcontain('Please provide the parameter imageDisplay in a comma separated list of 3 arguments (width,height,dpi)')
 
-    def test_identify_valid_topic_all(self):
+    def test_identify_valid_topic(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
-                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
+                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all:ch.swisstopo.fixpunkte-agnes'}
         resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
     def test_identify_valid_with_callback(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
-                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all',
+                  'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all:ch.swisstopo.fixpunkte-agnes',
                   'callback': 'cb_'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=509)
-        self.assertEqual(resp.content_type, 'text/plain')
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        self.assertEqual(resp.content_type, 'text/javascript')
 
     def test_identify_with_geojson(self):
         params = {'geometry': '600000,200000,631000,210000', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',

--- a/chsdi/tests/integration/test_layers.py
+++ b/chsdi/tests/integration/test_layers.py
@@ -109,6 +109,12 @@ class LayersChecker(object):
             resp = self.testapp.get(link)
             assert resp.status_int == 200, link
 
+    def checkIdentify(self, layer):
+        link = '/rest/services/all/MapServer/identify?geometry=558945.5,147956,559402,148103.5&geometryType=esriGeometryEnvelope&imageDisplay=500,600,96&mapExtent=558945.5,147956,559402,148103.5&tolerance=1&layers=all:' + layer
+        resp = self.testapp.get(link)
+        assert resp.status_int == 200, link
+        assert resp.content_type == 'application/json', link
+
     def checkLegendImage(self, layer, legendsPath, legendImages):
         for lang in ('de', 'fr', 'it', 'rm', 'en'):
             key = layer + '_' + lang
@@ -158,6 +164,12 @@ def test_all_legends():
     with LayersChecker() as lc:
         for layer in lc.ilayers(hasLegend=True):
             yield lc.checkLegend, layer
+
+
+def test_all_identify():
+    with LayersChecker() as lc:
+        for layer in lc.ilayers(tooltip=True, geojson=False):
+            yield lc.checkIdentify, layer
 
 
 def test_all_ids_mapping():


### PR DESCRIPTION
This should fix the jenkinds failures.

It removes the :all tests that interrogates all layers at the same time resulting in huge responses. In addition, it adds an identify test for every layer that has a tooltip.