### PR TITLE
bugfix to many vertexes in bafu.gefahren-baugrundklassen #2397

### DIFF
--- a/chsdi/models/vector/bafu.py
+++ b/chsdi/models/vector/bafu.py
@@ -2069,9 +2069,11 @@ class baugrundklassen(Base, Vector):
     __bodId__ = 'ch.bafu.gefahren-baugrundklassen'
     __template__ = 'templates/htmlpopup/baugrundklassen.mako'
     __label__ = 'bgk'
+    __returnedGeometry__ = 'the_geom_highlight'
     id = Column('_count', Integer, primary_key=True)
     bgk = Column('bgk', Text)
     the_geom = Column(Geometry2D)
+    the_geom_highlight = Column('the_geom_highlight', Geometry2D)
 
 register('ch.bafu.gefahren-baugrundklassen', baugrundklassen)
 


### PR DESCRIPTION
#2397 Here is a bugfix with simplified geometries... it was a hard time to find a solution to simplify:

**Garbage in, garbage out (GIGO)**
Out of the 50284 features that have been read, following amount of features failed:
- Dublicated Features: 668
-  Geometries that had to be repaired to be valid: 454

**Due to validation Problems with the Generalisation in FME I generalised without really preserving topologies with a PostGIS query:**
UPDATE gefahren.baugrundklassen SET the_geom_highlight = ST_MakeValid(ST_SimplifyPreserveTopology(the_geom, 80));

**Here is the validation Result SELECT _bgdi_analyze_geometry('gefahren.baugrundklassen','the_geom_highlight'):**

NOTICE:  geometry column will be analyzed : (bafu_master.gefahren.baugrundklassen.the_geom_highlight)
NOTICE:  count: 49616
NOTICE:  max. number of vertices: 28434
NOTICE:  max. number of geometries in Multigeometry: 655
NOTICE:  Geometry types: ST_MultiPolygon,ST_Polygon
NOTICE:  Geometry Coordinate Dimenstion: 2
NOTICE:  Geometry max. z value: 0
NOTICE:  Geometry Indices: baugrundklassen_the_geom_highlight
NOTICE:
NOTICE:  Optimization advice
NOTICE:      * add a geometry column with simplified geometry, some features have more than 10000 vertices

Total query runtime: 507 msec
1 row retrieved.


Have a try: [here](https://mf-geoadmin3.dev.bgdi.ch/ltrea/?url_api=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fltrea_fix_baugrundklassen_highlight&topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.bafu.gefahren-baugrundklassen&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&layers_opacity=1,1,1,1,0.75&X=168262.61&Y=572835.23&zoom=10)

@ltclm: Schlussendlich via SQL ...