### PR TITLE
[WIP] refactor lubis model, add url attribute to lubis kantone layer

### DIFF
--- a/chsdi/models/vector/lubis.py
+++ b/chsdi/models/vector/lubis.py
@@ -3,21 +3,17 @@
 from sqlalchemy import Column, Text, Integer, Boolean, Numeric
 from sqlalchemy.types import Unicode
 from chsdi.models import register, bases
-from chsdi.models.vector import Vector, Geometry2D, Geometry3D
+from chsdi.models.vector import Vector, Geometry3D
 
 Base = bases['lubis']
 
 
-class luftbilder_swisstopo_farbe(Base, Vector):
-    __tablename__ = 'luftbilder_swisstopo_color'
+class LuftbilderBase:
     __table_args__ = ({'schema': 'public', 'autoload': False})
     __template__ = 'templates/htmlpopup/lubis.mako'
-    __bodId__ = 'ch.swisstopo.lubis-luftbilder_farbe'
-    __queryable_attributes__ = ['id', 'ort']
     __returnedGeometry__ = 'the_geom_footprint'
     __timeInstant__ = 'bgdi_flugjahr'
     __extended_info__ = True
-    # Composite labels
     __label__ = 'flugdatum'
     id = Column('ebkey', Unicode, primary_key=True)
     filename = Column('filename', Text)
@@ -38,164 +34,59 @@ class luftbilder_swisstopo_farbe(Base, Vector):
     massstab = Column('massstab', Integer)
     filesize_mb = Column('filesize_mb', Text)
     bgdi_imagemode = Column('bgdi_imagemode', Text)
-    image_height = Column('image_height', Integer)
-    image_width = Column('image_width', Integer)
     the_geom_footprint = Column('the_geom_footprint', Geometry3D)
     the_geom = Column(Geometry3D)
+
+
+class luftbilder_swisstopo_farbe(Base, LuftbilderBase, Vector):
+    __tablename__ = 'luftbilder_swisstopo_color'
+    __bodId__ = 'ch.swisstopo.lubis-luftbilder_farbe'
+    __queryable_attributes__ = ['id', 'ort']
+    image_height = Column('image_height', Integer)
+    image_width = Column('image_width', Integer)
 
 register('ch.swisstopo.lubis-luftbilder_farbe', luftbilder_swisstopo_farbe)
 
 
-class luftbilder_swisstopo_ir(Base, Vector):
+class luftbilder_swisstopo_ir(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_swisstopo_ir'
-    __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
-    __template__ = 'templates/htmlpopup/lubis.mako'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder_infrarot'
     __queryable_attributes__ = ['id', 'ort']
-    __returnedGeometry__ = 'the_geom_footprint'
-    __timeInstant__ = 'bgdi_flugjahr'
-    __extended_info__ = True
-    # Composite labels
-    __label__ = 'flugdatum'
-    id = Column('ebkey', Unicode, primary_key=True)
-    filename = Column('filename', Text)
-    inventarnummer = Column('inventarnummer', Integer)
-    bildnummer = Column('bildnummer', Integer)
-    flugdatum = Column('flugdatum', Text)
-    firma = Column('firma', Text)
-    filmart = Column('filmart', Text)
-    bgdi_flugjahr = Column('bgdi_flugjahr', Integer)
-    orientierung = Column('orientierung', Boolean)
-    rotation = Column('rotation', Integer)
-    orthophoto = Column('orthophoto', Text)
-    originalsize = Column('originalsize', Text)
-    x = Column('x', Integer)
-    y = Column('y', Integer)
-    flughoehe = Column('flughoehe', Integer)
-    ort = Column('ort', Text)
-    massstab = Column('massstab', Integer)
-    filesize_mb = Column('filesize_mb', Text)
-    bgdi_imagemode = Column('bgdi_imagemode', Text)
     image_height = Column('image_height', Integer)
     image_width = Column('image_width', Integer)
-    the_geom_footprint = Column('the_geom_footprint', Geometry3D)
-    the_geom = Column(Geometry3D)
 
 register('ch.swisstopo.lubis-luftbilder_infrarot', luftbilder_swisstopo_ir)
 
 
-class luftbilder_swisstopo_sw(Base, Vector):
+class luftbilder_swisstopo_sw(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_swisstopo_bw'
-    __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
-    __template__ = 'templates/htmlpopup/lubis.mako'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder_schwarzweiss'
     __queryable_attributes__ = ['id', 'ort', 'filmart', 'bgdi_flugjahr']
-    __returnedGeometry__ = 'the_geom_footprint'
-    __timeInstant__ = 'bgdi_flugjahr'
-    __extended_info__ = True
-    # Composite labels
-    __label__ = 'flugdatum'
-    id = Column('ebkey', Unicode, primary_key=True)
-    filename = Column('filename', Text)
-    inventarnummer = Column('inventarnummer', Integer)
-    bildnummer = Column('bildnummer', Integer)
-    flugdatum = Column('flugdatum', Text)
-    firma = Column('firma', Text)
-    filmart = Column('filmart', Text)
-    bgdi_flugjahr = Column('bgdi_flugjahr', Integer)
-    orientierung = Column('orientierung', Boolean)
-    rotation = Column('rotation', Integer)
-    orthophoto = Column('orthophoto', Text)
-    originalsize = Column('originalsize', Text)
-    x = Column('x', Integer)
-    y = Column('y', Integer)
-    flughoehe = Column('flughoehe', Integer)
-    ort = Column('ort', Text)
-    massstab = Column('massstab', Integer)
-    filesize_mb = Column('filesize_mb', Text)
-    bgdi_imagemode = Column('bgdi_imagemode', Text)
     image_height = Column('image_height', Integer)
     image_width = Column('image_width', Integer)
-    the_geom_footprint = Column('the_geom_footprint', Geometry3D)
-    the_geom = Column(Geometry3D)
 
 register('ch.swisstopo.lubis-luftbilder_schwarzweiss', luftbilder_swisstopo_sw)
 
 
-class luftbilder_dritte_firmen(Base, Vector):
+class luftbilder_dritte_firmen(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_dritte_firmen'
-    __table_args__ = ({'schema': 'public', 'autoload': False})
-    __template__ = 'templates/htmlpopup/lubis.mako'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder-dritte-firmen'
     __queryable_attributes__ = ['id', 'ort', 'filmart', 'bgdi_flugjahr']
-    __returnedGeometry__ = 'the_geom_footprint'
-    __timeInstant__ = 'bgdi_flugjahr'
-    __extended_info__ = True
-    # Composite labels
-    __label__ = 'flugdatum'
-    id = Column('ebkey', Unicode, primary_key=True)
-    filename = Column('filename', Text)
-    inventarnummer = Column('inventarnummer', Integer)
-    bildnummer = Column('bildnummer', Integer)
-    flugdatum = Column('flugdatum', Text)
-    firma = Column('firma', Text)
-    filmart = Column('filmart', Text)
-    bgdi_flugjahr = Column('bgdi_flugjahr', Integer)
-    orientierung = Column('orientierung', Boolean)
-    originalsize = Column('originalsize', Text)
-    orthophoto = Column('orthophoto', Text)
-    rotation = Column('rotation', Integer)
-    x = Column('x', Integer)
-    y = Column('y', Integer)
-    flughoehe = Column('flughoehe', Integer)
-    ort = Column('ort', Text)
-    massstab = Column('massstab', Integer)
-    filesize_mb = Column('filesize_mb', Text)
     contact = Column('contact', Text)
     contact_email = Column('contact_email', Text)
     contact_web = Column('contact_web', Text)
-    bgdi_imagemode = Column('bgdi_imagemode', Text)
-    the_geom_footprint = Column('the_geom_footprint', Geometry2D)
-    the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.lubis-luftbilder-dritte-firmen', luftbilder_dritte_firmen)
 
 
-class luftbilder_dritte_kantone(Base, Vector):
+class luftbilder_dritte_kantone(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_dritte_kantone'
-    __table_args__ = ({'schema': 'public', 'autoload': False})
-    __template__ = 'templates/htmlpopup/lubis.mako'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder-dritte-kantone'
     __queryable_attributes__ = ['id', 'ort', 'filmart', 'bgdi_flugjahr']
-    __returnedGeometry__ = 'the_geom_footprint'
-    __timeInstant__ = 'bgdi_flugjahr'
-    __extended_info__ = True
-    # Composite labels
-    __label__ = 'flugdatum'
-    id = Column('ebkey', Unicode, primary_key=True)
-    filename = Column('filename', Text)
-    inventarnummer = Column('inventarnummer', Integer)
-    bildnummer = Column('bildnummer', Integer)
-    flugdatum = Column('flugdatum', Text)
-    firma = Column('firma', Text)
-    filmart = Column('filmart', Text)
-    bgdi_flugjahr = Column('bgdi_flugjahr', Integer)
-    orientierung = Column('orientierung', Boolean)
-    originalsize = Column('originalsize', Text)
-    orthophoto = Column('orthophoto', Text)
-    rotation = Column('rotation', Integer)
-    x = Column('x', Integer)
-    y = Column('y', Integer)
-    flughoehe = Column('flughoehe', Integer)
-    ort = Column('ort', Text)
-    massstab = Column('massstab', Integer)
-    filesize_mb = Column('filesize_mb', Text)
     contact = Column('contact', Text)
     contact_email = Column('contact_email', Text)
     contact_web = Column('contact_web', Text)
-    bgdi_imagemode = Column('bgdi_imagemode', Text)
-    the_geom_footprint = Column('the_geom_footprint', Geometry2D)
-    the_geom = Column(Geometry2D)
+    contact_image_url = Column('url', Text)
 
 register('ch.swisstopo.lubis-luftbilder-dritte-kantone', luftbilder_dritte_kantone)
 

--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -107,6 +107,13 @@ viewer_url = get_viewer_url(request, params)
   <td>${c['attributes']['filmart'] or '-'}</td>
 </tr>
 
+% if 'contact_image_url' in c['attributes'] and c['attributes']['contact_image_url']:
+<tr>
+  <td class="cell-left">${_('url')}</td>
+  <td><a href="${c['attributes']['contact_image_url']}" target="_blank">${c['attributes']['contact_image_url']}</a></td>
+</tr>
+% endif
+
 % if preview_url != "" and image_width != None:
 <tr>
   <td class="cell-left">${_('tt_lubis_Quickview')}</td>
@@ -212,6 +219,14 @@ shop_url = request.registry.settings['shop_url']
     <tr><th class="cell-left">${_('tt_lubis_y')}</th>                <td>${c['attributes']['x'] or '-'}</td></tr>
     <tr><th class="cell-left">${_('tt_lubis_x')}</th>                <td>${c['attributes']['y'] or '-'}</td></tr>
     <tr><th class="cell-left">${_('tt_lubis_Filmart')}</th>          <td>${c['attributes']['filmart'] or '-'}</td></tr>
+
+% if 'contact_image_url' in c['attributes'] and c['attributes']['contact_image_url']:
+<tr>
+  <th class="cell-left">${_('url')}</th>
+  <td><a href="${c['attributes']['contact_image_url']}" target="_blank">${c['attributes']['contact_image_url']}</a></td>
+</tr>
+% endif
+
     <tr><th class="cell-left">${_('tt_lubis_originalsize')}</th>     <td>${c['attributes']['originalsize'] or '-'}</td></tr>
     <tr><th class="cell-left">${_('tt_lubis_filesize_mb')}</th>      <td>${filesize_mb or '-'}</td></tr>
     <tr><th class="cell-left">${_('tt_lubis_bildpfad')}</th>         <td>${filename or '-'}</td></tr>


### PR DESCRIPTION
[Testlink](https://mf-geoadmin3.dev.bgdi.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fdev_ltclm_lubis_kantone&lang=de&topic=luftbilder&bgLayer=ch.swisstopo.pixelkarte-grau&layers_timestamp=99991231,99991231,99991231&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe,ch.swisstopo.lubis-luftbilder-dritte-kantone&catalogNodes=1179,1180,1186&layers_visibility=false,false,true&X=239516.23&Y=688141.08&zoom=4)

Tiles are not yet calculated for kanton zürich, but you can use identify tooltip.