### PR TITLE
Custom apache Cache-Control header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,8 @@ apache/wsgi.conf: apache/wsgi.conf.in apache/application.wsgi
 		--var "branch_staging=$(BRANCH_STAGING)" \
 		--var "git_branch=$(GIT_BRANCH)" \
 		--var "current_directory=$(CURRENT_DIRECTORY)" \
+		--var "deploy_target=$(DEPLOY_TARGET)" \
+		--var "cache_control=$(CACHE_CONTROL)" \
 		--var "modwsgi_user=$(MODWSGI_USER)" \
 		--var "wsgi_processes=$(WSGI_PROCESSES)" \
 		--var "wsgi_threads=$(WSGI_THREADS)" \

--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -35,11 +35,16 @@ RedirectMatch permanent ^${apache_entry_path}/iipimage/(.*)$ ${apache_entry_path
 # Redirect no-slash target to slashed version
 RedirectMatch ^${apache_entry_path}$ ${apache_entry_path}/
 
+
+
 # If URI has numbers at the start, we cache a year
 # This allows a client to create their own cache and
 # update at his discretion
 RewriteRule ^${apache_entry_path}/[0-9]+/(.*)$ ${apache_entry_path}/$1 [E=${apache_base_path}setyearcache:true,PT]
 Header merge Cache-Control "max-age=31536013, public" env=${apache_base_path}setyearcache
+
+# Default cache#
+Header setifempty  Cache-Control "${cache_control}"
 
 # Static for cross domain flash/arcgis
 RewriteRule ^${apache_entry_path}/(crossdomain.xml|clientaccesspolicy.xml) ${apache_entry_path}/static/$1 [PT]

--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -126,14 +126,9 @@ RewriteRule ^${apache_entry_path}/admin         https://%{HTTP_HOST}%{REQUEST_UR
     Require group iwi-team bgdi-team
 </LocationMatch>
 
-# MapProxy access control
+# WMTS GetCapabilities access control
 RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.EPSG.(\d+).xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,QSA,PT]
 RewriteRule ^${apache_entry_path}/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml [L,QSA,PT]
 # Better ArcGis support
 RewriteRule ^${apache_entry_path}/EPSG/(\d+)/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1 [L,QSA,PT]
 RewriteRule ^${apache_entry_path}/EPSG/(\d+)/(de|fr|it|rm|en)/1.0.0/WMTSCapabilities.xml ${apache_entry_path}/rest/services/api/1.0.0/WMTSCapabilities.xml?epsg=$1&lang=$2 [L,PT]
-
-# No GetFeatureInfo request is allowed for WMS service
-RewriteCond %{QUERY_STRING} SERVICE=WMS [NC]
-RewriteCond %{QUERY_STRING} REQUEST=GetFeatureInfo [NC]
-RewriteRule ^${apache_entry_path}/mapproxy/service - [F]

--- a/rc_ci
+++ b/rc_ci
@@ -7,3 +7,4 @@ export GEOADMINHOST=mf-geoadmin3.ci.bgdi.ch
 export HOST=mf-chsdi3.ci.bgdi.ch
 export KEEP_VERSION=false
 export WMTS_PUBLIC_HOST=tod.dev.bgdi.ch
+export CACHE_CONTROL=no-cache

--- a/rc_dev
+++ b/rc_dev
@@ -23,3 +23,4 @@ export WSGI_PROCESSES=1
 export WSGI_THREADS=15
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
 export LINKEDDATAHOST=https://ld.geo.admin.ch
+export CACHE_CONTROL=no-cache

--- a/rc_int
+++ b/rc_int
@@ -23,3 +23,4 @@ export WSGI_PROCESSES=1
 export WSGI_THREADS=15
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
 export LINKEDDATAHOST=https://ld.geo.admin.ch
+export CACHE_CONTROL=max-age=1800, public

--- a/rc_prod
+++ b/rc_prod
@@ -23,3 +23,4 @@ export WSGI_PROCESSES=4
 export WSGI_THREADS=30
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
 export LINKEDDATAHOST=https://ld.geo.admin.ch
+export CACHE_CONTROL=max-age=1800, public


### PR DESCRIPTION
**Cache**
```
curl -I http://mf-chsdi3.int.bgdi.ch/mom_apache_headers/666666/rest/services/api/MapServer/ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
HTTP/1.1 200 OK
Cache-Control: max-age=31536013, public
```

**No cache**
```
curl -I http://mf-chsdi3.int.bgdi.ch/mom_apache_headers/rest/services/api/MapServer/ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill
HTTP/1.1 200 OK
Cache-Control: max-age=1800
```


See https://github.com/geoadmin/mf-chsdi3/issues/2767