### PR TITLE
default search is divided into exact search and wildcard search

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -131,14 +131,14 @@ class Search(SearchValidation):
 
         if len(searchList) != 0:
             try:
-                # wildcard search
+                # standard wildcard search
                 self.sphinx.AddQuery(searchTextFinal, index='swisssearch')
-                # exact search
-                self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_PROXIMITY_BM25)
-                self.sphinx.SetGroupBy('origin', sphinxapi.SPH_GROUPBY_ATTR, 'rank ASC, @weight DESC, num ASC')
+                # exact search, first 10 results
+                self.sphinx.SetLimits(0, 10)
                 searchText = '@detail ^%s' % ' '.join(self.searchText)
                 self.sphinx.AddQuery(searchText, index='swisssearch')
-                self.sphinx.ResetGroupBy()
+                # reset settings
+                self.sphinx.SetLimits(0, limit)
 
                 temp = self.sphinx.RunQueries()
 


### PR DESCRIPTION
@davidoesch @gjn @danduk82 
the standard sphinx query will be converted into a sphinx multi-query [1].
It's still one network request, but there are two queries executed on sphinx side.
The standard query has been splitted into a
* exact match query, returning first result of each origin only
* wildcard query (same configuration as before)

triggered by https://github.com/geoadmin/mf-geoadmin3/issues/4287

[Testlink](https://mf-chsdi3.dev.bgdi.ch/dev_ltclm_exact_search/shorten/7f7c3a7288)

The results of the exact match query (**one per origin**) will be prepended to the results of the wildcard query.
p.e search for 
```
Entle
Dom
Rotten
Ricken
```
The results of the exact match search will be on top of the list now.

**question:**
* how should we merge the results of the two searches?

a) search1 (exact) results on top of search2 (wildcard) results **current implementation in this pr**
p.e.
```
search1->gg25
search1->gazetteer
search2->gg25
search2->gazetteer
search2->gazetteer
search2->gazetteer
search2->address
search2->address
search2->address
search2->address
```
b) search1 (exact) results on top of each search2 (wildcard) results origin
p.e
```
search1->gg25
search2->gg25
search1->gazetteer
search2->gazetteer
search2->gazetteer
search2->gazetteer
search2->address
search2->address
search2->address
search2->address
```

We will also have to do some yandex load tests an monitor the impact on sphinx of this change.

**TODO:**

- [x] Take a decision how to merge the results (exact on top of wildcard) how many of the exact search results should be used (currently one per origin)
> "Take a decision how to merge the results (exact on top of wildcard) how many of the exact search results should be used (currently one per origin)"
-> All exact results are shown in top. User gets what he expects
- [x] load tests
- [x] customer feedback (chmobil, others?)

[1] http://sphinxsearch.com/docs/current/multi-queries.html