### PR TITLE
Change date type (DateTimeChsdi) for ch.swisstopo-vd.spannungsarme-gebiete

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -1898,7 +1898,7 @@ class spannungsarmeGebiete(Base, Vector):
     __label__ = 'sg_name'
     id = Column('identifier', Unicode, primary_key=True)
     sg_name = Column('sg_name', Text)
-    vali_date = Column('vali_date', Text)
+    vali_date = Column('vali_date', DateTimeChsdi)
     the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.transformationsgenauigkeit', spannungsarmeGebiete)


### PR DESCRIPTION
Testlink:

https://mf-geoadmin3.dev.bgdi.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fltgar_spannungsarme_gebiete&lang=de&topic=ech&X=190000.00&Y=660000.00&zoom=1&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo-vd.spannungsarme-gebiete&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&layers_opacity=1,1,1,1,0.75