### PR TITLE
change Geometrytype Lubis models

### DIFF
--- a/chsdi/models/vector/lubis.py
+++ b/chsdi/models/vector/lubis.py
@@ -3,7 +3,7 @@
 from sqlalchemy import Column, Integer, Boolean, Numeric
 from sqlalchemy.types import Unicode
 from chsdi.models import register, bases
-from chsdi.models.vector import Vector, Geometry3D
+from chsdi.models.vector import Vector, Geometry2D
 
 Base = bases['lubis']
 
@@ -34,8 +34,8 @@ class LuftbilderBase:
     massstab = Column('massstab', Integer)
     filesize_mb = Column('filesize_mb', Unicode)
     bgdi_imagemode = Column('bgdi_imagemode', Unicode)
-    the_geom_footprint = Column('the_geom_footprint', Geometry3D)
-    the_geom = Column(Geometry3D)
+    the_geom_footprint = Column('the_geom_footprint', Geometry2D)
+    the_geom = Column(Geometry2D)
 
 
 class LuftbilderSwisstopoFarbe(Base, LuftbilderBase, Vector):
@@ -119,8 +119,8 @@ class Bildstreifen(Base, Vector):
     toposhop_date = Column('toposhop_date', Unicode)
     goal = Column('goal', Unicode)
     source_georef = Column('georef_source', Unicode)
-    the_geom_footprint = Column('the_geom_footprint', Geometry3D)
-    the_geom = Column(Geometry3D)
+    the_geom_footprint = Column('the_geom_footprint', Geometry2D)
+    the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.lubis-bildstreifen', Bildstreifen)
 
@@ -147,6 +147,6 @@ class LuftbilderSchraegaufnahmen(Base, Vector):
     y = Column('y', Integer)
     contact = Column('contact', Unicode)
     contact_email = Column('contact_email', Unicode)
-    the_geom = Column(Geometry3D)
+    the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.lubis-luftbilder_schraegaufnahmen', LuftbilderSchraegaufnahmen)


### PR DESCRIPTION
changing the geometry type in the model is not sufficient.
i had to modify the materialized views in the lubis database too, they are st_force2d now.

[NEW](http://mf-chsdi3.dev.bgdi.ch/dev_ltclm_lubis_2d/rest/services/all/MapServer/identify?geometry=765640.7099999998,201058.85499999998&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1141,1070,96&lang=de&layers=all:ch.swisstopo.lubis-luftbilder_farbe&limit=10&mapExtent=762480.71,198553.85499999998,768185.71,203903.85499999998&order=distance&returnGeometry=true&tolerance=10
) vs  [OLD](http://mf-chsdi3.prod.bgdi.ch/rest/services/all/MapServer/identify?geometry=765640.7099999998,201058.85499999998&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1141,1070,96&lang=de&layers=all:ch.swisstopo.lubis-luftbilder_farbe&limit=10&mapExtent=762480.71,198553.85499999998,768185.71,203903.85499999998&order=distance&returnGeometry=true&tolerance=10)

[Testlink](https://map.geo.admin.ch/?lang=de&topic=luftbilder&bgLayer=ch.swisstopo.pixelkarte-grau&layers=ch.swisstopo.lubis-luftbilder_schwarzweiss,ch.swisstopo.lubis-luftbilder_farbe&layers_timestamp=99991231,99991231&catalogNodes=1179,1180,1186&api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fdev_ltclm_lubis_2d)