### PR TITLE
Hide thumbnail for pixelkarte 50 and 100

### DIFF
--- a/chsdi/templates/htmlpopup/shop_product.mako
+++ b/chsdi/templates/htmlpopup/shop_product.mako
@@ -15,7 +15,9 @@ elif layer == 'ch.swisstopo.stk200-papierkarte.metadata':
     img_id = 'Strassenkarte' + fid
 
 image = cmsGeoadminHost + '/www.swisstopo.admin.ch/shop/swisstopoproducts/250/' + img_id + '.jpg'
-if layer == 'ch.swisstopo.pixelkarte-pk25.metadata':
+if (layer == 'ch.swisstopo.pixelkarte-pk25.metadata' or
+    layer == 'ch.swisstopo.pixelkarte-pk50.metadata' or
+    layer == 'ch.swisstopo.pixelkarte-pk100.metadata'):
     image_exists = False
 elif 'pk_product' not in c['attributes']:
     image_exists = h.resource_exists(image)


### PR DESCRIPTION
PK50: [Before](https://mf-chsdi3.int.bgdi.ch/1704061249/rest/services/swisstopo/MapServer/ch.swisstopo.pixelkarte-pk50.metadata/254/htmlPopup?coord=642250,174249.99999999997&imageDisplay=1919,617,96&lang=fr&mapExtent=180250,35750,1139750,344250) [after](https://mf-chsdi3.dev.bgdi.ch/ltteo/rest/services/swisstopo/MapServer/ch.swisstopo.pixelkarte-pk50.metadata/254/htmlPopup?coord=642250,174249.99999999997&imageDisplay=1919,617,96&lang=fr&mapExtent=180250,35750,1139750,344250)

PK100:[Before](https://mf-chsdi3.int.bgdi.ch/1704061249/rest/services/swisstopo/MapServer/ch.swisstopo.pixelkarte-pk100.metadata/37/htmlPopup?coord=679750,188249.99999999997&imageDisplay=1919,617,96&lang=fr&mapExtent=180250,35750,1139750,344250) [After](https://mf-chsdi3.dev.bgdi.ch/ltteo/rest/services/swisstopo/MapServer/ch.swisstopo.pixelkarte-pk100.metadata/37/htmlPopup?coord=679750,188249.99999999997&imageDisplay=1919,617,96&lang=fr&mapExtent=180250,35750,1139750,344250)