### PR TITLE
Update link pdf ch.bafu.wasser-entnahme

### DIFF
--- a/chsdi/templates/htmlpopup/wasserentnahme.mako
+++ b/chsdi/templates/htmlpopup/wasserentnahme.mako
@@ -11,7 +11,7 @@
     <tr><td class="cell-left">${_('ent_gew')}</td>      <td>${c['attributes']['ent_gew'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('pdf')}</td>          <td>
     % if c['attributes']['link']:
-      <a href="http://www.ubst.bafu.admin.ch/restwasser/data/data/er/${lang}/${c['attributes']['link']}" target="_blank">${_('link')}</a>
+      <a href="https://www.ubst.bafu.admin.ch/wasser/restwasser/data/data/er/${lang}/${c['attributes']['link']}" target="_blank">${_('link')}</a>
     % else:
         -
     % endif


### PR DESCRIPTION
There is a small correction on the links to the PDF's in the tooltips of the layer ch.bafu.wasser-entnahme

Right now, the links do not work anymore, because BAFU has changed the directory on its webserver.

[Test Link](https://mf-chsdi3.dev.bgdi.ch/gas_bafu_wasser-entnahme/shorten/7c82d34765)

Old incorrect URL: 
http://www.ubst.bafu.admin.ch/restwasser/data/data/er/de/GR001.pdf

New correct URL : 
https://www.ubst.bafu.admin.ch/wasser/restwasser/data/data/er/de/VS022.pdf

