### PR TITLE
Swissimage-product has two resolutions

### DIFF
--- a/chsdi/lib/validation/geometryservice.py
+++ b/chsdi/lib/validation/geometryservice.py
@@ -26,6 +26,7 @@ class GeometryServiceValidation(BaseFeaturesValidation):
         clipper = request.params.get('clipper')
         geometryType = request.params.get('geometryType')
         geometry = request.params.get('geometry')
+        groupby = request.params.get('groupby')
 
         self.esriGeometryTypes = (
             u'esriGeometryPolygon',
@@ -38,7 +39,12 @@ class GeometryServiceValidation(BaseFeaturesValidation):
 
         # No parameter -> we want the totalPerimeter
         if clipper is None and geometry is None and geometryType is None:
-            self.totalArea = True
+            if groupby is None:
+                self.totalArea = True
+            else:
+                # TODO hack for swissimage mixed: 25cm and 50cm
+                geometryType = 'esriGeometryEnvelope'
+                geometry = '0,0,9999999,9999999'
 
         if not self.totalArea:
             if not clipper:

--- a/tests/integration/test_features_service.py
+++ b/tests/integration/test_features_service.py
@@ -529,6 +529,19 @@ class TestFeaturesView(TestsBase):
         self.assertIn('groupby', resp.json['ch.swisstopo.images-swissimage.metadata'][0])
         self.assertIn('groupbyvalue', resp.json['ch.swisstopo.images-swissimage.metadata'][0])
 
+    def test_cut_swissimage_product_whole_dataset(self):
+        params = {'layers': 'all:ch.swisstopo.swissimage-product',
+                  'groupby': 'resolution'}
+        resp = self.testapp.get('/rest/services/ech/GeometryServer/cut', params=params, status=200)
+        self.assertIn('ch.swisstopo.swissimage-product', resp.json)
+        self.assertEqual(len(resp.json['ch.swisstopo.swissimage-product']), 2)
+        self.assertGreater(len(resp.json['ch.swisstopo.swissimage-product']), 1)
+        # A bit more than Switzerland should be covered by either resolution: 0.25 or 0.50m
+        totalArea = 0
+        for group in resp.json['ch.swisstopo.swissimage-product']:
+            totalArea += group['area']
+        self.assertGreater(totalArea, 45045)
+
     def test_cut_with_feature_clipper(self):
         params = {'clipper': 'ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill:2222',
                   'layers': 'all:ch.swisstopo.swisstlm3d-karte-farbe'}


### PR DESCRIPTION
See https://github.com/geoadmin/mf-chsdi3/issues/2975

Basically, both requests should return the same data

http://mf-chsdi3.int.bgdi.ch/mom_fix_swissimage/rest/services/ech/GeometryServer/cut?layers=all:ch.swisstopo.swissimage-product&groupby=resolution

http://mf-chsdi3.int.bgdi.ch/mom_fix_swissimage/rest/services/ech/GeometryServer/cut?geometryType=esriGeometryEnvelope&geometry=0,0,9999999,9999999&layers=all:ch.swisstopo.swissimage-product&groupby=resolution