### PR TITLE
Scale filtering zeitreihen and various improvements

### DIFF
--- a/chsdi/models/vector/zeitreihen.py
+++ b/chsdi/models/vector/zeitreihen.py
@@ -18,6 +18,7 @@ class Zeitreihen_15(Base, Vector):
     __bodId__ = 'ch.swisstopo.zeitreihen'
     __minresolution__ = 10.05
     __maxresolution__ = 500005
+    __minscale__ = 37984.176
     __timeInstant__ = 'years'
     __label__ = 'release_year'
     id = Column('bgdi_id', Unicode, primary_key=True)
@@ -40,6 +41,8 @@ class Zeitreihen_20(Base, Vector):
     __bodId__ = 'ch.swisstopo.zeitreihen'
     __minresolution__ = 5.05
     __maxresolution__ = 10.05
+    __minscale__ = 19086.576
+    __maxscale__ = 37984.176
     __timeInstant__ = 'years'
     __label__ = 'release_year'
     id = Column('bgdi_id', Unicode, primary_key=True)
@@ -62,6 +65,8 @@ class Zeitreihen_21(Base, Vector):
     __bodId__ = 'ch.swisstopo.zeitreihen'
     __minresolution__ = 2.55
     __maxresolution__ = 5.05
+    __minscale__ = 9637.776
+    __maxscale__ = 19086.576
     __timeInstant__ = 'years'
     __label__ = 'release_year'
     id = Column('bgdi_id', Unicode, primary_key=True)
@@ -84,6 +89,8 @@ class Zeitreihen_22(Base, Vector):
     __bodId__ = 'ch.swisstopo.zeitreihen'
     __minresolution__ = 0
     __maxresolution__ = 2.55
+    __minscale__ = 0
+    __maxscale__ = 9637.776
     __timeInstant__ = 'years'
     __label__ = 'release_year'
     id = Column('bgdi_id', Unicode, primary_key=True)

--- a/chsdi/tests/integration/test_features_service.py
+++ b/chsdi/tests/integration/test_features_service.py
@@ -447,7 +447,7 @@ class TestReleasesService(TestsBase):
                   }
         resp = self.testapp.get('/rest/services/all/MapServer/' + zlayer + '/releases', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue(len(resp.json['results']) >= 25, len(resp.json['results']))
+        self.assertGreaterEqual(len(resp.json['results']), 25)
         ist = resp.json['results']
         soll = ["18611231", "18641231", "18661231", "18711231", "18751231", "18761231",
                 "18791231", "18821231", "18851231", "18891231", "18931231", "18951231",
@@ -465,7 +465,7 @@ class TestReleasesService(TestsBase):
                   }
         resp = self.testapp.get('/rest/services/all/MapServer/' + zlayer + '/releases', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue(len(resp.json['results']) >= 25, len(resp.json['results']))
+        self.assertGreaterEqual(len(resp.json['results']), 25)
         ist = resp.json['results']
         soll = ["18611231", "18641231", "18661231", "18711231", "18751231", "18761231",
                 "18791231", "18821231", "18841231", "18961231", "18971231", "19011231",
@@ -482,7 +482,7 @@ class TestReleasesService(TestsBase):
                   }
         resp = self.testapp.get('/rest/services/all/MapServer/' + zlayer + '/releases', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue(len(resp.json['results']) >= 25, len(resp.json['results']))
+        self.assertGreaterEqual(len(resp.json['results']), 25)
         ist = resp.json['results']
         soll = ["18611231", "18641231", "18661231", "18711231", "18751231", "18761231",
                 "18791231", "18821231", "18841231", "18961231", "18971231", "19011231",

--- a/chsdi/tests/integration/test_identify_service.py
+++ b/chsdi/tests/integration/test_identify_service.py
@@ -194,6 +194,18 @@ class TestIdentifyService(TestsBase):
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
+        self.assertEqual(len(resp.json['results']), 2)
+
+    def test_identify_timeinstant_zeitreihen(self):
+        params = {'geometryType': 'esriGeometryPoint', 'geometry': '614277,188148', 'geometryFormat': 'geojson',
+                  'imageDisplay': '1920,573,96', 'mapExtent': '570727,172398,666727,201048', 'tolerance': '10', 'timeInstant': '2000',
+                  'returnGeometry': 'true', 'layers': 'all:ch.swisstopo.zeitreihen'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertIn('properties', resp.json['results'][0])
+        self.assertIn('geometry', resp.json['results'][0])
+        self.assertEqual(resp.json['results'][0]['properties']['produkt'], 'lk25')
+        self.assertEqual(len(resp.json['results']), 1)
 
     def test_identify_one_timeinstant_several_layers(self):
         params = {'geometryType': 'esriGeometryPoint', 'geometry': '630853.8,170647.9', 'geometryFormat': 'geojson',

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -778,8 +778,7 @@ def _get_features_releases(model, params):
         query = query.filter(geomFilter)
     if params.timeInstant is not None and hasattr(model, '__timeInstant__'):
         timeInstantColumn = model.time_instant_column()
-        if params.timeInstant:
-            query = query.filter(timeInstantColumn == params.timeInstant)
+        query = query.filter(timeInstantColumn == params.timeInstant)
     query = query.order_by(model.bgdi_order)
     query = query.limit(maxFeatures)
     for feature in query:


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-chsdi3/issues/2419
Fix for https://github.com/geoadmin/mf-chsdi3/issues/1056

Thanks @rebert for noticing the bug and for the inspiration in https://github.com/geoadmin/mf-chsdi3/pull/2421

This PR simplifies and improves the current code base. New tests have been added.

[Test Link](https://map.geo.admin.ch/?api_url=%2F%2Fmf-chsdi3.int.bgdi.ch%2Fgal_scale_zeitreihen&lang=fr&topic=ech&bgLayer=voidLayer&layers=ch.swisstopo.zeitreihen&layers_timestamp=20001231&X=186722.98&Y=618727.47&zoom=4)