### PR TITLE
Update setuptools on virtualenv install and install Pillow using pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ gdal: .venv
 	then \
 		echo "${GREEN}Installing GDAL...${RESET}"; \
 		mkdir -p $(INSTALL_DIRECTORY)/build && \
-		${PIP_CMD} install --download $(INSTALL_DIRECTORY)/build GDAL==$(GDAL_VERSION) && \
+		${PIP_CMD} download -d $(INSTALL_DIRECTORY)/build GDAL==$(GDAL_VERSION) && \
 		cd $(INSTALL_DIRECTORY)/build && \
 		tar -xzf GDAL-$(GDAL_VERSION).tar.gz && \
 		cd GDAL-$(GDAL_VERSION) && \

--- a/Makefile
+++ b/Makefile
@@ -349,10 +349,9 @@ requirements.txt:
 	@if [ ! -d $(INSTALL_DIRECTORY) ]; \
 	then \
 		virtualenv $(INSTALL_DIRECTORY); \
-		${PIP_CMD} install -U pip; \
+		${PIP_CMD} install -U pip setuptools; \
 	fi
-	${PYTHON_CMD} setup.py develop
-	${PIP_CMD} install Pillow==3.1.0
+	${PIP_CMD} install --find-links local_eggs/ -e .
 
 .venv/bin/git-secrets: .venv
 	@echo "${GREEN}Installing git secrets${RESET}";

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ nose==1.3.7
 networkx==1.10
 OWSLib==0.8.8
 papyrus==2.0dev1
+Pillow==3.1.0
 polib==1.0.3
 psycopg2==2.6.2
 Pygments


### PR DESCRIPTION
Enable Wheel download by updating setuptools.

Wheels are use by default when using 
`setuptools >= 0.8`

``time make cleanall user``

Build time before the first time: 3m43.512s
Build time before the second time: 3m48.863s

Build time after the first time: 3m25.514s
Build time after the second time (using cache): 3m19.680s


