### PR TITLE
Test if not none

### DIFF
--- a/chsdi/tests/integration/test_identify_service.py
+++ b/chsdi/tests/integration/test_identify_service.py
@@ -519,3 +519,15 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(len(resp.json['results']), 0)
+
+    def test_identify_no_geotable(self):
+        params = dict(geometryType='esriGeometryPoint',
+                      geometry='612824.615589634,177050.95813678834',
+                      geometryFormat='geojson',
+                      imageDisplay='1920,730,96',
+                      layers='all:ch.bakom.anschlussart-glasfaser',
+                      mapExtent='659174.774934163,256650.066299024,663974.774934163,259240.066299024',
+                      returnGeometry='true',
+                      tolerance='10',
+                      lang='fr')
+        self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -230,7 +230,7 @@ def _identify(request):
             else:
                 models = models_from_bodid(layerBodId, scale=scale)
                 # The layer has a model but not at the right scale
-                if len(models) == 0:
+                if models is not None and len(models) == 0:
                     return response
                 # There is no model for this layer
                 elif models is None:


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-chsdi3/issues/2449

Return now

400 Bad Request

The server could not comply with the request since it is either malformed or otherwise incorrect.

No GeoTable was found for ch.bakom.anschlussart-glasfaser