### PR TITLE
Fix polling for haltestellen and add iframe service

### DIFF
--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -66,6 +66,7 @@ def main(global_config, **settings):
     config.add_route('featureAttributes', '/rest/services/{map}/MapServer/{layerId}')
     config.add_route('feature', '/rest/services/{map}/MapServer/{layerId}/{featureId}')
     config.add_route('htmlPopup', '/rest/services/{map}/MapServer/{layerId}/{featureId}/htmlPopup')
+    config.add_route('iframeHtmlPopup', '/rest/services/{map}/MapServer/{layerId}/{featureId}/iframeHtmlPopup')
     config.add_route('extendedHtmlPopup', '/rest/services/{map}/MapServer/{layerId}/{featureId}/extendedHtmlPopup')
     config.add_route('search', '/rest/services/{map}/SearchServer')
     config.add_route('wmtscapabilities', '/rest/services/{map}/1.0.0/WMTSCapabilities.xml')

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -51,8 +51,15 @@ def make_api_url(request, agnostic=False):
     host = request.host + base_path if 'localhost' not in request.host else request.host
     if agnostic:
         return ''.join(('//', host))
-    else:
-        return ''.join((request.scheme, '://', host))
+    return ''.join((request.scheme, '://', host))
+
+
+def make_geoadmin_url(request, agnostic=False):
+    protocol = request.scheme
+    base_url = ''.join((protocol, '://', request.registry.settings['geoadminhost']))
+    if agnostic:
+        return make_agnostic(base_url)
+    return base_url
 
 
 def resource_exists(path, headers={}):

--- a/chsdi/lib/validation/features.py
+++ b/chsdi/lib/validation/features.py
@@ -24,6 +24,7 @@ class HtmlPopupServiceValidation(BaseFeaturesValidation):
         self.mapExtent = request.params.get('mapExtent')
 
         self.returnGeometry = False
+        self.geometryFormat = 'geojson'
 
     @property
     def layerId(self):

--- a/chsdi/static/less/extended.less
+++ b/chsdi/static/less/extended.less
@@ -1,4 +1,4 @@
-html, body, div, span, p, 
+html, body, div, span, p,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 dl, dt, dd, ol, ul, li,
 table, caption, tbody, tfoot, thead, tr, th, td {
@@ -10,7 +10,7 @@ body {
   overflow: auto!important;
 }
 .chsdi-htmlpopup-container {
-  width: 580px; /* size for A4 print */ 
+  width: 580px; /* size for A4 print */
   font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   margin: auto;
   color: #333333;
@@ -164,7 +164,7 @@ body {
       display: none;
     }
   }
-  
+
   .chsdi-map-container {
     width: 100%;
     height: 300px;
@@ -174,6 +174,47 @@ body {
       position: relative;
       width: 100%;
       height: 100%;
+    }
+  }
+}
+// ****** HTMLPOPUP
+.htmlpopup-container {
+  width: 100%;
+  font-size: 11px;
+
+  span {
+    font-weight: bold;
+  }
+
+  .htmlpopup-header {
+    background-color: #E9E9E9;
+    padding: 7px;
+    margin-bottom: 7px;
+  }
+
+  .htmlpopup-content {
+    padding: 0 7px 7px;
+
+    iframe {
+      border: none;
+    }
+
+    table {
+      font-size: 11px;
+      width: 100%;
+      border: 0;
+
+      td {
+        vertical-align: top;
+      }
+
+      .cell-left {
+        width: 150px;
+      }
+
+      .cell-left-large {
+        width: 320px;
+      }
     }
   }
 }

--- a/chsdi/templates/htmlpopup/base.mako
+++ b/chsdi/templates/htmlpopup/base.mako
@@ -5,35 +5,13 @@
   import chsdi.lib.helpers as h
 %>
 <%
-  protocol = request.scheme
   lang = request.lang
   topic = request.matchdict.get('map')
-  isGridLayer = False
-
-  c = {}
-
-  if 'feature' in feature:
-      if hasattr(feature['feature'], 'properties'):
-          c.update(feature['feature']);
-          c['attributes'] = feature['feature'].properties
-          c['attributes'].update(feature['feature'].extra);
-          c['bbox'] =  feature['feature'].extra['bbox']
-      else:
-          c = feature['feature']
-          c['bbox'] = feature.get('bbox')
-          c['scale'] = feature.get('scale')
-  else:
-      # For grid layers
-      c = feature
-      c['featureId'] = c['id']
-      isGridLayer = True
-
   c['stable_id'] = False
-  c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
-  c['attribution'] = feature['attribution']
-  c['fullName'] = feature['fullName']
-  isExtended = feature['isExtended']
-  isIframe = feature['isIframe']
+  hasExtendedInfo = c.get('hasExtendedInfo')
+  isExtended = c.get('isExtended')
+  isIframe = c.get('isIframe')
+  isGridLayer = c.get('isGridLayer')
  %>
 
 % if isExtended or isIframe:

--- a/chsdi/templates/htmlpopup/base.mako
+++ b/chsdi/templates/htmlpopup/base.mako
@@ -27,20 +27,21 @@
       c = feature
       c['featureId'] = c['id']
       isGridLayer = True
-  
+
   c['stable_id'] = False
   c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
   c['attribution'] = feature['attribution']
   c['fullName'] = feature['fullName']
-  extended = feature['extended']
+  isExtended = feature['isExtended']
+  isIframe = feature['isIframe']
  %>
 
-% if extended:
+% if isExtended or isIframe:
 <head>
   <!--[if !HTML5]>
   <meta http-equiv="X-UA-Compatible" content="IE=9,IE=10,IE=edge,chrome=1"/>
   <![endif]-->
-  <title>${c['fullName']}</title> 
+  <title>${c['fullName']}</title>
   <meta name="viewport" content="initial-scale=1.0"/>
   <link rel="shortcut icon" type="image/x-icon" href="${h.versioned(request.static_url('chsdi:static/images/favicon.ico'))}">
   <link rel="apple-touch-icon" sizes="76x76" href="${h.versioned(request.static_url('chsdi:static/images/touch-icon-bund-76x76.png'))}"/>
@@ -53,18 +54,26 @@
 </head>
 % endif
 
-% if extended:
+% if isExtended:
 <body>
   <div class="chsdi-htmlpopup-container">
 % else:
   <div id="${c['layerBodId']}#${c['featureId']}" class="htmlpopup-container">
 % endif
+
+% if not isIframe:
   <div class="htmlpopup-header">
     <span>${c['fullName']}</span> (${c['attribution']})
   </div>
+% endif
+
   <div class="htmlpopup-content">
-    % if extended:
+    % if isExtended:
       ${self.extended_info(c, lang)}
+    % elif isIframe:
+      % if hasattr(self, 'iframe_content'):
+        ${self.iframe_content(c, lang)}
+      % endif
     % else:
       <table>
         ${self.table_body(c, lang)}
@@ -99,7 +108,7 @@
       </table>
     % endif
   </div>
-  % if extended:
+  % if isExtended:
   <div class="htmlpopup-footer">
     <a href="${_('disclaimer url')}" target="_blank">
       ${_('disclaimer title')}
@@ -119,6 +128,6 @@
   </div>
   % endif
 </div>
-% if extended:
+% if isExtended:
 </body>
 % endif

--- a/chsdi/templates/htmlpopup/luftfahrthindernisse.mako
+++ b/chsdi/templates/htmlpopup/luftfahrthindernisse.mako
@@ -27,11 +27,11 @@ from pyramid.url import route_url
 <%
   c['last'] = False
   wms_url = 'http://' + request.registry.settings['wmshost']
-  attr = c['attributes'] 
+  attr = c['attributes']
   startofconstruction = str(attr['startofconstruction'].day) + '.' + str(attr['startofconstruction'].month) + '.' + str(attr['startofconstruction'].year)
   datenstand = str(attr['bgdi_created'].day) + '.' + str(attr['bgdi_created'].month) + '.' + str(attr['bgdi_created'].year)
 
-  if attr['bbox'][0] !=  attr['bbox'][2]:
+  if c['bbox'][0] !=  c['bbox'][2]:
     bbox = True
   else:
     bbox = False
@@ -46,7 +46,7 @@ from pyramid.url import route_url
   else:
     sanctiontext = attr['sanctiontext']
   
-  id = attr['featureId']
+  id = c['featureId']
   geometry = c['geometry']
 
 %>

--- a/chsdi/templates/htmlpopup/oev_haltestellen.mako
+++ b/chsdi/templates/htmlpopup/oev_haltestellen.mako
@@ -2,6 +2,14 @@
 
 <%def name="table_body(c, lang)">
 <%
+baseUrl = request.registry.settings['api_url']
+%>
+  <iframe src="${baseUrl}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/iframeHtmlPopup?lang=${lang}" width="100%" height="235" frameborder="0" style="border: 0;" scrolling="no"></iframe>
+</%def>
+
+
+<%def name="iframe_content(c, lang)">
+<%
     from pyramid.url import route_url
     protocol = request.scheme
     lang = request.lang
@@ -26,7 +34,7 @@
   }
   .col-destination, .col-departures, .col-time-diff {
      vertical-align: middle !important;
-  } 
+  }
   .col-label p {
     border: 1px solid #D8D8D8;
     border-radius: 4px;
@@ -40,10 +48,10 @@
 
 % if type_station == 'Bedienpunkt' :
 
-    <p><b>${c['attributes']['name'] or '-'}</b></p> 
+    <p><b>${c['attributes']['name'] or '-'}</b></p>
     <p>${_('ch.bav.haltestellen-oev.bedienpunkt')}</p>
 
-% elif type_station == 'Anschlusspunkt' : 
+% elif type_station == 'Anschlusspunkt' :
 
    <p><b>${c['attributes']['name'] or '-'}</b></p>
    <p>${_('ch.bav.haltestellen-oev.anschlusspunkt')}</p>
@@ -65,7 +73,7 @@ $(document).ready(function() {
   var destinationCol = $('#destination' + id);
   var departuresCol = $('#departures' + id);
   var timeDiffCol = $('#timeDiff' + id);
-    
+
   select.change(function() {
     onSelect(this.value);
   });
@@ -105,14 +113,14 @@ $(document).ready(function() {
       destinationCol.html(destination);
       departuresCol.html(departures);
       timeDiffCol.html(timeDiff);
-    }); 
+    });
   };
 
   var onSelect = function(val) {
     if (refresh) {
       clearInterval(refresh);
     }
-    getInfos(val); 
+    getInfos(val);
     refresh = setInterval(getInfos, 60000);
   };
 
@@ -121,7 +129,7 @@ $(document).ready(function() {
     for (var i = 0; i < result.length; i++) {
       if (result[i].destination == 'nodata') {
         selectDestination += '<option value="' + result[i].destination + '">${_("ch.bav.haltestellen-oev.nodata")}</option>';
-      } else { 
+      } else {
         selectDestination += '<option value="' + result[i].name + '">' + result[i].name + '</option>';
       }
     };
@@ -137,6 +145,7 @@ $(document).ready(function() {
       <option value="all">${_('ch.bav.haltestellen-oev.all_departures')}</option>
     </select>
     <br />
+  <table>
     <tr>
         <td id="numero${id}" class="col-label"></td>
         <td id="destination${id}" class="col-destination"></td>
@@ -146,36 +155,21 @@ $(document).ready(function() {
 % endif
     <tr>
       <td></td>
-      <td> 
-        <p style="margin:10px 0 0 0;">
-          <a href="${h.make_agnostic(request.route_url('extendedHtmlPopup', map=topic, layerId=c['layerBodId'], featureId=str(c['featureId'])))}?lang=${lang}"
-             target="_blank">${_('zusatzinfo')}&nbsp;<img src="${h.versioned(request.static_url('chsdi:static/images/ico_extern.gif'))}" />
-          </a>
-        </p>
-      </td>
-    </tr>
-    <tr>
       <td></td>
-      <td>
-        <p style="margin:0;">
-          <a href="${''.join((c['baseUrl'], '?', c['layerBodId'], '=', str(c['featureId']), '&lang=', lang, '&topic=', topic, '&showTooltip=true'))}" target="new">
-            ${_('Link to object')}
-          </a>
-        </p>
-      </td>
     </tr>
+  </table>
 </%def>
 
 <%def name="extended_info(c, lang)">
-    <%
-        protocol = request.scheme
-        lang = request.lang
-        topic = request.matchdict.get('map')
-        var_verkehrsmittel = '<i>haltestellen_' + c['attributes']['verkehrsmittel'] + '</i>'
-        verkehr = var_verkehrsmittel.lower()
-        type_station = c['attributes']['betriebspunkttyp']
-        c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
-    %>
+<%
+    protocol = request.scheme
+    lang = request.lang
+    topic = request.matchdict.get('map')
+    var_verkehrsmittel = '<i>haltestellen_' + c['attributes']['verkehrsmittel'] + '</i>'
+    verkehr = var_verkehrsmittel.lower()
+    type_station = c['attributes']['betriebspunkttyp']
+    c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
+%>
 <table>
   <tr>
       <td class="cell-meta">${_('ch.bav.haltestellen-oev.id')}</td>
@@ -219,10 +213,16 @@ $(document).ready(function() {
       <td class="cell-meta"><p><a href="${''.join((c['baseUrl'], '?', c['layerBodId'], '=', str(c['featureId']), '&lang=', lang, '&topic=', topic, '&showTooltip=true'))}" target="new">
         ${_('Link to object')}
       </a></p></td>
-  </tr> 
+  </tr>
 </table>
 <br />
 <div>
  <iframe src="${''.join((c['baseUrl'], '/embed.html', '?', c['layerBodId'], '=', str(c['featureId']), '&lang=', lang, '&topic=', topic))}" width='580' height='300' style="width: 100%;" frameborder='0' style='border:0'></iframe>
 </div>
+</%def>
+
+<%def name="extended_resources(c, lang)">
+  <link rel="stylesheet" href="//map.geo.admin.ch/master/2afd257/1610191614/1610191614/style/app.css">
+  <script src="${h.versioned(request.static_url('chsdi:static/js/jquery.min.js'))}"></script>
+  <script src="//map.geo.admin.ch/master/2afd257/1610191614/src/lib/moment-with-customlocales.min.js"></script>
 </%def>

--- a/chsdi/templates/htmlpopup/oev_haltestellen.mako
+++ b/chsdi/templates/htmlpopup/oev_haltestellen.mako
@@ -44,6 +44,9 @@ baseUrl = request.registry.settings['api_url']
      padding-top: 5px;
      margin-bottom: 2px;
   }
+  select.form-control {
+    font-size: 12px;
+  }
 </style>
 
 % if type_station == 'Bedienpunkt' :
@@ -141,7 +144,7 @@ $(document).ready(function() {
 </script>
     <br />
     <p><b>${c['attributes']['name'] or '-'}</b>, ${_('ch.bav.haltestellen-oev.next_departures')}:</p>
-    <select id="selectDestination${id}">
+    <select id="selectDestination${id}" class="form-control">
       <option value="all">${_('ch.bav.haltestellen-oev.all_departures')}</option>
     </select>
     <br />
@@ -222,7 +225,7 @@ $(document).ready(function() {
 </%def>
 
 <%def name="extended_resources(c, lang)">
-  <link rel="stylesheet" href="//map.geo.admin.ch/master/2afd257/1610191614/1610191614/style/app.css">
-  <script src="${h.versioned(request.static_url('chsdi:static/js/jquery.min.js'))}"></script>
-  <script src="//map.geo.admin.ch/master/2afd257/1610191614/src/lib/moment-with-customlocales.min.js"></script>
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.16.0/moment.min.js"></script>
 </%def>

--- a/chsdi/templates/htmlpopup/windatlas50.mako
+++ b/chsdi/templates/htmlpopup/windatlas50.mako
@@ -89,7 +89,7 @@ freq_total += props['freq_300'] + props['freq_330']
 try:
     iframe = request.GET['iframe'] if request.GET['iframe'] else False
 except:
-    iframe=False
+    iframe = False
     pass
 
 %>
@@ -523,7 +523,7 @@ var arc = d3.svg.arc()
 //svg definieren
 var svg = d3.select("#rose").append("svg")
 % if iframe:
-    .attr("width", width + 58) 
+    .attr("width", width + 58)
 % else:
     .attr("width", width + 48 + 140) //+140 damit rechts noch Legende Platz hat
 % endif

--- a/chsdi/templates/htmlpopup/windatlas50.mako
+++ b/chsdi/templates/htmlpopup/windatlas50.mako
@@ -26,7 +26,7 @@ baseUrl = request.registry.settings['api_url']
 dhm_altitude = int(round(float(getAltitude(baseUrl, center)),0))
 center = '2%s, 1%s' % (str(int(round(center[0], 0))), str(int(round(center[1], 0))))
 
-props = c['properties']
+props = c['attributes']
 %>
 <style>
 .htmlpopup-container {
@@ -79,7 +79,7 @@ dhm_altitude = int(round(float(getAltitude(baseUrl, center)),0))
 center = '2%s, 1%s' % (str(int(round(center[0], 0))), str(int(round(center[1], 0))))
 altitude = int(c['layerBodId'].split('ch.bfe.windenergie-geschwindigkeit_h')[1])
 
-props = c['properties']
+props = c['attributes']
 
 freq_total = props['freq_0']    + props['freq_30']
 freq_total += props['freq_60']  + props['freq_90']

--- a/chsdi/templates/htmlpopup/windatlas50.mako
+++ b/chsdi/templates/htmlpopup/windatlas50.mako
@@ -59,13 +59,16 @@ props = c['properties']
     </tr>
     <tr>
       <td colspan=2>
-        <iframe src="${baseUrl}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/extendedHtmlPopup?lang=${lang}&iframe=true" width="100%" height="230" frameborder="0" style="border: 0;" scrolling="no"></iframe>
+        <iframe src="${baseUrl}/rest/services/all/MapServer/${c['layerBodId']}/${c['featureId']}/iframeHtmlPopup?lang=${lang}" width="100%" height="230" frameborder="0" style="border: 0;" scrolling="no"></iframe>
       </td>
     </tr>
 </%def>
 
+<%def name="iframe_content(c, lang)">
+  ${self.extended_info(c, lang, iframe=True)}
+</%def>
 
-<%def name="extended_info(c, lang)">
+<%def name="extended_info(c, lang, iframe=False)">
 <%
 coordinates = c['geometry']['coordinates'][0]
 bottomLeft = coordinates[0]
@@ -84,13 +87,6 @@ freq_total += props['freq_120'] + props['freq_150']
 freq_total += props['freq_180'] + props['freq_210']
 freq_total += props['freq_240'] + props['freq_270']
 freq_total += props['freq_300'] + props['freq_330']
-
-# gracefully check if url request has get parameter iframe
-try:
-    iframe = request.GET['iframe'] if request.GET['iframe'] else False
-except:
-    iframe = False
-    pass
 
 %>
 <!-- html output -->

--- a/chsdi/tests/integration/test_features_service.py
+++ b/chsdi/tests/integration/test_features_service.py
@@ -267,6 +267,16 @@ class TestFeaturesView(TestsBase):
     def test_extendedhtmlpopup_noinfo(self):
         self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362/extendedHtmlPopup', status=404)
 
+    def test_iframehtmlpopup(self):
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bav.haltestellen-oev/8573140/iframeHtmlPopup', status=200)
+        self.assertEqual(resp.content_type, 'text/html')
+        resp.mustcontain('<script src=')
+
+    def test_htmlpopup_with_iframeservice(self):
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bav.haltestellen-oev/8573140/htmlPopup', status=200)
+        self.assertEqual(resp.content_type, 'text/html')
+        resp.mustcontain('<iframe src=')
+
     def test_cut_all_dataset(self):
         params = {'layers': 'all:ch.swisstopo.digitales-hoehenmodell_25_reliefschattierung'}
         resp = self.testapp.get('/rest/services/ech/GeometryServer/cut', params=params, status=200)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -23,7 +23,7 @@ from chsdi.lib.validation.features import (
 from chsdi.lib.validation.find import FindServiceValidation
 from chsdi.lib.validation.identify import IdentifyServiceValidation
 from chsdi.lib.validation.geometryservice import GeometryServiceValidation
-from chsdi.lib.helpers import format_query, decompress_gzipped_string, center_from_box2d
+from chsdi.lib.helpers import format_query, decompress_gzipped_string, center_from_box2d, make_geoadmin_url
 from chsdi.lib.exceptions import HTTPBandwidthLimited
 from chsdi.lib.filters import full_text_search
 from chsdi.models.clientdata_dynamodb import get_bucket
@@ -83,7 +83,7 @@ def view_attribute_values_geojson(request):
     return _attributes(request)
 
 
-def _get_feature_for_popup(request, params, isExtended=False, isIframe=False):
+def _get_feature_info_for_popup(request, params, isExtended=False, isIframe=False):
     feature, vectorModel = next(_get_features(params))
     layerModel = get_bod_model(params.lang)
     layer = next(get_layers_metadata_for_params(
@@ -92,44 +92,58 @@ def _get_feature_for_popup(request, params, isExtended=False, isIframe=False):
         layerModel,
         layerIds=[params.layerId]
     ))
-    feature.update({'attribution': layer.get('attributes')['dataOwner']})
-    feature.update({'fullName': layer.get('fullName')})
-    feature.update({'isExtended': isExtended})
-    feature.update({'isIframe': isIframe})
-    return feature, vectorModel
+    options = {}
+    if 'feature' in feature:
+        options.update(feature.pop('feature'))
+    else:
+        options.update(feature)
+
+    # Regular html popup don't return a geometry
+    if 'properties' in options:
+        if hasattr(options, 'extra'):
+            options['properties'].update(options['properties'].extra)
+            options['bbox'] = options.extra['bbox']
+        options['attributes'] = options.pop('properties')
+
+    options.update({
+        'featureId': options.get('featureId') or options.get('id'),  # For grid layer
+        'attributes': options['attributes'],
+        'scale': options.get('scale'),
+        'attribution': layer.get('attributes')['dataOwner'],
+        'fullName': layer.get('fullName'),
+        'vectorModel': vectorModel,
+        'isExtended': isExtended,
+        'isIframe': isIframe
+    })
+    return options
+
+
+def _prepare_popup_response(params, request, isExtended=False, isIframe=False):
+    options = _get_feature_info_for_popup(
+        request, params, isExtended=isExtended, isIframe=isIframe)
+    response = _render_feature_template(options, request)
+
+    if params.cbName is None:
+        return response
+    return response.body
 
 
 @view_config(route_name='htmlPopup', renderer='jsonp')
 def htmlpopup(request):
     params = HtmlPopupServiceValidation(request)
-    feature, vectorModel = _get_feature_for_popup(request, params)
-    response = _render_feature_template(vectorModel, feature, request)
-
-    if params.cbName is None:
-        return response
-    return response.body
+    return _prepare_popup_response(params, request)
 
 
 @view_config(route_name='extendedHtmlPopup', renderer='jsonp')
 def extendedhtmlpopup(request):
     params = ExtendedHtmlPopupServiceValidation(request)
-    feature, vectorModel = _get_feature_for_popup(request, params, isExtended=True)
-    response = _render_feature_template(vectorModel, feature, request)
-
-    if params.cbName is None:
-        return response
-    return response.body
+    return _prepare_popup_response(params, request, isExtended=True)
 
 
 @view_config(route_name='iframeHtmlPopup', renderer='jsonp')
 def iframeHtmlPopup(request):
     params = ExtendedHtmlPopupServiceValidation(request)
-    feature, vectorModel = _get_feature_for_popup(request, params, isIframe=True)
-    response = _render_feature_template(vectorModel, feature, request)
-
-    if params.cbName is None:
-        return response
-    return response.body
+    return _prepare_popup_response(params, request, isIframe=True)
 
 
 def _identify_oereb(request):
@@ -372,25 +386,33 @@ def _get_feature_grid(col, row, timestamp, grid, bucket, params):
     return feature, None
 
 
-def _render_feature_template(vectorModel, feature, request):
+def _has_extended_info(isExtended, hasExtendedInfo, bodId):
+    if isExtended and not hasExtendedInfo:
+        raise exc.HTTPNotFound('No extended info has been found for %s' % bodId)
+
+
+def _render_feature_template(options, request):
     # Determine if we should render the extended tooltip or the iframe
-    isIframe = feature.get('isIframe')
-    isExtended = feature.get('isExtended')
+    isExtended = options.get('isExtended')
+    vectorModel = options.get('vectorModel')
     if vectorModel:
-        hasExtendedInfo = True if hasattr(vectorModel, '__extended_info__') else False
-        if isExtended and not hasExtendedInfo:
-            raise exc.HTTPNotFound('No extended info has been found for %s' % vectorModel.__bodId__)
         template = vectorModel.__template__
+        options['hasExtendedInfo'] = hasattr(vectorModel, '__extended_info__')
     else:
-        layerProperties = get_grid_layer_properties(feature['layerBodId'])
+        # For grid like models
+        layerProperties = get_grid_layer_properties(options['layerBodId'])
         template = layerProperties.get('template')
-        hasExtendedInfo = layerProperties.get('extended')
+        options['hasExtendedInfo'] = layerProperties.get('extended')
+        options['isGridLayer'] = True
+
+    # We can't test earlier, some features may or may not have extended info for
+    # the same layer.
+    _has_extended_info(isExtended, options['hasExtendedInfo'], options['layerBodId'])
+
+    options['baseUrl'] = make_geoadmin_url(request)
     return render_to_response(
         'chsdi:%s' % template, {
-            'feature': feature,
-            'isExtended': isExtended,
-            'isFrame': isIframe,
-            'hasExtendedInfo': hasExtendedInfo
+            'c': options
         }, request=request)
 
 


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-chsdi3/issues/2235 (no more polling issue and htmlPopup as a service)

This PR introduces a popup service which we call "iframeHtmlPopup"

This is service is always meant to be called within the "regular" htmlPopup service.

As a side note, if the iframeHtmlPopup is called and no template is defined for this service, it will simply return an empty html.

[Now](https://mf-chsdi3.dev.bgdi.ch/iframe_service/rest/services/ech/MapServer/ch.bav.haltestellen-oev/8573140/htmlPopup?coord=688630.0000000001,165610.00000000006&imageDisplay=1920,750,96&lang=fr&mapExtent=605280.0000000001,149310.00000000006,701280.0000000001,186810.00000000006)

[Before](https://api3.geo.admin.ch/rest/services/ech/MapServer/ch.bav.haltestellen-oev/8573140/htmlPopup?coord=688630.0000000001,165610.00000000006&imageDisplay=1920,750,96&lang=fr&mapExtent=605280.0000000001,149310.00000000006,701280.0000000001,186810.00000000006)

[Test Link](https://mf-chsdi3.dev.bgdi.ch/iframe_service/shorten/6f2235f245)
