### PR TITLE
Update coordinate with last delivery

### DIFF
--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -762,7 +762,7 @@ class TestIdentifyService(TestsBase):
 
     def test_identify_treasurehunt_good_scale(self):
         params = dict(geometryType='esriGeometryPoint',
-                      geometry='611334,271015',
+                      geometry='2546959,1149075',
                       geometryFormat='geojson',
                       imageDisplay='1920,730,96',
                       layers='all:ch.swisstopo.treasurehunt',

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -762,7 +762,7 @@ class TestIdentifyService(TestsBase):
 
     def test_identify_treasurehunt_good_scale(self):
         params = dict(geometryType='esriGeometryPoint',
-                      geometry='2546959,1149075',
+                      geometry='546959,149075',
                       geometryFormat='geojson',
                       imageDisplay='1920,730,96',
                       layers='all:ch.swisstopo.treasurehunt',


### PR DESCRIPTION
Fix unittest for treasurehunt.
Use coordinate of a point from last delivery.

Test [1] return now a result

[1] Test link
https://mf-chsdi3.dev.bgdi.ch/ltalp/rest/services/all/MapServer/identify?geometry=2546959,1149075&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1020,730,96&lang=fr&layers=all:ch.swisstopo.treasurehunt&limit=10&mapExtent=611163,270868,611504,271135&returnGeometry=true&sr=2056&tolerance=10
