### PR TITLE
Return attributes even if geom is too big (fixe #2720)

### DIFF
--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -79,16 +79,16 @@ class Vector(object):
                     id = val
                 elif (isinstance(col.type, GeometryChsdi) and
                       col.name == self.geometry_column_to_return().name):
-                    if hasattr(self, '_shape'):
+                    if hasattr(self, '_shape') and \
+                            len(self._shape) < MAX_FEATURE_GEOMETRY_SIZE:
                         geom = self._shape
-                    elif val is not None:
+                    elif val is not None and \
+                            len(val.data) < MAX_FEATURE_GEOMETRY_SIZE:
                         geom = to_shape(val)
                     try:
                         bbox = geom.bounds
                     except:
                         pass
-                    if len(val.data) > MAX_FEATURE_GEOMETRY_SIZE:
-                        geom = None
                 elif (not col.foreign_keys and
                       not isinstance(col.type, GeometryChsdi)):
                     properties[p.key] = val

--- a/tests/integration/test_features_service.py
+++ b/tests/integration/test_features_service.py
@@ -282,6 +282,15 @@ class TestFeaturesView(TestsBase):
         self.assertEqual(resp.json['feature']['id'], featureId)
         self.assertGeojsonFeature(resp.json['feature'], 21781)
 
+    def test_too_large_feature_only_attributes(self):
+        bodId = 'ch.swisstopo.geologie-geologischer_atlas'
+        featureId = 680287
+        resp = self.testapp.get('/rest/services/ech/MapServer/%s/%s' % (bodId, featureId), params={'geometryFormat': 'geojson', 'returnGeometry': 'true'}, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertEqual(resp.json['feature']['id'], featureId)
+        self.assertGeojsonFeature(resp.json['feature'], 21781, hasGeometry=False)
+        self.assertIsNone(resp.json['feature']['geometry'])
+
     def test_several_features(self):
         bodId = 'ch.bafu.bundesinventare-bln'
         featureId1 = self.getRandomFeatureId(bodId)


### PR DESCRIPTION
If geometry is too big (WKB >1e6):
- Attributes are returned
- Only bbox is calculated
- geometry is null

[Demo (click on marker)](https://map.geo.admin.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fmom_too_big_geom&lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.geologie-geologischer_atlas&layers_opacity=0.75&E=2556761&N=1162056&zoom=9&crosshair=marker) _Moraine rhodanienne_ is the big geometry

Use http://mf-chsdi3.dev.bgdi.ch/mom_too_big_geom/

For instance:

https://mf-chsdi3.dev.bgdi.ch/mom_too_big_geom/rest/services/all/MapServer/identify?geometry=2556868,1162263&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=900,981,96&lang=fr&layers=all:ch.swisstopo.geologie-geologischer_atlas&limit=10&mapExtent=2555861,1161075,2557661,1163037&returnGeometry=true&sr=2056&tolerance=10

From the service point of view this is not a good solution



See https://github.com/geoadmin/mf-chsdi3/issues/2720