### PR TITLE
do not use head of git-secrets anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ requirements.txt:
 	if [ ! -d ".git" ]; then git init; fi
 	rm -rf .venv/git-secrets
 	git clone https://github.com/awslabs/git-secrets .venv/git-secrets
-	cd .venv/git-secrets && make install PREFIX=..
+	cd .venv/git-secrets  && git reset --hard 635895a8d1b7c976ac9794cef420f8dc111a24d4 && make install PREFIX=..
 	(git config --local --get-regexp secret && git config --remove-section secrets) || cd
 	.venv/bin/git-secrets --register-aws
 


### PR DESCRIPTION
the current implementation is using the latest version from github of git-secrets
@Sgachet had some troubles and was not able to commit anymore with the latest version.
this patch is reverting git-secrets to the last commit which is working.

@procrastinatio do agree with this, should we use a tag instead?