### PR TITLE
fix OpenLayers 3 documentation url

### DIFF
--- a/chsdi/static/doc/source/api/doc.rst
+++ b/chsdi/static/doc/source/api/doc.rst
@@ -8,7 +8,7 @@ API Doc
 =======
 
 - `GeoAdmin API Doc <http://geoadmin.github.io/ol3/apidoc/>`_
-- `OpenLayers 3 documentation <http://ol3js.org/>`_
+- `OpenLayers 3 documentation <https://openlayers.org/en/latest/doc/>`_
 - The GeoAdmin API uses the master branch of `OpenLayers 3 <https://github.com/openlayers/ol3/tree/master>`_.
 
 Since the GeoAdmin API is based on OpenLayers 3, the OpenLayers 3 documentation can also be used. The GeoAdmin API completes OpenLayers 3 with Swiss specific configurations and layers.


### PR DESCRIPTION
ol3js.org does no longer link to the OpenLayers 3 documentation.

URL: https://api3.geo.admin.ch/api/doc.html