### PR TITLE
Slowing down read/write on dynamodb while testing

### DIFF
--- a/chsdi/tests/integration/test_shortener.py
+++ b/chsdi/tests/integration/test_shortener.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 
+import time
+from random import randint
 from chsdi.tests.integration import TestsBase
 
 
 class TestShortenerView(TestsBase):
+
+    # 1 read capacity unit = 4 KB read capacity per second
+    def tearDown(self):
+        time.sleep(randint(1, 10))
 
     def test_shortener_toolong_url_insert(self):
         test_url = 'https://map.geo.admin.ch/?topic=ech&lang=en&bgLayer=ch.swisstopo.pixelkarte-farbe' \


### PR DESCRIPTION
On dev/test read/write capacity on dynamoDB is only 1 capacity unit. As all tests are lauch at the same time, we may hit a read/write limit. This is only affecting the *tests*

Ref https://github.com/geoadmin/mf-chsdi3/issues/2446