### PR TITLE
Adding linked data links to swissboundaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ production.ini: production.ini.in
 		--var "vector_profilename=$(VECTOR_PROFILENAME)" \
 		--var "datageoadminhost=$(DATAGEOADMINHOST)" \
 		--var "cmsgeoadminhost=$(CMSGEOADMINHOST)" \
+		--var "linkeddatahost=$(LINKEDDATAHOST)" \
 		--var "shortener_allowed_domains=$(SHORTENER_ALLOWED_DOMAINS)" $< > $@
 
 .venv/hooks: .venv/bin/git-secrets ./scripts/install-git-hooks.sh

--- a/chsdi/templates/htmlpopup/swissboundaries_bezirk.mako
+++ b/chsdi/templates/htmlpopup/swissboundaries_bezirk.mako
@@ -1,8 +1,13 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c,lang)">
+<%
+linkeddatahost = request.registry.settings['linkeddatahost']
+ldlink = linkeddatahost + '/boundaries/district/' + str(c['id'])
+%>
 <% c['stable_id'] = True %> 
 <tr><td class="cell-left">${_('bfsnr')}</td><td>${int(round(c['featureId'])) or '-'}</td></tr>
 <tr><td class="cell-left">${_('ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill.name')}</td><td>${c['attributes']['name']}</td></tr>
 <tr><td class="cell-left">${_('flaeche_ha')}</td><td>${int(round(c['attributes']['flaeche'])) or '-'} ha</td></tr>
+<tr><td class="cell-left">${_('link')}</td><td><a href="${ldlink}" target="_blank">Linked Data URI</a></td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/swissboundaries_gemeinde.mako
+++ b/chsdi/templates/htmlpopup/swissboundaries_gemeinde.mako
@@ -1,9 +1,14 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
+<%
+linkeddatahost = request.registry.settings['linkeddatahost']
+ldlink = linkeddatahost + '/boundaries/municipality/' + str(c['id'])
+%>
 <% c['stable_id'] = True %> 
 <tr><td class="cell-left">${_('ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill.id')}</td><td>${int(round(c['featureId'])) or '-'}</td></tr>
 <tr><td class="cell-left">${_('ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill.gemname')}</td><td>${c['attributes']['gemname']}</td></tr>
 <tr><td class="cell-left">${_('flaeche_ha')}</td><td>${int(round(c['attributes']['gemflaeche'])) or '-'} ha</td></tr>
 <tr><td class="cell-left">${_('perimeter_m')}</td><td>${int(round(c['attributes']['perimeter'])) or '-'} m</td></tr>
+<tr><td class="cell-left">${_('link')}</td><td><a href="${ldlink}" target="_blank">Linked Data URI</a></td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/swissboundaries_kanton.mako
+++ b/chsdi/templates/htmlpopup/swissboundaries_kanton.mako
@@ -1,9 +1,13 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c,lang)">
-
+<%
+linkeddatahost = request.registry.settings['linkeddatahost']
+ldlink = linkeddatahost + '/boundaries/canton/' + str(c['id'])
+%>
 <% c['stable_id'] = True %> 
 <tr><td class="cell-left">${_('ch.swisstopo.swissboundaries3d-kanton-flaeche.fill.ak')}</td><td>${c['attributes']['ak'] or '-'}</td></tr>
 <tr><td class="cell-left">${_('ch.swisstopo.swissboundaries3d-kanton-flaeche.fill.name')}</td><td>${c['attributes']['name']}</td></tr>
 <tr><td class="cell-left">${_('flaeche_ha')}</td><td>${int(round(c['attributes']['flaeche'])) or '-'} ha</td></tr>
+<tr><td class="cell-left">${_('link')}</td><td><a href="${ldlink}" target="_blank">Linked Data URI</a></td></tr>
 </%def>

--- a/production.ini.in
+++ b/production.ini.in
@@ -43,6 +43,7 @@ wmshost = ${wmshost}
 mapproxyhost = ${mapproxyhost}
 geoadminhost = ${geoadminhost}
 cmsgeoadminhost = ${cmsgeoadminhost}
+linkeddatahost = ${linkeddatahost}
 alti_url = ${alti_url}
 api_url = ${api_url}
 shop_url = ${shop_url}

--- a/rc_dev
+++ b/rc_dev
@@ -21,3 +21,4 @@ export VECTOR_PROFILENAME=chsdi_aws_admin_ro
 export WMSHOST=wms-bgdi.dev.bgdi.ch
 export WSGI_THREADS=15
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
+export LINKEDDATAHOST=https://ld.geo.admin.ch

--- a/rc_int
+++ b/rc_int
@@ -21,3 +21,4 @@ export VECTOR_PROFILENAME=chsdi_aws_admin_ro
 export WMSHOST=wms-bgdi.int.bgdi.ch
 export WSGI_THREADS=15
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
+export LINKEDDATAHOST=https://ld.geo.admin.ch

--- a/rc_prod
+++ b/rc_prod
@@ -21,3 +21,4 @@ export VECTOR_PROFILENAME=chsdi_aws_admin_ro
 export WMSHOST=wms.geo.admin.ch
 export WSGI_THREADS=30
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
+export LINKEDDATAHOST=https://ld.geo.admin.ch


### PR DESCRIPTION
This is a fix for https://github.com/geoadmin/mf-geoadmin3/issues/3899

[Testlink](https://mf-geoadmin3.int.bgdi.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fgjn_ld&lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill,ch.swisstopo.swissboundaries3d-kanton-flaeche.fill)

Ping @p1d1d1 @davidoesch 