### PR TITLE
remove ch.swisstopo.swissbuildings3d

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -7292,9 +7292,6 @@ msgstr "Landesgrenzen"
 msgid "ch.swisstopo.swissboundaries3d-land-grenze"
 msgstr "Landesgrenze"
 
-msgid "ch.swisstopo.swissbuildings3d"
-msgstr "Vereinfachte 3D-Gebäude"
-
 msgid "ch.swisstopo.swissbuildings3d_1.metadata"
 msgstr "Einteilung swissBUILDINGS3D 1.0 Vector"
 

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -7292,9 +7292,6 @@ msgstr "National boundaries"
 msgid "ch.swisstopo.swissboundaries3d-land-grenze"
 msgstr "National boundaries"
 
-msgid "ch.swisstopo.swissbuildings3d"
-msgstr "Simplified 3D buildings"
-
 msgid "ch.swisstopo.swissbuildings3d_1.metadata"
 msgstr "Division swissBUILDINGS3D 1.0 Vector"
 

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -7292,9 +7292,6 @@ msgstr "Cunfins naziunals"
 msgid "ch.swisstopo.swissboundaries3d-land-grenze"
 msgstr "Confins naziunals"
 
-msgid "ch.swisstopo.swissbuildings3d"
-msgstr "Edifizis simplifitgads en 3D"
-
 msgid "ch.swisstopo.swissbuildings3d_1.metadata"
 msgstr "Divisiun swissBUILDINGS3D 1.0 Vector"
 

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -7292,9 +7292,6 @@ msgstr "Frontières nationales"
 msgid "ch.swisstopo.swissboundaries3d-land-grenze"
 msgstr "Frontière nationale"
 
-msgid "ch.swisstopo.swissbuildings3d"
-msgstr "Les bâtiments en 3D simplifiés"
-
 msgid "ch.swisstopo.swissbuildings3d_1.metadata"
 msgstr "Découpage swissBUILDINGS3D 1.0 Vector"
 

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -7292,9 +7292,6 @@ msgstr "Frontiere nazionali"
 msgid "ch.swisstopo.swissboundaries3d-land-grenze"
 msgstr "Frontiere nazionali"
 
-msgid "ch.swisstopo.swissbuildings3d"
-msgstr "Gli edifici semplificati in 3D"
-
 msgid "ch.swisstopo.swissbuildings3d_1.metadata"
 msgstr "Divisione swissBUILDINGS3D 1.0 Vector"
 

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2450,16 +2450,6 @@ class SwissBuildings3d2Meta(Base, ShopStandardClass, Vector):
 register('ch.swisstopo.swissbuildings3d_2.metadata', SwissBuildings3d2Meta)
 
 
-class SwissBuildings3dPerimeter(Base, ShopStandardClass, Vector):
-    __tablename__ = 'shop_perimeter_swissbuildings3d'
-    __table_args__ = ({'autoload': False})
-    __bodId__ = 'ch.swisstopo.swissbuildings3d'
-    __totalArea__ = 41455.0
-    the_geom = Column(Geometry2D)
-
-register('ch.swisstopo.swissbuildings3d', SwissBuildings3dPerimeter)
-
-
 class Lotabweichungen(Base, Vector):
     __tablename__ = 'lotabweichungen_nur_punkte'
     __table_args__ = ({'schema': 'geodaesie', 'autoload': False})

--- a/chsdi/tests/e2e/test_wmtsgettile.py
+++ b/chsdi/tests/e2e/test_wmtsgettile.py
@@ -74,7 +74,7 @@ class TileChecker(MapProxyTestsBase):
         self.session.headers.update(h['Header'])
         resp = self.session.get(url, timeout=(5, 30))
         checkcode = resp.status_code in h['Results']
-        if 'ch.astra.ivs-nat-verlaeufe' in path or 'ch.swisstopo.vec25-eisenbahnnetz' in path or 'ch.swisstopo.swissbuildings3d' in path:
+        if 'ch.astra.ivs-nat-verlaeufe' in path or 'ch.swisstopo.vec25-eisenbahnnetz' in path:
             checkcode = (checkcode or resp.status_code == 500)
         assert checkcode, url
 


### PR DESCRIPTION
triggered by https://jira.swisstopo.ch/browse/BGDIDI_KB-870

has been decided by datenherr to remove this layer from  bgdi/chsdi/*
layer has been removed from bod_master already

https://github.com/geoadmin/wms-mapfile_include/pull/172
https://github.com/geoadmin/wms-bod/commit/d6e3591960b48c8ad95de694c82a7ca547c87f69
https://github.com/geoadmin/wms-test/commit/dd255c2e3e1a9723f2aaaf6ed6ffe189c73bb4f6