### PR TITLE
No stabil_id for ch.bav.anlagen-schienengueterverkehr

### DIFF
--- a/chsdi/templates/htmlpopup/anlagen_schienengueterverkehr.mako
+++ b/chsdi/templates/htmlpopup/anlagen_schienengueterverkehr.mako
@@ -2,7 +2,6 @@
 
 <%def name="table_body(c, lang)">
 <%
-    c['stable_id'] = True
     lang = lang if lang in ('fr','it') else 'de'
     typ = 'typ_%s' % lang
 %>


### PR DESCRIPTION
After discussion with Mario, there is no need for a stabil_id  for this layer 