### PR TITLE
Scale ordering rather than filtering for htmlpopup and feature services

### DIFF
--- a/chsdi/models/__init__.py
+++ b/chsdi/models/__init__.py
@@ -74,10 +74,20 @@ def oereb_models_from_bodid(bodId, scale=None):
     return models
 
 
-def models_from_bodid(bodId, scale=None, resolution=None):
+# Returns None is the bodId is not registered and an empty list if the bodId is registered but
+# the scale filtered all models out. orderScale orders by scale validity
+def models_from_bodid(bodId, scale=None, resolution=None, orderScale=None):
     models = bodmap.get(bodId)
     if models:
-        if scale is not None:
+        if orderScale is not None:
+            mdls = []
+            for m in models:
+                if orderScale < max_scale(m) and orderScale  >= min_scale(m):
+                    mdls.insert(0, m)
+                else:
+                    mdls.append(m)
+            models = mdls
+        elif scale is not None:
             models = [m for m in models if scale < max_scale(m) and scale >= min_scale(m)]
         elif resolution is not None:
             models = [m for m in models if resolution < max_resolution(m) and resolution >= min_resolution(m)]

--- a/chsdi/tests/integration/test_features_service.py
+++ b/chsdi/tests/integration/test_features_service.py
@@ -140,6 +140,11 @@ class TestFeaturesView(TestsBase):
         resp = self.testapp.get('/rest/services/api/MapServer/ch.bafu.bundesinventare-bln/htmlPopup', status=404)
         resp.mustcontain('No feature with id')
 
+    def test_feature_htmlpopup_not_scale_dep(self):
+        params = {'imageDisplay': '960,700,96', 'lang': 'it', 'mapExtent': '642389,81044,882389,256044'}
+        resp = self.testapp.get('/rest/services/swisstopo/MapServer/ch.swisstopo.treasurehunt/734/htmlPopup', params=params, status=200)
+        self.assertEqual(resp.content_type, 'text/html')
+
     def test_feature_valid(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362', status=200)
         self.assertEqual(resp.content_type, 'application/json')

--- a/scripts/models_scan.py
+++ b/scripts/models_scan.py
@@ -10,9 +10,12 @@ The output format is a csv with | delimiter and it contains the following attrib
 Usage:
 
   .venv/bin/python scripts/models_scan.py > results.csv
+
+  .venv/bin/python scripts/models_scan.py fixme (to display all duplicated pkeys)
 """
 
 import re
+import sys
 from pyramid.paster import get_app
 
 
@@ -20,8 +23,8 @@ def getPGTables(layerId, engine, dbname, schema, tablename):
     sqlTemplate = 'EXPLAIN VERBOSE SELECT * FROM %s.%s'
     try:
         t = []
-        sqlQuery = sqlTemplate %(schema, tablename) 
-        records = engine.execute(sqlQuery) 
+        sqlQuery = sqlTemplate %(schema, tablename)
+        records = engine.execute(sqlQuery)
         for i in records:
             table = re.search('[Bitmap Heap|Index|Seq] Scan.* on ([^ ]+)', i[0])
             table = table.group(1) if table else None
@@ -38,31 +41,69 @@ def getTableReferences(dbmap, engines):
         tmp = []
         tmpColumns = []
         for model in models:
-            dbname = re.match(
-                '^.*\/{1}([a-z]*)',
-                model.metadata.__str__()).group(1)
+            matches = re.match(
+                '^.*\/{1}([a-z]*_solarkataster)|^.*\/{1}([a-z]*)',
+                model.metadata.__str__())
+            dbname = matches.group(1) if matches.group(1) else matches.group(2)
             engine = engines.get(dbname)
             schema = model.__table_args__['schema'] if 'schema' in model.__table_args__ else 'public'
             tablename = model.__tablename__
             columnNames = [k.name for k in model.__table__.columns]
             tmp.append(getPGTables(layerId, engine, dbname, schema, tablename))
             tmpColumns += columnNames
+        if len(models) > 1:
+            print layerId
         result = [item for sublist in tmp for item in sublist]
         result = sorted(list(set(result)))
         resultColumns = sorted(list(set(tmpColumns)))
-        yield layerId, result, resultColumns
+        yield layerId, result, resultColumns, len(models), dbname
 
 
 def main():
+    bodIdsWithMultipleModels = []
+    dbsWithMultipleModels = []
     # Load app to register the models
     app = get_app('production.ini')
+    from sqlalchemy.orm import scoped_session, sessionmaker
     from chsdi.models import bodmap, oerebmap, perimetermap, engines
     print 'layerId|data|columns'
     dbsmap = [bodmap, oerebmap, perimetermap]
     for dbmap in dbsmap:
-        for layerId, ref, refColumns in getTableReferences(dbmap, engines):
+        for layerId, ref, refColumns, nbTables, dbname in getTableReferences(dbmap, engines):
             print '%s|%s|%s' %(layerId, ','.join(ref), ','.join(refColumns))
+            if nbTables > 1:
+                bodIdsWithMultipleModels.append(layerId)
+                dbsWithMultipleModels.append(dbname)
 
+    if len(sys.argv) == 1:
+        sys.exit(0)
+
+    fixme = []
+    # Test if we don't have the same IDs
+    for b in range(0, len(bodIdsWithMultipleModels)):
+        bodId = bodIdsWithMultipleModels[b]
+        dbname = dbsWithMultipleModels[b]
+        if dbname == 'uvek_solarkataster':
+            continue
+        models = bodmap.get(bodId)
+        nbModels = len(models)
+        engine = engines.get(dbname)
+        session = scoped_session(sessionmaker(bind=engine))
+        for i in range(0, nbModels):
+            for j in range(i, nbModels):
+                if i != j:
+                    iColType = models[i].primary_key_column().type
+                    jColType = models[j].primary_key_column().type
+                    if type(iColType) == type(jColType):
+                        subQuery = session.query(models[i].primary_key_column())
+                        subQuery = subQuery.filter(
+                                models[i].primary_key_column() == models[j].primary_key_column())
+                        exists = session.query(subQuery.exists()).scalar()
+                        if exists:
+                            fixme.append(
+                                [dbname, bodId, models[i], models[j], models[i].__tablename__, models[j].__tablename__])
+    for m in fixme:
+        print m
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
@gjn @procrastinatio please review. (possibly before the 22nd :) )

[Test Link](https://mf-geoadmin3.dev.bgdi.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fgal_scale_html&lang=fr)

A Bod ID and Feature ID is all we should need to retrieve a correct model. 

mapExtent and imageDisplay parameters are provided in geoadmin when requesting:

- a feature
- a htmlpopup content

Note that we alos need to fix (code to generate this list is in this PR):
https://github.com/geoadmin/mf-chsdi3/issues/2456

Right now we filter out models that are not suitable.
With this PR we use the models that are the most suitable first, and stop when we find the first match.