### PR TITLE
Change ids for cadastral web map test

### DIFF
--- a/chsdi/tests/e2e/test_links.py
+++ b/chsdi/tests/e2e/test_links.py
@@ -17,7 +17,7 @@ class TestLinks(TestsBase):
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.68 Safari/537.36'
         }
 
-        for i in range(1, 27):
+        for i in range(4300000, 4300010):
             response = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/%d/htmlPopup' % i, status=200)
 
             soup = response.html


### PR DESCRIPTION
I don't know if this PR is relevant but that fixes the links test. 
Maybe removing this test is a better solution.

Linked to https://github.com/geoadmin/mf-chsdi3/pull/2360