### PR TITLE
Run flake8 tests on Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+matrix:
+    allow_failures:
+        - python: 3.6
+install:
+    - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # add other tests here
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
Helps to find syntax errors and undefined names in the code.  Runs the [flake8](http://flake8.readthedocs.io) tests on Python 3 in __allow_failures__ mode.