### PR TITLE
Use parcel geometry from mogis lv03 for feature highlight

### DIFF
--- a/chsdi/models/__init__.py
+++ b/chsdi/models/__init__.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import engine_from_config, Column
 
 
-dbs = ['are', 'bafu', 'bak', 'bod', 'dritte', 'edi', 'evd', 'kogis', 'stopo', 'uvek', 'uvek_solarkataster', 'vbs', 'zeitreihen', 'lubis']
+dbs = ['are', 'bafu', 'bak', 'bod', 'dritte', 'edi', 'evd', 'kogis', 'mogis', 'stopo', 'uvek', 'uvek_solarkataster', 'vbs', 'zeitreihen', 'lubis']
 
 engines = {}
 bases = {}

--- a/chsdi/models/vector/mogis.py
+++ b/chsdi/models/vector/mogis.py
@@ -13,7 +13,7 @@ Base = bases['mogis']
 
 class CadastralWebMap(Base, Vector):
     __tablename__ = 'view_os_realestate_cwm'
-    __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
+    __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/cadastralwebmap.mako'
     __bodId__ = 'ch.kantone.cadastralwebmap-farbe'
     __label__ = 'ak'
@@ -26,7 +26,7 @@ register('ch.kantone.cadastralwebmap-farbe', CadastralWebMap)
 
 class CadastralWebMapOpenData(Base, Vector):
     __tablename__ = 'view_os_realestate_vd_opendata'
-    __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
+    __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/cadastralwebmap_opendata.mako'
     __bodId__ = 'ch.swisstopo-vd.amtliche-vermessung'
     __label__ = 'name'

--- a/chsdi/models/vector/mogis.py
+++ b/chsdi/models/vector/mogis.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from sqlalchemy import Column
+
+from sqlalchemy.types import Integer, Unicode
+
+from chsdi.models import register, bases
+from chsdi.models.vector import Vector, Geometry2D
+
+
+Base = bases['mogis']
+
+
+class CadastralWebMap(Base, Vector):
+    __tablename__ = 'view_os_realestate_cwm'
+    __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
+    __template__ = 'templates/htmlpopup/cadastralwebmap.mako'
+    __bodId__ = 'ch.kantone.cadastralwebmap-farbe'
+    __label__ = 'ak'
+    id = Column('id', Integer, primary_key=True)
+    ak = Column('ak', Unicode)
+    the_geom = Column(Geometry2D)
+
+register('ch.kantone.cadastralwebmap-farbe', CadastralWebMap)
+
+
+class CadastralWebMapOpenData(Base, Vector):
+    __tablename__ = 'view_os_realestate_vd_opendata'
+    __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
+    __template__ = 'templates/htmlpopup/cadastralwebmap_opendata.mako'
+    __bodId__ = 'ch.swisstopo-vd.amtliche-vermessung'
+    __label__ = 'name'
+    __extended_info__ = True
+    id = Column('id', Integer, primary_key=True)
+    bfsnr = Column('bfsnr', Integer)
+    ak = Column('ak', Unicode)
+    name = Column('name', Unicode)
+    the_geom = Column(Geometry2D)
+
+register('ch.swisstopo-vd.amtliche-vermessung', CadastralWebMapOpenData)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -504,34 +504,6 @@ class SwissBoundariesLand(Base, Vector):
 register('ch.swisstopo.swissboundaries3d-land-flaeche.fill', SwissBoundariesLand)
 
 
-class CadastralWebMap(Base, Vector):
-    __tablename__ = 'swissboundaries_kantone'
-    __table_args__ = ({'schema': 'tlm', 'autoload': False, 'extend_existing': True})
-    __template__ = 'templates/htmlpopup/cadastralwebmap.mako'
-    __bodId__ = 'ch.kantone.cadastralwebmap-farbe'
-    __label__ = 'ak'
-    id = Column('kantonsnr', Integer, primary_key=True)
-    ak = Column('ak', Unicode)
-    the_geom = Column(Geometry2D)
-
-register('ch.kantone.cadastralwebmap-farbe', CadastralWebMap)
-
-
-class CadastralWebMapOpenData(Base, Vector):
-    __tablename__ = 'swissboundaries_gemeinden_vd_opendata'
-    __table_args__ = ({'schema': 'tlm', 'autoload': False, 'extend_existing': True})
-    __template__ = 'templates/htmlpopup/cadastralwebmap_opendata.mako'
-    __bodId__ = 'ch.swisstopo-vd.amtliche-vermessung'
-    __label__ = 'name'
-    __extended_info__ = True
-    id = Column('bfsnr', Integer, primary_key=True)
-    ak = Column('ak', Unicode)
-    name = Column('name', Unicode)
-    the_geom = Column(Geometry2D)
-
-register('ch.swisstopo-vd.amtliche-vermessung', CadastralWebMapOpenData)
-
-
 class Vec200Terminal(Base, Vector):
     __tablename__ = 'vec200_terminal'
     __table_args__ = ({'autoload': False})

--- a/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
@@ -52,7 +52,7 @@
     % elif c['attributes']['ak'] == 'SG':
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="http://www.sg.ch/" target="_blank">SG</a></td></tr>
     % elif c['attributes']['ak'] == 'VS':
-        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://sitonline.vs.ch/urbanisation/mo/${c['fallbackLang']}/" target="_blnk">VS</a></td></br>
+        <tr><td class="cell-left">${_('link to canton geoportal')}</td><td><a href="https://sitonline.vs.ch/urbanisation/mo/${fallbackLang}/" target="_blnk">VS</a></td></br>
     % elif c['attributes']['ak'] == 'FL':
         <tr><td class="cell-left">${_('link to geoportal')}</td><td><a href="http://geodaten.llv.li/geoshop/public.html?zoombox=${c['bbox'][0]},${c['bbox'][1]},${c['bbox'][2]},${c['bbox'][3]}" target="_blank">${_('FL')}</a></td></tr>
     % else:

--- a/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
@@ -34,8 +34,8 @@
   lat = coord[0]
   lon = coord[1]
   pdf_url = "%s://geodata01.admin.ch/order/jPqrueQazrt/av_pdf.igs?pos=%s/%s" % (protocol, lat, lon)
-  shp_url = "%s://%s/ch.swisstopo-vd.amtliche-vermessung/DM01AVCH24D/SHP/%s/%s.zip" % (protocol, request.registry.settings['datageoadminhost'], c['attributes']['ak'],c['featureId'])
-  itf_url = "%s://%s/ch.swisstopo-vd.amtliche-vermessung/DM01AVCH24D/ITF/%s/%s.zip" % (protocol, request.registry.settings['datageoadminhost'], c['attributes']['ak'],c['featureId'])
+  shp_url = "%s://%s/ch.swisstopo-vd.amtliche-vermessung/DM01AVCH24D/SHP/%s/%s.zip" % (protocol, request.registry.settings['datageoadminhost'], c['attributes']['ak'],c['attributes']['bfsnr'])
+  itf_url = "%s://%s/ch.swisstopo-vd.amtliche-vermessung/DM01AVCH24D/ITF/%s/%s.zip" % (protocol, request.registry.settings['datageoadminhost'], c['attributes']['ak'],c['attributes']['bfsnr'])
   defaultCoord = [(c['bbox'][0]+c['bbox'][2])/2, (c['bbox'][1]+c['bbox'][3])/2]
   clickCoord = request.params.get('coord').split(',') if request.params.get('coord') else defaultCoord
 %>

--- a/chsdi/tests/integration/test_features_service.py
+++ b/chsdi/tests/integration/test_features_service.py
@@ -215,19 +215,19 @@ class TestFeaturesView(TestsBase):
 
     def test_htmlpopup_cadastralwebmap(self):
         params = {'mapExtent': '485412.34375,109644.67,512974.44,135580.01999999999', 'imageDisplay': '600,400,96'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/14/htmlPopup', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/4842983/htmlPopup', params=params, status=200)
         self.assertEqual(resp.content_type, 'text/html')
         resp.mustcontain('<table')
 
     def test_htmlpopup_bad_request_image_display(self):
         params = {'mapExtent': '485412.34375,109644.67,512974.44,135580.01999999999', 'imageDisplay': '600,96'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/14/htmlPopup', params=params, status=400)
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/4842983/htmlPopup', params=params, status=400)
         resp.mustcontain('Please provide the parameter imageDisplay in a comma separated list of 3 arguments '
                          '(width,height,dpi)')
 
     def test_htmlpopup_nan_image_display(self):
         params = {'mapExtent': '485412.34375,109644.67,512974.44,135580.01999999999', 'imageDisplay': '600,96,None'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/14/htmlPopup', params=params, status=400)
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/4842983/htmlPopup', params=params, status=400)
         resp.mustcontain('Please provide numerical values for the parameter imageDisplay')
 
     def test_htmlpopup_bad_request_map_extent(self):

--- a/production.ini.in
+++ b/production.ini.in
@@ -29,6 +29,7 @@ sqlalchemy.kogis.url = postgresql://${dbhost}:${dbport}/kogis_${dbstaging}
 sqlalchemy.stopo.url = postgresql://${dbhost}:${dbport}/stopo_${dbstaging}
 sqlalchemy.uvek.url = postgresql://${dbhost}:${dbport}/uvek_${dbstaging}
 sqlalchemy.uvek_solarkataster.url = postgresql://${dbhost}:${dbport}/uvek_solarkataster_${dbstaging}
+sqlalchemy.mogis.url = postgresql://${dbhost}:${dbport}/mogis_${dbstaging}
 sqlalchemy.vbs.url = postgresql://${dbhost}:${dbport}/vbs_${dbstaging}
 sqlalchemy.zeitreihen.url = postgresql://${dbhost}:${dbport}/zeitreihen_${dbstaging}
 sqlalchemy.lubis.url = postgresql://${dbhost}:${dbport}/lubis_${dbstaging}


### PR DESCRIPTION
this pr will use the mogis parcel geometry from os_realestate (npbund version) as feature highlight source for the layers:

* ch.kantone.cadastralwebmap-farbe
* ch.swisstopo-vd.amtliche-vermessung

[Testurl](https://map.geo.admin.ch/?topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.kantone.cadastralwebmap-farbe,ch.swisstopo-vd.amtliche-vermessung&X=238326.78&Y=611421.08&zoom=10&layers_visibility=false,true&api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fdev_ltclm_av_parcel_highlight)

Note: the coverage of os_realestate is actually not as it should be, there are big holes in the dataset, we are trying to solve this. so the tooltip is not working everywhere, p.e. Geneva:
![image](https://cloud.githubusercontent.com/assets/5286659/20802124/4a4f8d52-b7eb-11e6-9d6a-e4d46e8bab17.png)


ping @davidoesch @rebert  @cedricmoullet @gjn 

