### PR TITLE
Image filter for LUBIS

### DIFF
--- a/chsdi/templates/luftbilder/lubis_map.mako
+++ b/chsdi/templates/luftbilder/lubis_map.mako
@@ -16,11 +16,7 @@
           resolutions.unshift(curResolution);
         }
 
-        var lubisMap = new ol.Map({
-          layers: [
-            new ol.layer.Tile({
-              preload: 0,
-              source: new ol.source.TileImage({
+        var tileimage = new ol.source.TileImage({
                 crossOrigin: null,
                 tileGrid: new ol.tilegrid.TileGrid({
                   origin: [0, 0],
@@ -35,13 +31,18 @@
                   if (coords[1] * factor > width || coords[2] * factor > height) {
                     return undefined;
                   }
-
                   curInstance = (++curInstance > MAX_INSTANCES) ? 0 : curInstance;
                   return url.replace('{curInstance}', curInstance) + tileCoord.join('/') + ".jpg";
                 }
-              })
-            })
-          ],
+              });
+
+        var tile = new ol.layer.Tile({
+              preload: 0,
+              source: tileimage
+            });
+
+        var lubisMap = new ol.Map({
+          layers: [ tile ],
           controls: ol.control.defaults().extend([new ol.control.FullScreen()]),
           renderer: 'canvas',
           target: ${target},

--- a/chsdi/templates/luftbilder/lubis_map.mako
+++ b/chsdi/templates/luftbilder/lubis_map.mako
@@ -11,6 +11,113 @@
         var curResolution = resolutions[0];
         var maxResolution = Math.max(width, height) / TILE_SIZE;
 
+        var Xn = 0.950470;
+        var Yn = 1;
+        var Zn = 1.088830;
+        var t0 = 4 / 29;
+        var t1 = 6 / 29;
+        var t2 = 3 * t1 * t1;
+        var t3 = t1 * t1 * t1;
+        var twoPi = 2 * Math.PI;
+
+
+        /**
+         * Convert an RGB pixel into an HCL pixel.
+         * @param {Array.<number>} pixel A pixel in RGB space.
+         * @return {Array.<number>} A pixel in HCL space.
+        */
+        function rgb2hcl(pixel) {
+          var red = rgb2xyz(pixel[0]);
+          var green = rgb2xyz(pixel[1]);
+          var blue = rgb2xyz(pixel[2]);
+
+          var x = xyz2lab(
+            (0.4124564 * red + 0.3575761 * green + 0.1804375 * blue) / Xn);
+          var y = xyz2lab(
+            (0.2126729 * red + 0.7151522 * green + 0.0721750 * blue) / Yn);
+          var z = xyz2lab(
+            (0.0193339 * red + 0.1191920 * green + 0.9503041 * blue) / Zn);
+
+          var l = 116 * y - 16;
+          var a = 500 * (x - y);
+          var b = 200 * (y - z);
+
+          var c = Math.sqrt(a * a + b * b);
+          var h = Math.atan2(b, a);
+          if (h < 0) {
+            h += twoPi;
+          }
+
+          pixel[0] = h;
+          pixel[1] = c;
+          pixel[2] = l;
+
+          return pixel;
+        }
+
+
+        /**
+         * Convert an HCL pixel into an RGB pixel.
+         * @param {Array.<number>} pixel A pixel in HCL space.
+         * @return {Array.<number>} A pixel in RGB space.
+        */
+        function hcl2rgb(pixel) {
+          var h = pixel[0];
+          var c = pixel[1];
+          var l = pixel[2];
+
+          var a = Math.cos(h) * c;
+          var b = Math.sin(h) * c;
+
+          var y = (l + 16) / 116;
+          var x = isNaN(a) ? y : y + a / 500;
+          var z = isNaN(b) ? y : y - b / 200;
+
+          y = Yn * lab2xyz(y);
+          x = Xn * lab2xyz(x);
+          z = Zn * lab2xyz(z);
+
+          pixel[0] = xyz2rgb(3.2404542 * x - 1.5371385 * y - 0.4985314 * z);
+          pixel[1] = xyz2rgb(-0.9692660 * x + 1.8760108 * y + 0.0415560 * z);
+          pixel[2] = xyz2rgb(0.0556434 * x - 0.2040259 * y + 1.0572252 * z);
+
+          return pixel;
+        }
+
+        function xyz2lab(t) {
+          return t > t3 ? Math.pow(t, 1 / 3) : t / t2 + t0;
+        }
+
+        function lab2xyz(t) {
+          return t > t1 ? t * t * t : t2 * (t - t0);
+        }
+
+        function rgb2xyz(x) {
+          return (x /= 255) <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+        }
+
+        function xyz2rgb(x) {
+          return 255 * (x <= 0.0031308 ?
+            12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
+        }
+
+        function getPixelValue(degree, pixel, mean, equalizedValues){
+          var hcl = rgb2hcl(pixel);
+          var l = parseInt(hcl[2]);
+          var equalizedValue = equalizedValues[l];
+          var new_l;
+
+          if (degree<100){
+            new_l = mean * (1 - (degree / 100)) + l * (degree / 100);
+          }else{
+            new_l = l * (2 - (degree / 100)) + ((degree / 100)-1) * 100 * equalizedValue;
+          }
+
+          hcl[2] = new_l;
+          return hcl2rgb(hcl);
+        }
+
+
         while (curResolution < maxResolution) {
           curResolution *= 2;
           resolutions.unshift(curResolution);
@@ -43,12 +150,34 @@
 
         var raster = new ol.source.Raster({
           sources: [tileimage],
+          crossOrigin: 'anonymous',
           operation: function(pixels, data) {
             var pixel = pixels[0];
-            pixel[0] = (data.contrast / 100) * pixel[0];
-            pixel[1] = (data.contrast / 100) * pixel[1];
-            pixel[2] = (data.contrast / 100) * pixel[2];
+            var degree_contrast = data.contrast;
+            if (data.equalizedValues && pixel[3]!=0){
+              var new_pixel = getPixelValue(degree_contrast, pixel, data.mean, data.equalizedValues);
+              pixel[0] = new_pixel[0];
+              pixel[1] = new_pixel[1];
+              pixel[2] = new_pixel[2];
+            }
             return pixel;
+          },
+          lib:{
+            getPixelValue: getPixelValue,
+            rgb2hcl: rgb2hcl,
+            hcl2rgb: hcl2rgb,
+            rgb2xyz: rgb2xyz,
+            lab2xyz: lab2xyz,
+            xyz2lab: xyz2lab,
+            xyz2rgb: xyz2rgb,
+            Xn: Xn,
+            Yn: Yn,
+            Zn: Zn,
+            t0: t0,
+            t1: t1,
+            t2: t2,
+            t3: t3,
+            twoPi: twoPi
           }
         });
 

--- a/chsdi/templates/luftbilder/lubis_map.mako
+++ b/chsdi/templates/luftbilder/lubis_map.mako
@@ -17,32 +17,47 @@
         }
 
         var tileimage = new ol.source.TileImage({
-                crossOrigin: null,
-                tileGrid: new ol.tilegrid.TileGrid({
-                  origin: [0, 0],
-                  resolutions: resolutions
-                }),
-                tileUrlFunction: function(tileCoord, pixelRatio, projection) {
-                  var coords = tileCoord;
-                  if (coords[0] < 0 || coords[1] < 0 || coords[2] < 0) {
-                    return undefined;
-                  }
-                  var factor = this.getTileGrid().getTileSize() * this.getTileGrid().getResolutions()[coords[0]];
-                  if (coords[1] * factor > width || coords[2] * factor > height) {
-                    return undefined;
-                  }
-                  curInstance = (++curInstance > MAX_INSTANCES) ? 0 : curInstance;
-                  return url.replace('{curInstance}', curInstance) + tileCoord.join('/') + ".jpg";
-                }
-              });
+          crossOrigin: 'anonymous',
+          tileGrid: new ol.tilegrid.TileGrid({
+            origin: [0, 0],
+            resolutions: resolutions
+          }),
+          tileUrlFunction: function(tileCoord, pixelRatio, projection) {
+            var coords = tileCoord;
+            if (coords[0] < 0 || coords[1] < 0 || coords[2] < 0) {
+              return undefined;
+            }
+            var factor = this.getTileGrid().getTileSize() * this.getTileGrid().getResolutions()[coords[0]];
+            if (coords[1] * factor > width || coords[2] * factor > height) {
+              return undefined;
+            }
+            curInstance = (++curInstance > MAX_INSTANCES) ? 0 : curInstance;
+            return url.replace('{curInstance}', curInstance) + tileCoord.join('/') + ".jpg";
+          }
+        });
 
         var tile = new ol.layer.Tile({
-              preload: 0,
-              source: tileimage
-            });
+          preload: 0,
+          source: tileimage
+        });
+
+        var raster = new ol.source.Raster({
+          sources: [tileimage],
+          operation: function(pixels, data) {
+            var pixel = pixels[0];
+            pixel[0] = (data.contrast / 100) * pixel[0];
+            pixel[1] = (data.contrast / 100) * pixel[1];
+            pixel[2] = (data.contrast / 100) * pixel[2];
+            return pixel;
+          }
+        });
 
         var lubisMap = new ol.Map({
-          layers: [ tile ],
+          layers: [
+            new ol.layer.Image({
+              source: raster
+            })
+          ],
           controls: ol.control.defaults().extend([new ol.control.FullScreen()]),
           renderer: 'canvas',
           target: ${target},

--- a/chsdi/templates/luftbilder/lubis_map.mako
+++ b/chsdi/templates/luftbilder/lubis_map.mako
@@ -155,10 +155,7 @@
             var pixel = pixels[0];
             var degree_contrast = data.contrast;
             if (data.equalizedValues && pixel[3]!=0){
-              var new_pixel = getPixelValue(degree_contrast, pixel, data.mean, data.equalizedValues);
-              pixel[0] = new_pixel[0];
-              pixel[1] = new_pixel[1];
-              pixel[2] = new_pixel[2];
+              pixel = getPixelValue(degree_contrast, pixel, data.mean, data.equalizedValues);
             }
             return pixel;
           },

--- a/chsdi/templates/luftbilder/lubis_map.mako
+++ b/chsdi/templates/luftbilder/lubis_map.mako
@@ -101,11 +101,13 @@
             12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
         }
 
-        function getPixelValue(degree, pixel, mean, equalizedValues){
+        // in case you want to add a slider, add a degree parameter (value range:0-200)
+        function getPixelValue(pixel, mean, equalizedValues){
           var hcl = rgb2hcl(pixel);
           var l = parseInt(hcl[2]);
           var equalizedValue = equalizedValues[l];
           var new_l;
+          var degree = 150;
 
           if (degree<100){
             new_l = mean * (1 - (degree / 100)) + l * (degree / 100);
@@ -145,7 +147,8 @@
 
         var tile = new ol.layer.Tile({
           preload: 0,
-          source: tileimage
+          source: tileimage,
+          visible: true
         });
 
         var raster = new ol.source.Raster({
@@ -153,9 +156,8 @@
           crossOrigin: 'anonymous',
           operation: function(pixels, data) {
             var pixel = pixels[0];
-            var degree_contrast = data.contrast;
             if (data.equalizedValues && pixel[3]!=0){
-              pixel = getPixelValue(degree_contrast, pixel, data.mean, data.equalizedValues);
+              pixel = getPixelValue(pixel, data.mean, data.equalizedValues);
             }
             return pixel;
           },
@@ -178,11 +180,14 @@
           }
         });
 
+        var contrastLayer = new ol.layer.Image({
+          source: raster,
+          visible: false
+        });
+
         var lubisMap = new ol.Map({
           layers: [
-            new ol.layer.Image({
-              source: raster
-            })
+            tile, contrastLayer
           ],
           controls: ol.control.defaults().extend([new ol.control.FullScreen()]),
           renderer: 'canvas',

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -79,7 +79,7 @@
         position: absolute;
         top: 60px;
         right: 10px;
-        bottom: 50px;
+        bottom: 65px;
         left: 10px;
         border: 1px solid #EFEFEF;
       }
@@ -93,8 +93,8 @@
         text-align:center;
       }
       .controls{
-        margin-left:auto; 
-        margin-right:auto;
+        margin-left: auto;
+        margin-right: auto;
       }
       .percent{
         margin-left: 10px;
@@ -115,6 +115,7 @@
       }
       #reset {
         margin-left: 10px;
+        display: none;
       }
       @media print { /* Used by Chrome */
         #lubismap, .wrapper {
@@ -373,24 +374,28 @@
 
         function onSliderChange() {
           contrastOut.innerHTML = contrastSlider.value + "%";
+          displayButton();
           raster.changed();
         }
 
         function onReset(){
           contrastSlider.value = 100;
           contrastOut.innerHTML = "100%";
+          displayButton();
           raster.changed();
         }
 
         function moreContrast(){
           contrastSlider.value = parseInt(contrastSlider.value) + 5;
           contrastOut.innerHTML = contrastSlider.value + "%";
+          displayButton();
           raster.changed();
         }
 
         function lessContrast(){
           contrastSlider.value = parseInt(contrastSlider.value) - 5;
           contrastOut.innerHTML = contrastSlider.value + "%";
+          displayButton();
           raster.changed();
         }
 
@@ -399,6 +404,14 @@
           resetButton.addEventListener("click", onReset);
           plusButton.addEventListener("click", moreContrast);
           minusButton.addEventListener("click", lessContrast);
+        }
+
+        function displayButton() {
+          if (contrastSlider.value != 100) {
+            resetButton.style.display = "block";
+          } else {
+            resetButton.style.display = "none";
+          }
         }
       }
    </script>

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -92,6 +92,12 @@
         margin: 10px 0px;
         text-align:center;
       }
+      .controls{
+       margin-left: 10px;
+      }
+      .percent{
+        margin-left: 10px;
+      }
       .footer a {
         padding: 0px 10px;
       }
@@ -103,8 +109,14 @@
       }
       #lubismap {
         width: 100%;
-        height: 100%;
+        height: 95%;
         font-size: 16px;
+      }
+      .slider {
+        margin: 20px 20px 20px 20px;
+      }
+      #reset {
+        margin-left: 10px;
       }
       @media print { /* Used by Chrome */
         #lubismap, .wrapper {
@@ -123,30 +135,21 @@
 
     </style>
     <link rel="shortcut icon" type="image/x-icon" href="${h.versioned(request.static_url('chsdi:static/images/favicon.ico'))}">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
   </head>
   <body onload="init()">
     <div class="header">${title}</div>
     <div class="wrapper">
+    <div id="lubismap"></div>
     <table class="controls">
        <tr>
-         <td>Contrast</td>
-         <td><span id="contrastOut"></span>%</td>
-         <td><input id="contrast" type="range" min="0" max="200" value="100"/></td>
-       </tr>
-       <tr>
-         <td>Saturation</td>
-         <td><span id="saturationOut"></span> %</td>
-         <td><input id="saturation" type="range" min="0" max="200" value="100"/></td>
-       </tr>
-       <tr>
-         <td>Brightness</td>
-         <td><span id="brightnessOut"></span> %</td>
-         <td><input id="brightness" type="range" min="0" max="200" value="100"/></td>
+         <td>${_('image_contrast')}</td>
+         <td><input id="contrast" class="slider" type="range" min="0" max="200" value="100"/></td>
+         <td id="contrastOut" class="percent">100%</td>
+         <td><button id="reset" class="btn btn-secondary btn-sm" onclick="reset()">Reset</button></td>
        </tr>
     </table>
-    <button id="reset" onclick="reset()">Reset</button>
-    <div id="lubismap"></div>
-    </div>
+   </div>
 
     <div class="footer">
       <a class="pull-left" href="${_('disclaimer url')}" target="_blank">Copyright</a>
@@ -280,54 +283,37 @@
         updateUrl();
 
         tile.on('postcompose', function(event) {
-          filter(event.context, lubisMap);
+          setSliderListeners(event.context, lubisMap);
+          //don't listen to event once slider listeners are set
+          tile.un('postcompose');
         });
 
-        function filter(context, lubisMap) {
+        function setSliderListeners(context, lubisMap) {
           var canvas = context.canvas;
-          var brightnessSlider = document.getElementById("brightness");
           var contrastSlider = document.getElementById("contrast");
-          var saturationSlider = document.getElementById("saturation");
-          brightnessSlider.addEventListener("change", brightnessFunction(canvas, brightnessSlider.value, lubisMap));
-          contrastSlider.addEventListener("change", contrastFunction(canvas, contrastSlider.value, lubisMap));
-          saturationSlider.addEventListener("change", saturationFunction(canvas, saturationSlider.value, lubisMap));
+          if (window.attachEvent) {
+            contrastSlider.attachEvent("onchange", updateFilter(canvas, "contrast", contrastSlider, lubisMap));
+          } else if (window.addEventListener) {
+            contrastSlider.addEventListener("change", updateFilter(canvas, "contrast", contrastSlider, lubisMap));
+            }
         }
       }
 
-      var brightnessFunction = function(canvas, brightnessVal, map) {
-        if (map){
-          var context = canvas.getContext('2d');
-          context.filter = "brightness(" + brightnessVal + "%)";
-          context.drawImage(canvas, 0, 0);
-          map.render();
-        }
-      };
-
-      var contrastFunction = function(canvas, contrastVal, map) {
-        if (map){
-          var context = canvas.getContext('2d');
-          context.filter = "contrast(" + contrastVal + "%)";
-          context.drawImage(canvas, 0, 0);
-          map.render();
-        }
-      };
-
-      var saturationFunction = function(canvas, saturationVal, map) {
-        if (map){
-          var context = canvas.getContext('2d');
-          context.filter = "saturate(" + saturationVal + "%)";
-          context.drawImage(canvas, 0, 0);
-          map.render();
-        }
-      };
+      var updateFilter = function(canvas, filter,  slider, map){
+        var context = canvas.getContext('2d');
+        var value = slider.value;
+        var percent = document.getElementById(filter + "Out");
+        percent.innerHTML = value + "%";
+        context.filter = filter + "(" + value + "%)";
+        context.drawImage(canvas, 0, 0);
+        map.render();
+      }
 
       var reset = function(){
-        var brightnessSlider = document.getElementById("brightness");
         var contrastSlider = document.getElementById("contrast");
-        var saturationSlider = document.getElementById("saturation");
-        brightnessSlider.value = 100;
         contrastSlider.value = 100;
-        saturationSlider.value = 100;
+        var percent = document.getElementById("contrastOut");
+        percent.innerHTML = "100%"
       }
 
 

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -127,8 +127,27 @@
   <body onload="init()">
     <div class="header">${title}</div>
     <div class="wrapper">
-      <div id="lubismap"></div>
+    <table class="controls">
+       <tr>
+         <td>Contrast</td>
+         <td><span id="contrastOut"></span>%</td>
+         <td><input id="contrast" type="range" min="0" max="200" value="100"/></td>
+       </tr>
+       <tr>
+         <td>Saturation</td>
+         <td><span id="saturationOut"></span> %</td>
+         <td><input id="saturation" type="range" min="0" max="200" value="100"/></td>
+       </tr>
+       <tr>
+         <td>Brightness</td>
+         <td><span id="brightnessOut"></span> %</td>
+         <td><input id="brightness" type="range" min="0" max="200" value="100"/></td>
+       </tr>
+    </table>
+    <button id="reset" onclick="reset()">Reset</button>
+    <div id="lubismap"></div>
     </div>
+
     <div class="footer">
       <a class="pull-left" href="${_('disclaimer url')}" target="_blank">Copyright</a>
       <div id="messagectrl"></div>
@@ -260,7 +279,58 @@
         view.on('propertychange', debounce(updateUrl));
         updateUrl();
 
+        tile.on('postcompose', function(event) {
+          filter(event.context, lubisMap);
+        });
+
+        function filter(context, lubisMap) {
+          var canvas = context.canvas;
+          var brightnessSlider = document.getElementById("brightness");
+          var contrastSlider = document.getElementById("contrast");
+          var saturationSlider = document.getElementById("saturation");
+          brightnessSlider.addEventListener("change", brightnessFunction(canvas, brightnessSlider.value, lubisMap));
+          contrastSlider.addEventListener("change", contrastFunction(canvas, contrastSlider.value, lubisMap));
+          saturationSlider.addEventListener("change", saturationFunction(canvas, saturationSlider.value, lubisMap));
+        }
       }
+
+      var brightnessFunction = function(canvas, brightnessVal, map) {
+        if (map){
+          var context = canvas.getContext('2d');
+          context.filter = "brightness(" + brightnessVal + "%)";
+          context.drawImage(canvas, 0, 0);
+          map.render();
+        }
+      };
+
+      var contrastFunction = function(canvas, contrastVal, map) {
+        if (map){
+          var context = canvas.getContext('2d');
+          context.filter = "contrast(" + contrastVal + "%)";
+          context.drawImage(canvas, 0, 0);
+          map.render();
+        }
+      };
+
+      var saturationFunction = function(canvas, saturationVal, map) {
+        if (map){
+          var context = canvas.getContext('2d');
+          context.filter = "saturate(" + saturationVal + "%)";
+          context.drawImage(canvas, 0, 0);
+          map.render();
+        }
+      };
+
+      var reset = function(){
+        var brightnessSlider = document.getElementById("brightness");
+        var contrastSlider = document.getElementById("contrast");
+        var saturationSlider = document.getElementById("saturation");
+        brightnessSlider.value = 100;
+        contrastSlider.value = 100;
+        saturationSlider.value = 100;
+      }
+
+
     </script>
   </body>
 </html>

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -94,10 +94,13 @@
         text-align:center;
       }
       .button{
-        margin-top: 0.5%;
-        margin-left: auto;
-        margin-right: auto;
-        width: 150px;
+        position: absolute;
+        right: 0px;
+        bottom: 0px;
+        left: 50%;
+        height: 30px;
+        margin: 10px 0px;
+        text-align:center;
       }
       .footer a {
         padding: 0px 10px;
@@ -138,8 +141,9 @@
   <body onload="init()">
     <div class="header">${title}</div>
     <div class="wrapper">
-      <div id="lubismap"></div>
-      <button id="contrast_activate" class="button btn btn-secondary btn-sm d-block">${_('image_contrast_activate')}</button>
+      <div id="lubismap">
+        <button id="contrast_activate" class="button btn btn-secondary btn-sm d-block">${_('image_contrast_activate')}</button>
+      </div>
     </div>
     <div class="footer">
       <a class="pull-left" href="${_('disclaimer url')}" target="_blank">Copyright</a>

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -93,7 +93,8 @@
         text-align:center;
       }
       .controls{
-        margin-left: 10px;
+        margin-left:auto; 
+        margin-right:auto;
       }
       .percent{
         margin-left: 10px;
@@ -290,9 +291,9 @@
 
         var contrastSlider = document.getElementById("contrast");
         var contrastOut = document.getElementById("contrastOut");
-        var resetbutton = document.getElementById("reset");
-        var minusbutton = document.getElementById("minus-button");
-        var plusbutton = document.getElementById("plus-button");
+        var resetButton = document.getElementById("reset");
+        var minusButton = document.getElementById("minus-button");
+        var plusButton = document.getElementById("plus-button");
 
         setSliderListeners();
 
@@ -300,19 +301,19 @@
         var mean = undefined;
 
         function getPixelList(data){
-          var pixel_list = [];
+          var pixelList = [];
           for (var i=0; i<(data.length);i+=4){
             if (data[i+3]!=0){
               var pixel = [data[i], data[i+1], data[i+2], data[i+3]];
-              pixel_list.push(pixel);
+              pixelList.push(pixel);
             }
           }
-          return pixel_list;
+          return pixelList;
         }
 
         function allZero(data){
-          for (var key in data){
-            if (data[key] != 0) return false
+          for (var i = 0; i < data.length; i += 4){
+            if (data[i] != 0) return false
           }
           return true
         }
@@ -321,7 +322,7 @@
         function getHistogramProperties(pixels){
           var histogram = {};
           var equalizedHistogram = {};
-          var number_pixels = pixels.length;
+          var numberPixels = pixels.length;
           var sum = 0;
           var mean_luminance = 0;
 
@@ -342,7 +343,7 @@
 
           //normalization of histogram + compute equalized Values and Mean
           for (var i in histogram){
-            histogram[i] = histogram[i] / number_pixels;
+            histogram[i] = histogram[i] / numberPixels;
             sum += histogram[i];
             equalizedHistogram[i] = sum;
             mean_luminance += histogram[i]*i;
@@ -356,8 +357,8 @@
           var imageData = context.getImageData(0,0, canvas.width, canvas.height).data;
           // to prevent that recomputed every time map rendered
           if (!allZero(imageData) && !mean) {
-            var pixel_list = getPixelList(imageData);
-            var histogramProperties = getHistogramProperties(pixel_list);
+            var pixelList = getPixelList(imageData);
+            var histogramProperties = getHistogramProperties(pixelList);
             equalizedValues = histogramProperties[0];
             mean = histogramProperties[1];
           }
@@ -365,7 +366,7 @@
 
         raster.on('beforeoperations', function(event) {
           var data = event.data;
-          data["contrast"] = Number(contrastSlider.value);
+          data["contrast"] = parseInt(contrastSlider.value);
           data["equalizedValues"] = equalizedValues;
           data["mean"] = mean;
         });
@@ -393,11 +394,11 @@
           raster.changed();
         }
 
-       function setSliderListeners() {
+        function setSliderListeners() {
           contrastSlider.addEventListener("change", onSliderChange);
-          resetbutton.addEventListener("click", onReset);
-          plusbutton.addEventListener("click", moreContrast);
-          minusbutton.addEventListener("click", lessContrast);
+          resetButton.addEventListener("click", onReset);
+          plusButton.addEventListener("click", moreContrast);
+          minusButton.addEventListener("click", lessContrast);
         }
       }
    </script>

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -134,6 +134,7 @@
         height: 30px;
         margin: 10px 0px;
         text-align:center;
+        z-index:10;
       }
       .footer a {
         padding: 0px 10px;
@@ -146,7 +147,7 @@
       }
       #lubismap {
         width: 100%;
-        height: 95%;
+        height: 100%;
         font-size: 16px;
       }
       @media print { /* Used by Chrome */

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -93,7 +93,7 @@
         text-align:center;
       }
       .controls{
-       margin-left: 10px;
+        margin-left: 10px;
       }
       .percent{
         margin-left: 10px;
@@ -146,7 +146,7 @@
          <td>${_('image_contrast')}</td>
          <td><input id="contrast" class="slider" type="range" min="0" max="200" value="100"/></td>
          <td id="contrastOut" class="percent">100%</td>
-         <td><button id="reset" class="btn btn-secondary btn-sm" onclick="reset()">Reset</button></td>
+         <td><button id="reset" class="btn btn-secondary btn-sm">Reset</button></td>
        </tr>
     </table>
    </div>
@@ -282,41 +282,33 @@
         view.on('propertychange', debounce(updateUrl));
         updateUrl();
 
-        tile.on('postcompose', function(event) {
-          setSliderListeners(event.context, lubisMap);
-          //don't listen to event once slider listeners are set
-          tile.un('postcompose');
+        var contrastSlider = document.getElementById("contrast");
+        var contrastOut = document.getElementById("contrastOut");
+        var resetbutton = document.getElementById("reset");
+
+        setSliderListeners();
+
+        raster.on('beforeoperations', function(event) {
+          var data = event.data;
+          data["contrast"] = Number(contrastSlider.value);
         });
 
-        function setSliderListeners(context, lubisMap) {
-          var canvas = context.canvas;
-          var contrastSlider = document.getElementById("contrast");
-          if (window.attachEvent) {
-            contrastSlider.attachEvent("onchange", updateFilter(canvas, "contrast", contrastSlider, lubisMap));
-          } else if (window.addEventListener) {
-            contrastSlider.addEventListener("change", updateFilter(canvas, "contrast", contrastSlider, lubisMap));
-            }
+        function onSliderChange() {
+          contrastOut.innerHTML = contrastSlider.value + "%";
+          raster.changed();
+        }
+
+        function onReset(){
+          contrastSlider.value = 100;
+          contrastOut.innerHTML = "100%";
+          raster.changed();
+        }
+
+        function setSliderListeners() {
+          contrastSlider.addEventListener("change", onSliderChange);
+          resetbutton.addEventListener("click", onReset);
         }
       }
-
-      var updateFilter = function(canvas, filter,  slider, map){
-        var context = canvas.getContext('2d');
-        var value = slider.value;
-        var percent = document.getElementById(filter + "Out");
-        percent.innerHTML = value + "%";
-        context.filter = filter + "(" + value + "%)";
-        context.drawImage(canvas, 0, 0);
-        map.render();
-      }
-
-      var reset = function(){
-        var contrastSlider = document.getElementById("contrast");
-        contrastSlider.value = 100;
-        var percent = document.getElementById("contrastOut");
-        percent.innerHTML = "100%"
-      }
-
-
-    </script>
+   </script>
   </body>
 </html>

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -11,6 +11,7 @@
   baseUrl = '//' + c.get('baseUrl')
   layerBodId = c.get('layer')
   featureId = c.get('bildnummer')
+  contrast = 'true' if c.get('contrast')=='true' else 'false'
   displayLink = True
   ## This is a HACK to ensure backward compatibility
   if not layerBodId.startswith('ch.'):
@@ -140,7 +141,6 @@
       <div id="lubismap"></div>
       <button id="contrast_activate" class="button btn btn-secondary btn-sm d-block">${_('image_contrast_activate')}</button>
     </div>
-
     <div class="footer">
       <a class="pull-left" href="${_('disclaimer url')}" target="_blank">Copyright</a>
       <div id="messagectrl"></div>
@@ -290,7 +290,8 @@
        function getPixelList(data){
           var pixelList = [];
           for (var i=0; i<(data.length);i+=4){
-            pixel_values = data.slice(i, i+4);
+            //data-.slice() doesnt work for E11
+            pixel_values = [data[i], data[i+1], data[i+2], data[i+3]];
             if (pixel_values[3]!=0 && !(isBlack(pixel_values) || isWhite(pixel_values))){
               var pixel = [pixel_values[0], pixel_values[1], pixel_values[2], pixel_values[3]];
               pixelList.push(pixel);
@@ -340,6 +341,9 @@
         }
 
         lubisMap.on('postrender', function(event){
+          if (mean) {
+            return;
+          }
           var canvas = document.getElementsByTagName('canvas')[0];
           var context = canvas.getContext('2d');
           var imageData = context.getImageData(0,0, canvas.width, canvas.height).data;
@@ -362,14 +366,24 @@
           if (contrastLayer.getVisible() == true){
             contrastLayer.setVisible(false);
             contrastButtonActivate.innerHTML = "${_('image_contrast_activate')}";
+            setContrastPermalink('false')
           } else{
             contrastLayer.setVisible(true);
             contrastButtonActivate.innerHTML = "${_('image_contrast_deactivate')}";
+            setContrastPermalink('true')
           }
         }
-
+        var contrast = ${contrast};
+        if (contrast) {
+          onButtonChange();
+        }
         function setButtonListener() {
           contrastButtonActivate.addEventListener("click", onButtonChange);
+        }
+
+        function setContrastPermalink(state){
+          var newHref = updateQueryStringParameter(window.location.href, 'contrast', state);
+          window.history.replaceState(null, '', newHref);
         }
       }
    </script>

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -93,7 +93,40 @@
         margin: 10px 0px;
         text-align:center;
       }
+      .btn {
+        display: inline-block;
+        margin-bottom: 0;
+        font-weight: normal;
+        text-align: center;
+        vertical-align: middle;
+        -ms-touch-action: manipulation;
+        touch-action: manipulation;
+        cursor: pointer;
+        background-image: none;
+        border: 1px solid transparent;
+        white-space: nowrap;
+        padding: 6px 12px;
+        font-size: 14px;
+        line-height: 1.42857143;
+        border-radius: 4px;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+      .btn-sm {
+        padding: 5px 10px;
+        font-size: 12px;
+        line-height: 1.5;
+        border-radius: 3px;
+      }
+      .btn-secondary {
+        color: #fff;
+        background-color: #6c757d;
+        border-color: #6c757d;
+      }
       .button{
+        width:150px;
         position: absolute;
         right: 0px;
         bottom: 0px;
@@ -133,10 +166,6 @@
 
     </style>
     <link rel="shortcut icon" type="image/x-icon" href="${h.versioned(request.static_url('chsdi:static/images/favicon.ico'))}">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
   </head>
   <body onload="init()">
     <div class="header">${title}</div>

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -318,9 +318,12 @@
         }
 
         // computes normalized histogram
-        function getHistogram(pixels){
-          histogram = {};
+        function getHistogramProperties(pixels){
+          var histogram = {};
+          var equalizedHistogram = {};
           var number_pixels = pixels.length;
+          var sum = 0;
+          var mean_luminance = 0;
 
           //initialize histogram 
           for (var i = 0; i < 101; i++){
@@ -337,30 +340,14 @@
             histogram[l] = histogram[l] + 1;
           }
 
-          //normalization of histogram
-          for (var i = 0; i < 101; i++){
+          //normalization of histogram + compute equalized Values and Mean
+          for (var i in histogram){
             histogram[i] = histogram[i] / number_pixels;
-          }
-          return histogram;
-        }
-
-        //computes mean of RGB in image
-        function getMeanLuminance(histogram){
-          var mean_luminance = 0;
-          for (var i = 0; i < 101; i++){
+            sum += histogram[i];
+            equalizedHistogram[i] = sum;
             mean_luminance += histogram[i]*i;
           }
-          return mean_luminance;
-        }
-
-        function getEqualizedValues(histogram){
-          var equalizedValues = {};
-          var sum = 0;
-          for ( var i in histogram){
-            sum += histogram[i];
-            equalizedValues[i] = sum;
-          }
-          return equalizedValues;
+          return [equalizedHistogram, mean_luminance];
         }
 
         lubisMap.on('postrender', function(event){
@@ -370,9 +357,9 @@
           // to prevent that recomputed every time map rendered
           if (!allZero(imageData) && !mean) {
             var pixel_list = getPixelList(imageData);
-            var histogram = getHistogram(pixel_list);
-            mean = getMeanLuminance(histogram);
-            equalizedValues = getEqualizedValues(histogram);
+            var histogramProperties = getHistogramProperties(pixel_list);
+            equalizedValues = histogramProperties[0];
+            mean = histogramProperties[1];
           }
         });
 

--- a/chsdi/views/luftbilder.py
+++ b/chsdi/views/luftbilder.py
@@ -15,6 +15,7 @@ def luftbilder(request):
     bildnummer = request.params.get('bildnummer')
     datenherr = request.params.get('datenherr')
     layer = request.params.get('layer')
+    contrast = request.params.get('contrast')
     lang = request.params.get('lang')
     baseUrl = request.registry.settings.get('geoadminhost')
 
@@ -32,6 +33,7 @@ def luftbilder(request):
             'datenherr': datenherr,
             'layer': layer,
             'baseUrl': baseUrl,
+            'contrast': contrast,
             'lang': lang
         },
         request=request


### PR DESCRIPTION
Fix https://github.com/geoadmin/mf-geoadmin3/issues/1350
Provides the user with the possibility to modify contrast, saturation and brightness of the image. 

Black and white:
[Testlink](https://mf-chsdi3.dev.bgdi.ch/ltpin_lubis/luftbilder/viewer.html?lang=fr&width=8954&layer=ch.swisstopo.lubis-luftbilder_schwarzweiss&bildnummer=19531910013240&title=ch.swisstopo.lubis-luftbilder-dritte-kantone.ebkey&rotation=0&datenherr=swisstopo&height=9430&x=7381.84&y=7999.27&zoom=2)

Color:
[Testlink](https://mf-chsdi3.dev.bgdi.ch/ltpin_lubis/luftbilder/viewer.html?lang=de&width=16574&layer=ch.swisstopo.lubis-luftbilder_farbe&bildnummer=20057120330698&title=ch.swisstopo.lubis-luftbilder-dritte-kantone.ebkey&rotation=0&datenherr=swisstopo&height=17001&x=9220.98&y=4156.53&zoom=3)

