### PR TITLE
update layer ch.bav.schienennetz_*

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -3908,6 +3908,15 @@ msgstr "Planerische Massnahme"
 msgid "ch.bav.schienennetz"
 msgstr "Schienennetz"
 
+msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
+msgstr "KM-Linie Name"
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
+msgstr "KM-Linie Nr."
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
+msgstr "Segement-ID"
+
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "PB-Abk."
 
@@ -3931,6 +3940,21 @@ msgstr "Km Anfang"
 
 msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km Ende"
+
+msgid "ch.bav.schienennetz.kmnumero"
+msgstr "ch.bav.schienennetz.kmnumero"
+
+msgid "ch.bav.schienennetz.no_debut"
+msgstr "BP-Nr. Anfang"
+
+msgid "ch.bav.schienennetz.no_fin"
+msgstr "BP-Nr. Ende"
+
+msgid "ch.bav.schienennetz.nom_debut"
+msgstr "BP-Name Anfang"
+
+msgid "ch.bav.schienennetz.nom_fin"
+msgstr "BP-Name Ende"
 
 msgid "ch.bav.schienennetz.nom_point"
 msgstr "BP-Name"

--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -3737,6 +3737,9 @@ msgstr "BAV"
 msgid "ch.bav.haltestellen-oev"
 msgstr "öV-Haltestellen"
 
+msgid "ch.bav.haltestellen-oev.abkuerzung"
+msgstr "Abkürzung"
+
 msgid "ch.bav.haltestellen-oev.all_departures"
 msgstr "Alle Reiseziele"
 
@@ -3908,15 +3911,6 @@ msgstr "Planerische Massnahme"
 msgid "ch.bav.schienennetz"
 msgstr "Schienennetz"
 
-msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
-msgstr "KM-Linie Name"
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
-msgstr "KM-Linie Nr."
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
-msgstr "Segement-ID"
-
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "PB-Abk."
 
@@ -3942,7 +3936,10 @@ msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km Ende"
 
 msgid "ch.bav.schienennetz.kmnumero"
-msgstr "ch.bav.schienennetz.kmnumero"
+msgstr "KM-Linie Nr."
+
+msgid "ch.bav.schienennetz.kmtext"
+msgstr "KM-Linie Name"
 
 msgid "ch.bav.schienennetz.no_debut"
 msgstr "BP-Nr. Anfang"
@@ -3976,6 +3973,9 @@ msgstr "PB-Abk-Datenherr"
 
 msgid "ch.bav.schienennetz.xtf_id"
 msgstr "Netzknoten-ID"
+
+msgid "ch.bav.schienennetz.xtf_id_tooltip"
+msgstr "Segment-ID"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=de"

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -685,10 +685,34 @@ msgstr ""
 msgid "ch.bav.schienennetz.kmfin"
 msgstr ""
 
+msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
+msgstr ""
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
+msgstr ""
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
+msgstr ""
+
+msgid "ch.bav.schienennetz.kmnumero"
+msgstr ""
+
 msgid "ch.bav.schienennetz.nombrevoies"
 msgstr ""
 
 msgid "ch.bav.schienennetz.nom_point"
+msgstr ""
+
+msgid "ch.bav.schienennetz.no_debut"
+msgstr ""
+
+msgid "ch.bav.schienennetz.nom_debut"
+msgstr ""
+
+msgid "ch.bav.schienennetz.no_fin"
+msgstr ""
+
+msgid "ch.bav.schienennetz.nom_fin"
 msgstr ""
 
 msgid "ch.bav.schienennetz.nom_segment"

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -685,13 +685,7 @@ msgstr ""
 msgid "ch.bav.schienennetz.kmfin"
 msgstr ""
 
-msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
-msgstr ""
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
-msgstr ""
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
+msgid "ch.bav.schienennetz.kmtext"
 msgstr ""
 
 msgid "ch.bav.schienennetz.kmnumero"
@@ -728,6 +722,9 @@ msgid "ch.bav.schienennetz.respdonneesabreviation"
 msgstr ""
 
 msgid "ch.bav.schienennetz.xtf_id"
+msgstr ""
+
+msgid "ch.bav.schienennetz.xtf_id_tooltip"
 msgstr ""
 
 msgid "ch.bfe.windenergie-geschwindigkeit_h50"
@@ -1285,6 +1282,9 @@ msgid "ch.bav.haltestellen-oev.id"
 msgstr ""
 
 msgid "ch.bav.haltestellen-oev.tuabkuerzung"
+msgstr ""
+
+msgid "ch.bav.haltestellen-oev.abkuerzung"
 msgstr ""
 
 msgid "ch.bav.haltestellen-oev.verkehrsmittel"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -3737,6 +3737,9 @@ msgstr "FOT"
 msgid "ch.bav.haltestellen-oev"
 msgstr "Public transport stops"
 
+msgid "ch.bav.haltestellen-oev.abkuerzung"
+msgstr "Abreviation"
+
 msgid "ch.bav.haltestellen-oev.all_departures"
 msgstr "All destinations"
 
@@ -3771,7 +3774,7 @@ msgid "ch.bav.haltestellen-oev.reiner_betriebspunkt"
 msgstr "Simple operating point"
 
 msgid "ch.bav.haltestellen-oev.tuabkuerzung"
-msgstr "TO"
+msgstr "IM"
 
 msgid "ch.bav.haltestellen-oev.verkehrsmittel"
 msgstr "Means of transport"
@@ -3908,15 +3911,6 @@ msgstr "Measure"
 msgid "ch.bav.schienennetz"
 msgstr "Railway network | Rait da viafier"
 
-msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
-msgstr "Km line name"
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
-msgstr "Km line nr."
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
-msgstr "Segment ID"
-
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "OP abbrev."
 
@@ -3942,7 +3936,10 @@ msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km end"
 
 msgid "ch.bav.schienennetz.kmnumero"
-msgstr "ch.bav.schienennetz.kmnumero"
+msgstr "Km line nr."
+
+msgid "ch.bav.schienennetz.kmtext"
+msgstr "Km line name"
 
 msgid "ch.bav.schienennetz.no_debut"
 msgstr "Beginning OP nr."
@@ -3976,6 +3973,9 @@ msgstr "PB-Abk-Datenherr"
 
 msgid "ch.bav.schienennetz.xtf_id"
 msgstr "Node ID"
+
+msgid "ch.bav.schienennetz.xtf_id_tooltip"
+msgstr "Segment ID"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=en"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -3908,6 +3908,15 @@ msgstr "Measure"
 msgid "ch.bav.schienennetz"
 msgstr "Railway network | Rait da viafier"
 
+msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
+msgstr "Km line name"
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
+msgstr "Km line nr."
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
+msgstr "Segment ID"
+
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "OP abbrev."
 
@@ -3931,6 +3940,21 @@ msgstr "Km beginning"
 
 msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km end"
+
+msgid "ch.bav.schienennetz.kmnumero"
+msgstr "ch.bav.schienennetz.kmnumero"
+
+msgid "ch.bav.schienennetz.no_debut"
+msgstr "Beginning OP nr."
+
+msgid "ch.bav.schienennetz.no_fin"
+msgstr "End OP nr."
+
+msgid "ch.bav.schienennetz.nom_debut"
+msgstr "Beginning OP name"
+
+msgid "ch.bav.schienennetz.nom_fin"
+msgstr "End OP name"
 
 msgid "ch.bav.schienennetz.nom_point"
 msgstr "OP name"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -3737,6 +3737,9 @@ msgstr "BAV"
 msgid "ch.bav.haltestellen-oev"
 msgstr "Fermadas dal traffic public"
 
+msgid "ch.bav.haltestellen-oev.abkuerzung"
+msgstr "Abkürzung"
+
 msgid "ch.bav.haltestellen-oev.all_departures"
 msgstr "Alle Reiseziele"
 
@@ -3908,15 +3911,6 @@ msgstr "Planerische Massnahme"
 msgid "ch.bav.schienennetz"
 msgstr "Schienennetz"
 
-msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
-msgstr "KM-Linie Name"
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
-msgstr "KM-Linie Nr."
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
-msgstr "Segment-ID"
-
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "PB-Abk."
 
@@ -3942,7 +3936,10 @@ msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km Ende"
 
 msgid "ch.bav.schienennetz.kmnumero"
-msgstr "ch.bav.schienennetz.kmnumero"
+msgstr "KM-Linie Nr."
+
+msgid "ch.bav.schienennetz.kmtext"
+msgstr "KM-Linie Name"
 
 msgid "ch.bav.schienennetz.no_debut"
 msgstr "BP-Nr. Anfang"
@@ -3976,6 +3973,9 @@ msgstr "PB-Abk-Datenherr"
 
 msgid "ch.bav.schienennetz.xtf_id"
 msgstr "Netzknoten-ID"
+
+msgid "ch.bav.schienennetz.xtf_id_tooltip"
+msgstr "Segment-ID"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=de"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -3908,6 +3908,15 @@ msgstr "Planerische Massnahme"
 msgid "ch.bav.schienennetz"
 msgstr "Schienennetz"
 
+msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
+msgstr "KM-Linie Name"
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
+msgstr "KM-Linie Nr."
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
+msgstr "Segment-ID"
+
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "PB-Abk."
 
@@ -3931,6 +3940,21 @@ msgstr "Km Anfang"
 
 msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km Ende"
+
+msgid "ch.bav.schienennetz.kmnumero"
+msgstr "ch.bav.schienennetz.kmnumero"
+
+msgid "ch.bav.schienennetz.no_debut"
+msgstr "BP-Nr. Anfang"
+
+msgid "ch.bav.schienennetz.no_fin"
+msgstr "BP-Nr. Ende"
+
+msgid "ch.bav.schienennetz.nom_debut"
+msgstr "BP-Name Anfang"
+
+msgid "ch.bav.schienennetz.nom_fin"
+msgstr "BP-Name Ende"
 
 msgid "ch.bav.schienennetz.nom_point"
 msgstr "BP-Name"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -3908,6 +3908,15 @@ msgstr "Mesure"
 msgid "ch.bav.schienennetz"
 msgstr "Réseau ferré"
 
+msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
+msgstr "Nom ligne de kilom."
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
+msgstr "No. de ligne de kilom."
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
+msgstr "ID de segment"
+
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "Abr. PE"
 
@@ -3931,6 +3940,22 @@ msgstr "Km début"
 
 msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km fin"
+
+#. TODO
+msgid "ch.bav.schienennetz.kmnumero"
+msgstr "ch.bav.schienennetz.kmnumero"
+
+msgid "ch.bav.schienennetz.no_debut"
+msgstr "No. PE début"
+
+msgid "ch.bav.schienennetz.no_fin"
+msgstr "No. PE fin"
+
+msgid "ch.bav.schienennetz.nom_debut"
+msgstr "Nom PE début"
+
+msgid "ch.bav.schienennetz.nom_fin"
+msgstr "Nom PE fin"
 
 msgid "ch.bav.schienennetz.nom_point"
 msgstr "Nom PE"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -3737,6 +3737,9 @@ msgstr "OFT"
 msgid "ch.bav.haltestellen-oev"
 msgstr "Arrêts tp"
 
+msgid "ch.bav.haltestellen-oev.abkuerzung"
+msgstr "Abréviation"
+
 msgid "ch.bav.haltestellen-oev.all_departures"
 msgstr "Toutes les destinations"
 
@@ -3771,7 +3774,7 @@ msgid "ch.bav.haltestellen-oev.reiner_betriebspunkt"
 msgstr "Point d’exploitation simple"
 
 msgid "ch.bav.haltestellen-oev.tuabkuerzung"
-msgstr "ET"
+msgstr "GI"
 
 msgid "ch.bav.haltestellen-oev.verkehrsmittel"
 msgstr "Moyen de transport"
@@ -3908,15 +3911,6 @@ msgstr "Mesure"
 msgid "ch.bav.schienennetz"
 msgstr "Réseau ferré"
 
-msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
-msgstr "Nom ligne de kilom."
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
-msgstr "No. de ligne de kilom."
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
-msgstr "ID de segment"
-
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "Abr. PE"
 
@@ -3941,9 +3935,11 @@ msgstr "Km début"
 msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km fin"
 
-#. TODO
 msgid "ch.bav.schienennetz.kmnumero"
-msgstr "ch.bav.schienennetz.kmnumero"
+msgstr "No. ligne de kilom."
+
+msgid "ch.bav.schienennetz.kmtext"
+msgstr "Nom ligne de kilom."
 
 msgid "ch.bav.schienennetz.no_debut"
 msgstr "No. PE début"
@@ -3977,6 +3973,9 @@ msgstr "Autorité Abr. PE"
 
 msgid "ch.bav.schienennetz.xtf_id"
 msgstr "ID de noeud-réseau"
+
+msgid "ch.bav.schienennetz.xtf_id_tooltip"
+msgstr "ID de segment"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=fr"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -3737,6 +3737,9 @@ msgstr "UFT"
 msgid "ch.bav.haltestellen-oev"
 msgstr "Stazioni tp"
 
+msgid "ch.bav.haltestellen-oev.abkuerzung"
+msgstr "Abbreviazione"
+
 msgid "ch.bav.haltestellen-oev.all_departures"
 msgstr "Tutte le destinazioni"
 
@@ -3771,7 +3774,7 @@ msgid "ch.bav.haltestellen-oev.reiner_betriebspunkt"
 msgstr "Punto operativo semplice"
 
 msgid "ch.bav.haltestellen-oev.tuabkuerzung"
-msgstr "IT"
+msgstr "GI"
 
 msgid "ch.bav.haltestellen-oev.verkehrsmittel"
 msgstr "Mezzo di trasporto"
@@ -3908,15 +3911,6 @@ msgstr "Misura"
 msgid "ch.bav.schienennetz"
 msgstr "Rete ferroviaria"
 
-msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
-msgstr "Nome di linea km"
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
-msgstr "No. di linea km"
-
-msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
-msgstr "ID di segmento"
-
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "Abbrev. di PE"
 
@@ -3942,7 +3936,10 @@ msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km fine"
 
 msgid "ch.bav.schienennetz.kmnumero"
-msgstr "ch.bav.schienennetz.kmnumero"
+msgstr "No. di linea km"
+
+msgid "ch.bav.schienennetz.kmtext"
+msgstr "Nome di linea km"
 
 msgid "ch.bav.schienennetz.no_debut"
 msgstr "No. di PE inizio"
@@ -3966,7 +3963,7 @@ msgid "ch.bav.schienennetz.nombrevoies"
 msgstr "No. di binari"
 
 msgid "ch.bav.schienennetz.numero"
-msgstr "No di PE"
+msgstr "No. di PE"
 
 msgid "ch.bav.schienennetz.numeroet"
 msgstr "No. GI"
@@ -3976,6 +3973,9 @@ msgstr "Autorité Abr. PE"
 
 msgid "ch.bav.schienennetz.xtf_id"
 msgstr "ID di nodo"
+
+msgid "ch.bav.schienennetz.xtf_id_tooltip"
+msgstr "ID di segmento"
 
 msgid "ch.bav.url"
 msgstr "http://www.bav.admin.ch/?lang=it"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -3908,6 +3908,15 @@ msgstr "Misura"
 msgid "ch.bav.schienennetz"
 msgstr "Rete ferroviaria"
 
+msgid "ch.bav.schienennetz-kilometrierungslinien.nom"
+msgstr "Nome di linea km"
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.numero"
+msgstr "No. di linea km"
+
+msgid "ch.bav.schienennetz-kilometrierungslinien.xtf_id"
+msgstr "ID di segmento"
+
 msgid "ch.bav.schienennetz.abreviation"
 msgstr "Abbrev. di PE"
 
@@ -3931,6 +3940,21 @@ msgstr "Km inizio"
 
 msgid "ch.bav.schienennetz.kmfin"
 msgstr "Km fine"
+
+msgid "ch.bav.schienennetz.kmnumero"
+msgstr "ch.bav.schienennetz.kmnumero"
+
+msgid "ch.bav.schienennetz.no_debut"
+msgstr "No. di PE inizio"
+
+msgid "ch.bav.schienennetz.no_fin"
+msgstr "No. di PE fine"
+
+msgid "ch.bav.schienennetz.nom_debut"
+msgstr "Nome di PE inzio"
+
+msgid "ch.bav.schienennetz.nom_fin"
+msgstr "Nome di PE fine"
 
 msgid "ch.bav.schienennetz.nom_point"
 msgstr "Nome di PE"

--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -41,16 +41,17 @@ class SchienennetzPoint(Base, Vector):
     __bodId__ = 'ch.bav.schienennetz'
     __label__ = 'nom_point'
     __queryable_attributes__ = ['numero', 'nom_point', 'abreviation']
-    id = Column('xtf_id', Integer, primary_key=True)
+    id = Column('id', Integer, primary_key=True)
+    xtf_id = Column('xtf_id', Unicode)
     numero = Column('numero', Integer)
-    nom_point = Column('nom_point', Text)
-    abreviation = Column('abreviation', Text)
-    respdonneesabreviation = Column('respdonneesabreviation', Text)
-    debutvalidite = Column('debutvalidite', Text)
-    finvalidite = Column('finvalidite', Text)
+    nom_point = Column('nom_point', Unicode)
+    abreviation = Column('abreviation', Unicode)
+    respdonneesabreviation = Column('respdonneesabreviation', Unicode)
+    debutvalidite = Column('debutvalidite', Unicode)
+    finvalidite = Column('finvalidite', Unicode)
     the_geom = Column(Geometry2D)
 
-register('ch.bav.schienennetz', SchienennetzPoint)
+register(SchienennetzPoint.__bodId__, SchienennetzPoint)
 
 
 class SchienennetzSegment(Base, Vector):
@@ -60,22 +61,28 @@ class SchienennetzSegment(Base, Vector):
     __bodId__ = 'ch.bav.schienennetz'
     __label__ = 'nom_segment'
     __queryable_attributes__ = ['nom_segment']
-    id = Column('id', Integer, primary_key=True)
-    xtf_id = Column('xtf_id', Integer)
+    id = Column('bgdi_id', Integer, primary_key=True)
+    xtf_id = Column('xtf_id', Unicode)
     numeroet = Column('numeroet', Integer)
-    nom_segment = Column('nom_segment', Text)
+    nom_segment = Column('nom_segment', Unicode)
+    point_debut_nom = Column('point_debut_nom', Unicode)
+    point_debut_nummero = Column('point_debut_nummero', Unicode)
+    point_fin_nom = Column('point_fin_nom', Unicode)
+    point_fin_nummero = Column('point_fin_nummero', Unicode)
     kmdebut = Column('kmdebut', Numeric)
     kmfin = Column('kmfin', Numeric)
-    abreviationet = Column('abreviationet', Text)
+    kmtext = Column('kmtext', Unicode)
+    kmnummero = Column('kmnumero', Unicode)
+    abreviationet = Column('abreviationet', Unicode)
     nombrevoies = Column('nombrevoies', Integer)
-    ecartement = Column('ecartement', Text)
-    electrification_fr = Column('electrification_fr', Text)
-    electrification_de = Column('electrification_de', Text)
-    debutvalidite = Column('debutvalidite', Text)
-    finvalidite = Column('finvalidite', Text)
+    ecartement = Column('ecartement', Unicode)
+    electrification_fr = Column('electrification_fr', Unicode)
+    electrification_de = Column('electrification_de', Unicode)
+    debutvalidite = Column('debutvalidite', Unicode)
+    finvalidite = Column('finvalidite', Unicode)
     the_geom = Column(Geometry2D)
 
-register('ch.bav.schienennetz', SchienennetzSegment)
+register(SchienennetzSegment.__bodId__, SchienennetzSegment)
 
 
 class OevHaltestellen:

--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -41,14 +41,11 @@ class SchienennetzPoint(Base, Vector):
     __bodId__ = 'ch.bav.schienennetz'
     __label__ = 'nom_point'
     __queryable_attributes__ = ['numero', 'nom_point', 'abreviation']
-    id = Column('id', Integer, primary_key=True)
-    xtf_id = Column('xtf_id', Unicode)
+    id = Column('xtf_id', Integer, primary_key=True)
+    xtf_id_tooltip = Column('xtf_id_tooltip', Unicode)
     numero = Column('numero', Integer)
     nom_point = Column('nom_point', Unicode)
     abreviation = Column('abreviation', Unicode)
-    respdonneesabreviation = Column('respdonneesabreviation', Unicode)
-    debutvalidite = Column('debutvalidite', Unicode)
-    finvalidite = Column('finvalidite', Unicode)
     the_geom = Column(Geometry2D)
 
 register(SchienennetzPoint.__bodId__, SchienennetzPoint)
@@ -61,8 +58,8 @@ class SchienennetzSegment(Base, Vector):
     __bodId__ = 'ch.bav.schienennetz'
     __label__ = 'nom_segment'
     __queryable_attributes__ = ['nom_segment']
-    id = Column('bgdi_id', Integer, primary_key=True)
-    xtf_id = Column('xtf_id', Unicode)
+    id = Column('id', Integer, primary_key=True)
+    xtf_id_tooltip = Column('xtf_id_tooltip', Unicode)
     numeroet = Column('numeroet', Integer)
     nom_segment = Column('nom_segment', Unicode)
     point_debut_nom = Column('point_debut_nom', Unicode)
@@ -96,9 +93,10 @@ class OevHaltestellen:
     __returnedGeometry__ = 'the_geom_point'
     id = Column('nummer', Integer, primary_key=True)
     name = Column('name', Text)
-    tuabkuerzung = Column('tuabkuerzung', Text)
-    betriebspunkttyp = Column('betriebspunkttyp', Text)
-    verkehrsmittel = Column('verkehrsmittel', Text)
+    abkuerzung = Column('abkuerzung', Unicode)
+    tuabkuerzung = Column('tuabkuerzung', Unicode)
+    betriebspunkttyp = Column('betriebspunkttyp', Unicode)
+    verkehrsmittel = Column('verkehrsmittel', Unicode)
     # point geometry hilight
     the_geom_point = Column('the_geom', Geometry2D)
 
@@ -108,14 +106,14 @@ class OevHaltestellenZoom1(Base, OevHaltestellen, Vector):
     __maxscale__ = 3000
     the_geom = Column('bgdi_geom_poly', Geometry2D)
 
-register('ch.bav.haltestellen-oev', OevHaltestellenZoom1)
+register(OevHaltestellen.__bodId__, OevHaltestellenZoom1)
 
 
 class OevHaltestellenZoom2(Base, OevHaltestellen, Vector):
     __minscale__ = 3000
     the_geom = Column('bgdi_geom_poly_overview', Geometry2D)
 
-register('ch.bav.haltestellen-oev', OevHaltestellenZoom2)
+register(OevHaltestellen.__bodId__, OevHaltestellenZoom2)
 
 
 class OevDepartures(Base):

--- a/chsdi/templates/htmlpopup/oev_haltestellen.mako
+++ b/chsdi/templates/htmlpopup/oev_haltestellen.mako
@@ -183,6 +183,10 @@ $(document).ready(function() {
     <td class="cell-meta">${c['attributes']['name'] or '-'}</td>
   </tr>
   <tr>
+    <td class="cell-meta">${_('ch.bav.haltestellen-oev.abkuerzung')}</td>
+    <td class="cell-meta">${c['attributes']['abkuerzung'] or '-'}</td>
+  </tr>
+  <tr>
     <td class="cell-meta">${_('ch.bav.haltestellen-oev.tuabkuerzung')}</td>
     <td class="cell-meta">${c['attributes']['tuabkuerzung'] or '-'}</td>
   </tr>

--- a/chsdi/templates/htmlpopup/schienennetz_point.mako
+++ b/chsdi/templates/htmlpopup/schienennetz_point.mako
@@ -1,21 +1,13 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
-
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.xtf_id')}</td>                                            
-	<td>${c['featureId'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.xtf_id')}</td>
+	  <td>${c['attributes']['xtf_id'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.numero')}</td>
-    <td>${c['attributes']['numero'] or '-'}</td></tr>    
+    <td>${c['attributes']['numero'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.nom_point')}</td>
     <td>${c['attributes']['nom_point'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.abreviation')}</td>
     <td>${c['attributes']['abreviation'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.respdonneesabreviation')}</td>
-    <td>${c['attributes']['respdonneesabreviation'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.debutvalidite')}</td>
-    <td>${c['attributes']['debutvalidite'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.finvalidite')}</td>
-    <td>${c['attributes']['finvalidite'] or '-'}</td></tr>
-   
 </%def>
 

--- a/chsdi/templates/htmlpopup/schienennetz_point.mako
+++ b/chsdi/templates/htmlpopup/schienennetz_point.mako
@@ -2,7 +2,7 @@
 
 <%def name="table_body(c, lang)">
     <tr><td class="cell-left">${_('ch.bav.schienennetz.xtf_id')}</td>
-	  <td>${c['attributes']['xtf_id'] or '-'}</td></tr>
+	  <td>${c['attributes']['xtf_id_tooltip'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.numero')}</td>
     <td>${c['attributes']['numero'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.nom_point')}</td>

--- a/chsdi/templates/htmlpopup/schienennetz_segment.mako
+++ b/chsdi/templates/htmlpopup/schienennetz_segment.mako
@@ -1,8 +1,8 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
-    <tr><td class="cell-left">${_('ch.bav.schienennetz-kilometrierungslinien.xtf_id')}</td>
-  	<td>${c['attributes']['xtf_id'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.xtf_id_tooltip')}</td>
+  	<td>${c['attributes']['xtf_id_tooltip'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.nom_segment')}</td>
     <td>${c['attributes']['nom_segment'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.no_debut')}</td>
@@ -13,9 +13,9 @@
     <td>${c['attributes']['point_fin_nummero'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.nom_fin')}</td>
     <td>${c['attributes']['point_fin_nom'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('ch.bav.schienennetz-kilometrierungslinien.numero')}</td>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.kmnumero')}</td>
     <td>${c['attributes']['kmnummero'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('ch.bav.schienennetz-kilometrierungslinien.nom')}</td>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.kmtext')}</td>
     <td>${c['attributes']['kmtext'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.kmdebut')}</td>
     <td>${c['attributes']['kmdebut'] or '-'}</td></tr>

--- a/chsdi/templates/htmlpopup/schienennetz_segment.mako
+++ b/chsdi/templates/htmlpopup/schienennetz_segment.mako
@@ -1,18 +1,26 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
-
-
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.xtf_id')}</td>                                            
-	<td>${c['attributes']['xtf_id'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz-kilometrierungslinien.xtf_id')}</td>
+  	<td>${c['attributes']['xtf_id'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.nom_segment')}</td>
-    <td>${c['attributes']['nom_segment'] or '-'}</td></tr>    
+    <td>${c['attributes']['nom_segment'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.no_debut')}</td>
+    <td>${c['attributes']['point_debut_nummero'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.nom_debut')}</td>
+    <td>${c['attributes']['point_debut_nom'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.no_fin')}</td>
+    <td>${c['attributes']['point_fin_nummero'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz.nom_fin')}</td>
+    <td>${c['attributes']['point_fin_nom'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz-kilometrierungslinien.numero')}</td>
+    <td>${c['attributes']['kmnummero'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bav.schienennetz-kilometrierungslinien.nom')}</td>
+    <td>${c['attributes']['kmtext'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.kmdebut')}</td>
     <td>${c['attributes']['kmdebut'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.kmfin')}</td>
     <td>${c['attributes']['kmfin'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.numeroet')}</td>
-    <td>${c['attributes']['numeroet'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.abreviationet')}</td>
     <td>${c['attributes']['abreviationet'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bav.schienennetz.nombrevoies')}</td>
@@ -22,13 +30,8 @@
     <tr><td class="cell-left">${_('ch.bav.schienennetz.electrification')}</td>
 % if lang == 'de' or lang == "rm"  or lang == "en":
     <td>${c['attributes']['electrification_de'] or '-'}</td></tr>
-% else : 
+% else :
     <td>${c['attributes']['electrification_fr'] or '-'}</td></tr>
 % endif
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.debutvalidite')}</td>
-    <td>${c['attributes']['debutvalidite'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('ch.bav.schienennetz.finvalidite')}</td>
-    <td>${c['attributes']['finvalidite'] or '-'}</td></tr>
-   
 </%def>
 


### PR DESCRIPTION
For the update of the schienennetz, the tooltip had to be adapted as well: [try](https://mf-geoadmin3.dev.bgdi.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fltrea_bav_eisenbahn_strecke&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.bav.schienennetz&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&X=215750.00&Y=644000.00&zoom=5)