### PR TITLE
Update in tooltip of ch.bafu.schutzgebiete-paerke_nationaler_bedeutung*

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -5852,8 +5852,29 @@ msgstr "Emissionsplan Eisenbahnlärm 2015 T"
 msgid "ch.lw"
 msgstr "LW"
 
+msgid "ch.meteoschweiz"
+msgstr "MeteoSchweiz"
+
 msgid "ch.meteoschweiz.globalstrahlung-monatlich"
 msgstr "Globalstrahlung test"
+
+msgid "ch.meteoschweiz.messdaten-foehn"
+msgstr "Messdaten Föhn"
+
+msgid "ch.meteoschweiz.messdaten-globalstrahlung"
+msgstr "Messdaten Globalstrahlung"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qfe"
+msgstr "Messdaten Luftdruck Stationshöhe QFE"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qff"
+msgstr "Messdaten Luftdruck Meereshöhe QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qnh"
+msgstr "Messdaten Luftdruck Meereshöhe QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftfeuchtigkeit"
+msgstr "Messdaten Luftfeuchtigkeit"
 
 msgid "ch.meteoschweiz.messdaten-lufttemperatur"
 msgstr "Messdaten Lufttemperatur"
@@ -5863,6 +5884,18 @@ msgstr "Messdaten Niederschlag"
 
 msgid "ch.meteoschweiz.messdaten-niederschlag-tagessummen"
 msgstr "Messdaten Niederschlag Tagessumme"
+
+msgid "ch.meteoschweiz.messdaten-sonnenscheindauer"
+msgstr "Messdaten Sonnenscheindauer"
+
+msgid "ch.meteoschweiz.messdaten-taupunkt"
+msgstr "Messdaten Taupunkt"
+
+msgid "ch.meteoschweiz.messdaten-wind-boenspitze"
+msgstr "Messdaten Böenspitze"
+
+msgid "ch.meteoschweiz.messdaten-windgeschwindigkeit"
+msgstr "Messdaten Windgeschwindigkeit"
 
 msgid "ch.mobility.standorte"
 msgstr "Carsharing"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -5852,8 +5852,29 @@ msgstr "Emissionsplan Eisenbahnlärm 2015 T"
 msgid "ch.lw"
 msgstr "AF"
 
+msgid "ch.meteoschweiz"
+msgstr "MeteoSwiss"
+
 msgid "ch.meteoschweiz.globalstrahlung-monatlich"
 msgstr "Globalstrahlung test"
+
+msgid "ch.meteoschweiz.messdaten-foehn"
+msgstr "Foehn data"
+
+msgid "ch.meteoschweiz.messdaten-globalstrahlung"
+msgstr "Global radiation data"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qfe"
+msgstr "Air pressure at station altitude QFE"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qff"
+msgstr "Air pressure reduced at sea level QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qnh"
+msgstr "Air pressure reduced at sea level QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftfeuchtigkeit"
+msgstr "Humidity data"
 
 msgid "ch.meteoschweiz.messdaten-lufttemperatur"
 msgstr "Air temperature data"
@@ -5863,6 +5884,18 @@ msgstr "Precipitation data"
 
 msgid "ch.meteoschweiz.messdaten-niederschlag-tagessummen"
 msgstr "Precipitation data daily values"
+
+msgid "ch.meteoschweiz.messdaten-sonnenscheindauer"
+msgstr "Sunshine duration data"
+
+msgid "ch.meteoschweiz.messdaten-taupunkt"
+msgstr "Dew point data"
+
+msgid "ch.meteoschweiz.messdaten-wind-boenspitze"
+msgstr "Wind gust data"
+
+msgid "ch.meteoschweiz.messdaten-windgeschwindigkeit"
+msgstr "Wind speed data"
 
 msgid "ch.mobility.standorte"
 msgstr "Carsharing"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -5852,8 +5852,29 @@ msgstr "Emissionsplan Eisenbahnlärm 2015 T"
 msgid "ch.lw"
 msgstr "LW"
 
+msgid "ch.meteoschweiz"
+msgstr "MeteoSchweiz"
+
 msgid "ch.meteoschweiz.globalstrahlung-monatlich"
 msgstr "Globalstrahlung test"
+
+msgid "ch.meteoschweiz.messdaten-foehn"
+msgstr "Messdaten Föhn"
+
+msgid "ch.meteoschweiz.messdaten-globalstrahlung"
+msgstr "Messdaten Globalstrahlung"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qfe"
+msgstr "Messdaten Luftdruck Stationshöhe QFE"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qff"
+msgstr "Messdaten Luftdruck Meereshöhe QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qnh"
+msgstr "Messdaten Luftdruck Meereshöhe QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftfeuchtigkeit"
+msgstr "Messdaten Luftfeuchtigkeit"
 
 msgid "ch.meteoschweiz.messdaten-lufttemperatur"
 msgstr "Messdaten Lufttemperatur"
@@ -5863,6 +5884,18 @@ msgstr "Messdaten Niederschlag"
 
 msgid "ch.meteoschweiz.messdaten-niederschlag-tagessummen"
 msgstr "Messdaten Niederschlag Tagessumme"
+
+msgid "ch.meteoschweiz.messdaten-sonnenscheindauer"
+msgstr "Messdaten Sonnenscheindauer"
+
+msgid "ch.meteoschweiz.messdaten-taupunkt"
+msgstr "Messdaten Taupunkt"
+
+msgid "ch.meteoschweiz.messdaten-wind-boenspitze"
+msgstr "Messdaten Böenspitze"
+
+msgid "ch.meteoschweiz.messdaten-windgeschwindigkeit"
+msgstr "Messdaten Windgeschwindigkeit"
 
 msgid "ch.mobility.standorte"
 msgstr "Carsharing"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -5852,8 +5852,29 @@ msgstr "Rép. émissions sonores ferr. 2015 J"
 msgid "ch.lw"
 msgstr "FA"
 
+msgid "ch.meteoschweiz"
+msgstr "MétéoSuisse"
+
 msgid "ch.meteoschweiz.globalstrahlung-monatlich"
 msgstr "Globalstrahlung test"
+
+msgid "ch.meteoschweiz.messdaten-foehn"
+msgstr "Données foehn"
+
+msgid "ch.meteoschweiz.messdaten-globalstrahlung"
+msgstr "Données rayonnement global"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qfe"
+msgstr "Pression atmosphérique altitude station QFE"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qff"
+msgstr "Pression atmosphérique réduite niveau mer QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qnh"
+msgstr "Pression atmosphérique réduite niveau mer QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftfeuchtigkeit"
+msgstr "Données humidité"
 
 msgid "ch.meteoschweiz.messdaten-lufttemperatur"
 msgstr "Données température de l'air"
@@ -5863,6 +5884,18 @@ msgstr "Données de précipitations"
 
 msgid "ch.meteoschweiz.messdaten-niederschlag-tagessummen"
 msgstr "Données de précipitations journalière"
+
+msgid "ch.meteoschweiz.messdaten-sonnenscheindauer"
+msgstr "Données durée d'ensoleillement"
+
+msgid "ch.meteoschweiz.messdaten-taupunkt"
+msgstr "Données point de rosée"
+
+msgid "ch.meteoschweiz.messdaten-wind-boenspitze"
+msgstr "Données rafales"
+
+msgid "ch.meteoschweiz.messdaten-windgeschwindigkeit"
+msgstr "Données vitesse du vent"
 
 msgid "ch.mobility.standorte"
 msgstr "Autopartage (carsharing)"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -5852,8 +5852,29 @@ msgstr "Piano emissioni foniche ferr 2015 G"
 msgid "ch.lw"
 msgstr "FA"
 
+msgid "ch.meteoschweiz"
+msgstr "MeteoSvizzera"
+
 msgid "ch.meteoschweiz.globalstrahlung-monatlich"
 msgstr "Globalstrahlung test"
+
+msgid "ch.meteoschweiz.messdaten-foehn"
+msgstr "Dati favonio"
+
+msgid "ch.meteoschweiz.messdaten-globalstrahlung"
+msgstr "Dati radiazione globale"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qfe"
+msgstr "Pressione alla stazione QFE"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qff"
+msgstr "Pressione ridotta livello mare QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftdruck-qnh"
+msgstr "Pressione ridotta livello mare QFF"
+
+msgid "ch.meteoschweiz.messdaten-luftfeuchtigkeit"
+msgstr "Dati umidità"
 
 msgid "ch.meteoschweiz.messdaten-lufttemperatur"
 msgstr "Dati temperatura aria"
@@ -5863,6 +5884,18 @@ msgstr "Dati precipitazioni"
 
 msgid "ch.meteoschweiz.messdaten-niederschlag-tagessummen"
 msgstr "Dati precipitazioni giornaliere"
+
+msgid "ch.meteoschweiz.messdaten-sonnenscheindauer"
+msgstr "Dati soleggiamento"
+
+msgid "ch.meteoschweiz.messdaten-taupunkt"
+msgstr "Dati punto di rugiada"
+
+msgid "ch.meteoschweiz.messdaten-wind-boenspitze"
+msgstr "Dati raffica"
+
+msgid "ch.meteoschweiz.messdaten-windgeschwindigkeit"
+msgstr "Dati velocità del vento"
 
 msgid "ch.mobility.standorte"
 msgstr "Carsharing"

--- a/chsdi/models/vector/bafu.py
+++ b/chsdi/models/vector/bafu.py
@@ -1572,6 +1572,7 @@ class PaerkeNationalerBedeutung (Base, Paerke, Vector):
     teil_nummer = Column('teil_nummer', Integer)
     objektnummer = Column('objektnummer', Integer)
     zone = Column('zone', Unicode)
+    shape_area = Column('shape_area', Numeric)
 
 register('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung', PaerkeNationalerBedeutung)
 
@@ -1581,6 +1582,7 @@ class PaerkeNationalerBedeutungPerimeter(Base, Paerke, Vector):
     __bodId__ = 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter'
     __template__ = 'templates/htmlpopup/paerke_nationaler_bedeutung_perimeter.mako'
     id = Column('objektnummer', Integer, primary_key=True)
+    shape_area = Column('shape_area', Numeric)
 
 register('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter', PaerkeNationalerBedeutungPerimeter)
 

--- a/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung.mako
+++ b/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung.mako
@@ -6,12 +6,12 @@ kategorie = '%s_%s' % ('kategorie',c['attributes']['kategorie'])
 zone = '%s_%s' % ('zone',c['attributes']['zone'])
 rechtsgrundlage = '%s_%s' % ('rechtsgrundlage',c['attributes']['rechtsgrundlage'])
 %>
-    <tr><td class="cell-left">${_('name')}</td>                 <td>${c['attributes']['name'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('objnummer')}</td>            <td>${int(c['attributes']['objektnummer']) or '-'}</td></tr>
-    <tr><td class="cell-left">${_('status')}</td>               <td>${_(status)}</td></tr>
-    <tr><td class="cell-left">${_('kategorie')}</td>            <td>${_(kategorie)}</td></tr>
-    <tr><td class="cell-left">${_('rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
-    <tr><td class="cell-left">${_('teilobjnummer')}</td>        <td>${c['attributes']['teil_nummer'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('zone')}</td>                 <td>${_(zone)}</td></tr>
-    <tr><td class="cell-left">${_('ch.bafu.bundesinventare-moorlandschaften.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.name')}</td>                 <td>${c['attributes']['name'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.objnummer')}</td>            <td>${int(c['attributes']['objektnummer']) or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.status')}</td>               <td>${_(status)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.kategorie')}</td>            <td>${_(kategorie)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.teilobjnummer')}</td>        <td>${c['attributes']['teil_nummer'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.zone')}</td>                 <td>${_(zone)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung.mako
+++ b/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung.mako
@@ -13,4 +13,5 @@ rechtsgrundlage = '%s_%s' % ('rechtsgrundlage',c['attributes']['rechtsgrundlage'
     <tr><td class="cell-left">${_('rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
     <tr><td class="cell-left">${_('teilobjnummer')}</td>        <td>${c['attributes']['teil_nummer'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('zone')}</td>                 <td>${_(zone)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.bundesinventare-moorlandschaften.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung.mako
+++ b/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung.mako
@@ -13,5 +13,5 @@ rechtsgrundlage = '%s_%s' % ('rechtsgrundlage',c['attributes']['rechtsgrundlage'
     <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
     <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.teilobjnummer')}</td>        <td>${c['attributes']['teil_nummer'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.zone')}</td>                 <td>${_(zone)}</td></tr>
-    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1)}</td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung_perimeter.mako
+++ b/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung_perimeter.mako
@@ -11,5 +11,5 @@ rechtsgrundlage = '%s_%s' % ('rechtsgrundlage',c['attributes']['rechtsgrundlage'
     <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.status')}</td>               <td>${_(status)}</td></tr>
     <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.kategorie')}</td>            <td>${_(kategorie)}</td></tr>
     <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
-    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1)}</td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung_perimeter.mako
+++ b/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung_perimeter.mako
@@ -11,4 +11,5 @@ rechtsgrundlage = '%s_%s' % ('rechtsgrundlage',c['attributes']['rechtsgrundlage'
     <tr><td class="cell-left">${_('status')}</td>               <td>${_(status)}</td></tr>
     <tr><td class="cell-left">${_('kategorie')}</td>            <td>${_(kategorie)}</td></tr>
     <tr><td class="cell-left">${_('rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.bundesinventare-moorlandschaften.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung_perimeter.mako
+++ b/chsdi/templates/htmlpopup/paerke_nationaler_bedeutung_perimeter.mako
@@ -6,10 +6,10 @@ status = '%s_%s' % ('status',c['attributes']['status'])
 kategorie = '%s_%s' % ('kategorie',c['attributes']['kategorie'])
 rechtsgrundlage = '%s_%s' % ('rechtsgrundlage',c['attributes']['rechtsgrundlage'])
 %>
-    <tr><td class="cell-left">${_('name')}</td>                 <td>${c['attributes']['name'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('objnummer')}</td>            <td>${c['featureId'] or '-'}</td>
-    <tr><td class="cell-left">${_('status')}</td>               <td>${_(status)}</td></tr>
-    <tr><td class="cell-left">${_('kategorie')}</td>            <td>${_(kategorie)}</td></tr>
-    <tr><td class="cell-left">${_('rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
-    <tr><td class="cell-left">${_('ch.bafu.bundesinventare-moorlandschaften.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.name')}</td>                 <td>${c['attributes']['name'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.objnummer')}</td>            <td>${c['featureId'] or '-'}</td>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.status')}</td>               <td>${_(status)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.kategorie')}</td>            <td>${_(kategorie)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.rechtsgrundlage')}</td>      <td>${_(rechtsgrundlage)}</td></tr>
+    <tr><td class="cell-left">${_('ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter.shape_area')}</td>         <td>${round(c['attributes']['shape_area']/10000,1) or '-'}</td></tr>
 </%def>


### PR DESCRIPTION
Update for two layers: 
- ch.bafu.schutzgebiete-paerke_nationaler_bedeutung
- ch.bafu.schutzgebiete-paerke_nationaler_bedeutung_perimeter

[Testlink](https://mf-chsdi3.int.bgdi.ch/ltpin_paerke/shorten/77ec8fdf62)
  
  