### PR TITLE
bugfix for issue #2419

### DIFF
--- a/chsdi/models/__init__.py
+++ b/chsdi/models/__init__.py
@@ -79,7 +79,7 @@ def models_from_bodid(bodId, scale=None, resolution=None):
     if models:
         if scale is not None:
             models = [m for m in models if scale < max_scale(m) and scale >= min_scale(m)]
-        elif resolution is not None:
+        if resolution is not None:
             models = [m for m in models if resolution < max_resolution(m) and resolution >= min_resolution(m)]
     return models
 


### PR DESCRIPTION
@loicgasser : 
- this fixed the bug #2419 
- no more layer specific ch.swisstopo.zeitreihen #1056  

[try](https://mf-geoadmin3.dev.bgdi.ch/src/?api_url=%2F%2Fmf-chsdi3.int.bgdi.ch%2Fltrea_bugfix_zeitreihe&topic=ech&lang=de&bgLayer=ch.swisstopo.pixelkarte-grau&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.astra.wanderland&layers_visibility=true,false,false,false&layers_timestamp=18641231,,,&X=199858.28&Y=599908.66&zoom=6&catalogNodes=687,720)