### PR TITLE
WSGI: Use 4 processes in prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ apache/wsgi.conf: apache/wsgi.conf.in apache/application.wsgi
 		--var "git_branch=$(GIT_BRANCH)" \
 		--var "current_directory=$(CURRENT_DIRECTORY)" \
 		--var "modwsgi_user=$(MODWSGI_USER)" \
+		--var "wsgi_processes=$(WSGI_PROCESSES)" \
 		--var "wsgi_threads=$(WSGI_THREADS)" \
 		--var "wsgi_app=$(WSGI_APP)" \
 		--var "kml_temp_dir=$(KML_TEMP_DIR)" $< > $@

--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -76,7 +76,7 @@ RewriteRule ^${apache_entry_path}/(.*)$ ${apache_entry_path}/shorten/$1 [PT]
 
 # define a process group
 # WSGIDaemonProcess, default are 1 process and 15 threads
-WSGIDaemonProcess mf-chsdi3:${apache_base_path} display-name=%{GROUP} user=${modwsgi_user} threads=${wsgi_threads}
+WSGIDaemonProcess mf-chsdi3:${apache_base_path} display-name=%{GROUP} user=${modwsgi_user} processes=${wsgi_processes} threads=${wsgi_threads}
 
 # define the path to the WSGI app
 WSGIScriptAliasMatch ^${apache_entry_path}/ ${wsgi_app}/

--- a/rc_dev
+++ b/rc_dev
@@ -19,6 +19,7 @@ export SPHINXHOST=service-sphinxsearch.dev.bgdi.ch
 export VECTOR_BUCKET=mwks6dv2y5dsbbgg-vectortiles
 export VECTOR_PROFILENAME=chsdi_aws_admin_ro
 export WMSHOST=wms-bgdi.dev.bgdi.ch
+export WSGI_PROCESSES=1
 export WSGI_THREADS=15
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
 export LINKEDDATAHOST=https://ld.geo.admin.ch

--- a/rc_int
+++ b/rc_int
@@ -19,6 +19,7 @@ export SPHINXHOST=service-sphinxsearch.int.bgdi.ch
 export VECTOR_BUCKET=mwks6dv2y5dsbbgg-vectortiles
 export VECTOR_PROFILENAME=chsdi_aws_admin_ro
 export WMSHOST=wms-bgdi.int.bgdi.ch
+export WSGI_PROCESSES=1
 export WSGI_THREADS=15
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
 export LINKEDDATAHOST=https://ld.geo.admin.ch

--- a/rc_prod
+++ b/rc_prod
@@ -19,6 +19,7 @@ export SPHINXHOST=service-sphinxsearch.prod.bgdi.ch
 export VECTOR_BUCKET=mwks6dv2y5dsbbgg-vectortiles
 export VECTOR_PROFILENAME=chsdi_aws_admin_ro
 export WMSHOST=wms.geo.admin.ch
+export WSGI_PROCESSES=4
 export WSGI_THREADS=30
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
 export LINKEDDATAHOST=https://ld.geo.admin.ch


### PR DESCRIPTION
I made some tests and I think we're being overly conservative by using only one process and 15 threads in prod.
Our machines have no charge, but they can't process any more requests.
It seems that increasing the number of processes to 4 already improves the situation drastically while remaining conservative.

Doc for wsgi daemon can be found here:
http://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIDaemonProcess.html

@gjn @procrastinatio Do you agree?

I made some batch tests on the WMTS get cap document and here are the results (I kept the best of 5):

```
$ ab -n 150 -c 50 http://mf-chsdi3.dev.bgdi.ch/ltgal/EPSG/4326/1.0.0/WMTSCapabilities.xml
1

This is ApacheBench, Version 2.3 <$Revision: 1604373 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking mf-chsdi3.dev.bgdi.ch (be patient).....done


Server Software:        Apache/2.4.10
Server Hostname:        mf-chsdi3.dev.bgdi.ch
Server Port:            80

Document Path:          /ltgal/EPSG/4326/1.0.0/WMTSCapabilities.xml
Document Length:        787802 bytes

Concurrency Level:      50
Time taken for tests:   25.322 seconds
Complete requests:      150
Failed requests:        0
Total transferred:      118245899 bytes
HTML transferred:       118170300 bytes
Requests per second:    5.92 [#/sec] (mean)
Time per request:       8440.616 [ms] (mean)
Time per request:       168.812 [ms] (mean, across all concurrent requests)
Transfer rate:          4560.27 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        1    2   1.0      2       8
Processing:  1722 7450 1962.2   8278    9747
Waiting:     1659 7395 1979.7   8233    9692
Total:       1724 7452 1962.1   8280    9751

Percentage of the requests served within a certain time (ms)
  50%   8280
  66%   8495
  75%   8619
  80%   8675
  90%   8868
  95%   9134
  98%   9309
  99%   9349
 100%   9751 (longest request)


4

This is ApacheBench, Version 2.3 <$Revision: 1604373 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking mf-chsdi3.dev.bgdi.ch (be patient).....done


Server Software:        Apache/2.4.10
Server Hostname:        mf-chsdi3.dev.bgdi.ch
Server Port:            80

Document Path:          /ltgal/EPSG/4326/1.0.0/WMTSCapabilities.xml
Document Length:        787802 bytes

Concurrency Level:      50
Time taken for tests:   9.361 seconds
Complete requests:      150
Failed requests:        0
Total transferred:      118245899 bytes
HTML transferred:       118170300 bytes
Requests per second:    16.02 [#/sec] (mean)
Time per request:       3120.189 [ms] (mean)
Time per request:       62.404 [ms] (mean, across all concurrent requests)
Transfer rate:          12336.27 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        1    2   1.4      2      12
Processing:   492 2844 870.4   3011    4209
Waiting:      466 2800 865.3   2973    4168
Total:        493 2846 870.6   3013    4215

Percentage of the requests served within a certain time (ms)
  50%   3013
  66%   3358
  75%   3550
  80%   3659
  90%   4007
  95%   4125
  98%   4171
  99%   4186
 100%   4215 (longest request)

8

This is ApacheBench, Version 2.3 <$Revision: 1604373 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking mf-chsdi3.dev.bgdi.ch (be patient).....done


Server Software:        Apache/2.4.10
Server Hostname:        mf-chsdi3.dev.bgdi.ch
Server Port:            80

Document Path:          /ltgal/EPSG/4326/1.0.0/WMTSCapabilities.xml
Document Length:        787802 bytes

Concurrency Level:      50
Time taken for tests:   8.656 seconds
Complete requests:      150
Failed requests:        0
Total transferred:      118245900 bytes
HTML transferred:       118170300 bytes
Requests per second:    17.33 [#/sec] (mean)
Time per request:       2885.436 [ms] (mean)
Time per request:       57.709 [ms] (mean, across all concurrent requests)
Transfer rate:          13339.93 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        1    2   1.0      2       6
Processing:   335 2686 1138.2   2672    4841
Waiting:      303 2627 1126.9   2588    4672
Total:        337 2688 1138.1   2674    4842

Percentage of the requests served within a certain time (ms)
  50%   2674
  66%   3258
  75%   3654
  80%   3825
  90%   4236
  95%   4463
  98%   4698
  99%   4825
 100%   4842 (longest request)


12
$ ab -n 150 -c 50 http://mf-chsdi3.dev.bgdi.ch/ltgal/EPSG/4326/1.0.0/WMTSCapabilities.xml
This is ApacheBench, Version 2.3 <$Revision: 1604373 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking mf-chsdi3.dev.bgdi.ch (be patient).....done


Server Software:        Apache/2.4.10
Server Hostname:        mf-chsdi3.dev.bgdi.ch
Server Port:            80

Document Path:          /ltgal/EPSG/4326/1.0.0/WMTSCapabilities.xml
Document Length:        787802 bytes

Concurrency Level:      50
Time taken for tests:   8.469 seconds
Complete requests:      150
Failed requests:        0
Total transferred:      118245898 bytes
HTML transferred:       118170300 bytes
Requests per second:    17.71 [#/sec] (mean)
Time per request:       2823.036 [ms] (mean)
Time per request:       56.461 [ms] (mean, across all concurrent requests)
Transfer rate:          13634.79 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        1    3   3.0      2      23
Processing:   301 2548 1195.4   2594    4432
Waiting:      275 2475 1155.6   2552    4411
Total:        302 2551 1196.2   2595    4433

Percentage of the requests served within a certain time (ms)
  50%   2595
  66%   3260
  75%   3674
  80%   3860
  90%   4170
  95%   4240
  98%   4270
  99%   4270
 100%   4433 (longest request)
```
 