### PR TITLE
Do not make apache crash if config are missing

### DIFF
--- a/deploy/conf/00-branch.conf.in
+++ b/deploy/conf/00-branch.conf.in
@@ -1,1 +1,1 @@
-Include /var/www/vhosts/mf-chsdi3/private/branch/${git_branch}/apache/*.conf
+IncludeOptional /var/www/vhosts/mf-chsdi3/private/branch/${git_branch}/apache/*.conf

--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -16,7 +16,7 @@ dir = /var/www/vhosts/mf-chsdi3/private/chsdi/
 
 [apache]
 dest = /var/www/vhosts/mf-chsdi3/conf/99-chsdi.conf
-content = Include /var/www/vhosts/mf-chsdi3/private/chsdi/apache/*.conf
+content = IncludeOptional /var/www/vhosts/mf-chsdi3/private/chsdi/apache/*.conf
 
 [remote_hosts]
 # mf1i


### PR DESCRIPTION
If an apache `Include` directory does not have a single `.conf` file it crashes. Use `IncludeOptional` instead. 
Warning apache 2.4 only (Jessie)

