### PR TITLE
Htmlpopup test for CadastralWebMap failed

### DIFF
--- a/chsdi/tests/integration/test_features_service.py
+++ b/chsdi/tests/integration/test_features_service.py
@@ -372,7 +372,7 @@ class TestFeaturesView(TestsBase):
     def test_htmlpopup_cadastralwebmap(self):
         params = {'mapExtent': '485412.34375,109644.67,512974.44,135580.01999999999',
                   'imageDisplay': '600,400,96'}
-        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/21648723/htmlPopup', params=params, status=200)
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.kantone.cadastralwebmap-farbe/3144368/htmlPopup', params=params, status=200)
         self.assertEqual(resp.content_type, 'text/html')
         resp.mustcontain('<table')
 


### PR DESCRIPTION
The test regarding the htmlpopup of cadastralwebmap failed because it couldn't find the ID. I also couldn't find it in the DB `os_realestate`. Therefore, I assumed that the ID in the REST call of `test_htmlpopup_cadastralwebmap` in `tests/integration/test_features_service.py` had to be updated. 
