### PR TITLE
Add layers extent in layersConfig

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from gatilegrid import GeoadminTileGrid
-from sqlalchemy import Column, Text, Integer, Boolean, DateTime
+from sqlalchemy import Column, Text, Integer, Boolean, DateTime, Float
 from sqlalchemy.dialects import postgresql
 
 from chsdi.lib.helpers import make_agnostic
@@ -90,6 +90,7 @@ class LayersConfig(Base):
     config3d = Column('fk_config3d', Boolean)
     srid = Column('srid', Text)
     shop = Column('shop_option_arr', postgresql.ARRAY(Text))
+    extent = Column('extent', postgresql.ARRAY(Float))
 
     def layerConfig(self, params):
         config = {}

--- a/chsdi/tests/integration/test_layers_service.py
+++ b/chsdi/tests/integration/test_layers_service.py
@@ -111,7 +111,7 @@ class TestMapServiceView(TestsBase):
         self.assertIn('label', resp.json['ch.swisstopo.pixelkarte-farbe'])
         self.assertIn('background', resp.json['ch.swisstopo.pixelkarte-farbe'])
 
-    def test_layersconfig_geojson_layer(self):
+    def test_layersconfig_geojson_and_extent_layer(self):
         resp = self.testapp.get('/rest/services/all/MapServer/layersConfig', status=200)
         self.assertTrue(resp.content_type == 'application/json')
         jsonData = resp.json
@@ -122,6 +122,14 @@ class TestMapServiceView(TestsBase):
             self.assertNotIn('geojsonUrlDe', layer)
             self.assertIn('styleUrl', layer)
             self.assertIn('updateDelay', layer)
+        if 'ch.swisstopo.swiss-map-vector1000.metadata' in jsonData:
+            layer = jsonData['ch.swisstopo.swiss-map-vector1000.metadata']
+            self.assertIn('extent', layer)
+            self.assertEqual(len(layer['extent']), 4)
+            self.assertIsInstance(layer['extent'][0], float)
+            self.assertIsInstance(layer['extent'][1], float)
+            self.assertIsInstance(layer['extent'][2], float)
+            self.assertIsInstance(layer['extent'][3], float)
 
     def test_layersconfig_with_callback(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/layersConfig', params={'callback': 'cb_'}, status=200)


### PR DESCRIPTION
Some shop layers have an extent bigger than the default one and as a result part of the layer is hidden.

One can now configure a layer extent in re3.layers_js which will in turn be available in layersConfig service.

extent is present -> apply it
no extent -> apply the default one

ping @pfanguin @oterral @pauloamado 

ch.swisstopo.images-spot-5.metadata
ch.swisstopo.swiss-map-vector1000.metadata