### PR TITLE
Remove restrictions on address geometries

### DIFF
--- a/chsdi/lib/validation/__init__.py
+++ b/chsdi/lib/validation/__init__.py
@@ -59,8 +59,6 @@ class BaseFeaturesValidation(BaseLayersValidation):
         self._geometryFormat = None
 
         self.geometryFormat = request.params.get('geometryFormat')
-        self.varnish_authorized = request.headers.get(
-            'X-SearchServer-Authorized', 'false').lower() == 'true'
 
     @property
     def geometryFormat(self):

--- a/chsdi/lib/validation/find.py
+++ b/chsdi/lib/validation/find.py
@@ -28,7 +28,6 @@ class FindServiceValidation(MapNameValidation):
         self.translate = request.translate
         self.cbName = request.params.get('callback')
         self.geodataStaging = request.registry.settings['geodata_staging']
-        self.varnish_authorized = request.headers.get('X-SearchServer-Authorized', 'false').lower() == u'true'
 
     @property
     def layer(self):

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -502,7 +502,7 @@ The search service is separated in 3 various categories or types:
   * All names as printed on the national map (`SwissNames <https://shop.swisstopo.admin.ch/de/products/landscape/names3D>`_)
   * The districts
   * The ZIP codes
-  * The addresses (!! the Swiss cantons only allow websites of the federal government to use the addresses search service !!)
+  * The addresses
   * The cadastral parcels
 * The **layer search** wich enables the search of layers belonging to the GeoAdmin API.
 * The **feature search** which is used to search through features descriptions. Note: you can also specify a bounding box to filter the features. (`Searchable layers <../../../api/faq/index.html#which-layers-are-searchable>`_)

--- a/chsdi/tests/integration/test_features_service.py
+++ b/chsdi/tests/integration/test_features_service.py
@@ -372,50 +372,23 @@ class TestFeaturesView(TestsBase):
 
 class TestGebauedeGeometry(TestsBase):
 
-    def test_feature_not_authorized(self):
-        headers = {'X-SearchServer-Authorized': 'false'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register/490830_0', headers=headers, status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertNotIn('geometry', resp.json['feature'])
-
     def test_feature_authorized(self):
-        headers = {'X-SearchServer-Authorized': 'true'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register/490830_0', headers=headers, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register/490830_0', status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertIn('geometry', resp.json['feature'])
 
-    def test_find_not_authorized(self):
-        headers = {'X-SearchServer-Authorized': 'false'}
-        params = {'layer': 'ch.bfs.gebaeude_wohnungs_register', 'searchText': 'berges', 'searchField': 'strname1'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/find', params=params, headers=headers, status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue(len(resp.json['results']) >= 1)
-        self.assertNotIn('geometry', resp.json['results'][0])
-
     def test_find_authorized(self):
-        headers = {'X-SearchServer-Authorized': 'true'}
         params = {'layer': 'ch.bfs.gebaeude_wohnungs_register', 'searchText': 'berges', 'searchField': 'strname1'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/find', params=params, headers=headers, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/find', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertTrue(len(resp.json['results']) >= 1)
         self.assertIn('geometry', resp.json['results'][0])
 
-    def test_identify_not_authorized(self):
-        headers = {'X-SearchServer-Authorized': 'false'}
-        params = {'geometry': '653199.9,137409.9', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryPoint',
-                  'imageDisplay': '1920,623,96', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register', 'mapExtent': '633200,132729.9,671600,145189.9',
-                  'tolerance': '5'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=headers, status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue(len(resp.json['results']) >= 1)
-        self.assertNotIn('geometry', resp.json['results'][0])
-
     def test_identify_authorized(self):
-        headers = {'X-SearchServer-Authorized': 'true'}
         params = {'geometry': '653199.9,137409.9', 'geometryFormat': 'geojson', 'geometryType': 'esriGeometryPoint',
                   'imageDisplay': '1920,623,96', 'layers': 'all:ch.bfs.gebaeude_wohnungs_register', 'mapExtent': '633200,132729.9,671600,145189.9',
                   'tolerance': '5'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=headers, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertTrue(len(resp.json['results']) >= 1)
         self.assertIn('geometry', resp.json['results'][0])

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -171,32 +171,14 @@ class TestSearchServiceView(TestsBase):
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(len(resp.json['results']), 1)
 
-    def test_search_locations_not_authorized(self):
-        self.testapp.extra_environ = {'HTTP_X_SEARCHSERVER_AUTHORIZED': 'false'}
-        resp = self.testapp.get('/rest/services/inspire/SearchServer', params={'searchText': 'Beaulieustrasse 2', 'type': 'locations'}, status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue('geom_st_box2d' not in resp.json['results'][0]['attrs'].keys())
-
     def test_search_locations_escape_charachters(self):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params={'searchText': 'Biel/Bienne', 'type': 'locations'}, status=200)
         self.assertGreater(len(resp.json['results']), 0)
 
     def test_search_locations_authorized(self):
-        self.testapp.extra_environ = {'HTTP_X_SEARCHSERVER_AUTHORIZED': 'true'}
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params={'searchText': 'Beaulieustrasse 2', 'type': 'locations'}, status=200)
         self.assertEqual(resp.content_type, 'application/json')
         self.assertTrue('geom_st_box2d' in resp.json['results'][0]['attrs'].keys())
-
-    def test_search_locations_authorized_not_set(self):
-        self.testapp.extra_environ = {}
-        resp = self.testapp.get('/rest/services/inspire/SearchServer', params={'searchText': 'Beaulieustrasse 2', 'type': 'locations'}, status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue('geom_st_box2d' not in resp.json['results'][0]['attrs'].keys())
-
-    def test_search_locations_authorized_no_geometry(self):
-        resp = self.testapp.get('/rest/services/inspire/SearchServer', params={'searchText': 'Beaulieustrasse 2', 'type': 'locations', 'returnGeometry': 'false'}, headers=dict(HTTP_X_SEARCHSERVER_AUTHORIZED='true'), status=200)
-        self.assertEqual(resp.content_type, 'application/json')
-        self.assertTrue('geom_st_box2d' not in resp.json['results'][0]['attrs'].keys())
 
     def test_search_locations_one_origin(self):
         params = {'searchText': 'vaud', 'type': 'locations', 'origins': 'gg25'}

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -37,7 +37,6 @@ from chsdi.models.grid import get_grid_spec, get_grid_layer_properties
 from chsdi.views.layers import get_layer, get_layers_metadata_for_params
 
 
-PROTECTED_GEOMETRY_LAYERS = ['ch.bfs.gebaeude_wohnungs_register']
 MAX_FEATURES = 201
 
 
@@ -757,13 +756,7 @@ def _process_feature(feature, params):
         raise HTTPBandwidthLimited('Feature ID %s: is too large' % feature.id)
 
     if params.returnGeometry:
-        # Filter out this layer individually, disregarding of the global returnGeometry
-        # setting
-        if not params.varnish_authorized and \
-                feature.__bodId__ in PROTECTED_GEOMETRY_LAYERS:
-            f = convert_no_geom(feature, params.geometryFormat)
-        else:
-            f = feature.__geo_interface__
+        f = feature.__geo_interface__
     else:
         f = convert_no_geom(feature, params.geometryFormat)
     # TODO find a way to use translate directly in the model

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -39,7 +39,6 @@ class Search(SearchValidation):
         self.timeStamps = request.params.get('timeStamps')
         self.typeInfo = request.params.get('type')
         self.limit = request.params.get('limit')
-        self.varnish_authorized = request.headers.get('X-SearchServer-Authorized', 'false').lower() == 'true'
 
         self.geodataStaging = request.registry.settings['geodata_staging']
         self.results = {'results': []}
@@ -383,7 +382,7 @@ class Search(SearchValidation):
             self.sphinx.AddQuery(queryText, index=str(index))
 
     def _parse_address(self, res):
-        if not (self.varnish_authorized and self.returnGeometry):
+        if not self.returnGeometry:
             attrs2Del = ['x', 'y', 'lon', 'lat', 'geom_st_box2d']
             popAtrrs = lambda x: res.pop(x) if x in res else x
             map(popAtrrs, attrs2Del)

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -422,8 +422,6 @@ class Search(SearchValidation):
                         res['attrs']['featureId'] = res['attrs']['feature_id']
                     if self.typeInfo == 'featuresearch' or not self.bbox or \
                             self._bbox_intersection(self.bbox, res['attrs']['geom_st_box2d']):
-                        if res['attrs']['layer'] == 'ch.bfs.gebaeude_wohnungs_register':
-                            res['attrs'] = self._parse_address(res['attrs'])
                         self.results['results'].append(res)
 
     def _get_quad_index(self):


### PR DESCRIPTION
This PR removes the restrictions on the geometries of the address. This has been approved by the Datenherr. We await the final go of @beat-github. So don't merge it yet.

**Identify**:
```
No geometry
curl "https://api3.geo.admin.ch/rest/services/all/MapServer/identify?geometry=616752.5000000001,157754.9999999999&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1920,645,96&lang=de&layers=all:ch.bfs.gebaeude_wohnungs_register&mapExtent=615042.5000000002,157184.9999999999,619842.5000000002,158797.4999999999&returnGeometry=true&tolerance=10"

With geometry
curl "https://mf-chsdi3.dev.bgdi.ch/gjn_free_the_search/rest/services/all/MapServer/identify?geometry=616752.5000000001,157754.9999999999&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1920,645,96&lang=de&layers=all:ch.bfs.gebaeude_wohnungs_register&mapExtent=615042.5000000002,157184.9999999999,619842.5000000002,158797.4999999999&returnGeometry=true&tolerance=10"
```

**Find:**
```
No geometry
curl "http://api3.geo.admin.ch/rest/services/ech/MapServer/find?layer=ch.bfs.gebaeude_wohnungs_register&searchText=%C3%A4nnerh%C3%BCs&searchField=strname1"

With geometry
curl "https://mf-chsdi3.dev.bgdi.ch/gjn_free_the_search/rest/services/ech/MapServer/find?layer=ch.bfs.gebaeude_wohnungs_register&searchText=%C3%A4nnerh%C3%BCs&searchField=strname1"
```

**Search:**
```
No geometry
curl "http://api3.geo.admin.ch/rest/services/inspire/SearchServer?searchText=bahnhofstrasse%201%20z%C3%BCrich&type=locations"

With geometry
curl "https://mf-chsdi3.dev.bgdi.ch/gjn_free_the_search//rest/services/inspire/SearchServer?searchText=bahnhofstrasse%201%20z%C3%BCrich&type=locations"
```

Note: the X-SearchServer-Authorized flag needs to stay as it's used to protect other services.