### PR TITLE
add stellvertreter info to geometer tooltip

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -4691,6 +4691,9 @@ msgstr "Gebiete in Arbeit"
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Nachführungsgeometer/in"
 
+msgid "ch.swisstopo-vd.geometa-nfgeom.stellvertreter"
+msgstr "Stellvertreter"
+
 msgid "ch.swisstopo-vd.geometa-periodische_nachfuehrung"
 msgstr "Periodische Nachführung"
 

--- a/chsdi/locale/empty_chsdi.po
+++ b/chsdi/locale/empty_chsdi.po
@@ -9026,3 +9026,6 @@ msgstr ""
 
 msgid "ch.swisstopo-vd.amtliche-vermessung.noitf"
 msgstr ""
+
+msgid "ch.swisstopo-vd.geometa-nfgeom.stellvertreter"
+msgstr ""

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -4691,6 +4691,9 @@ msgstr "Cadastral surveying lots."
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Cadastral surveyor"
 
+msgid "ch.swisstopo-vd.geometa-nfgeom.stellvertreter"
+msgstr "Stellvertreter"
+
 msgid "ch.swisstopo-vd.geometa-periodische_nachfuehrung"
 msgstr "Periodic updating"
 

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -4691,6 +4691,9 @@ msgstr "Territoris en lavur"
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Geometer-revisur"
 
+msgid "ch.swisstopo-vd.geometa-nfgeom.stellvertreter"
+msgstr "Stellvertreter"
+
 msgid "ch.swisstopo-vd.geometa-periodische_nachfuehrung"
 msgstr "Actualisaziun periodica"
 

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -4691,6 +4691,9 @@ msgstr "Secteurs en travaux"
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Géomètre-conservateur"
 
+msgid "ch.swisstopo-vd.geometa-nfgeom.stellvertreter"
+msgstr "remplaçant"
+
 msgid "ch.swisstopo-vd.geometa-periodische_nachfuehrung"
 msgstr "Mise à jour periodique"
 

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -4691,6 +4691,9 @@ msgstr "Aree con lavori in corso"
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Geometra revisore"
 
+msgid "ch.swisstopo-vd.geometa-nfgeom.stellvertreter"
+msgstr "sostituto"
+
 msgid "ch.swisstopo-vd.geometa-periodische_nachfuehrung"
 msgstr "Tenuta a giorno periodica"
 

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -1743,6 +1743,7 @@ class geometaNfgeom(Base, Vector):
     adresse = Column('adresse', Text)
     telefon = Column('telefon', Text)
     email = Column('email', Text)
+    stellvertreter = Column('ist_stellvertreter', Boolean)
     bgdi_created = Column('bgdi_created', Text)
     the_geom_gen50 = Column('the_geom_gen50', Geometry2D)
     the_geom = Column('the_geom', Geometry2D)

--- a/chsdi/templates/htmlpopup/nfgeom.mako
+++ b/chsdi/templates/htmlpopup/nfgeom.mako
@@ -2,7 +2,11 @@
 
 <%def name="table_body(c,lang)">
     <tr><td class="cell-left">${_('nffirmenname')}</td>    <td>${c['attributes']['firmenname'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('nfname')}</td>    <td>${c['attributes']['name'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('nfname')}</td>    <td>${c['attributes']['name'] or '-'}
+      % if c['attributes']['stellvertreter']:
+           (${_('ch.swisstopo-vd.geometa-nfgeom.stellvertreter')})
+      % endif
+    </td></tr>
     <tr><td class="cell-left">${_('grundadresse')}</td>
       % if c['attributes']['adresse'].strip() == '#':
            <td>-</td>


### PR DESCRIPTION
[Testlink](https://map.geo.admin.ch/?topic=ech&lang=de&bgLayer=ch.swisstopo.swissimage&layers=ch.swisstopo-vd.geometa-nfgeom&layers_opacity=0.75&X=131754.28&Y=598818.14&zoom=6&api_url=//mf-chsdi3.dev.bgdi.ch/dev_ltclm_vd_stellvertreter)

new attribute is already present on dev,int and prod