### PR TITLE
fix type on ch.vbs.sachplan-infrastruktur-militaer_anhoerung layer name

### DIFF
--- a/chsdi/models/vector/vbs.py
+++ b/chsdi/models/vector/vbs.py
@@ -190,9 +190,9 @@ class SimFacilities:
 
 class SimFacilitiesA(Base, SimFacilities, Vector):
     __tablename__ = 'sim_fac_anhoerung'
-    __bodId__ = 'ch.vbs.sachplan-infrastruktur-militaer_anhorung'
+    __bodId__ = 'ch.vbs.sachplan-infrastruktur-militaer_anhoerung'
 
-register('ch.vbs.sachplan-infrastruktur-militaer_anhorung', SimFacilitiesA)
+register('ch.vbs.sachplan-infrastruktur-militaer_anhoerung', SimFacilitiesA)
 
 
 class SimFacilitiesK(Base, SimFacilities, Vector):
@@ -243,20 +243,20 @@ register('ch.vbs.sachplan-infrastruktur-militaer_kraft', SimPlanningK)
 
 class SimPlanningA(Base, SimPlanning, Vector):
     __tablename__ = 'sim_pl_anhoerung'
-    __bodId__ = 'ch.vbs.sachplan-infrastruktur-militaer_anhorung'
+    __bodId__ = 'ch.vbs.sachplan-infrastruktur-militaer_anhoerung'
     __minscale__ = 20005
     __maxscale__ = 500005
 
-register('ch.vbs.sachplan-infrastruktur-militaer_anhorung', SimPlanningA)
+register('ch.vbs.sachplan-infrastruktur-militaer_anhoerung', SimPlanningA)
 
 
 class SimPlanningRasterA(Base, SimPlanning, Vector):
     __tablename__ = 'sim_pl_r_anhoerung'
-    __bodId__ = 'ch.vbs.sachplan-infrastruktur-militaer_anhorung'
+    __bodId__ = 'ch.vbs.sachplan-infrastruktur-militaer_anhoerung'
     __maxscale__ = 20005
     __minscale__ = 1
 
-register('ch.vbs.sachplan-infrastruktur-militaer_anhorung', SimPlanningRasterA)
+register('ch.vbs.sachplan-infrastruktur-militaer_anhoerung', SimPlanningRasterA)
 
 
 class SimPlanningRasterK(Base, SimPlanning, Vector):


### PR DESCRIPTION
the layer ch.vbs.sachplan-infrastruktur-militaer_anhoerung was wrongly written in the model definition.
