### PR TITLE
Pypdf is not a dep anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ psycopg2==2.6.2
 pycodestyle==2.0.0
 pyflakes==1.2.3
 Pygments==2.1.3
-PyPDF2==1.23
 pyramid==1.8.3
 pyramid-debugtoolbar==3.0.2
 pyramid-mako==1.0.2


### PR DESCRIPTION
The following packages have been removed

- PyPDF2 (used in multiprint)