### PR TITLE
Requests to create pdfs will not verify SSL

### DIFF
--- a/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
@@ -81,7 +81,9 @@ ${partials.table_body_cadastral(c, lang, fallbackLang, clickCoord)}
     download_url = context.get('request').params.get('download_url')
     pdf = False
     try:
-        r = requests.get(download_url)
+        # For some reason, the new SSL certificate can't be verified. So we do
+        # without verification
+        r = requests.get(download_url, verify = False)
         download_url = h.make_agnostic(r.text.strip())
         if r.status_code == 200:
             pdf = True


### PR DESCRIPTION
The geoshop backend installed new SSL certificates over the weekend. Apparently, those SSL certificates can't be verified by python/requests behind a WSGI application in mako rendering.

Using python and requests on console does work without any problems.

This PR disables SSL verification for the PDF request and makes it work again.

[Not working on prod](https://mf-chsdi3.dev.bgdi.ch/gjn_openv/rest/services/ech/MapServer/ch.swisstopo-vd.amtliche-vermessung/21011143/extendedHtmlPopup?lang=en&download_url=https://geodata01.admin.ch/order/jPqrueQazrt/av_pdf.igs?pos=2606893.4900001707/1231744.609852284)
[Working on this branch](https://api3.geo.admin.ch/rest/services/ech/MapServer/ch.swisstopo-vd.amtliche-vermessung/21011143/extendedHtmlPopup?lang=en&download_url=https://geodata01.admin.ch/order/jPqrueQazrt/av_pdf.igs?pos=2606893.4900001707/1231744.609852284)

This needs an emergency deploy today. Therefore, I merge and deploy this.