### PR TITLE
Reflect DB changes and preserve catalog order

### DIFF
--- a/chsdi/views/catalog.py
+++ b/chsdi/views/catalog.py
@@ -24,6 +24,7 @@ def tree_data(G, root, attrs, meta):
         raise nx.NetworkXError('Attribute names are not unique.')
 
     def add_children(n, G):
+        distinct_order_keys = set()
         order_key = lambda x: x['orderKey']
         label_key = lambda x: x['label'].replace(u'Ü', u'U').replace(u'Ä', u'A')
         nbrs = G[n]
@@ -37,7 +38,7 @@ def tree_data(G, root, attrs, meta):
             d['staging'] = meta[d['id']]['staging']
             d['label'] = meta[d['id']]['label']
             # only for sorting according to 'orderKey'
-            if ('orderKey' in meta[d['id']]):
+            if 'orderKey' in meta[d['id']]:
                 d['orderKey'] = meta[d['id']]['orderKey']
             if (d['category'] == 'layer'):
                 d['layerBodId'] = meta[d['id']]['layerBodId']
@@ -49,10 +50,14 @@ def tree_data(G, root, attrs, meta):
             elif d['category'] != 'layer':
                 d[children] = []
             children_.append(d)
-            if ('orderKey' in d):
-                children_ = sorted(children_, key=order_key)
-            else:
-                children_ = sorted(children_, key=label_key)
+            if 'orderKey' in d:
+                distinct_order_keys.add(d['orderKey'])
+
+        if len(distinct_order_keys) > 1:
+            children_ = sorted(children_, key=order_key)
+        else:
+            children_ = sorted(children_, key=label_key)
+
         for d in children_:
             d.pop('orderKey', None)
         return children_


### PR DESCRIPTION
We are not dealing with `None` values in the orderKey field anymore in the catalogs. (It does simplify the logic a bit)
Instead orderKey now defaults to 0.
Instead of relying on the fact that we have None values in the children to order them alphabetically or by order key. We make sure all order keys are different, if not the case we order alphabetically.

[Test Link](mf-chsdi3.dev.bgdi.ch/gal_order/rest/services/inspire/CatalogServer?lang=fr)