### PR TITLE
WMS URL from build env

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -81,7 +81,6 @@ class LayersConfig(Base):
     chargeable = Column('chargeable', Boolean)
     staging = Column('staging', Text)
     wmsLayers = Column('wms_layers', Text)
-    wmsUrl = Column('wms_url', Text)
     updateDelay = Column('geojson_update_delay', Integer)
     geojsonUrlde = Column('geojson_url_de', Text)
     geojsonUrlfr = Column('geojson_url_fr', Text)
@@ -96,7 +95,6 @@ class LayersConfig(Base):
         config = {}
         translate = params.translate
         settings = params.request.registry.settings
-        geodataStaging = settings['geodata_staging']
         wmsHost = settings['wmshost']
         for k in self.__dict__.keys():
             val = self.__dict__[k]
@@ -120,9 +118,7 @@ class LayersConfig(Base):
             del config['singleTile']
 
         if config['type'] == 'wms':
-            if geodataStaging != 'prod':
-                config['wmsUrl'] = make_agnostic(
-                    config['wmsUrl'].replace('wms.geo.admin.ch', wmsHost))
+            config['wmsUrl'] = 'https://%s' % wmsHost
         elif config['type'] == 'geojson':
             api_url = params.request.registry.settings['api_url']
             config['styleUrl'] = make_agnostic(


### PR DESCRIPTION
@ltclm This PR follows the changes made in wms_metadata table.

Official WMS staging should always follow the app staging and should alwas be https://wms.geo.admin.ch

Now that we are flexible with the `wms_url` permalink parameter in geoadmin, we no longer need to reference it in the layers configuration. (and wmsUrl in layersConfig is already ignored in geoadmin but is still used in JS geoadmin API)