### PR TITLE
add minimal doc for vectortiles

### DIFF
--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -1039,6 +1039,37 @@ Example
 
 * A `Terrain tile <https://terrain2.geo.admin.ch/1.0.0/ch.swisstopo.terrain.3d/default/20160115/4326/12/4309/3111.terrain>`_
 
+.. _vectortiles_description:
+
+-------------------
+
+Mapbox Vector Tiles
+-------------------
+A RESTFul implementation of `Mapbox Vector Tiles <https://www.mapbox.com/vector-tiles>`_.
+For the testing phase, the service is free for use.
+
+The service provides both *tiles* and *styles* that the customer can use. 
+
+URL
+***
+
+- vector tiles: `https://vectortiles.geo.admin.ch/mbtiles/<layername>/<version>/<zoomlevel>/<x>/<y>.pbf`
+- gl-styles: `https://vectortiles.geo.admin.ch/gl-styles/<layername>/<version>/style.json`
+
+
+Metadata Service
+****************
+
+Each tileset has a corresponding metatda `json` file that describes the available set of tiles.
+The URL of the metadata `json` file is :  `https://vectortiles.geo.admin.ch/mbtiles/<layername>/<version>.json`
+
+
+Example
+*******
+
+* A `Vector tile <https://vectortiles.geo.admin.ch/mbtiles/ch.swisstopo.swissnames3d/v004/7/67/44.pbf>`_
+* A `Tileset <https://vectortiles.geo.admin.ch/mbtiles/ch.swisstopo.swissnames3d/v004.json>`_
+* A `Mapbox-gl appication using our light base map <https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v004/?vector#7/47/8/0/6>`_
 
 .. _tiles3d_description:
 

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -1046,7 +1046,8 @@ Example
 Mapbox Vector Tiles
 -------------------
 A RESTFul implementation of `Mapbox Vector Tiles <https://www.mapbox.com/vector-tiles>`_.
-For the testing phase, the service is free for use. See conditions `conditions <https://www.swisstopo.ch>`_ give us feedback via our `survey <https://findmind.ch/c/23dXpBlbQq>`_  
+The service has be developed for testing purposes. The service is free for use during the test phase (until June 30th 2019). swisstopo reserves the right to change or suspend the service at any time without prior notice.
+Feel free to test the service and give us feedback to help us optimize our product via our `survey <https://findmind.ch/c/vectortilesEN>`_  
 
 The service provides both *tiles* and *styles* that the customer can use. 
 

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -1050,26 +1050,44 @@ For the testing phase, the service is free for use.
 
 The service provides both *tiles* and *styles* that the customer can use. 
 
+GetTile
+*******
+
+::
+
+    <Scheme>://<ServerName>/mbtiles/<LayerName>/<version>/<zoomlevel>/<x>/<y>.pbf
+
+GetStyle
+********
+
+::
+
+    <Scheme>://<ServerName>/gl-styles/<layername>/<version>/style.json
+
 URL
 ***
 
-- vector tiles: `https://vectortiles.geo.admin.ch/mbtiles/<layername>/<version>/<zoomlevel>/<x>/<y>.pbf`
-- gl-styles: `https://vectortiles.geo.admin.ch/gl-styles/<layername>/<version>/style.json`
-
+- vector tiles: https://vectortiles.geo.admin.ch/mbtiles/
+- gl-styles: https://vectortiles.geo.admin.ch/gl-styles/
 
 Metadata Service
 ****************
 
 Each tileset has a corresponding metatda `json` file that describes the available set of tiles.
-The URL of the metadata `json` file is :  `https://vectortiles.geo.admin.ch/mbtiles/<layername>/<version>.json`
+The URL of the metadata `json` file is : 
+
+::
+
+   <Scheme>://<ServerName>/mbtiles/<LayerName>/<version>.json
 
 
 Example
 *******
 
 * A `Vector tile <https://vectortiles.geo.admin.ch/mbtiles/ch.swisstopo.swissnames3d/v004/7/67/44.pbf>`_
+* A `Style <https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v004/style.json>`_
 * A `Tileset <https://vectortiles.geo.admin.ch/mbtiles/ch.swisstopo.swissnames3d/v004.json>`_
-* A `Mapbox-gl appication using our light base map <https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v004/?vector#7/47/8/0/6>`_
+* A `Mapbox-gl application using our light base map <https://vectortiles.geo.admin.ch/gl-styles/ch.swisstopo.leichte-basiskarte.vt/v004/?vector#7/47/8/0/6>`_
 
 .. _tiles3d_description:
 


### PR DESCRIPTION
we need to put the list of layers and styles somewhere, but I would prefer to put them somewhere where it is dynamically generated. And not here.


[Edit: ltmom, add a link]
http://mf-chsdi3.int.bgdi.ch/ltbon_add_vectortiles_description/services/sdiservices.html#mapbox-vector-tiles