### PR TITLE
improve portal links, fix sz portal link

### DIFF
--- a/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
@@ -1,4 +1,4 @@
-<%def name="table_body_cadastral(c, lang, fallbackLang)">
+<%def name="table_body_cadastral(c, lang, fallbackLang, clickCoord)">
     % if c['attributes']['ak'] in ['D','I','F','AUT']:
         <tr><td class="cell-left">${_('No info outside CH and FL')}</td><td></td></tr>
     % elif c['attributes']['ak'] == 'AG':
@@ -16,21 +16,21 @@
     % elif c['attributes']['ak'] == 'JU':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://geo.jura.ch/theme/Cadastre?&map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=8" target="_blank">JU</a></td></tr>
     % elif c['attributes']['ak'] == 'SH':
-       <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.gis.sh.ch/GIS_SH/?idp=1&uid=1&pwd=&map=10&lan=de&typ=3&bmurl=Nav@g@98@u@West@g@${(c['bboxlv95'][0] + c['bboxlv95'][2])/2}@u@Nord@g@${(c['bboxlv95'][1] + c['bboxlv95'][3])/2}@u@B@g@600" target="_blank">SH</a></td></tr>
+       <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.gis.sh.ch/GIS_SH/?idp=1&uid=1&pwd=&map=10&lan=de&typ=3&bmurl=Nav@g@98@u@West@g@2${clickCoord[0]}@u@Nord@g@1${clickCoord[1]}@u@B@g@600" target="_blank">SH</a></td></tr>
     % elif c['attributes']['ak'] == 'SZ':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://webmap.sz.ch/BM31_WebMap/?idp=1&uid=3&pwd=&map=4&lan=de&typ=2&bmurl=Nav@g@22@u@West@g@${(c['bbox'][0] + c['bbox'][2])/2}@u@Nord@g@${(c['bbox'][1] + c['bbox'][3])/2}@u@B@g@${c['scale']}&dat=fs@g@0:4ae2e22b77b5091c,c967cd4c6822eee0,e99c56f567e5e97f,39483bcc77f422f5,4b048b83437bf7a9,b3b7203380d15873,bee3f1c60e1a845d,1728eb497f622a93,f78552014874d11f,136b202945b6b1b9,d9cf9214542c77c1,7eb16002e8c2dc47,ec974776a1ceeba0,f897f15fead4f6fd,37fd92a6ed58174e,e1887984e14002b7,f44d637c3584e8d0,e9e2a442eff50877,bc8022b4deccd819,6a214c64af1721ce,eaf8a22a527854e5,0945f4c1d24d86b7,98fa7375c309e508,e934449118c9c6dd,55a6326db48f4bea,e990f36363ef5fc3,4621149cf57bddac,ba256921c07443d2,c6d3efbdb9cc23d0,fe44ed10bed4a1b3,995c9ae4589a187f,a19e8b7259324d5b,2446246ca20351ce,7775ce4adaf02f1b,d23b3744bec5675b,2d9ca26cb61f96e1,1baecfb88f9662f3,be06a6503cc9e520!!" target="_blank">SZ</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://map.geo.sz.ch/?map_x=2${clickCoord[0]}&map_y=1${clickCoord[1]}&map_zoom=9&baselayer_opacity=70&baselayer_ref=ch.sz.ortsplan_farbig&tree_group_layers_grp_Geb_u_Anl_Gebaeude=&tree_group_layers_grp_Grenzen_Gemeindegrenzen=&tree_group_layers_grp_GS_Kat_Fixpunkte=ch.sz.a018.amtliche_vermessung.fixpunktkategorie3.hoeheposition,ch.sz.a018.amtliche_vermessung.fixpunktkategorie2.hoeheposition,ch.sz.a018.amtliche_vermessung.fixpunktkategorie1.hoeheposition,ch.sz.a018.amtliche_vermessung.fixpunktkategorie3.lageposition,ch.sz.a018.amtliche_vermessung.fixpunktkategorie2.lageposition,ch.sz.a018.amtliche_vermessung.fixpunktkategorie1.lageposition&tree_group_layers_grp_GS_Kat_Grenzpunkte=&tree_group_layers_grp_GS_Kat_Grundstuecke=ch.sz.a018.amtliche_vermessung.liegenschaften.liegenschaft&tree_enable_ch.swisstopo-vd.spannungsarme-gebiete=false&tree_group_layers_grp_GS_Kat_Toleranzstufen=&tree_group_layers_grp_GS_Kat_Vermessungsstandard=&tree_groups=grp_Geb_u_Anl_Gebaeude,grp_Grenzen_Gemeindegrenzen,grp_GS_Kat_Fixpunkte,grp_GS_Kat_Grenzpunkte,grp_GS_Kat_Grundstuecke,grp_GS_Kat_Spannungsarme_Gebiete_wmts,grp_GS_Kat_Toleranzstufen,grp_GS_Kat_Vermessungsstandard" target="_blank">SZ</a></td></tr>
     % elif c['attributes']['ak'] == 'SO':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geoweb.so.ch/map/ortsplan?startExtent=${','.join(map(str, c['bbox']))}" target="_blank">SO</a></td></tr>
     % elif c['attributes']['ak'] == 'TI':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.sitmap.ti.ch/index.php?ct=mue" target="_blank">TI</a></td></tr>
     % elif c['attributes']['ak'] == 'VD':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.vd.ch/theme/cadastre_thm?map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=10" target="_blank">VD</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.vd.ch/theme/cadastre_thm?map_x=${clickCoord[0]}&map_y=${clickCoord[1]}&map_zoom=10" target="_blank">VD</a></td></tr>
     % elif c['attributes']['ak'] == 'TG':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geo.tg.ch/mapbender/frames/login.php?gui_id=Amtliche%20Vermessung&mb_myBBOX=${','.join(map(str,c['bboxlv95']))}" target="_blank">TG</a></td></tr>
     % elif c['attributes']['ak'] == 'NE':
-        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://sitn.ne.ch/theme/cadastre?map_x=${(c['bbox'][0] + c['bbox'][2])/2}&map_y=${(c['bbox'][1] + c['bbox'][3])/2}&map_zoom=10" target="_blank">NE</a></td></tr>
+        <tr><td width="150">${_('link to canton geoportal')}</td><td><a href="http://sitn.ne.ch/theme/cadastre?map_x=2${clickCoord[0]}&map_y=1${clickCoord[1]}&map_zoom=10" target="_blank">NE</a></td></tr>
     % elif c['attributes']['ak'] == 'LU':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.lu.ch/map/grundbuchplan/?FOCUS=${(c['bbox'][0] + c['bbox'][2])/2}:${(c['bbox'][1] + c['bbox'][3])/2}:${c['scale']}" target="_blank">LU</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.geo.lu.ch/map/grundbuchplan/?FOCUS=${clickCoord[0]}:${clickCoord[1]}:${c['scale']}" target="_blank">LU</a></td></tr>
     % elif c['attributes']['ak'] == 'OW':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://map.gis-daten.ch/plan_fuer_grundbuch_bund_ow?xmin=${c['bbox'][0]}&ymin=${c['bbox'][1]}&xmax=${c['bbox'][2]}&ymax=${c['bbox'][3]}" target="_blank">OW</a></td></tr>
     % elif c['attributes']['ak'] == 'NW':
@@ -44,15 +44,15 @@
     % elif c['attributes']['ak'] == 'AR':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.ar.ch" target="_blank">AR</a></td></tr>
     % elif c['attributes']['ak'] == 'ZH':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://maps.zh.ch/?topic=AVfarbigwwwZH&scale=${c['scale']}&x=${(c['bbox'][0] + c['bbox'][2])/2}&y=${(c['bbox'][1] + c['bbox'][3])/2}&offlayers=LCOBJPROJ%2Cbezirkslabels" target="_blank">ZH</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://maps.zh.ch/?topic=AVfarbigwwwZH&scale=${c['scale']}&x=${clickCoord[0]}&y=${clickCoord[1]}&offlayers=LCOBJPROJ%2Cbezirkslabels" target="_blank">ZH</a></td></tr>
     % elif c['attributes']['ak'] == 'BL':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geoview.bl.ch/?map_x=${(c['bboxlv95'][0] + c['bboxlv95'][2])/2}&map_y=${(c['bboxlv95'][1] + c['bboxlv95'][3])/2}&map_zoom=9" target="_blank">BL</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://geoview.bl.ch/?map_x=2${clickCoord[0]}&map_y=1${clickCoord[1]}&map_zoom=9" target="_blank">BL</a></td></tr>
     % elif c['attributes']['ak'] == 'ZG':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.zugmap.ch/zugmap/?idp=1&uid=1&pwd=&map=1&lan=de&typ=3&bmurl=Nav@g@22@u@West@g@${(c['bbox'][0] + c['bbox'][2])/2}@u@Nord@g@${(c['bbox'][1] + c['bbox'][3])/2}@u@B@g@${c['scale']}&dat=fs@g@0:371167b2bf7dfc4b,c7bfc487a7a729d3,9d1d191f82fb57e3,1fb440cdc612de80,4119ae2a85acc4b5,b7b8c26dbec351a9!!" target="_blank">ZG</a></td></tr>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.zugmap.ch/zugmap/?idp=1&uid=1&pwd=&map=1&lan=de&typ=3&bmurl=Nav@g@22@u@West@g@${clickCoord[0]}@u@Nord@g@${clickCoord[1]}@u@B@g@${c['scale']}&dat=fs@g@0:371167b2bf7dfc4b,c7bfc487a7a729d3,9d1d191f82fb57e3,1fb440cdc612de80,4119ae2a85acc4b5,b7b8c26dbec351a9!!" target="_blank">ZG</a></td></tr>
     % elif c['attributes']['ak'] == 'SG':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.sg.ch/" target="_blank">SG</a></td></tr>
     % elif c['attributes']['ak'] == 'VS':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://sitonline.vs.ch/urbanisation/mo/${fallbackLang}/" target="_blnk">VS</a></td></br>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://sitonline.vs.ch/urbanisation/mo/${c['fallbackLang']}/" target="_blnk">VS</a></td></br>
     % elif c['attributes']['ak'] == 'FL':
         <tr><td class="cell-left">${_('link to geoportal')}</td><td><a href="http://geodaten.llv.li/geoshop/public.html?zoombox=${c['bbox'][0]},${c['bbox'][1]},${c['bbox'][2]},${c['bbox'][3]}" target="_blank">${_('FL')}</a></td></tr>
     % else:

--- a/chsdi/templates/htmlpopup/cadastralwebmap.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.mako
@@ -20,6 +20,8 @@
   c['bbox'] = params.mapExtent.bounds
   c['bboxlv95'] = [2000000 + c['bbox'][0], 1000000 + c['bbox'][1], 2000000 + c['bbox'][2], 1000000 + c['bbox'][3]]
   c['scale']  = getScale(params.imageDisplay, params.mapExtent)
+  defaultCoord = [(c['bbox'][0]+c['bbox'][2])/2, (c['bbox'][1]+c['bbox'][3])/2]
+  clickCoord = request.params.get('coord').split(',') if request.params.get('coord') else defaultCoord
 %>
-${partials.table_body_cadastral(c, lang, fallbackLang)}
+${partials.table_body_cadastral(c, lang, fallbackLang, clickCoord)}
 </%def>

--- a/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
@@ -36,9 +36,11 @@
   pdf_url = "%s://geodata01.admin.ch/order/jPqrueQazrt/av_pdf.igs?pos=%s/%s" % (protocol, lat, lon)
   shp_url = "%s://%s/ch.swisstopo-vd.amtliche-vermessung/DM01AVCH24D/SHP/%s/%s.zip" % (protocol, request.registry.settings['datageoadminhost'], c['attributes']['ak'],c['featureId'])
   itf_url = "%s://%s/ch.swisstopo-vd.amtliche-vermessung/DM01AVCH24D/ITF/%s/%s.zip" % (protocol, request.registry.settings['datageoadminhost'], c['attributes']['ak'],c['featureId'])
+  defaultCoord = [(c['bbox'][0]+c['bbox'][2])/2, (c['bbox'][1]+c['bbox'][3])/2]
+  clickCoord = request.params.get('coord').split(',') if request.params.get('coord') else defaultCoord
 %>
 
-${partials.table_body_cadastral(c, lang, fallbackLang)}
+${partials.table_body_cadastral(c, lang, fallbackLang, clickCoord)}
 
 <tr>
     <td class="cell-left">${_('ch.swisstopo-vd.amtliche-vermessung.pdf')}</td><td>


### PR DESCRIPTION
use click coordinates for portal link

This pr will 
* update the link to sz portal
* use exact click coordinate instead of bbox center for portal link with bbox center as fallback

[Testlink (click on a building)](https://mf-geoadmin3.dev.bgdi.ch/?topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.kantone.cadastralwebmap-farbe,ch.swisstopo-vd.amtliche-vermessung&X=208858.59&Y=694017.04&zoom=11&api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fdev_ltclm_cwm_portal_links&layers_visibility=true,false)

