### PR TITLE
[WIP] Update tooltip info according DIF

### DIFF
--- a/chsdi/models/vector/bafu.py
+++ b/chsdi/models/vector/bafu.py
@@ -1232,7 +1232,7 @@ register('ch.bafu.bundesinventare-bln', BLN)
 
 
 class HM(Base, Vector):
-    __tablename__ = 'hm'
+    __tablename__ = 'hm_update'
     __table_args__ = ({'schema': 'bundinv', 'autoload': False})
     __bodId__ = 'ch.bafu.bundesinventare-hochmoore'
     __template__ = 'templates/htmlpopup/hochmoore.mako'

--- a/chsdi/models/vector/bafu.py
+++ b/chsdi/models/vector/bafu.py
@@ -1243,6 +1243,12 @@ class HM(Base, Vector):
     hm_typ = Column('hm_typ', Integer)
     hm_fl = Column('hm_fl', Numeric)
     hm_ke = Column('hm_ke', Integer)
+    description_de = Column('description_de', Unicode)
+    description_fr = Column('description_fr', Unicode)
+    description_it = Column('description_it', Unicode)
+    type_de = Column('type_de', Unicode)
+    type_fr = Column('type_fr', Unicode)
+    type_it = Column('type_it', Unicode)
     the_geom = Column(Geometry2D)
 
 register('ch.bafu.bundesinventare-hochmoore', HM)

--- a/chsdi/templates/htmlpopup/hochmoore.mako
+++ b/chsdi/templates/htmlpopup/hochmoore.mako
@@ -1,10 +1,15 @@
 <%inherit file="base.mako"/>
-
 <%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr','it') else 'de'
+    description = 'description_%s' % lang
+    type = 'type_%s' % lang
+%>
+
     <tr><td class="cell-left">${_('objektname')}</td>         <td>${c['attributes']['hm_name']}</td></tr>
     <tr><td class="cell-left">${_('objektnr')}</td>           <td>${c['attributes']['hm_obj'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('typ')}</td>                <td>${c['attributes']['hm_typ'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('flaeche_ha')}</td>         <td>${c['attributes']['hm_fl'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('typ')}</td>                <td>${c['attributes'][type] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('flaeche_ha')}</td>         <td>${round(c['attributes']['hm_fl'], 3) or '-'}</td></tr>
     <tr><td class="cell-left">${_('kartiereinheit')}</td>     <td>${c['attributes']['hm_ke'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('description')}</td>        <td>${c['attributes'][description] or '-'}</td></tr>
 </%def>
-


### PR DESCRIPTION
DIF available here: M:\Org\5-KOGIS\51-BGDI\5103-Geobasisdaten\5103-04-Originaldaten\5103-04-03-bund-bafu\20171005_ch.bafu.bundesinventare-hochmoore

Need display the type with a label (not a integer value like before).
The label is available in 3 languages (de, fr ,it)
Add new info "Description", also available in 3 languages.

Table bundinv.hm updated with new necessary attributs
Prepare sphinx search config