### PR TITLE
Add product image if exist

### DIFF
--- a/chsdi/templates/htmlpopup/shop_product.mako
+++ b/chsdi/templates/htmlpopup/shop_product.mako
@@ -15,10 +15,10 @@ elif layer == 'ch.swisstopo.stk200-papierkarte.metadata':
     img_id = 'Strassenkarte' + fid
 
 image = cmsGeoadminHost + '/www.swisstopo.admin.ch/shop/swisstopoproducts/250/' + img_id + '.jpg'
-if 'pk_product' not in c['attributes']:
-    image_exists = h.resource_exists(image)
 if layer == 'ch.swisstopo.pixelkarte-pk25.metadata':
     image_exists = False
+elif 'pk_product' not in c['attributes']:
+    image_exists = h.resource_exists(image)
 else:
     image_exists = False
 


### PR DESCRIPTION
`image_exists ` was always false
[Before](https://api3.geo.admin.ch/1703010952/rest/services/swisstopo/MapServer/ch.swisstopo.landeskarte25_papier.metadata/1211/htmlPopup?coord=681000,175749.99999999997&imageDisplay=1920,653,96&lang=fr&mapExtent=180000,26750,1140000,353250)
[After](https://mf-chsdi3.dev.bgdi.ch/ltteo/rest/services/swisstopo/MapServer/ch.swisstopo.landeskarte25_papier.metadata/1211/htmlPopup?coord=681000,175749.99999999997&imageDisplay=1920,653,96&lang=fr&mapExtent=180000,26750,1140000,353250)