### PR TITLE
Using the right address in doc/example

### DIFF
--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -868,13 +868,13 @@ Beside, the **LV03** projection, the same tiles are offered in four other *tilem
 These projections are:
 
 * Plate-Carrée WGS1984 (EPSG:4326)
-    `http://wmts10.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml>`_
+    `http://wmts20.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml <https://wmts20.geo.admin.ch/EPSG/4326/1.0.0/WMTSCapabilities.xml>`_
 * Plate-Carrée ETRS89 (EPSG:4258)
-    `http://wmts10.geo.admin.ch/EPSG/4258/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/4258/1.0.0/WMTSCapabilities.xml>`_
+    `http://wmts20.geo.admin.ch/EPSG/4258/1.0.0/WMTSCapabilities.xml <https://wmts20.geo.admin.ch/EPSG/4258/1.0.0/WMTSCapabilities.xml>`_
 * LV95/CH1903+ (EPSG:2056)
-    `http://wmts10.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml>`_
+    `http://wmts20.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml <https://wmts20.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml>`_
 * WGS84/Pseudo-Mercator (EPSG:3857, as used in OSM, Bing, Google Map)
-    `http://wmts10.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml <https://wmts10.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml>`_
+    `http://wmts20.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml <https://wmts20.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml>`_
 
 
 Note:
@@ -896,11 +896,11 @@ Note:
 
 Example
 *******
-* At tile: `http://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/9/266/180.jpeg <https://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/9/266/180.jpeg>`_
+* At tile: `http://wmts20.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/9/266/180.jpeg <https://wmts20.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/9/266/180.jpeg>`_
 
 .. raw:: html
 
-       <img src="https://wmts10.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/9/266/180.jpeg" />
+       <img src="https://wmts20.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/9/266/180.jpeg" />
 
 * An OpenLayers3 application using the `pseudo-Mercator projection <http://codepen.io/geoadmin/pen/pyzwwL?editors=0010>`_
 * An OpenLayers3 example showing the `Cadastralwebmap as WMTS <http://codepen.io/geoadmin/pen/xVKLdV?editors=0010>`_
@@ -1184,8 +1184,8 @@ Response syntax
         var l = document.links;
         for(var i=0; i<l.length; i++) {
             var href = l[i].href;
-            if (href.indexOf('wmts10') > -1) {
-                 l[i].href = href.replace(/^https:\/\/wmts10\.geo\.admin\.ch/, hostname);
+            if (href.indexOf('wmts20') > -1) {
+                 l[i].href = href.replace(/^https:\/\/wmts20\.geo\.admin\.ch/, hostname);
             }
         }
    </script>


### PR DESCRIPTION
In WMTS 1.0 you may have only one **host**

For LV03, we have **wmts** instead of of _wmts{10-15}_ or _wmts{100-105}_ (most peoply are asking why _wmts{100-105}_ is not working).
For the rest, we have **wmts20**

Fixes https://github.com/geoadmin/service-mapproxy/issues/59#event-997159976

[Link](http://mf-chsdi3.dev.bgdi.ch/mom_doku/)

