### PR TITLE
Basic auth credentials files are managedd by popets now

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -121,8 +121,8 @@ RewriteRule ^${apache_entry_path}/admin         https://%{HTTP_HOST}%{REQUEST_UR
     AuthName "Your IWI credential"
     # Optional line:
     AuthBasicProvider file
-    AuthUserFile "/var/www/vhosts/mf-chsdi3/private/htpasswd"
-    AuthGroupFile "/var/www/vhosts/mf-chsdi3/private/htgroup"
+    AuthUserFile "/etc/apache2/htpasswd"
+    AuthGroupFile "/etc/apache2/htgroup"
     Require group iwi-team bgdi-team
 </LocationMatch>
 


### PR DESCRIPTION
See https://github.com/geoadmin/mf-chsdi3/issues/2407 and https://github.com/geoadmin/mf-chsdi3/issues/2371

And remove _/var/www/vhosts/mf-chsdi3/private/htpasswd_ and _/var/www/vhosts/mf-chsdi3/private/htgroup_ once merged (not in github obviously)