### PR TITLE
Assure verified ssl connection to avoid warnings

### DIFF
--- a/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
@@ -81,7 +81,7 @@ ${partials.table_body_cadastral(c, lang, fallbackLang, clickCoord)}
     download_url = context.get('request').params.get('download_url')
     pdf = False
     try:
-        r = requests.get(download_url, verify=False)
+        r = requests.get(download_url)
         download_url = h.make_agnostic(r.text.strip())
         if r.status_code == 200:
             pdf = True

--- a/chsdi/views/qrcode_generator.py
+++ b/chsdi/views/qrcode_generator.py
@@ -44,7 +44,7 @@ def _make_qrcode_img(url):
 def _shorten_url(request, url):
     API3_SHORTEN_URL = make_api_url(request) + '/shorten.json?url=%s'
     try:
-        resp = requests.get(API3_SHORTEN_URL % url, verify=False)
+        resp = requests.get(API3_SHORTEN_URL % url)
         data = resp.json()
         return data['shorturl']
     except:


### PR DESCRIPTION
The error log of mf-chsdi3 is full of messages like the below:

```
[Thu Jul 27 13:02:34.236327 2017] [wsgi:error] [pid 23002] /var/www/vhosts/mf-chsdi3/private/chsdi/.venv/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:734: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
[Thu Jul 27 13:02:34.236353 2017] [wsgi:error] [pid 23002]   InsecureRequestWarning)
```

The PR gets rid of those messages. It means that the request connections [1] will verify the SSL certificates. This has been tested and works on my branch on mf1-dev.

Is this risky?

[1] qrcodegenerator and opendata cadastral webmap extended tooltip are affected