### PR TITLE
Remove dot from location search

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -127,6 +127,13 @@ def format_search_text(input_str):
     )
 
 
+def format_locations_search_text(input_str):
+    if input_str is None:
+        return input_str
+    input_str = input_str.replace('.', '')
+    return format_search_text(input_str)
+
+
 def remove_accents(input_str):
     if input_str is None:
         return input_str

--- a/chsdi/tests/integration/test_search.py
+++ b/chsdi/tests/integration/test_search.py
@@ -348,6 +348,29 @@ class TestSearchServiceView(TestsBase):
         self.assertEqual(resp.json['results'][0]['attrs']['num'], 1)
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056)
 
+    def test_locations_searchtext_abbreviations(self):
+        params = {
+            'type': 'locations',
+            'searchText': 'Seftigenstr.',
+            'sr': '2056'
+        }
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056)
+        params = {
+            'type': 'locations',
+            'searchText': 'Bundespl.',
+            'sr': '2056'
+        }
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056)
+        params = {
+            'type': 'locations',
+            'searchText': 'pl. du March',
+            'sr': '2056'
+        }
+        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
+        self.assertAttrs('locations', resp.json['results'][0]['attrs'], 2056)
+
     def test_address_order(self):
         params = {
             'type': 'locations',

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -7,7 +7,8 @@ from pyramid.view import view_config
 from shapely.geometry import box, Point
 
 from chsdi.lib.validation.search import SearchValidation
-from chsdi.lib.helpers import format_search_text, transform_coordinate, parse_box2d, shift_to
+from chsdi.lib.helpers import format_search_text, format_locations_search_text
+from chsdi.lib.helpers import transform_coordinate, parse_box2d, shift_to
 from chsdi.lib.helpers import center_from_box2d
 from chsdi.lib.sphinxapi import sphinxapi
 from chsdi.lib import mortonspacekey as msk
@@ -71,7 +72,7 @@ class Search(SearchValidation):
             )
             self._feature_search()
         elif self.typeInfo in ('locations', 'locations_preview'):
-            self.searchText = format_search_text(
+            self.searchText = format_locations_search_text(
                 self.request.params.get('searchText', '')
             )
             # swiss search


### PR DESCRIPTION
I analyzed locations content, we should be able to remove the dots from the location search.
Fix for https://github.com/geoadmin/mf-chsdi3/issues/2726 and https://github.com/geoadmin/mf-geoadmin3/issues/4036
[Test Link](https://mf-chsdi3.int.bgdi.ch/search_locations_special_charaters/shorten/773d811bd8)