### PR TITLE
Always build with the correct branch

### DIFF
--- a/scripts/deploybranch.sh
+++ b/scripts/deploybranch.sh
@@ -22,7 +22,7 @@ make cleanall
 
 # This creates the branch configuration
 make setup
-make rc_branch DEPLOY_TARGET=dev
+make rc_branch DEPLOY_TARGET=dev GIT_BRANCH=$GIT_BRANCH
 source rc_branch
 make all
 make deploy/deploy-branch.cfg


### PR DESCRIPTION
If this variable was previously exported, it is possible to override GIT_BRANCH, this PR makes sure we always build with the good branch.