### PR TITLE
Received an alert that pillow < 3.3.2 had a moderate security vulnera…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ OWSLib==0.8.8
 papyrus==2.1
 PasteDeploy==1.5.2
 pep8==1.7.0
-Pillow==3.1.0
+Pillow==3.3.2
 polib==1.0.3
 psycopg2==2.6.2
 pycodestyle==2.0.0


### PR DESCRIPTION
…bility. https://www.cvedetails.com/vulnerability-list/vendor_id-10210/product_id-27460/Python-Pillow.html for references. Thought it would be a good idea to update that before we have some problems.

We should verify that builds are still valid after the update.