### PR TITLE
New regbl addresses

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -1694,8 +1694,41 @@ msgstr "Amphibien Ortsfeste Objekte"
 msgid "ch.bafu.bundesinventare-amphibien_anhang4"
 msgstr "Amphibien Anhang 4"
 
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-amphibien.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-amphibien.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-amphibien.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-amphibien.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-amphibien.site"
+msgstr "Bereich"
+
 msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte"
 msgstr "Amphibien Wanderobjekte"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.refobjblat"
+msgstr "Objektblatt"
 
 msgid "ch.bafu.bundesinventare-auen"
 msgstr "Auengebiete"
@@ -1718,11 +1751,26 @@ msgstr "Objektblatt"
 msgid "ch.bafu.bundesinventare-auen_anhang2.type"
 msgstr "Typ"
 
+msgid "ch.bafu.bundesinventare-auen.auen_type"
+msgstr "Typ"
+
 msgid "ch.bafu.bundesinventare-auen.au_name"
 msgstr "Name"
 
 msgid "ch.bafu.bundesinventare-auen.au_obj"
 msgstr "Objektnummer"
+
+msgid "ch.bafu.bundesinventare-auen.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-auen.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-auen.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-auen.shape_area"
+msgstr "Fläche [ha]"
 
 msgid "ch.bafu.bundesinventare-bln"
 msgstr "BLN"
@@ -1748,11 +1796,41 @@ msgstr "Teilobjekt-Nr."
 msgid "ch.bafu.bundesinventare-flachmoore"
 msgstr "Flachmoore"
 
+msgid "ch.bafu.bundesinventare-flachmoore.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-flachmoore.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-flachmoore.refobjblat"
+msgstr "Objektblatt"
+
 msgid "ch.bafu.bundesinventare-flachmoore_regional"
 msgstr "Flachmoore regional"
 
+msgid "ch.bafu.bundesinventare-flachmoore.shape_area"
+msgstr "Fläche [ha]"
+
 msgid "ch.bafu.bundesinventare-hochmoore"
 msgstr "Hochmoore"
+
+msgid "ch.bafu.bundesinventare-hochmoore.hochmoore_type"
+msgstr "Typ"
+
+msgid "ch.bafu.bundesinventare-hochmoore.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-hochmoore.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-hochmoore.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-hochmoore.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-hochmoore.unit"
+msgstr "Kartiereinheit"
 
 msgid "ch.bafu.bundesinventare-jagdbanngebiete"
 msgstr "Jagdbanngebiete"
@@ -1763,11 +1841,53 @@ msgstr "Objektnummer"
 msgid "ch.bafu.bundesinventare-moorlandschaften"
 msgstr "Moorlandschaften"
 
+msgid "ch.bafu.bundesinventare-moorlandschaften.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.shape_area"
+msgstr "Fläche [ha]"
+
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden"
 msgstr "Trockenwiesen und -weiden (TWW)"
 
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2"
 msgstr "TWW Anhang 2"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.teilobjnummer"
+msgstr "Teilobjekt-Nr."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.teilobjnummer"
+msgstr "Teilobjekt-Nr."
 
 msgid "ch.bafu.bundesinventare-vogelreservate"
 msgstr "Wasser- und Zugvogelreservate"
@@ -3956,6 +4076,21 @@ msgstr "BAV"
 msgid "ch.bav.anlagen-schienengueterverkehr"
 msgstr "Anlagen Schienengüterverkehr"
 
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_abk"
+msgstr "Abkürzung"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_nr"
+msgstr "Nummer"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.isb"
+msgstr "ISB"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.name"
+msgstr "Name"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.typ"
+msgstr "Anlagenkategorie"
+
 msgid "ch.bav.baulinien-eisenbahnanlagen.oereb"
 msgstr "Baulinien Eisenbahnen ÖREB"
 
@@ -5567,8 +5702,80 @@ msgstr "MCPFE1.3 Biodiversitätsförderung durch gezielte Eingriffe"
 msgid "ch.sem.sachplan-asyl_anhoerung"
 msgstr "SPA Anhörung"
 
+msgid "ch.sem.sachplan-asyl_anhoerung.coordlevel_text_lang"
+msgstr "Stand der Koordination"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.description_text_lang"
+msgstr "Beschreibung"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.document_web"
+msgstr "Weitere Informationen"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.fackind_text_lang"
+msgstr "Anlageart"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facname_lang"
+msgstr "Anlage"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facstatus_text_lang"
+msgstr "Anlagestatus"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.meastype_text_lang"
+msgstr "Massnahmetyp"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.objectname_lang"
+msgstr "Übergeordnetes Objekt"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plname_lang"
+msgstr "Planerische Massnahme"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plstatus_text_lang"
+msgstr "Planungsstand"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validfrom"
+msgstr "Beschlussdatum"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validuntil"
+msgstr "bis"
+
 msgid "ch.sem.sachplan-asyl_kraft"
 msgstr "SPA Asyl"
+
+msgid "ch.sem.sachplan-asyl_kraft.coordlevel_text_lang"
+msgstr "Stand der Koordination"
+
+msgid "ch.sem.sachplan-asyl_kraft.description_text_lang"
+msgstr "Beschreibung"
+
+msgid "ch.sem.sachplan-asyl_kraft.document_web"
+msgstr "Weitere Informationen"
+
+msgid "ch.sem.sachplan-asyl_kraft.fackind_text_lang"
+msgstr "Anlageart"
+
+msgid "ch.sem.sachplan-asyl_kraft.facname_lang"
+msgstr "Anlage"
+
+msgid "ch.sem.sachplan-asyl_kraft.facstatus_text_lang"
+msgstr "Anlagestatus"
+
+msgid "ch.sem.sachplan-asyl_kraft.meastype_text_lang"
+msgstr "Massnahmetyp"
+
+msgid "ch.sem.sachplan-asyl_kraft.objectname_lang"
+msgstr "Übergeordnetes Objekt"
+
+msgid "ch.sem.sachplan-asyl_kraft.plname_lang"
+msgstr "Planerische Massnahme"
+
+msgid "ch.sem.sachplan-asyl_kraft.plstatus_text_lang"
+msgstr "Planungsstand"
+
+msgid "ch.sem.sachplan-asyl_kraft.validfrom"
+msgstr "Beschlussdatum"
+
+msgid "ch.sem.sachplan-asyl_kraft.validuntil"
+msgstr "bis"
 
 msgid "ch.sgpk.maechtigkeit-lockergesteine"
 msgstr "Mächtigkeit der Lockergesteine"
@@ -5828,6 +6035,21 @@ msgstr "Ausgabejahr"
 msgid "ch.swisstopo.geologie-geocover"
 msgstr "GeoCover - Vektordaten"
 
+msgid "ch.swisstopo.geologie-geocover.chrono"
+msgstr "Chrono (B-T)"
+
+msgid "ch.swisstopo.geologie-geocover.description"
+msgstr "Formation"
+
+msgid "ch.swisstopo.geologie-geocover.harmos_rev"
+msgstr "Revision"
+
+msgid "ch.swisstopo.geologie-geocover.litho"
+msgstr "Lithologie(n)"
+
+msgid "ch.swisstopo.geologie-geocover.litstrat_link"
+msgstr "Link Strati.ch"
+
 msgid "ch.swisstopo.geologie-geocover.metadata"
 msgstr "Einteilung GeoCover"
 
@@ -5926,6 +6148,33 @@ msgstr "Ausgabejahr"
 
 msgid "ch.swisstopo.geologie-geologischer_atlas.release"
 msgstr "Ausgabejahr"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata"
+msgstr "Einteilung Geologischer Atlas 25 Vector"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.author"
+msgstr "Autor(en)"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.data"
+msgstr "Nachführungsstand"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.isbn"
+msgstr "ISBN-Nummer"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.price"
+msgstr "Stückpreis"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.release"
+msgstr "Ausgabejahr"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.scale"
+msgstr "Massstab"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_map_number"
+msgstr "Nummer"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_title_de"
+msgstr "Name"
 
 msgid "ch.swisstopo.geologie-geomorphologie"
 msgstr "Übersicht Geomorphologie"
@@ -6557,8 +6806,14 @@ msgstr "ch.swisstopo.images-spotimage"
 msgid "ch.swisstopo.images-swissimage"
 msgstr "SWISSIMAGE"
 
+msgid "ch.swisstopo.images-swissimage-dop10.metadata"
+msgstr "Einteilung SWISSIMAGE 10 cm Raster"
+
 msgid "ch.swisstopo.images-swissimage.metadata"
 msgstr "Einteilung SWISSIMAGE Raster"
+
+msgid "ch.swisstopo.images-swissimage.metadata.base"
+msgstr "Basis"
 
 msgid "ch.swisstopo.images-swissimage.metadata-kartenblatt"
 msgstr "Flugjahr SWISSIMAGE"
@@ -6580,6 +6835,9 @@ msgstr "Blattbezeichnung"
 
 msgid "ch.swisstopo.images-swissimage.metadata.name_it"
 msgstr "Blattbezeichnung"
+
+msgid "ch.swisstopo.images-swissimage.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo-karto.hangneigung"
 msgstr "Hangneigung ab 30°"
@@ -6803,6 +7061,9 @@ msgstr "Einteilung Landeskarte 25 Papier"
 msgid "ch.swisstopo.lk25-papierkarte.metadata.author"
 msgstr "Autor(en)"
 
+msgid "ch.swisstopo.lk25-papierkarte.metadata.base"
+msgstr "Basis"
+
 msgid "ch.swisstopo.lk25-papierkarte.metadata.data"
 msgstr "Nachführungsstand"
 
@@ -6841,6 +7102,9 @@ msgstr "Massstab"
 
 msgid "ch.swisstopo.lk25-papierkarte.metadata.tileid"
 msgstr "Blattnummer"
+
+msgid "ch.swisstopo.lk25-papierkarte.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo.lk25-papierkarte-zusammensetzung.metadata"
 msgstr "Landeskarte 1:25 000 Zus. Papier"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -1694,8 +1694,41 @@ msgstr "Amphibians stationary objects"
 msgid "ch.bafu.bundesinventare-amphibien_anhang4"
 msgstr "Amphibians appendix 4"
 
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.refobjblat"
+msgstr "Objectsheet"
+
+msgid "ch.bafu.bundesinventare-amphibien.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-amphibien.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien.refobjblat"
+msgstr "Objectsheet"
+
+msgid "ch.bafu.bundesinventare-amphibien.shape_area"
+msgstr "Area [ha]"
+
+msgid "ch.bafu.bundesinventare-amphibien.site"
+msgstr "Domain"
+
 msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte"
 msgstr "Amphibians shifting sites"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.refobjblat"
+msgstr "Objectsheet"
 
 msgid "ch.bafu.bundesinventare-auen"
 msgstr "Floodplains"
@@ -1718,11 +1751,26 @@ msgstr "Objectsheet"
 msgid "ch.bafu.bundesinventare-auen_anhang2.type"
 msgstr "Type"
 
+msgid "ch.bafu.bundesinventare-auen.auen_type"
+msgstr "Type"
+
 msgid "ch.bafu.bundesinventare-auen.au_name"
 msgstr "Name"
 
 msgid "ch.bafu.bundesinventare-auen.au_obj"
 msgstr "Objektnummer"
+
+msgid "ch.bafu.bundesinventare-auen.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-auen.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-auen.refobjblat"
+msgstr "Objectsheet"
+
+msgid "ch.bafu.bundesinventare-auen.shape_area"
+msgstr "Area [ha]"
 
 msgid "ch.bafu.bundesinventare-bln"
 msgstr "ILNM"
@@ -1748,11 +1796,41 @@ msgstr "Subarea-No."
 msgid "ch.bafu.bundesinventare-flachmoore"
 msgstr "Fens"
 
+msgid "ch.bafu.bundesinventare-flachmoore.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-flachmoore.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-flachmoore.refobjblat"
+msgstr "Objectsheet"
+
 msgid "ch.bafu.bundesinventare-flachmoore_regional"
 msgstr "Regional fens"
 
+msgid "ch.bafu.bundesinventare-flachmoore.shape_area"
+msgstr "Area [ha]"
+
 msgid "ch.bafu.bundesinventare-hochmoore"
 msgstr "Raised bogs"
+
+msgid "ch.bafu.bundesinventare-hochmoore.hochmoore_type"
+msgstr "Type"
+
+msgid "ch.bafu.bundesinventare-hochmoore.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-hochmoore.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-hochmoore.refobjblat"
+msgstr "Objectsheet"
+
+msgid "ch.bafu.bundesinventare-hochmoore.shape_area"
+msgstr "Area [ha]"
+
+msgid "ch.bafu.bundesinventare-hochmoore.unit"
+msgstr "Quartier unit"
 
 msgid "ch.bafu.bundesinventare-jagdbanngebiete"
 msgstr "Swiss game reserves"
@@ -1763,11 +1841,53 @@ msgstr "Objektnummer"
 msgid "ch.bafu.bundesinventare-moorlandschaften"
 msgstr "Mire landscapes"
 
+msgid "ch.bafu.bundesinventare-moorlandschaften.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.refobjblat"
+msgstr "Objectsheet"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.shape_area"
+msgstr "Area [ha]"
+
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden"
 msgstr "Dry grasslands (DGS)"
 
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2"
 msgstr "Dry grasslands appendix 2"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.refobjblat"
+msgstr "Objectsheet"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.shape_area"
+msgstr "Area [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.teilobjnummer"
+msgstr "Subarea-No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.name"
+msgstr "Name"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.refobjblat"
+msgstr "Objectsheet"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.shape_area"
+msgstr "Area [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.teilobjnummer"
+msgstr "Subarea-No."
 
 msgid "ch.bafu.bundesinventare-vogelreservate"
 msgstr "Water & migrant bird reserves"
@@ -3956,6 +4076,21 @@ msgstr "FOT"
 msgid "ch.bav.anlagen-schienengueterverkehr"
 msgstr "Anlagen Schienengüterverkehr"
 
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_abk"
+msgstr "Abkürzung"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_nr"
+msgstr "Nummer"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.isb"
+msgstr "ISB"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.name"
+msgstr "Name"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.typ"
+msgstr "Anlagenkategorie"
+
 msgid "ch.bav.baulinien-eisenbahnanlagen.oereb"
 msgstr "Building lines railways PLR"
 
@@ -5567,8 +5702,80 @@ msgstr "MCPFE1.3 Conservation through active management"
 msgid "ch.sem.sachplan-asyl_anhoerung"
 msgstr "SPA consultation"
 
+msgid "ch.sem.sachplan-asyl_anhoerung.coordlevel_text_lang"
+msgstr "Coordination level"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.description_text_lang"
+msgstr "Description"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.document_web"
+msgstr "More information"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.fackind_text_lang"
+msgstr "Facility type"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facname_lang"
+msgstr "Facility"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facstatus_text_lang"
+msgstr "Facility status"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.meastype_text_lang"
+msgstr "Measure type"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.objectname_lang"
+msgstr "Belongs to object"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plname_lang"
+msgstr "Measure"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plstatus_text_lang"
+msgstr "Planning status"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validfrom"
+msgstr "Valid from"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validuntil"
+msgstr "until"
+
 msgid "ch.sem.sachplan-asyl_kraft"
 msgstr "SP Asylum"
+
+msgid "ch.sem.sachplan-asyl_kraft.coordlevel_text_lang"
+msgstr "Coordination level"
+
+msgid "ch.sem.sachplan-asyl_kraft.description_text_lang"
+msgstr "Description"
+
+msgid "ch.sem.sachplan-asyl_kraft.document_web"
+msgstr "More information"
+
+msgid "ch.sem.sachplan-asyl_kraft.fackind_text_lang"
+msgstr "Facility type"
+
+msgid "ch.sem.sachplan-asyl_kraft.facname_lang"
+msgstr "Facility"
+
+msgid "ch.sem.sachplan-asyl_kraft.facstatus_text_lang"
+msgstr "Facility status"
+
+msgid "ch.sem.sachplan-asyl_kraft.meastype_text_lang"
+msgstr "Measure type"
+
+msgid "ch.sem.sachplan-asyl_kraft.objectname_lang"
+msgstr "Belongs to object"
+
+msgid "ch.sem.sachplan-asyl_kraft.plname_lang"
+msgstr "Measure"
+
+msgid "ch.sem.sachplan-asyl_kraft.plstatus_text_lang"
+msgstr "Planning status"
+
+msgid "ch.sem.sachplan-asyl_kraft.validfrom"
+msgstr "Valid from"
+
+msgid "ch.sem.sachplan-asyl_kraft.validuntil"
+msgstr "until"
 
 msgid "ch.sgpk.maechtigkeit-lockergesteine"
 msgstr "Sediment thickness"
@@ -5828,6 +6035,21 @@ msgstr "Edition"
 msgid "ch.swisstopo.geologie-geocover"
 msgstr "GeoCover - Vector Datasets"
 
+msgid "ch.swisstopo.geologie-geocover.chrono"
+msgstr "Chrono (B-T)"
+
+msgid "ch.swisstopo.geologie-geocover.description"
+msgstr "Formation"
+
+msgid "ch.swisstopo.geologie-geocover.harmos_rev"
+msgstr "Revision"
+
+msgid "ch.swisstopo.geologie-geocover.litho"
+msgstr "Lithologie(n)"
+
+msgid "ch.swisstopo.geologie-geocover.litstrat_link"
+msgstr "Link Strati.ch"
+
 msgid "ch.swisstopo.geologie-geocover.metadata"
 msgstr "Division GeoCover"
 
@@ -5926,6 +6148,33 @@ msgstr "Edition"
 
 msgid "ch.swisstopo.geologie-geologischer_atlas.release"
 msgstr "Edition"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata"
+msgstr "Division geological atlas 25 Vector"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.author"
+msgstr "Author(s)"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.data"
+msgstr "State of updates"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.isbn"
+msgstr "ISBN number"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.price"
+msgstr "Unit price"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.release"
+msgstr "Edition"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.scale"
+msgstr "Scale"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_map_number"
+msgstr "Number"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_title_de"
+msgstr "Name"
 
 msgid "ch.swisstopo.geologie-geomorphologie"
 msgstr "Overview of geomorphology"
@@ -6557,8 +6806,14 @@ msgstr "ch.swisstopo.images-spotimage"
 msgid "ch.swisstopo.images-swissimage"
 msgstr "SWISSIMAGE"
 
+msgid "ch.swisstopo.images-swissimage-dop10.metadata"
+msgstr "Division SWISSIMAGE 10 cm Raster"
+
 msgid "ch.swisstopo.images-swissimage.metadata"
 msgstr "Division SWISSIMAGE Raster"
+
+msgid "ch.swisstopo.images-swissimage.metadata.base"
+msgstr "Base"
 
 msgid "ch.swisstopo.images-swissimage.metadata-kartenblatt"
 msgstr "Flugjahr SWISSIMAGE"
@@ -6580,6 +6835,9 @@ msgstr "Mapsheet name"
 
 msgid "ch.swisstopo.images-swissimage.metadata.name_it"
 msgstr "Mapsheet name"
+
+msgid "ch.swisstopo.images-swissimage.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo-karto.hangneigung"
 msgstr "Slope over 30°"
@@ -6803,6 +7061,9 @@ msgstr "Division national map 25 Paper"
 msgid "ch.swisstopo.lk25-papierkarte.metadata.author"
 msgstr "Author(s)"
 
+msgid "ch.swisstopo.lk25-papierkarte.metadata.base"
+msgstr "Base"
+
 msgid "ch.swisstopo.lk25-papierkarte.metadata.data"
 msgstr "State of updates"
 
@@ -6841,6 +7102,9 @@ msgstr "Scale"
 
 msgid "ch.swisstopo.lk25-papierkarte.metadata.tileid"
 msgstr "Mapsheet number"
+
+msgid "ch.swisstopo.lk25-papierkarte.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo.lk25-papierkarte-zusammensetzung.metadata"
 msgstr "National Map 1:25'000 comp. printed"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -1694,8 +1694,41 @@ msgstr "Amfibis, objects fixs"
 msgid "ch.bafu.bundesinventare-amphibien_anhang4"
 msgstr "Amfibis – agiunta 4"
 
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-amphibien.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-amphibien.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-amphibien.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-amphibien.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-amphibien.site"
+msgstr "Bereich"
+
 msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte"
 msgstr "Amfibis, objects movibels"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.refobjblat"
+msgstr "Objektblatt"
 
 msgid "ch.bafu.bundesinventare-auen"
 msgstr "Zonas umidas"
@@ -1718,11 +1751,26 @@ msgstr "Objektblatt"
 msgid "ch.bafu.bundesinventare-auen_anhang2.type"
 msgstr "Typ"
 
+msgid "ch.bafu.bundesinventare-auen.auen_type"
+msgstr "Typ"
+
 msgid "ch.bafu.bundesinventare-auen.au_name"
 msgstr "Num"
 
 msgid "ch.bafu.bundesinventare-auen.au_obj"
 msgstr "Objektnummer"
+
+msgid "ch.bafu.bundesinventare-auen.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-auen.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-auen.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-auen.shape_area"
+msgstr "Fläche [ha]"
 
 msgid "ch.bafu.bundesinventare-bln"
 msgstr "IFC"
@@ -1748,11 +1796,41 @@ msgstr "Teilobjekt-Nr."
 msgid "ch.bafu.bundesinventare-flachmoore"
 msgstr "Palids planivas"
 
+msgid "ch.bafu.bundesinventare-flachmoore.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-flachmoore.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-flachmoore.refobjblat"
+msgstr "Objektblatt"
+
 msgid "ch.bafu.bundesinventare-flachmoore_regional"
 msgstr "Palids planivas regiunal"
 
+msgid "ch.bafu.bundesinventare-flachmoore.shape_area"
+msgstr "Fläche [ha]"
+
 msgid "ch.bafu.bundesinventare-hochmoore"
 msgstr "Palids autas"
+
+msgid "ch.bafu.bundesinventare-hochmoore.hochmoore_type"
+msgstr "Typ"
+
+msgid "ch.bafu.bundesinventare-hochmoore.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-hochmoore.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-hochmoore.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-hochmoore.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-hochmoore.unit"
+msgstr "Kartiereinheit"
 
 msgid "ch.bafu.bundesinventare-jagdbanngebiete"
 msgstr "Asils da selvaschina"
@@ -1763,11 +1841,53 @@ msgstr "Objektnummer"
 msgid "ch.bafu.bundesinventare-moorlandschaften"
 msgstr "Cuntradas da palì"
 
+msgid "ch.bafu.bundesinventare-moorlandschaften.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.shape_area"
+msgstr "Fläche [ha]"
+
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden"
 msgstr "Pastgiras e prads sitgs (PPS)"
 
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2"
 msgstr "PPS – agiunta 2"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.teilobjnummer"
+msgstr "Teilobjekt-Nr."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.name"
+msgstr "Objektname"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.objnummer"
+msgstr "Nr."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.refobjblat"
+msgstr "Objektblatt"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.shape_area"
+msgstr "Fläche [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.teilobjnummer"
+msgstr "Teilobjekt-Nr."
 
 msgid "ch.bafu.bundesinventare-vogelreservate"
 msgstr "Reservats d'utschels: aua, migrants"
@@ -3956,6 +4076,21 @@ msgstr "BAV"
 msgid "ch.bav.anlagen-schienengueterverkehr"
 msgstr "Anlagen Schienengüterverkehr"
 
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_abk"
+msgstr "Abkürzung"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_nr"
+msgstr "Nummer"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.isb"
+msgstr "ISB"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.name"
+msgstr "Name"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.typ"
+msgstr "Anlagenkategorie"
+
 msgid "ch.bav.baulinien-eisenbahnanlagen.oereb"
 msgstr "Lingias construcziun viafiers RPDP"
 
@@ -5567,8 +5702,80 @@ msgstr "MCPFE1.3 Biodiversitätsförderung durch gezielte Eingriffe"
 msgid "ch.sem.sachplan-asyl_anhoerung"
 msgstr "SPA Anhörung"
 
+msgid "ch.sem.sachplan-asyl_anhoerung.coordlevel_text_lang"
+msgstr "Stand der Koordination"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.description_text_lang"
+msgstr "Beschreibung"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.document_web"
+msgstr "Weitere Informationen"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.fackind_text_lang"
+msgstr "Anlageart"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facname_lang"
+msgstr "Anlage"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facstatus_text_lang"
+msgstr "Anlagestatus"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.meastype_text_lang"
+msgstr "Massnahmetyp"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.objectname_lang"
+msgstr "Übergeordnetes Objekt"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plname_lang"
+msgstr "Planerische Massnahme"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plstatus_text_lang"
+msgstr "Planungsstand"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validfrom"
+msgstr "Beschlussdatum"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validuntil"
+msgstr "bis"
+
 msgid "ch.sem.sachplan-asyl_kraft"
 msgstr "SPA Asyl"
+
+msgid "ch.sem.sachplan-asyl_kraft.coordlevel_text_lang"
+msgstr "Stand der Koordination"
+
+msgid "ch.sem.sachplan-asyl_kraft.description_text_lang"
+msgstr "Beschreibung"
+
+msgid "ch.sem.sachplan-asyl_kraft.document_web"
+msgstr "Weitere Informationen"
+
+msgid "ch.sem.sachplan-asyl_kraft.fackind_text_lang"
+msgstr "Anlageart"
+
+msgid "ch.sem.sachplan-asyl_kraft.facname_lang"
+msgstr "Anlage"
+
+msgid "ch.sem.sachplan-asyl_kraft.facstatus_text_lang"
+msgstr "Anlagestatus"
+
+msgid "ch.sem.sachplan-asyl_kraft.meastype_text_lang"
+msgstr "Massnahmetyp"
+
+msgid "ch.sem.sachplan-asyl_kraft.objectname_lang"
+msgstr "Übergeordnetes Objekt"
+
+msgid "ch.sem.sachplan-asyl_kraft.plname_lang"
+msgstr "Planerische Massnahme"
+
+msgid "ch.sem.sachplan-asyl_kraft.plstatus_text_lang"
+msgstr "Planungsstand"
+
+msgid "ch.sem.sachplan-asyl_kraft.validfrom"
+msgstr "Beschlussdatum"
+
+msgid "ch.sem.sachplan-asyl_kraft.validuntil"
+msgstr "bis"
 
 msgid "ch.sgpk.maechtigkeit-lockergesteine"
 msgstr "Autezza da la crappa lucca"
@@ -5828,6 +6035,21 @@ msgstr "Ausgabejahr"
 msgid "ch.swisstopo.geologie-geocover"
 msgstr "GeoCover – datas vectorialas"
 
+msgid "ch.swisstopo.geologie-geocover.chrono"
+msgstr "Chrono (B-T)"
+
+msgid "ch.swisstopo.geologie-geocover.description"
+msgstr "Formation"
+
+msgid "ch.swisstopo.geologie-geocover.harmos_rev"
+msgstr "Revision"
+
+msgid "ch.swisstopo.geologie-geocover.litho"
+msgstr "Lithologie(n)"
+
+msgid "ch.swisstopo.geologie-geocover.litstrat_link"
+msgstr "Link Strati.ch"
+
 msgid "ch.swisstopo.geologie-geocover.metadata"
 msgstr "Divisiun GeoCover"
 
@@ -5926,6 +6148,33 @@ msgstr "Ausgabejahr"
 
 msgid "ch.swisstopo.geologie-geologischer_atlas.release"
 msgstr "Ausgabejahr"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata"
+msgstr "Divisiun atlas geologic 25 Vector"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.author"
+msgstr "Autor(en)"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.data"
+msgstr "Nachführungsstand"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.isbn"
+msgstr "ISBN-Nummer"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.price"
+msgstr "Stückpreis"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.release"
+msgstr "Ausgabejahr"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.scale"
+msgstr "Massstab"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_map_number"
+msgstr "Nummer"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_title_de"
+msgstr "Name"
 
 msgid "ch.swisstopo.geologie-geomorphologie"
 msgstr "Survista da la geomorfologia"
@@ -6557,8 +6806,14 @@ msgstr "ch.swisstopo.images-spotimage"
 msgid "ch.swisstopo.images-swissimage"
 msgstr "Fotografia or da l'aria"
 
+msgid "ch.swisstopo.images-swissimage-dop10.metadata"
+msgstr "Divisiun SWISSIMAGE 10 cm Raster"
+
 msgid "ch.swisstopo.images-swissimage.metadata"
 msgstr "Divisiun SWISSIMAGE Raster"
+
+msgid "ch.swisstopo.images-swissimage.metadata.base"
+msgstr "Basis"
 
 msgid "ch.swisstopo.images-swissimage.metadata-kartenblatt"
 msgstr "Flugjahr SWISSIMAGE"
@@ -6580,6 +6835,9 @@ msgstr "Blattbezeichnung"
 
 msgid "ch.swisstopo.images-swissimage.metadata.name_it"
 msgstr "Blattbezeichnung"
+
+msgid "ch.swisstopo.images-swissimage.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo-karto.hangneigung"
 msgstr "Pendenza dapli che 30°"
@@ -6803,6 +7061,9 @@ msgstr "Divisiun charta naziunala 25 Stampa"
 msgid "ch.swisstopo.lk25-papierkarte.metadata.author"
 msgstr "Autori"
 
+msgid "ch.swisstopo.lk25-papierkarte.metadata.base"
+msgstr "Basis"
+
 msgid "ch.swisstopo.lk25-papierkarte.metadata.data"
 msgstr "Nachführungsstand"
 
@@ -6841,6 +7102,9 @@ msgstr "Massstab"
 
 msgid "ch.swisstopo.lk25-papierkarte.metadata.tileid"
 msgstr "Blattnummer"
+
+msgid "ch.swisstopo.lk25-papierkarte.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo.lk25-papierkarte-zusammensetzung.metadata"
 msgstr "Charta naziunala 1:25'000 cump."

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -1694,8 +1694,41 @@ msgstr "Batraciens objets fixes"
 msgid "ch.bafu.bundesinventare-amphibien_anhang4"
 msgstr "Batraciens sites de l’annexe 4"
 
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.refobjblat"
+msgstr "Description d’objet"
+
+msgid "ch.bafu.bundesinventare-amphibien.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-amphibien.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien.refobjblat"
+msgstr "Description d’objet"
+
+msgid "ch.bafu.bundesinventare-amphibien.shape_area"
+msgstr "Surface [ha]"
+
+msgid "ch.bafu.bundesinventare-amphibien.site"
+msgstr "Site"
+
 msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte"
 msgstr "Batraciens objets itinérants"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.refobjblat"
+msgstr "Description d’objet"
 
 msgid "ch.bafu.bundesinventare-auen"
 msgstr "Zones alluviales"
@@ -1718,11 +1751,26 @@ msgstr "Description d’objet"
 msgid "ch.bafu.bundesinventare-auen_anhang2.type"
 msgstr "Type"
 
+msgid "ch.bafu.bundesinventare-auen.auen_type"
+msgstr "Type"
+
 msgid "ch.bafu.bundesinventare-auen.au_name"
 msgstr "Nom"
 
 msgid "ch.bafu.bundesinventare-auen.au_obj"
 msgstr "Numéro de l´objet"
+
+msgid "ch.bafu.bundesinventare-auen.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-auen.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-auen.refobjblat"
+msgstr "Description d’objet"
+
+msgid "ch.bafu.bundesinventare-auen.shape_area"
+msgstr "Surface [ha]"
 
 msgid "ch.bafu.bundesinventare-bln"
 msgstr "IFP"
@@ -1748,11 +1796,41 @@ msgstr "Partie-No."
 msgid "ch.bafu.bundesinventare-flachmoore"
 msgstr "Bas-marais"
 
+msgid "ch.bafu.bundesinventare-flachmoore.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-flachmoore.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-flachmoore.refobjblat"
+msgstr "Description d’objet"
+
 msgid "ch.bafu.bundesinventare-flachmoore_regional"
 msgstr "Bas-marais régionaux"
 
+msgid "ch.bafu.bundesinventare-flachmoore.shape_area"
+msgstr "Surface [ha]"
+
 msgid "ch.bafu.bundesinventare-hochmoore"
 msgstr "Hauts-marais"
+
+msgid "ch.bafu.bundesinventare-hochmoore.hochmoore_type"
+msgstr "Type"
+
+msgid "ch.bafu.bundesinventare-hochmoore.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-hochmoore.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-hochmoore.refobjblat"
+msgstr "Description d’objet"
+
+msgid "ch.bafu.bundesinventare-hochmoore.shape_area"
+msgstr "Surface [ha]"
+
+msgid "ch.bafu.bundesinventare-hochmoore.unit"
+msgstr "Unité de cartographie"
 
 msgid "ch.bafu.bundesinventare-jagdbanngebiete"
 msgstr "Districts francs"
@@ -1763,11 +1841,53 @@ msgstr "Numéro de l´objet"
 msgid "ch.bafu.bundesinventare-moorlandschaften"
 msgstr "Sites marécageux"
 
+msgid "ch.bafu.bundesinventare-moorlandschaften.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.refobjblat"
+msgstr "Description d’objet"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.shape_area"
+msgstr "Surface [ha]"
+
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden"
 msgstr "Prairies et pâturages secs (PPS)"
 
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2"
 msgstr "PPS annexe 2"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.refobjblat"
+msgstr "Description d’objet"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.shape_area"
+msgstr "Surface [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.teilobjnummer"
+msgstr "Partie-No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.name"
+msgstr "Nom"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.refobjblat"
+msgstr "Description d’objet"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.shape_area"
+msgstr "Surface [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.teilobjnummer"
+msgstr "Partie-No."
 
 msgid "ch.bafu.bundesinventare-vogelreservate"
 msgstr "Réserves d'oiseaux d'eau"
@@ -3956,6 +4076,21 @@ msgstr "OFT"
 msgid "ch.bav.anlagen-schienengueterverkehr"
 msgstr "Anlagen Schienengüterverkehr"
 
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_abk"
+msgstr "Abréviation"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_nr"
+msgstr "Numéro"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.isb"
+msgstr "GI"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.name"
+msgstr "Nom"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.typ"
+msgstr "Catégorie d’installations"
+
 msgid "ch.bav.baulinien-eisenbahnanlagen.oereb"
 msgstr "Alignements chemins de fer RDPPF"
 
@@ -5567,8 +5702,80 @@ msgstr "MCPFE1.3 Promotion de la biodiversité par des interventions ciblées"
 msgid "ch.sem.sachplan-asyl_anhoerung"
 msgstr "PSA consultation"
 
+msgid "ch.sem.sachplan-asyl_anhoerung.coordlevel_text_lang"
+msgstr "Etat de coordination"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.description_text_lang"
+msgstr "Description"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.document_web"
+msgstr "Autres informations"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.fackind_text_lang"
+msgstr "Type d‘installation"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facname_lang"
+msgstr "Installation"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facstatus_text_lang"
+msgstr "Statut de l‘installation"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.meastype_text_lang"
+msgstr "Type de mesure"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.objectname_lang"
+msgstr "Objet d‘appartenance"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plname_lang"
+msgstr "Mesure"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plstatus_text_lang"
+msgstr "Etat de la planification"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validfrom"
+msgstr "Date de l’arrêt"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validuntil"
+msgstr "au"
+
 msgid "ch.sem.sachplan-asyl_kraft"
 msgstr "PS Asile"
+
+msgid "ch.sem.sachplan-asyl_kraft.coordlevel_text_lang"
+msgstr "Etat de coordination"
+
+msgid "ch.sem.sachplan-asyl_kraft.description_text_lang"
+msgstr "Description"
+
+msgid "ch.sem.sachplan-asyl_kraft.document_web"
+msgstr "Autres informations"
+
+msgid "ch.sem.sachplan-asyl_kraft.fackind_text_lang"
+msgstr "Type d‘installation"
+
+msgid "ch.sem.sachplan-asyl_kraft.facname_lang"
+msgstr "Installation"
+
+msgid "ch.sem.sachplan-asyl_kraft.facstatus_text_lang"
+msgstr "Statut de l‘installation"
+
+msgid "ch.sem.sachplan-asyl_kraft.meastype_text_lang"
+msgstr "Type de mesure"
+
+msgid "ch.sem.sachplan-asyl_kraft.objectname_lang"
+msgstr "Objet d‘appartenance"
+
+msgid "ch.sem.sachplan-asyl_kraft.plname_lang"
+msgstr "Mesure"
+
+msgid "ch.sem.sachplan-asyl_kraft.plstatus_text_lang"
+msgstr "Etat de la planification"
+
+msgid "ch.sem.sachplan-asyl_kraft.validfrom"
+msgstr "Date de l’arrêt"
+
+msgid "ch.sem.sachplan-asyl_kraft.validuntil"
+msgstr "au"
 
 msgid "ch.sgpk.maechtigkeit-lockergesteine"
 msgstr "Epaisseur des roches meubles"
@@ -5828,6 +6035,21 @@ msgstr "Édition"
 msgid "ch.swisstopo.geologie-geocover"
 msgstr "GeoCover - données vectorielles"
 
+msgid "ch.swisstopo.geologie-geocover.chrono"
+msgstr "Chrono (B-T)"
+
+msgid "ch.swisstopo.geologie-geocover.description"
+msgstr "Formation"
+
+msgid "ch.swisstopo.geologie-geocover.harmos_rev"
+msgstr "Révision"
+
+msgid "ch.swisstopo.geologie-geocover.litho"
+msgstr "Lithologie(s)"
+
+msgid "ch.swisstopo.geologie-geocover.litstrat_link"
+msgstr "Lien Strati.ch"
+
 msgid "ch.swisstopo.geologie-geocover.metadata"
 msgstr "Découpage GeoCover"
 
@@ -5926,6 +6148,33 @@ msgstr "Édition"
 
 msgid "ch.swisstopo.geologie-geologischer_atlas.release"
 msgstr "Édition"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata"
+msgstr "Découpage atlas géologique 25 Vector"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.author"
+msgstr "Auteur(s)"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.data"
+msgstr "Etat de mise à jour"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.isbn"
+msgstr "Numéro ISBN"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.price"
+msgstr "Prix unitaire"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.release"
+msgstr "Édition"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.scale"
+msgstr "Echelle"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_map_number"
+msgstr "Numéro"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_title_de"
+msgstr "Nom"
 
 msgid "ch.swisstopo.geologie-geomorphologie"
 msgstr "Géomorphologie, vue d'ensemble"
@@ -6557,8 +6806,14 @@ msgstr "ch.swisstopo.images-spotimage"
 msgid "ch.swisstopo.images-swissimage"
 msgstr "SWISSIMAGE"
 
+msgid "ch.swisstopo.images-swissimage-dop10.metadata"
+msgstr "Découpage SWISSIMAGE 10 cm Raster"
+
 msgid "ch.swisstopo.images-swissimage.metadata"
 msgstr "Découpage SWISSIMAGE Raster"
+
+msgid "ch.swisstopo.images-swissimage.metadata.base"
+msgstr "Base"
 
 msgid "ch.swisstopo.images-swissimage.metadata-kartenblatt"
 msgstr "Année de vol SWISSIMAGE"
@@ -6580,6 +6835,9 @@ msgstr "Nom de la feuille"
 
 msgid "ch.swisstopo.images-swissimage.metadata.name_it"
 msgstr "Nom de la feuille"
+
+msgid "ch.swisstopo.images-swissimage.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo-karto.hangneigung"
 msgstr "Pente plus de 30°"
@@ -6803,6 +7061,9 @@ msgstr "Découpage carte nationale 25 Papier"
 msgid "ch.swisstopo.lk25-papierkarte.metadata.author"
 msgstr "Auteur(s)"
 
+msgid "ch.swisstopo.lk25-papierkarte.metadata.base"
+msgstr "Base"
+
 msgid "ch.swisstopo.lk25-papierkarte.metadata.data"
 msgstr "Etat de mise à jour"
 
@@ -6841,6 +7102,9 @@ msgstr "Échelle"
 
 msgid "ch.swisstopo.lk25-papierkarte.metadata.tileid"
 msgstr "Numéro de la feuille"
+
+msgid "ch.swisstopo.lk25-papierkarte.metadata.version"
+msgstr "Version"
 
 msgid "ch.swisstopo.lk25-papierkarte-zusammensetzung.metadata"
 msgstr "Carte nationale 1:25'000 Ass. papier"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -1694,8 +1694,41 @@ msgstr "Anfibi oggetti fissi"
 msgid "ch.bafu.bundesinventare-amphibien_anhang4"
 msgstr "Anfibi allegato 4"
 
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien_anhang4.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-amphibien.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-amphibien.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-amphibien.shape_area"
+msgstr "Superficie [ha]"
+
+msgid "ch.bafu.bundesinventare-amphibien.site"
+msgstr "Sito"
+
 msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte"
 msgstr "Anfibi oggetti mobili"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-amphibien_wanderobjekte.refobjblat"
+msgstr "Descrizione dell'oggetto"
 
 msgid "ch.bafu.bundesinventare-auen"
 msgstr "Zone golenali"
@@ -1718,11 +1751,26 @@ msgstr "Descrizione dell'oggetto"
 msgid "ch.bafu.bundesinventare-auen_anhang2.type"
 msgstr "Tipo"
 
+msgid "ch.bafu.bundesinventare-auen.auen_type"
+msgstr "Tipo"
+
 msgid "ch.bafu.bundesinventare-auen.au_name"
 msgstr "Nome"
 
 msgid "ch.bafu.bundesinventare-auen.au_obj"
 msgstr "Numero dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-auen.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-auen.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-auen.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-auen.shape_area"
+msgstr "Superficie [ha]"
 
 msgid "ch.bafu.bundesinventare-bln"
 msgstr "IFP"
@@ -1748,11 +1796,41 @@ msgstr "Sottozona-No."
 msgid "ch.bafu.bundesinventare-flachmoore"
 msgstr "Paludi"
 
+msgid "ch.bafu.bundesinventare-flachmoore.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-flachmoore.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-flachmoore.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
 msgid "ch.bafu.bundesinventare-flachmoore_regional"
 msgstr "Paludi regionali"
 
+msgid "ch.bafu.bundesinventare-flachmoore.shape_area"
+msgstr "Superficie [ha]"
+
 msgid "ch.bafu.bundesinventare-hochmoore"
 msgstr "Torbiere alte"
+
+msgid "ch.bafu.bundesinventare-hochmoore.hochmoore_type"
+msgstr "Tipo"
+
+msgid "ch.bafu.bundesinventare-hochmoore.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-hochmoore.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-hochmoore.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-hochmoore.shape_area"
+msgstr "Superficie [ha]"
+
+msgid "ch.bafu.bundesinventare-hochmoore.unit"
+msgstr "Unité de cartographie"
 
 msgid "ch.bafu.bundesinventare-jagdbanngebiete"
 msgstr "Bandite federali di caccia"
@@ -1763,11 +1841,53 @@ msgstr "Numero dell'oggetto"
 msgid "ch.bafu.bundesinventare-moorlandschaften"
 msgstr "Zone palustri"
 
+msgid "ch.bafu.bundesinventare-moorlandschaften.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-moorlandschaften.shape_area"
+msgstr "Superficie [ha]"
+
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden"
 msgstr "Prati e pascoli secchi (PPS)"
 
 msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2"
 msgstr "PPS allegato 2"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.shape_area"
+msgstr "Superficie [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2.teilobjnummer"
+msgstr "Sottozona-No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.name"
+msgstr "Nome"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.objnummer"
+msgstr "No."
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.refobjblat"
+msgstr "Descrizione dell'oggetto"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.shape_area"
+msgstr "Superficie [ha]"
+
+msgid "ch.bafu.bundesinventare-trockenwiesen_trockenweiden.teilobjnummer"
+msgstr "Sottozona-No."
 
 msgid "ch.bafu.bundesinventare-vogelreservate"
 msgstr "Riserve di uccelli acquatici"
@@ -3956,6 +4076,21 @@ msgstr "UFT"
 msgid "ch.bav.anlagen-schienengueterverkehr"
 msgstr "Anlagen Schienengüterverkehr"
 
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_abk"
+msgstr "Abbreviazione"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.dst_nr"
+msgstr "Numero"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.isb"
+msgstr "GI"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.name"
+msgstr "Nome"
+
+msgid "ch.bav.anlagen-schienengueterverkehr.typ"
+msgstr "Categorie di impianti"
+
 msgid "ch.bav.baulinien-eisenbahnanlagen.oereb"
 msgstr "Linee di costruzione ferrovie RDPP"
 
@@ -5567,8 +5702,80 @@ msgstr "MCPFE1.3 Promozione delle biodiversità per mezzo di interventi specific
 msgid "ch.sem.sachplan-asyl_anhoerung"
 msgstr "PSA consultazione"
 
+msgid "ch.sem.sachplan-asyl_anhoerung.coordlevel_text_lang"
+msgstr "Stato di coordinamento"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.description_text_lang"
+msgstr "Descrizione"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.document_web"
+msgstr "Informazioni supplementari"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.fackind_text_lang"
+msgstr "Tipo d‘installazione"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facname_lang"
+msgstr "Installazione"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.facstatus_text_lang"
+msgstr "Stato dell‘installazione"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.meastype_text_lang"
+msgstr "Tipo di misura"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.objectname_lang"
+msgstr "Oggetto preposto"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plname_lang"
+msgstr "Misura"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.plstatus_text_lang"
+msgstr "Stato della pianificazione"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validfrom"
+msgstr "Data della delibera"
+
+msgid "ch.sem.sachplan-asyl_anhoerung.validuntil"
+msgstr "al"
+
 msgid "ch.sem.sachplan-asyl_kraft"
 msgstr "PS Asilo"
+
+msgid "ch.sem.sachplan-asyl_kraft.coordlevel_text_lang"
+msgstr "Stato di coordinamento"
+
+msgid "ch.sem.sachplan-asyl_kraft.description_text_lang"
+msgstr "Descrizione"
+
+msgid "ch.sem.sachplan-asyl_kraft.document_web"
+msgstr "Informazioni supplementari"
+
+msgid "ch.sem.sachplan-asyl_kraft.fackind_text_lang"
+msgstr "Tipo d‘installazione"
+
+msgid "ch.sem.sachplan-asyl_kraft.facname_lang"
+msgstr "Installazione"
+
+msgid "ch.sem.sachplan-asyl_kraft.facstatus_text_lang"
+msgstr "Stato dell‘installazione"
+
+msgid "ch.sem.sachplan-asyl_kraft.meastype_text_lang"
+msgstr "Tipo di misura"
+
+msgid "ch.sem.sachplan-asyl_kraft.objectname_lang"
+msgstr "Oggetto preposto"
+
+msgid "ch.sem.sachplan-asyl_kraft.plname_lang"
+msgstr "Misura"
+
+msgid "ch.sem.sachplan-asyl_kraft.plstatus_text_lang"
+msgstr "Stato della pianificazione"
+
+msgid "ch.sem.sachplan-asyl_kraft.validfrom"
+msgstr "Data della delibera"
+
+msgid "ch.sem.sachplan-asyl_kraft.validuntil"
+msgstr "al"
 
 msgid "ch.sgpk.maechtigkeit-lockergesteine"
 msgstr "Spessore dei sedimenti"
@@ -5828,6 +6035,21 @@ msgstr "Edizione"
 msgid "ch.swisstopo.geologie-geocover"
 msgstr "GeoCover - dati vettoriali"
 
+msgid "ch.swisstopo.geologie-geocover.chrono"
+msgstr "Chrono (B-T)"
+
+msgid "ch.swisstopo.geologie-geocover.description"
+msgstr "Formation"
+
+msgid "ch.swisstopo.geologie-geocover.harmos_rev"
+msgstr "Révision"
+
+msgid "ch.swisstopo.geologie-geocover.litho"
+msgstr "Lithologie(s)"
+
+msgid "ch.swisstopo.geologie-geocover.litstrat_link"
+msgstr "Lien Strati.ch"
+
 msgid "ch.swisstopo.geologie-geocover.metadata"
 msgstr "Divisione GeoCover"
 
@@ -5926,6 +6148,33 @@ msgstr "Edizione"
 
 msgid "ch.swisstopo.geologie-geologischer_atlas.release"
 msgstr "Edizione"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata"
+msgstr "Divisione atlante geologico 25 Vector"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.author"
+msgstr "Autori"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.data"
+msgstr "Stato di aggiornamento"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.isbn"
+msgstr "Codice ISBN"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.price"
+msgstr "Prezzo al pezzo"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.release"
+msgstr "Edizione"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.scale"
+msgstr "Scala"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_map_number"
+msgstr "Numero"
+
+msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_title_de"
+msgstr "Nome"
 
 msgid "ch.swisstopo.geologie-geomorphologie"
 msgstr "Geomorfologia, visione d'insieme"
@@ -6557,8 +6806,14 @@ msgstr "ch.swisstopo.images-spotimage"
 msgid "ch.swisstopo.images-swissimage"
 msgstr "SWISSIMAGE"
 
+msgid "ch.swisstopo.images-swissimage-dop10.metadata"
+msgstr "Divisione SWISSIMAGE 10 cm Raster"
+
 msgid "ch.swisstopo.images-swissimage.metadata"
 msgstr "Divisione SWISSIMAGE Raster"
+
+msgid "ch.swisstopo.images-swissimage.metadata.base"
+msgstr "Base"
 
 msgid "ch.swisstopo.images-swissimage.metadata-kartenblatt"
 msgstr "Année de vol SWISSIMAGE"
@@ -6580,6 +6835,9 @@ msgstr "Denominazione di foglio"
 
 msgid "ch.swisstopo.images-swissimage.metadata.name_it"
 msgstr "Denominazione di foglio"
+
+msgid "ch.swisstopo.images-swissimage.metadata.version"
+msgstr "Versione"
 
 msgid "ch.swisstopo-karto.hangneigung"
 msgstr "Pendenza maggiori 30°"
@@ -6803,6 +7061,9 @@ msgstr "Divisione carta nazionale 25 Stampa"
 msgid "ch.swisstopo.lk25-papierkarte.metadata.author"
 msgstr "Autore"
 
+msgid "ch.swisstopo.lk25-papierkarte.metadata.base"
+msgstr "Base"
+
 msgid "ch.swisstopo.lk25-papierkarte.metadata.data"
 msgstr "Stato di aggiornamento"
 
@@ -6841,6 +7102,9 @@ msgstr "Scala"
 
 msgid "ch.swisstopo.lk25-papierkarte.metadata.tileid"
 msgstr "Numero di foglio"
+
+msgid "ch.swisstopo.lk25-papierkarte.metadata.version"
+msgstr "Versione"
 
 msgid "ch.swisstopo.lk25-papierkarte-zusammensetzung.metadata"
 msgstr "Carta nazionale 1:25'000 stampata"

--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -40,6 +40,38 @@ class Gebaeuderegister(Base, Vector):
 register('ch.bfs.gebaeude_wohnungs_register', Gebaeuderegister)
 
 
+class GebaeuderegisterPreview(Base, Vector):
+    __tablename__ = 'view_adr_preview'
+    __table_args__ = ({'schema': 'bfs', 'autoload': False})
+    __template__ = 'templates/htmlpopup/gebaeuderegister.mako'
+    __bodId__ = 'ch.bfs.gebaeude_wohnungs_register_preview'
+    __label__ = 'strname_de'
+    id = Column('egid_edid', Unicode, primary_key=True)
+    egid = Column('egid', Integer)
+    strname1 = Column('strname1', Unicode, nullable=False)
+    strname_de = Column('strname_de', Unicode, nullable=True)
+    strname_fr = Column('strname_fr', Unicode, nullable=True)
+    strname_it = Column('strname_it', Unicode, nullable=True)
+    strname_rm = Column('strname_rm', Unicode, nullable=True)
+    deinr = Column('deinr', Unicode)
+    plz4 = Column('plz4', Integer, nullable=False)
+    plz6 = Column('plz6', Integer, nullable=False)
+    plzname = Column('plzname', Unicode)
+    gdename = Column('gdename', Unicode, nullable=False)
+    gdekt = Column('gdekt', Unicode)
+    gdename_de = Column('gdename_de', Unicode, nullable=True)
+    gdename_fr = Column('gdename_fr', Unicode, nullable=True)
+    gdename_it = Column('gdename_it', Unicode, nullable=True)
+    gdename_rm = Column('gdename_rm', Unicode, nullable=True)
+    dstrid = Column('dstrid', Integer)
+    gstat = Column('gstat', Integer)
+    gdenr = Column('gdenr', Integer)
+    bgdi_created = Column('bgdi_created', Unicode)
+    the_geom = Column(Geometry2D)
+
+register(GebaeuderegisterPreview.__bodId__, GebaeuderegisterPreview)
+
+
 class Agnes(Base, Vector):
     __tablename__ = 'agnes'
     __table_args__ = ({'schema': 'fpds', 'autoload': False})

--- a/chsdi/tests/integration/test_file_storage.py
+++ b/chsdi/tests/integration/test_file_storage.py
@@ -18,7 +18,7 @@ VALID_KML = '''<?xml version="1.0" encoding="UTF-8"?>
       <coordinates>7.0,46.0,0</coordinates>
     </Point>
   </Placemark>
-</kml>''' # noqa
+</kml>'''  # noqa
 
 URLENCODED_KML = '%3Ckml+xmlns=%22http%3A%2F%2Fwww.opengis.net%2Fkml%2F2.2%22+xmlns%3Axsi%3D%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema-instance%22+xsi%3AschemaLocation%3D%22http%3A%2F%2Fwww.opengis.net%2Fkml%2F2.2+https%3A%2F%2Fdevelopers.google.com%2Fkml%2Fschema%2Fkml22gx.xsd%22%3E%3CDocument%3E%3Cname%3EDrawing%3C%2Fname%3E%3CPlacemark%3E%3CStyle%3E%3CIconStyle%3E%3Cscale%3E0.25%3C%2Fscale%3E%3CIcon%3E%3Chref%3Ehttps%3A%2F%2Fmf-geoadmin3.dev.bgdi.ch%2Fltjeg%2F1432804593%2Fimg%2Fmaki%2Fcircle-24%402x.png%3C%2Fhref%3E%3Cgx%3Aw+xmlns%3Agx%3D%22http%3A%2F%2Fwww.google.com%2Fkml%2Fext%2F2.2%22%3E48%3C%2Fgx%3Aw%3E%3Cgx%3Ah+xmlns%3Agx%3D%22http%3A%2F%2Fwww.google.com%2Fkml%2Fext%2F2.2%22%3E48%3C%2Fgx%3Ah%3E%3C%2FIcon%3E%3ChotSpot+x%3D%2224%22+y%3D%2224%22+xunits%3D%22pixels%22+yunits%3D%22pixels%22+%2F%3E%3C%2FIconStyle%3E%3C%2FStyle%3E%3CPoint%3E%3Ccoordinates%3E6.724650291365927%2C46.804920188214076%3C%2Fcoordinates%3E%3C%2FPoint%3E%3C%2FPlacemark%3E%3CPlacemark%3E%3CStyle%3E%3CIconStyle%3E%3Cscale%3E0.25%3C%2Fscale%3E%3CIcon%3E%3Chref%3Ehttps%3A%2F%2Fmf-geoadmin3.dev.bgdi.ch%2Fltjeg%2F1432804593%2Fimg%2Fmaki%2Fcircle-24%402x.png%3C%2Fhref%3E%3Cgx%3Aw+xmlns%3Agx%3D%22http%3A%2F%2Fwww.google.com%2Fkml%2Fext%2F2.2%22%3E48%3C%2Fgx%3Aw%3E%3Cgx%3Ah+xmlns%3Agx%3D%22http%3A%2F%2Fwww.google.com%2Fkml%2Fext%2F2.2%22%3E48%3C%2Fgx%3Ah%3E%3C%2FIcon%3E%3ChotSpot+x%3D%2224%22+y%3D%2224%22+xunits%3D%22pixels%22+yunits%3D%22pixels%22+%2F%3E%3C%2FIconStyle%3E%3C%2FStyle%3E%3CPoint%3E%3Ccoordinates%3E6.728334379750007%2C46.52607115587267%3C%2Fcoordinates%3E%3C%2FPoint%3E%3C%2FPlacemark%3E%3C%2FDocument%3E%3C%2Fkml%3E'
 
@@ -44,7 +44,7 @@ INVALID_KML1_once = '''<?xml version="1.0" encoding="UTF-8"?>
       <coordinates>7.0,46.0,0</coordinates>
     </Point>
   </Placemark>
-</kml>''' # noqa
+</kml>'''  # noqa
 
 INVALID_KML2_once = '''<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
@@ -58,7 +58,7 @@ INVALID_KML2_once = '''<?xml version="1.0" encoding="UTF-8"?>
       <coordinates>7.0,46.0,0</coordinates>
     </Point>
   </Placemark>
-</kml>''' # noqa
+</kml>'''  # noqa
 
 INVALID_KML1 = '''<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
@@ -88,7 +88,7 @@ blabla random text blabla
       <coordinates>7.0,46.0,0</coordinates>
     </Point>
   </Placemark>
-</kml>''' # noqa
+</kml>'''  # noqa
 
 
 class TestFileView(TestsBase):

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -10,7 +10,15 @@ class TestSearchServiceView(TestsBase):
         self.assertIn('detail', attrs)
         self.assertIn('origin', attrs)
         self.assertIn('label', attrs)
-        if type_ == 'locations':
+        self.assertNotIn('detail_de', attrs)
+        self.assertNotIn('detail_fr', attrs)
+        self.assertNotIn('detail_it', attrs)
+        self.assertNotIn('detail_rm', attrs)
+        self.assertNotIn('label_de', attrs)
+        self.assertNotIn('label_fr', attrs)
+        self.assertNotIn('label_it', attrs)
+        self.assertNotIn('label_rm', attrs)
+        if type_ in ('locations',  'locations_preview'):
             self.assertIn('geom_quadindex', attrs)
             if returnGeometry:
                 self.assertIn('lon', attrs)
@@ -284,12 +292,12 @@ class TestSearchServiceView(TestsBase):
         }
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'chemin de fontenay  1007 lausanne 5586 lausanne ch vd')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'chemin de fontenay  1007 lausanne 5586 lausanne vd')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)
         params['sr'] = '2056'
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'chemin de fontenay  1007 lausanne 5586 lausanne ch vd')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'chemin de fontenay  1007 lausanne 5586 lausanne vd')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056)
 
     def test_search_locations_wilenstrasse_wil(self):
@@ -338,13 +346,13 @@ class TestSearchServiceView(TestsBase):
         }
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'avenue du mont-d\'or 1 1003 lausanne 5586 lausanne ch vd')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'avenue du mont-d\'or 1 1003 lausanne 5586 lausanne vd')
         self.assertEqual(resp.json['results'][0]['attrs']['num'], 1)
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)
         params['sr'] = '2056'
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'avenue du mont-d\'or 1 1003 lausanne 5586 lausanne ch vd')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'avenue du mont-d\'or 1 1003 lausanne 5586 lausanne vd')
         self.assertEqual(resp.json['results'][0]['attrs']['num'], 1)
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056)
 
@@ -355,7 +363,7 @@ class TestSearchServiceView(TestsBase):
         }
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'chemin isabelle-de-montolieu 2 1010 lausanne 5586 lausanne ch vd')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'chemin isabelle-de-montolieu 2 1010 lausanne 5586 lausanne vd')
         self.assertEqual(resp.json['results'][0]['attrs']['num'], 2)
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)
 
@@ -366,7 +374,7 @@ class TestSearchServiceView(TestsBase):
         }
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['results'][1]['attrs']['detail'], 'rhonesandstrasse 16a 3900 brig 6002 brig-glis ch vs')
+        self.assertEqual(resp.json['results'][1]['attrs']['detail'], 'rhonesandstrasse 16a 3900 brig 6002 brig-glis vs')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)
 
     def test_search_ranking(self):
@@ -382,7 +390,7 @@ class TestSearchServiceView(TestsBase):
             'searchText': 'gstaad 10'
         }
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'gstaadstrasse 10 3792 saanen 843 saanen ch be')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'gstaadstrasse 10 3792 saanen 843 saanen be')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)
 
     def test_search_features_identify(self):
@@ -515,13 +523,13 @@ class TestSearchServiceView(TestsBase):
             'bbox': '664100,268443,664150,268643'
         }
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ch ag')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ag')
         self.assertEqual(len(resp.json['results']), 1)
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781, spatialOrder=True)
         params['sr'] = '2056'
         params['bbox'] = shift_to_lv95(params['bbox'])
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ch ag')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ag')
         self.assertEqual(len(resp.json['results']), 1)
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056, spatialOrder=True)
 
@@ -532,12 +540,12 @@ class TestSearchServiceView(TestsBase):
             'bbox': '564100,168443,664150,268643'
         }
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ch ag')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ag')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781, spatialOrder=True)
         params['sr'] = '2056'
         params['bbox'] = shift_to_lv95(params['bbox'])
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ch ag')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ag')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056, spatialOrder=True)
         params = {
             'type': 'locations',
@@ -546,7 +554,7 @@ class TestSearchServiceView(TestsBase):
             'sortbbox': 'true'
         }
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ch ag')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli 1 5306 tegerfelden 4320 tegerfelden ag')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781, spatialOrder=True)
         params = {
             'type': 'locations',
@@ -555,7 +563,7 @@ class TestSearchServiceView(TestsBase):
             'sortbbox': 'false'
         }
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
-        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ch ag')
+        self.assertEqual(resp.json['results'][0]['attrs']['detail'], 'buechli  5306 tegerfelden 4320 tegerfelden ag')
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)
 
     def test_search_locations_bbox_only(self):
@@ -855,3 +863,43 @@ class TestSearchServiceView(TestsBase):
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertGreater(len(resp.json['results']), 0)
         self.assertEqual(resp.json['fuzzy'], 'true')
+
+    def test_search_lang_param_same_entry(self):
+        params = {
+            'type': 'locations_preview',
+            'searchLang': 'fr',
+            'searchText': 'boujean',
+            'origins': 'address',
+            'sr': '2056'
+        }
+        resp_fr = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.assertAttrs('locations_preview', resp_fr.json['results'][0]['attrs'], 2056)
+        params = {
+            'type': 'locations_preview',
+            'searchLang': 'de',
+            'searchText': 'bözingenstrasse',
+            'origins': 'address',
+            'sr': '2056'
+        }
+        resp_de = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.assertAttrs('locations_preview', resp_de.json['results'][0]['attrs'], 2056)
+        self.assertEqual(resp_fr.json['results'][0]['attrs']['featureId'], resp_de.json['results'][0]['attrs']['featureId'])
+
+    def test_search_lang_param_no_preview(self):
+        params = {
+            'type': 'locations',
+            'searchLang': 'fr',
+            'searchText': 'boujean'
+        }
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)
+
+    def test_search_lang_with_lang(self):
+        params = {
+            'type': 'locations_preview',
+            'searchLang': 'fr',
+            'lang': 'de',
+            'searchText': 'boujean'
+        }
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.assertAttrs('locations_preview', resp.json['results'][0]['attrs'], 21781)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -79,11 +79,12 @@ def view_attribute_values_geojson(request):
 def _get_feature_info_for_popup(request, params, isExtended=False, isIframe=False):
     feature, vector_model = next(_get_features(params))
     layerModel = get_bod_model(params.lang)
+    # TODO Remove this ugly hack
     layer = next(get_layers_metadata_for_params(
         params,
         request.db.query(layerModel),
         layerModel,
-        layerIds=[params.layerId]
+        layerIds=[params.layerId if params.layerId != 'ch.bfs.gebaeude_wohnungs_register_preview' else 'ch.bfs.gebaeude_wohnungs_register']
     ))
     options = {}
     if 'feature' in feature:


### PR DESCRIPTION
Works with https://github.com/geoadmin/service-sphinxsearch/pull/343/files

This is an early version of the integration of  the new addresses in the search.

For now we only have  the addresses in the `locations_preview` service, it is based on the very first gdb created by Elias which I imported in `kogis_master.bfs.gwr_addresses` and I created the view `bfs.adressen_sphinx_preview` for sphinx.

That makes the search language specific which is somewhat incompatible with what we have at the moment.

In geoadmin for instance we always provide the `lang` parameter which will determine the language of the label and not apply filters like it is requested for the regBL project.

Therefore we have to introduce a new parameter to support regBL use case and still be backward compatible with geoadmin.
I propose we use the parameter `searchLang` to support both use cases.

Language rules will be applied as follow:
`lang=de`: current behaviour. search is performed in all languages and labels are returned in german
`searchLang=de`: we search only in the german fields and we return the labels in german

As explained earlier I still needed to add a generic detail field (search text) to keep the current behavior of the search as we want to search in all the addresses all the time.

[1]
We currently have overall 18'112 addresses for which we have multiple languages.

The only combinations we have are:

de-fr: 17'020
de-rm: 1'092

-> 17'020 + 1'092 = 18'112 -> CQFD

So the general detail field (the search text) would hold one of the 4 languages or a combination of at most 2 languages.
So at the moment we only have one language in the generic detail field.
(if de -> de elif fr -> fr elif it -> it else -> rm) 
Combining different address langs in the detail field may have undesired side effects on the search ranking.

[1]
```sql
SELECT count(a.sum_of_notnulls) as nb_multiple_langs
FROM
(SELECT (
 CASE WHEN stn_strname_de is NULL THEN 0 ELSE 1 END +
 CASE WHEN stn_strname_fr is NULL THEN 0 ELSE 1 END +
 CASE WHEN stn_strname_it is NULL THEN 0 ELSE 1 END +
 CASE WHEN stn_strname_rm is NULL THEN 0 ELSE 1 END
) as sum_of_notnulls
FROM bfs.gwr_addresses) a
WHERE a.sum_of_notnulls > 1
```
I will also have to introduce some redundancy in the other indices that are involved in the locations search as I can't combine distributed indices that have a different structure. (thus indexing each detail field 5 extra times, but I may be able to tweak it)

De only
[Test Link Seftigenstrasse De](http://mf-chsdi3.dev.bgdi.ch/gal_regbl/rest/services/api/SearchServer?searchText=seftigenstrasse&type=locations_preview&searchLang=de)
[Test Link Seftigenstrasse Fr](http://mf-chsdi3.dev.bgdi.ch/gal_regbl/rest/services/api/SearchServer?searchText=seftigenstrasse&type=locations_preview&searchLang=fr)

De and Fr (entry in both french and german see feature_id):
[Test Link boujean Fr](http://mf-chsdi3.dev.bgdi.ch/gal_regbl/rest/services/api/SearchServer?searchText=boujean&type=locations_preview&searchLang=fr)
[Test Link bözingenstrasse De](http://mf-chsdi3.dev.bgdi.ch/gal_regbl/rest/services/api/SearchServer?searchText=bözingenstrasse&type=locations_preview&searchLang=de)

ping @gjn @cedricmoullet @ltclm 
