### PR TITLE
add filmart attribute for shop price service

### DIFF
--- a/chsdi/models/vector/lubis.py
+++ b/chsdi/models/vector/lubis.py
@@ -141,6 +141,7 @@ class LuftbilderSchraegaufnahmen(Base, Vector):
     medium_format = Column('medium_format', Unicode)
     filesize_mb = Column('filesize_mb', Unicode)
     filename = Column('filename', Unicode)
+    filmart = Column('filmart', Unicode)
     stereo_couple = Column('stereo_couple', Unicode)
     bgdi_flugjahr = Column('bgdi_flugjahr', Integer)
     x = Column('x', Integer)


### PR DESCRIPTION
@pauloamado 
as discussed, i have added the attribute ``filmart`` to the identify response of ch.swisstopo.lubis-luftbilder_schraegaufnahmen for the shop price calculation:

when do we have to publish this?

[testlink](https://mf-chsdi3.dev.bgdi.ch/dev_ltclm_shop_oblique/shorten/7e1de45da3)
[identify](https://mf-chsdi3.dev.bgdi.ch/dev_ltclm_shop_oblique/rest/services/all/MapServer/identify?geometry=2622250.0000000005,1206750&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1135,1037,96&lang=de&layers=all:ch.swisstopo.lubis-luftbilder_schraegaufnahmen&limit=10&mapExtent=2376250,930750,2943750,1449250&returnGeometry=true&sr=2056&tolerance=10)

