### PR TITLE
remove unused attributes from gwr model

### DIFF
--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -30,10 +30,8 @@ class Gebaeuderegister(Base, Vector):
     gdename = Column('gdename', Text)
     gdekt = Column('gdekt', Text)
     dstrid = Column('dstrid', Integer)
-    gkplaus = Column('gkplaus', Integer)
     gstat = Column('gstat', Integer)
     gdenr = Column('gdenr', Integer)
-    ggbkr = Column('ggbkr', Text)
     bgdi_created = Column('bgdi_created', Text)
     the_geom = Column(Geometry2D)
 


### PR DESCRIPTION
some attributes are not used and can be removed. they can be removed from the database kogis_master when this pr has been merged and deployed to prod.

```sql
begin;
DROP VIEW bfs.view_adr;
ALTER TABLE bfs.adr DROP COLUMN ggbkr;
ALTER TABLE bfs.adr DROP COLUMN gkplaus;

CREATE OR REPLACE VIEW bfs.view_adr AS 
 SELECT adr.egid_edid,
    adr.egid,
    adr.strname1,
    adr.deinr,
    adr.plz4::integer AS plz4,
    adr.plz4 * 100 + adr.plzz AS plz6,
    adr.plzname,
    adr.gdename,
    adr.gdekt,
    adr.dstrid,
    adr.gstat,
    adr.gdenr,
    adr.bgdi_created,
    adr.the_geom,
    adr.gkodx,
    adr.gkody
   FROM bfs.adr;

ALTER TABLE bfs.view_adr
  OWNER TO postgres;
GRANT ALL ON TABLE bfs.view_adr TO postgres;
GRANT ALL ON TABLE bfs.view_adr TO pgkogis;
GRANT SELECT ON TABLE bfs.view_adr TO "www-data";
rollback;
```