### PR TITLE
http exceptions defaults to json formatting

### DIFF
--- a/chsdi/tests/integration/test_identify_service.py
+++ b/chsdi/tests/integration/test_identify_service.py
@@ -3,52 +3,66 @@
 from chsdi.tests.integration import TestsBase
 
 
+accept_headers = {'Accept': 'application/json, text/plain, */*'}
+
+
 class TestIdentifyService(TestsBase):
 
     def test_identify_no_parameters(self):
-        self.testapp.get('/rest/services/ech/MapServer/identify', status=400)
+        self.testapp.get('/rest/services/ech/MapServer/identify', headers=accept_headers, status=400)
 
     def test_identify_without_geometry(self):
         params = {'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96', 'mapExtent': '548945.5,147956,549402,148103.5',
                   'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide the parameter geometry')
 
     def test_identify_invalid_geometrytype(self):
         params = {'geometryType': 'Envelope', 'geometry': '548945.5,147956,549402,148103.5', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide a valid geometry type')
 
     def test_identify_without_geometrytype(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
-        resp.mustcontain('Please provide the parameter geometryType')
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['code'], 400)
+        self.assertEqual(resp.json['status'], 'error')
+        self.assertTrue(resp.json['detail'].startswith('Please provide the parameter geometryType'))
 
     def test_identify_without_imagedisplay(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
-        resp.mustcontain('Please provide the parameter imageDisplay')
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['code'], 400)
+        self.assertEqual(resp.json['status'], 'error')
+        self.assertTrue(resp.json['detail'].startswith('Please provide the parameter imageDisplay'))
 
     def test_identify_without_mapextent(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope',
                   'imageDisplay': '500,600,96', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
-        resp.mustcontain('')
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['code'], 400)
+        self.assertEqual(resp.json['status'], 'error')
 
     def test_identify_without_tolerance(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
-        resp.mustcontain('Please provide the parameter tolerance')
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['code'], 400)
+        self.assertEqual(resp.json['status'], 'error')
+        self.assertTrue(resp.json['detail'].startswith('Please provide the parameter tolerance'))
 
     def test_identify_polyline(self):
         params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bazl.sachplan-infrastruktur-luftfahrt_kraft'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('attributes', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -57,7 +71,7 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('attributes', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -66,46 +80,46 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon', 'imageDisplay': '500,600,96',
                   'mapExtent': 'NaN,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide numerical values for the parameter mapExtent')
         params = {'geometryType': 'esriGeometryPoint', 'geometry': '600000,NaN,549402,148103.5', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide a valid geometry')
         params = {'geometry': '{"rings":[[[NaN,NaN],[NaN,NaN],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon', 'imageDisplay': '500,600,96',
                   'mapExtent': '600000,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide a valid geometry')
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon', 'imageDisplay': '500,NaN,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '0', 'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide numerical values for the parameter imageDisplay')
         params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': 'NaN', 'layers': 'all:ch.bazl.sachplan-infrastruktur-luftfahrt_kraft'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide an integer value for the pixel tolerance')
 
     def test_identify_zero_tolerance_and_scale(self):
         params = {'geometry': '681999,251083,682146,251190', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryEnvelope',
                   'imageDisplay': '1920,452,96', 'layers': 'all:ch.bazl.sachplan-infrastruktur-luftfahrt_kraft',
                   'mapExtent': '679364.12,250588.34,684164.12,251718.34', 'tolerance': '0'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(len(resp.json['results']), 1)
 
     def test_identify_valid(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all:ch.swisstopo.fixpunkte-agnes'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
     def test_identify_valid_on_grid(self):
         params = {'geometry': '555000,171125', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryPoint',
                   'imageDisplay': '1920,793,96', 'layers': 'all:ch.bfe.windenergie-geschwindigkeit_h50',
                   'mapExtent': '346831.18,86207.571,826831.18,284457.57', 'returnGeometry': 'true', 'tolerance': '10'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('results', resp.json)
         self.assertEqual(len(resp.json['results']), 1)
@@ -114,7 +128,7 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '555000,171125,556000,172125', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryEnvelope',
                   'imageDisplay': '1920,793,96', 'layers': 'all:ch.bfe.windenergie-geschwindigkeit_h50',
                   'mapExtent': '346831.18,86207.57,826831.18,284457.57', 'returnGeometry': 'true', 'tolerance': '10'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('results', resp.json)
         self.assertEqual(len(resp.json['results']), 1)
@@ -123,32 +137,40 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96', 'layers': 'all:ch.bfe.windenergie-geschwindigkeit_h100',
                   'mapExtent': '346831.18,86207.57,826831.18,284457.57', 'returnGeometry': 'true', 'tolerance': '10'}
-        self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['code'], 400)
+        self.assertEqual(resp.json['status'], 'error')
 
     def test_invalid_imageDisplay(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
-        resp.mustcontain('Please provide the parameter imageDisplay in a comma separated list of 3 arguments (width,height,dpi)')
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['code'], 400)
+        self.assertEqual(resp.json['status'], 'error')
+        self.assertTrue(resp.json['detail'].startswith('Please provide the parameter imageDisplay in a comma separated list of 3 arguments (width,height,dpi)'))
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers={'Accept': 'text/html'}, status=400)
+        self.assertEqual(resp.content_type, 'text/html')
 
     def test_identify_valid_topic(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all:ch.swisstopo.fixpunkte-agnes'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
 
     def test_identify_valid_with_callback(self):
         params = {'geometry': '548945.5,147956,549402,148103.5', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1', 'layers': 'all:ch.swisstopo.fixpunkte-agnes',
                   'callback': 'cb_'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'text/javascript')
 
     def test_identify_with_geojson(self):
         params = {'geometry': '600000,200000,631000,210000', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1',
                   'layers': 'all:ch.bafu.bundesinventare-bln', 'geometryFormat': 'geojson'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -157,7 +179,7 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '600000,200000,631000,210000', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '1',
                   'layers': 'all:ch.swisstopo.lubis-luftbilder_farbe', 'geometryFormat': 'geojson'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn(resp.json['results'][0]['geometry']['type'], ['Polygon', 'GeometryCollection'])
 
@@ -165,7 +187,7 @@ class TestIdentifyService(TestsBase):
         params = {'geometryType': 'esriGeometryPoint', 'returnGeometry': 'false', 'layers': 'all:ch.swisstopo-vd.geometa-gemeinde',
                   'geometry': '561289,185240', 'mapExtent': '561156.75,185155,561421.25,185325',
                   'imageDisplay': '529,340,96', 'tolerance': '5'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertNotEqual(len(resp.json['results']), 0)
         self.assertIn('attributes', resp.json['results'][0])
         self.assertNotIn('geometry', resp.json['results'][0])
@@ -174,7 +196,7 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '630000,245000,645000,265000', 'geometryType': 'esriGeometryEnvelope', 'imageDisplay': '500,600,96',
                   'mapExtent': '545132,147068,550132,150568', 'tolerance': '1', 'layers': 'all',
                   'returnGeometry': 'false'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertNotIn('geometry', resp.json['results'][0])
         self.assertNotIn('geometryType', resp.json['results'][0])
@@ -184,13 +206,13 @@ class TestIdentifyService(TestsBase):
                   'mapExtent': '0,0,0,0', 'tolerance': 0,
                   'layers': 'all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.swisstopo.swissboundaries3d-land-flaeche.fill',
                   'returnGeometry': 'false', 'lang': 'fr'}
-        self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=400)
+        self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=400)
 
     def test_identify_timeinstant(self):
         params = {'geometryType': 'esriGeometryPoint', 'geometry': '630853.809670509,170647.93120352627', 'geometryFormat': 'geojson',
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997',
                   'tolerance': '5', 'layers': 'all:ch.swisstopo.zeitreihen', 'timeInstant': '1936'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -200,7 +222,7 @@ class TestIdentifyService(TestsBase):
         params = {'geometryType': 'esriGeometryPoint', 'geometry': '614277,188148', 'geometryFormat': 'geojson',
                   'imageDisplay': '1920,573,96', 'mapExtent': '570727,172398,666727,201048', 'tolerance': '10', 'timeInstant': '2000',
                   'returnGeometry': 'true', 'layers': 'all:ch.swisstopo.zeitreihen'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -212,7 +234,7 @@ class TestIdentifyService(TestsBase):
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997', 'tolerance': '5',
                   'layers': 'all:ch.swisstopo.zeitreihen,ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.bazl.luftfahrthindernis',
                   'timeInstant': '2000'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -222,7 +244,10 @@ class TestIdentifyService(TestsBase):
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997', 'tolerance': '5',
                   'layers': 'all:ch.swisstopo.zeitreihen,ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.bazl.luftfahrthindernis',
                   'timeInstant': '2000,2002'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['code'], 400)
+        self.assertEqual(resp.json['status'], 'error')
         resp.mustcontain('Number of timInstants')
 
     def test_identify_several_timeinstants(self):
@@ -230,7 +255,7 @@ class TestIdentifyService(TestsBase):
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997', 'tolerance': '5',
                   'layers': 'all:ch.swisstopo.zeitreihen,ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.bazl.luftfahrthindernis',
                   'timeInstant': '1936,,2014'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -240,86 +265,86 @@ class TestIdentifyService(TestsBase):
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997', 'tolerance': '5',
                   'layers': 'all:ch.swisstopo.zeitreihen,ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.bazl.luftfahrthindernis',
                   'timeInstant': '1936,,toto'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide an integer for the parameter timeInstant')
 
     def test_invalid_timeinstant(self):
         params = {'geometryType': 'esriGeometryPoint', 'geometry': '630853.809670509,170647.93120352627', 'geometryFormat': 'geojson',
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997',
                   'tolerance': '5', 'layers': 'all:ch.swisstopo.zeitreihen', 'timeInstant': 'asdf'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide an integer for the parameter timeInstant')
 
     def test_identify_wrong_timeinstant(self):
         params = {'geometryType': 'esriGeometryPoint', 'geometry': '630853.809670509,170647.93120352627', 'geometryFormat': 'geojson',
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997', 'tolerance': '5',
                   'layers': 'all:ch.swisstopo.zeitreihen', 'timeInstant': '19366'}
-        self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
 
     def test_identify_timeinstant_nottimeenabled_layer(self):
         params = {'geometryType': 'esriGeometryPoint', 'geometry': '630853.809670509,170647.93120352627', 'geometryFormat': 'geojson',
                   'imageDisplay': '1920,734,96', 'mapExtent': '134253,-21102,1382253,455997', 'tolerance': '5',
                   'layers': 'all:ch.bafu.bundesinventare-bln', 'timeInstant': '1936'}
-        self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
 
     def test_identify_oereb(self):
         params = {'geometry': '618953,170093', 'geometryType': 'esriGeometryPoint', 'imageDisplay': '1920,576,96',
                   'layers': 'all:ch.bav.kataster-belasteter-standorte-oev.oereb',
                   'mapExtent': '671164.31244,253770,690364.31244,259530', 'tolerance': '5', 'geometryFormat': 'interlis'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'text/xml')
 
     def test_identify_oereb_several_layers(self):
         params = {'geometry': '618953,170093', 'geometryType': 'esriGeometryPoint', 'imageDisplay': '1920,576,96',
                   'layers': 'all:ch.bav.kataster-belasteter-standorte-oev.oereb,ch.bazl.sicherheitszonenplan.oereb',
                   'mapExtent': '671164.31244,253770,690364.31244,259530', 'tolerance': '5', 'geometryFormat': 'interlis'}
-        self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
 
     def test_identify_query_time(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'startofconstruction > \'2014-12-01\''}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
 
     def test_identify_query_null(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp', 'where': 'andere_stoffe is null'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
 
     def test_identify_query_not_null(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp', 'where': 'andere_stoffe is not null'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
 
     def test_identify_query_number(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'maxheightagl > 210'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
 
     def test_identify_query_text(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'state ilike \'%a%\''}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
 
     def test_identify_query_or(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'state ilike \'%a%\' and startofconstruction > \'2014-12-01\''}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
 
     def test_identify_query_and(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'state ilike \'%a%\' or startofconstruction > \'2014-12-01\''}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
@@ -328,19 +353,19 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '663500,224750,698500,281250', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryEnvelope',
                   'imageDisplay': '876,1075,96', 'lang': 'fr',
                   'layers': 'all:ch.swisstopo.hebungsraten', 'mapExtent': '441000,-78750,879000,458750', 'tolerance': '5', 'where': 'contour < 0.4'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('properties', resp.json['results'][0])
         self.assertIn('geometry', resp.json['results'][0])
 
     def test_identify_query_bad_operator(self):
         params = {'geometryFormat': 'geojson', 'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'state ilike \'%a%\' maybe abortionaccomplished > \'2014-12-01\''}
-        self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
 
     def test_identify_query_and_bbox(self):
         params = {'geometryType': 'esriGeometryEnvelope', 'geometry': '502722,36344,745822,253444', 'imageDisplay': '0,0,0', 'mapExtent': '0,0,0,0', 'tolerance': '0',
                   'layers': 'all:ch.bazl.luftfahrthindernis', 'where': 'obstacletype = \'Antenna\''}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertGreater(len(resp.json['results']), 0)
         self.assertIn('attributes', resp.json['results'][0])
@@ -349,7 +374,7 @@ class TestIdentifyService(TestsBase):
     def test_identify_query_escape_quote(self):
         params = {'geometryFormat': 'geojson', 'lang': 'en', 'layers': 'all:ch.bafu.hydrologie-wassertemperaturmessstationen',
                   'time': '2013', 'where': "name ilike \'%Broye-Payerne, Caserne d'aviation%\' or name ilike \'%Aare-Bern, Schönau%\'"}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertGreater(len(resp.json['results']), 0)
         self.assertIn('properties', resp.json['results'][0])
@@ -358,15 +383,15 @@ class TestIdentifyService(TestsBase):
     def test_identify_query_offset(self):
         params = {'layers': 'all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill', 'returnGeometry': 'false', 'timeInstant': '2015',
                   'where': 'gemname ilike \'%a%\''}
-        resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         params.update({'offset': '2'})
         self.assertNotIn('geometry', resp1.json['results'][0])
-        resp2 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp2 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp1.json['results'][2]['featureId'], resp2.json['results'][0]['featureId'])
         self.assertEqual(resp1.json['results'][5]['featureId'], resp2.json['results'][3]['featureId'])
         self.assertNotIn('geometry', resp2.json['results'][0])
         params.update({'offset': '5'})
-        resp3 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp3 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp2.json['results'][3]['featureId'], resp3.json['results'][0]['featureId'])
         self.assertEqual(resp1.json['results'][5]['featureId'], resp3.json['results'][0]['featureId'])
         self.assertNotIn('geometry', resp3.json['results'][0])
@@ -375,20 +400,20 @@ class TestIdentifyService(TestsBase):
         params = {'layers': 'all:ch.bazl.luftfahrthindernis', 'timeInstant': '2015', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryEnvelope',
                   'geometry': '573788,93220,750288,192720',
                   'imageDisplay': '1920,778,96', 'mapExtent': '107788,-5279,1067788,383720', 'tolerance': '0'}
-        resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         params.update({'offset': '2'})
-        resp2 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp2 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp1.json['results'][2]['featureId'], resp2.json['results'][0]['featureId'])
         self.assertEqual(resp1.json['results'][5]['featureId'], resp2.json['results'][3]['featureId'])
         params.update({'offset': '4'})
-        resp3 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp3 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp2.json['results'][2]['featureId'], resp3.json['results'][0]['featureId'])
         self.assertEqual(resp1.json['results'][4]['featureId'], resp3.json['results'][0]['featureId'])
 
     def test_identify_query_wrong_offset(self):
         params = {'layers': 'all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill', 'timeInstant': '2015',
                   'where': 'gemname ilike \'%aven%\'', 'offset': '12.1'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('provide an integer')
 
     def test_identify_result_limit(self):
@@ -396,7 +421,7 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '10', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(201, len(resp.json['results']))
 
@@ -405,30 +430,30 @@ class TestIdentifyService(TestsBase):
         params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolyline', 'imageDisplay': '500,600,96',
                   'mapExtent': '548945.5,147956,549402,148103.5', 'tolerance': '10', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertLess(10, len(resp.json['results']))
 
         # Limit parameter
         params.update({'limit': '5'})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(5, len(resp.json['results']))
         params.update({'limit': '1'})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(1, len(resp.json['results']))
         params.update({'limit': '0'})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(0, len(resp.json['results']))
 
         # Invalid limit parameters
         params.update({'limit': '-1'})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('provide a positive integer')
         params.update({'limit': 'a'})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
 
     def test_identify_quer_spatial_filters_scale_dep(self):
         params = {'layers': 'all:ch.bav.haltestellen-oev',
@@ -440,7 +465,7 @@ class TestIdentifyService(TestsBase):
                   'tolerance': '5',
                   'where': 'name ilike \'%dietikon%\''
                   }
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(len(resp.json['results']), 0)
 
@@ -453,13 +478,13 @@ class TestIdentifyService(TestsBase):
                   'mapExtent': '641960.1008933608,163518.83578498938,646760.1008933608,165431.33578498938',
                   'tolerance': '50'
                   }
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertLess(1, len(resp.json['results']))
         firstBefore = resp.json['results'][0]['properties']['deinr']
 
         params.update({'order': 'distance'})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertLess(1, len(resp.json['results']))
         firstAfter = resp.json['results'][0]['properties']['deinr']
@@ -468,14 +493,14 @@ class TestIdentifyService(TestsBase):
 
         # Wrong order parameter should not have impact
         params.update({'order': 'x'})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('valid order parameter')
 
         # order does only work with geometry
         params.update({'order': 'distance'})
         params.pop('geometry', None)
         params.update({'where': 'abortionaccomplished > \'2014-12-01\''})
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('together with a geometry')
 
     def test_identify_outside_extent(self):
@@ -488,7 +513,7 @@ class TestIdentifyService(TestsBase):
                       layers='all:ch.bfe.windenergie-geschwindigkeit_h125',
                       lang='de'
                       )
-        resp = self.testapp.get('/rest/services/api/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/api/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(len(resp.json['results']), 0)
 
@@ -502,7 +527,7 @@ class TestIdentifyService(TestsBase):
                       returnGeometry='true',
                       tolerance='10',
                       lang='fr')
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(len(resp.json['results']), 1)
 
@@ -516,7 +541,7 @@ class TestIdentifyService(TestsBase):
                       returnGeometry='true',
                       tolerance='10',
                       lang='fr')
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=200)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(len(resp.json['results']), 0)
 
@@ -530,4 +555,4 @@ class TestIdentifyService(TestsBase):
                       returnGeometry='true',
                       tolerance='10',
                       lang='fr')
-        self.testapp.get('/rest/services/all/MapServer/identify', params=params, status=400)
+        self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -36,6 +36,7 @@ from chsdi.models.vector import getScale, getResolution, hasBuffer
 from chsdi.models.grid import get_grid_spec, get_grid_layer_properties
 from chsdi.views.layers import get_layer, get_layers_metadata_for_params
 
+
 PROTECTED_GEOMETRY_LAYERS = ['ch.bfs.gebaeude_wohnungs_register']
 MAX_FEATURES = 201
 

--- a/chsdi/views/httpexception_json.py
+++ b/chsdi/views/httpexception_json.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from webob.acceptparse import Accept
+from pyramid.view import exception_view_config
+from pyramid.httpexceptions import HTTPException
+
+
+def format_exception_context(context):
+    return {
+        'detail': context.detail if context.detail else 'Unknown error',
+        'status': 'error',
+        'code': context.code if context.code else 500
+    }
+
+
+@exception_view_config(context=HTTPException, renderer='json')
+def exception_view_json(context, request):
+    headers = dict(request.headers)
+    accept_header = headers.get('Accept')
+    if accept_header is None:
+        return context
+    accept_parser = Accept(accept_header)
+    if '*/*' in accept_header or 'application/json' in accept_parser:
+        context.json_body = format_exception_context(context)
+        context.content_type = 'application/json'
+    return context

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pycodestyle==2.0.0
 pyflakes==1.2.3
 Pygments==2.1.3
 PyPDF2==1.23
-pyramid==1.7
+pyramid==1.8.3
 pyramid-debugtoolbar==3.0.2
 pyramid-mako==1.0.2
 pyramid-tm==0.7
@@ -55,7 +55,7 @@ transaction==2.0.2
 translationstring==1.3
 venusian==1.0
 waitress==0.9.0
-WebOb==1.6.1
+WebOb==1.7.1
 WebTest==2.0.21
 zope.deprecation==4.2.0
 zope.interface==4.2.0


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-chsdi3/issues/2453

[Test link error topics](https://mf-chsdi3.dev.bgdi.ch/gal_jsonerror//rest/services/dd/CatalogServer?callback=callback)
[Test Link bad param](https://mf-chsdi3.dev.bgdi.ch/gal_jsonerror/rest/services/ech/MapServer/identify?geometryType=esriGeometry&geometry=545000,145000,555000,155000&imageDisplay=500,600,96&mapExtent=548945.5,147956,549402,148103.5&tolerance=1&layers=all:ch.bafu.bundesinventare-bln)

That is the cleanest way to do it in pyramid. I know I  checked with the author.

[Test Link not found](https://mf-chsdi3.dev.bgdi.ch/gal_jsonerror/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/10001)

This is not formatting the response for 404 error code. Varnish does some funny buisness with the accept header in some cases... (while it works as excpected locally)

TODO:
- Fix varnish config for not found error codes