### PR TITLE
Make loading of polyfill optional via parameter

### DIFF
--- a/chsdi/static/doc/source/api/quickstart.rst
+++ b/chsdi/static/doc/source/api/quickstart.rst
@@ -80,6 +80,12 @@ Available versions are (which are all based on ol3 releases):
 - 3.6.0
 - 3.18.2
 
+The loader is including a polyfill that might conflict with other JavaScript libraries and frameworks you are using in your application. For such cases, you can specify the ignore_polyfill parameter to not include the polyfill.
+
+.. code-block:: html
+
+  <script src="http://api3.geo.admin.ch/loader.js?ignore_polyfill=true" type="text/javascript"></script>
+
 The first part is to include the GeoAdmin API library. This loader will load all necessary JavaScript and CSS code. You can force the language (en, de, fr, it, rm) or let the navigator language be used.
 
 <div> to contain the map

--- a/chsdi/templates/loader.js
+++ b/chsdi/templates/loader.js
@@ -4,6 +4,7 @@
 lang = pageargs['lang']
 data = pageargs['data']
 api_url = pageargs['api_url']
+ignore_polyfill = pageargs['ignore_polyfill']
 layersconfig = """window.GeoAdmin.getConfig  = function(){ return %s } """ % data
 %>
 (function() {
@@ -14,7 +15,9 @@ ${layersconfig|n}
 
 document.write('<link rel="stylesheet" type="text/css" href="${ol_css}" />');
 document.write('<link rel="stylesheet" type="text/css" href="${ga_css}" />');
-document.write('<scr' + 'ipt type="text/javascript" src="//cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL"></scr' + 'ipt>');
+if ('${ignore_polyfill}' != 'true') {
+  document.write('<scr' + 'ipt type="text/javascript" src="//cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL"></scr' + 'ipt>');
+}
 document.write('<scr' + 'ipt type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/proj4js/2.2.1/proj4.js"></scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript" src="${epsg_21781_js}"></scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript" src="${epsg_2056_js}"></scr' + 'ipt>');

--- a/chsdi/views/loader.py
+++ b/chsdi/views/loader.py
@@ -13,6 +13,7 @@ available_versions = ['3.6.0', '3.18.2']
 @view_config(route_name='ga_api', renderer='json')
 def loadjs(request):
     mode = request.params.get('mode')
+    ignore_polyfill = request.params.get('ignore_polyfill')
     # Determined automatically in subscriber
     lang = request.lang
     geoadmin_file_storage_bucket = 'public.geo.admin.ch'
@@ -52,6 +53,7 @@ def loadjs(request):
             'epsg_21781_js': epsg_21781_js,
             'epsg_2056_js': epsg_2056_js,
             'api_url': request.path_url.replace('/loader.js', ''),
+            'ignore_polyfill': ignore_polyfill,
             'data': json.dumps(data, separators=(',', ':'))
         },
         request=request


### PR DESCRIPTION
The polyfill might be in conflict with other libaries. This adds a parameter to the loader to avoid loading our polyfill into the application.

@loicgasser: I think your original idea is best.