### PR TITLE
Add a extended tooltip for lubis layers

### DIFF
--- a/chsdi/models/vector/lubis.py
+++ b/chsdi/models/vector/lubis.py
@@ -240,6 +240,7 @@ class LuftbilderSchraegaufnahmen(Base, Vector):
     __template__ = 'templates/htmlpopup/lubis_schraegaufnahmen.mako'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder_schraegaufnahmen'
     __timeInstant__ = 'bgdi_flugjahr'
+    __extended_info__ = True
     # Composite labels
     __label__ = 'flightdate'
     __queryable_attributes__ = ['id', 'bgdi_flugjahr', 'medium_format']

--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -19,7 +19,7 @@ def determinePreviewUrl(ebkey):
         return tileUrlBasePath + '/' + ebkey + '/quickview.jpg'
 
     def getZeroTileUrl(ebkey):
-        return tileUrlBasePath + '/' + ebkey + '/0/0/0.jpg'
+        return tileUrlBasePath + '/' + ebkey + '/1/0/0.jpg'
 
     headers = {'Referer': 'http://admin.ch'}
     url = getPreviewImageUrl(ebkey)
@@ -156,6 +156,10 @@ elif c['layerBodId'] == 'ch.swisstopo.lubis-luftbilder_infrarot':
 else:
     imgtype = 0
 endif
+protocol = request.scheme
+c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
+topic = request.matchdict.get('map')
+lang = request.lang
 
 preview_url = determinePreviewUrl(c['featureId'])
 
@@ -228,52 +232,22 @@ shop_url = request.registry.settings['shop_url']
   </tr>
 % endif
   </table>
-  <div class="chsdi-map-container table-with-border" >
-    <div id="map"></div>
-  </div>
   <br>
-
+<div class="chsdi-map-container table-with-border">
+ <iframe src="${''.join((c['baseUrl'], '/embed.html', '?', c['layerBodId'], '=', str(c['featureId']), '&lang=', lang, '&topic=', topic,'&bgLayer=ch.swisstopo.pixelkarte-grau'))}" width='580' height='300' style="width: 100%;" frameborder='0' style='border:0'></iframe>
+</div>
+  <br>
 % if preview_url != "" and image_width != None:
-  <span class="chsdi-no-print">${_('tt_luftbilderOL')}<a href="${viewer_url}" target="_blank" alt="Fullscreen">(fullscreen)</a></span>
-  <div class="chsdi-map-container table-with-border">
+  <div class="chsdi-map-container table-with-border" >
     <div id="lubismap"></div>
   </div>
 % endif
-
+  <br>
   <script type="text/javascript">
     function init() {
-      // Create a GeoAdmin Map
-      var map = new ga.Map({
-        // Define the div where the map is placed
-        target: 'map',
-        tooltip: false,
-        view: new ol.View({
-          // Define the default resolution
-          // 10 means that one pixel is 10m width and height
-          // List of resolution of the WMTS layers:
-          // 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5, 0.25, 0.1
-          resolution: 10,
-          // Define a coordinate CH1903 (EPSG:21781) for the center of the view
-          center: [${c['attributes']['x']},${c['attributes']['y']}]
-        })
-      });
-
-      // Create a background layer
-      var lyr1 = ga.layer.create('ch.swisstopo.pixelkarte-grau');
-      // Create an overlay layer
-      var lyr2 = ga.layer.create('${c['layerBodId']}');
-
-      // Add the layers in the map
-      map.addLayer(lyr1);
-      map.addLayer(lyr2);
-
-      map.highlightFeature('${c['layerBodId']}', '${c['featureId']}');
-      map.recenterFeature('${c['layerBodId']}', '${c['featureId']}');
-
 % if preview_url != "" and image_width != None:
      ${lubis_map.init_map(c['featureId'], image_width, image_height, image_rotation, 'lubismap')}
 %endif
-
     }
   </script>
 

--- a/chsdi/templates/htmlpopup/lubis_bildstreifen.mako
+++ b/chsdi/templates/htmlpopup/lubis_bildstreifen.mako
@@ -22,6 +22,10 @@ shop_url = request.registry.settings['shop_url']
 <%
 c['stable_id'] = True
 shop_url = request.registry.settings['shop_url']
+protocol = request.scheme
+c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
+topic = request.matchdict.get('map')
+lang = request.lang
 %>
 <title>${_('tt_lubis_ebkey')}: ${c['featureId']}</title>
 <body onload="init()">
@@ -45,38 +49,10 @@ target="toposhop">Toposhop</a></td></tr>
         <tr><th class="cell-left">${_('tt_firmen_Link ')}</th>              <td><a href="mailto:geodata@swisstopo.ch?subject=${_('tt_firmen_Link ')} ebkey:${c['featureId']}">geodata@swisstopo.ch</a></td></tr>
 % endif
 </table>
-
-  <div class="chsdi-map-container table-with-border" >
-    <div id="map"></div>
-  </div>
-  <script type="text/javascript">
-    function init() {
-      // Create a GeoAdmin Map
-      var map = new ga.Map({
-        // Define the div where the map is placed
-        target: 'map',
-        tooltip: false,
-        view: new ol.View({
-          // Define the default resolution
-          // 10 means that one pixel is 10m width and height
-          // List of resolution of the WMTS layers:
-          // 650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5, 0.25, 0.1
-          resolution: 10
-        })
-      });
-      // Create a background layer
-      var lyr1 = ga.layer.create('ch.swisstopo.pixelkarte-grau');
-      // Create an overlay layer
-      var lyr2 = ga.layer.create('${c['layerBodId']}');
-
-      // Add the layers in the map
-      map.addLayer(lyr1);
-      map.addLayer(lyr2);
-
-      map.highlightFeature('${c['layerBodId']}', '${c['featureId']}');
-      map.recenterFeature('${c['layerBodId']}', '${c['featureId']}');
-    }
-  </script>
+  <br>
+<div class="chsdi-map-container table-with-border">
+ <iframe src="${''.join((c['baseUrl'], '/embed.html', '?', c['layerBodId'], '=', str(c['featureId']), '&lang=', lang, '&topic=', topic,'&bgLayer=ch.swisstopo.pixelkarte-grau'))}" width='580' height='300' style="width: 100%;" frameborder='0' style='border:0'></iframe>
+</div>
 
 </body>
 

--- a/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
+++ b/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
@@ -78,12 +78,6 @@ viewer_url = get_viewer_url(request, params)
     <tr><td class="cell-left">${_('tt_lubis_ebkey')}</td>                               <td>${c['featureId']}</td></tr>
     <tr><td class="cell-left">${_('tt_lubis_inventarnummer')}</td>                      <td>${c['attributes']['inventory_number']}</td></tr>
     <tr><td class="cell-left">${_('tt_lubis_Flugdatum')}</td>                           <td>${datum}</td></tr>
-    <tr><td class="cell-left">${_('tt_lubis_originalsize')}</td>                        <td>${c['attributes']['medium_format']}</td></tr>
-    <tr><td class="cell-left">${_('tt_lubis_filesize_mb')}</td>                         <td>${c['attributes']['filesize_mb']} MB</td></tr>
-    <tr><td class="cell-left">${_('tt_lubis_bildpfad')}</td>                            <td>${c['attributes']['filename']}</td></tr>
-    <tr><td class="cell-left">${_('tt_lubis_schraegaufnahmen_stereo_couple')}</td>      <td>${c['attributes']['stereo_couple']}</td></tr>
-    <tr><td class="cell-left">${_('tt_lubis_schraegaufnahmen_x')}</td>                  <td>${c['attributes']['x']}</td></tr>
-    <tr><td class="cell-left">${_('tt_lubis_schraegaufnahmen_y')}</td>                  <td>${c['attributes']['y']}</td></tr>
 
 % if preview_url != "" and image_width != None:
 <tr>
@@ -99,13 +93,71 @@ viewer_url = get_viewer_url(request, params)
 </tr>
 % endif
 
-<tr>
-  <td class="cell-left">${_('tt_lubis_bildorder')}</th>
-  <td>
-    ${c['attributes']['contact'] | br }
-    <br/>
-    ${c['attributes']['contact_email']}
-  </td>
 </tr>
+</%def>
 
+<%def name="extended_info(c, lang)">
+<%
+c['stable_id'] = True
+protocol = request.scheme
+c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
+topic = request.matchdict.get('map')
+lang = request.lang
+
+preview_url = determinePreviewUrl(c['featureId'])
+image_rotation = 0
+wh = h.imagesize_from_metafile(tileUrlBasePath, c['featureId'])
+image_width = wh[0]
+image_height = wh[1]
+datum = date_to_str(c['attributes']['flightdate'])
+params = (
+    image_width,
+    image_height,
+    _('tt_lubis_ebkey'),
+    c['featureId'],
+    'swisstopo',
+    c['layerBodId'],
+    lang,
+    image_rotation)
+viewer_url = get_viewer_url(request, params)
+%>
+
+<title>${_('tt_lubis_ebkey')}: ${c['featureId']}</title>
+
+<body onload="init()">
+  <table class="table-with-border kernkraftwerke-extended">
+    <tr><th class="cell-left">${_('tt_lubis_ebkey')}</th>                               <td>${c['featureId']}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_inventarnummer')}</th>                      <td>${c['attributes']['inventory_number']}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_Flugdatum')}</th>                           <td>${datum}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_originalsize')}</th>                        <td>${c['attributes']['medium_format']}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_filesize_mb')}</th>                         <td>${c['attributes']['filesize_mb']} MB</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_bildpfad')}</th>                            <td>${c['attributes']['filename']}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_schraegaufnahmen_stereo_couple')}</th>      <td>${c['attributes']['stereo_couple']}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_schraegaufnahmen_x')}</th>                  <td>${c['attributes']['x']}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_schraegaufnahmen_y')}</th>                  <td>${c['attributes']['y']}</td></tr>
+    <tr><th class="cell-left">${_('tt_lubis_bildorder')}</th>                           <td>${c['attributes']['contact'] | br } <br/>${c['attributes']['contact_email']}</td></tr>
+  </table>
+  <br>
+<div class="chsdi-map-container table-with-border">
+ <iframe src="${''.join((c['baseUrl'], '/embed.html', '?', c['layerBodId'], '=', str(c['featureId']), '&lang=', lang, '&topic=', topic,'&bgLayer=ch.swisstopo.pixelkarte-grau'))}" width='580' height='300' style="width: 100%;" frameborder='0' style='border:0'></iframe>
+</div>
+  <br>
+% if preview_url != "" and image_width != None:
+<div class="chsdi-map-container table-with-border">
+    <div id="lubismap"></div>
+  </div>
+% endif
+  <script type="text/javascript">
+    function init() {
+% if preview_url != "" and image_width != None:
+     ${lubis_map.init_map(c['featureId'], image_width, image_height, image_rotation, 'lubismap')}
+%endif
+    }
+  </script>
+
+</body>
+</%def>
+
+<%def name="extended_resources(c, lang)">
+  <script type="text/javascript" src="${h.get_loaderjs_url(request)}"></script>
 </%def>


### PR DESCRIPTION
@pfanguin could you please review this PR ? This is only an update of the tooltip (extended tooltip) 

[test link](https://mf-geoadmin3.dev.bgdi.ch/ltgas/?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.lubis-luftbilder_schraegaufnahmen&layers_timestamp=&X=130690.00&Y=617280.00&zoom=5)