### PR TITLE
Allow NOT to sort when bbox is specified

### DIFF
--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -15,7 +15,7 @@ class Gebaeuderegister(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __template__ = 'templates/htmlpopup/gebaeuderegister.mako'
     __bodId__ = 'ch.bfs.gebaeude_wohnungs_register'
-    __queryable_attributes__ = ['strname1', 'deinr', 'plz4', 'plzname', 'gdename', 'egid']
+    __queryable_attributes__ = ['strname1', 'deinr', 'plz4', 'plzname', 'gdename', 'egid', 'gdenr']
     # __minscale__ = 5001
     # due to https://redmine.bgdi.admin.ch/issues/3146 ltmoc  __maxscale__ = 25000
     # Composite labels

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -522,9 +522,11 @@ Only RESTFul interface is available.
 | **type (required)**                 | The type of performed search. Specify `locations` to perform a location search.           |
 +-------------------------------------+-------------------------------------------------------------------------------------------+
 | **bbox (required/optional)**        | Must be provided if the `searchText` is not. A comma separated list of 4 coordinates      |
-|                                     | representing the bounding box on which features should be filtered (SRID: 21781). If      |
-|                                     | this parameter is defined, the ranking of the results is performed according to the       |
-|                                     | distance between the locations and the center of the bounding box.                        |
+|                                     | representing the bounding box on which features should be filtered (SRID: 21781).         |
++-------------------------------------+-------------------------------------------------------------------------------------------+
+| **sortbbox (optional)**             | When `bbox` is specified and this parameter is "true", then the ranking of the results is |
+|                                     | performed according to the distance between the locations and the center of the bounding  |
+|                                     | box. Default to "true".                                                                   |
 +-------------------------------------+-------------------------------------------------------------------------------------------+
 | **returnGeometry (optional)**       | This parameter defines whether the geometry is returned or not. Default to "true".        |
 +-------------------------------------+-------------------------------------------------------------------------------------------+
@@ -564,6 +566,10 @@ Only RESTFul interface is available.
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **bbox (optional)**               | A comma separated list of 4 coordinates representing the bounding box according to which  |
 |                                   | features should be ordered (SRID: 21781).                                                 |
++-----------------------------------+-------------------------------------------------------------------------------------------+
+| **sortbbox (optional)**           | When `bbox` is specified and this parameter is "true", then the ranking of the results is |
+|                                   | performed according to the distance between the locations and the center of the bounding  |
+|                                   | box. Default to "true".                                                                   |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **features (required)**           | A comma separated list of technical layer names.                                          |
 +-----------------------------------+-------------------------------------------------------------------------------------------+

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -233,6 +233,17 @@ class TestSearchServiceView(TestsBase):
         self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ch ag')
         self.assertEqual(len(resp.json['results']), 1)
 
+    def test_search_locations_with_bbox_sort(self):
+        params = {'type': 'locations', 'searchText': 'buechli tegerfelden', 'bbox': '564100,168443,664150,268643'}
+        resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ch ag')
+        params = {'type': 'locations', 'searchText': 'buechli tegerfelden', 'bbox': '564100,168443,664150,268643', 'sortbbox': 'true'}
+        resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ch ag')
+        params = {'type': 'locations', 'searchText': 'buechli tegerfelden', 'bbox': '564100,168443,664150,268643', 'sortbbox': 'false'}
+        resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ch ag')
+
     def test_search_locations_bbox_only(self):
         params = {'type': 'locations', 'bbox': '664126,268543,664126,268543'}
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -29,6 +29,7 @@ class Search(SearchValidation):
         self.lang = request.lang
         self.cbName = request.params.get('callback')
         self.bbox = request.params.get('bbox')
+        self.sortbbox = request.params.get('sortbbox', 'true').lower() == 'true'
         self.returnGeometry = request.params.get('returnGeometry', 'true').lower() == 'true'
         self.quadindex = None
         self.origins = request.params.get('origins')
@@ -104,7 +105,7 @@ class Search(SearchValidation):
         self.sphinx.SetLimits(0, limit)
 
         # Define ranking mode
-        if self.bbox is not None:
+        if self.bbox is not None and self.sortbbox:
             geoAnchor = self._get_geoanchor_from_bbox()
             self.sphinx.SetGeoAnchor('lat', 'lon', geoAnchor.GetY(), geoAnchor.GetX())
             self.sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, '@geodist ASC')
@@ -218,7 +219,7 @@ class Search(SearchValidation):
         featureLimit = self.limit if self.limit and self.limit <= self.FEATURE_LIMIT else self.FEATURE_LIMIT
         self.sphinx.SetLimits(0, featureLimit)
         self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_WORDCOUNT)
-        if self.bbox:
+        if self.bbox and self.sortbbox:
             geoAnchor = self._get_geoanchor_from_bbox()
             self.sphinx.SetGeoAnchor('lat', 'lon', geoAnchor.GetY(), geoAnchor.GetX())
             self.sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, '@weight DESC, @geodist ASC')


### PR DESCRIPTION
Currently, when in the search a bbox is specified, it has 2 distinct effects:

a) it filter results according to bbox
b) it sorts results by distance to middle point of bbox.

In order to have a) but not b), a new parameter `sortbbox` is introduced. It's default is true and means b). But when false is specified, the results are sorted according to the standard ranking system. As we don't change the default behaviour, the impact is not visible in map.geo.admin.ch.

[Sorted by bbox](http://mf-chsdi3.dev.bgdi.ch/ltjeg/rest/services/inspire/SearchServer?type=locations&searchText=buechli%20tegerfelden&bbox=564100,168443,664150,268643)
[Sorted via traditional ranking](http://mf-chsdi3.dev.bgdi.ch/ltjeg/rest/services/inspire/SearchServer?type=locations&searchText=buechli%20tegerfelden&bbox=564100,168443,664150,268643&sortbbox=false)

This PR is a requirement for the RegBL application. It would be good to merge this for the next deploy.