### PR TITLE
Use latest api version in lubis viewer

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -369,8 +369,8 @@ def int_with_apostrophe(x):
     return "%d%s" % (x, result)
 
 
-def get_loaderjs_url(request):
-    return make_agnostic(route_url('ga_api', request))
+def get_loaderjs_url(request, version='3.6.0'):
+    return make_agnostic(route_url('ga_api', request)) + '?version=' + version
 
 
 def decompress_gzipped_string(string):

--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -271,5 +271,5 @@ shop_url = request.registry.settings['shop_url']
 
 
 <%def name="extended_resources(c, lang)">
-  <script type="text/javascript" src="${h.get_loaderjs_url(request)}"></script>
+  <script type="text/javascript" src="${h.get_loaderjs_url(request, '3.18.2')}"></script>
 </%def>

--- a/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
+++ b/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
@@ -159,5 +159,5 @@ viewer_url = get_viewer_url(request, params)
 </%def>
 
 <%def name="extended_resources(c, lang)">
-  <script type="text/javascript" src="${h.get_loaderjs_url(request)}"></script>
+  <script type="text/javascript" src="${h.get_loaderjs_url(request, '3.18.2')}"></script>
 </%def>

--- a/chsdi/templates/luftbilder/lubis_map.mako
+++ b/chsdi/templates/luftbilder/lubis_map.mako
@@ -10,7 +10,7 @@
         var resolutions = [1]; // 1 is the min resolution of the pyramid (for all images)
         var curResolution = resolutions[0];
         var maxResolution = Math.max(width, height) / TILE_SIZE;
-        
+
         while (curResolution < maxResolution) {
           curResolution *= 2;
           resolutions.unshift(curResolution);

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -151,7 +151,7 @@
     <script type="text/javascript">
       function init() {
         ${lubis_map.init_map(c.get('bildnummer'), c.get('width'), c.get('height'), c.get('rotation'), 'lubismap')}
-       
+
         // FF/IE
         if ('onbeforeprint' in window) {
           var element = document.getElementById('lubismap');
@@ -169,7 +169,7 @@
         if (window.matchMedia) {
           window.matchMedia('print').addListener(function(mql) {
             if (mql.matches) {
-              lubisMap.updateSize(); 
+              lubisMap.updateSize();
             } else {
               window.setTimeout(function(){lubisMap.updateSize()}, 500);
             }

--- a/chsdi/tests/functional/test_helpers.py
+++ b/chsdi/tests/functional/test_helpers.py
@@ -8,7 +8,7 @@ from chsdi.lib.helpers import (
     check_even, format_search_text, remove_accents, escape_sphinx_syntax,
     quoting, float_raise_nan, resource_exists, parseHydroXML, locale_negotiator,
     versioned, parse_box2d, center_from_box2d, format_scale,
-    parse_date_string, parse_date_datenstand, int_with_apostrophe
+    parse_date_string, parse_date_datenstand, int_with_apostrophe, get_loaderjs_url
 )
 from urlparse import urljoin
 
@@ -285,3 +285,14 @@ class Test_Helpers(unittest.TestCase):
         x2 = -5
         result2 = int_with_apostrophe(x2)
         self.assertEqual(result2, str(x2))
+
+    def test_get_loaderjs_url(self):
+        api_url = '//example.com'
+        config = testing.setUp()
+        config.add_route('ga_api', '/loader.js')
+        request = testing.DummyRequest()
+        url = get_loaderjs_url(request)
+        self.assertEqual(url, '%s/loader.js?version=3.6.0' % api_url)
+        url = get_loaderjs_url(request, version='3.18.2')
+        self.assertEqual(url, '%s/loader.js?version=3.18.2' % api_url)
+        testing.tearDown()


### PR DESCRIPTION
Fix for https://github.com/geoadmin/mf-chsdi3/issues/2535

[Test Link](https://mf-chsdi3.dev.bgdi.ch/gal_lubisfix/rest/services/swisstopo/MapServer/ch.swisstopo.lubis-luftbilder_schwarzweiss/19811880016532/extendedHtmlPopup)