### PR TITLE
lk100 fullres viewer backlink to map.geo.admin.ch is now visible in firefox (fix for #1755)

### DIFF
--- a/chsdi/templates/historicalmaps/viewer.mako
+++ b/chsdi/templates/historicalmaps/viewer.mako
@@ -128,7 +128,8 @@
     <link rel="shortcut icon" type="image/x-icon" href="${h.versioned(request.static_url('chsdi:static/images/favicon.ico'))}">
   </head>
   <body onload="init()">
-    <div class="header">${title}
+    <div class="header">
+      <div class="pull-left">${title}</div>
       <a class="pull-right" href="${geoadminUrl}" target="_blank">${_('link to geoportal')}</a>
     </div>
     <div class="wrapper">


### PR DESCRIPTION
Fix for #1755 

Testlink:

https://mf-chsdi3.dev.bgdi.ch/ltgar/historicalmaps/viewer.html?lang=de&layer=ch.swisstopo.zeitreihen&release_year=1975&title=kartenwerk_lk100&height=8250&width=11400&bildnummer=bv80032241&x=6449.82&y=5498.47&zoom=1&rotation=0


