### PR TITLE
remove temporary transition mode locations_preview

### DIFF
--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -14,7 +14,7 @@ class SearchValidation(MapNameValidation):
     def __init__(self, request):
         super(SearchValidation, self).__init__()
         self.availableLangs = request.registry.settings['available_languages'].split(' ')
-        self.locationTypes = [u'locations', u'locations_preview']
+        self.locationTypes = [u'locations']
         self.layerTypes = [u'layers']
         self.featureTypes = [u'featuresearch']
         self.supportedTypes = self.locationTypes + self.layerTypes + self.featureTypes

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -72,7 +72,7 @@ class Search(SearchValidation):
                 self.request.params.get('searchText')
             )
             self._feature_search()
-        elif self.typeInfo in ('locations', 'locations_preview'):
+        elif self.typeInfo in ('locations'):
             self.searchText = format_locations_search_text(
                 self.request.params.get('searchText', '')
             )
@@ -88,7 +88,7 @@ class Search(SearchValidation):
         # Only include results with a certain weight. This might need tweaking
         self.sphinx.SetFilterRange('@weight', 5000, 2 ** 32 - 1)
         try:
-            if self.typeInfo in ('locations', 'locations_preview'):
+            if self.typeInfo in ('locations'):
                 temp = self.sphinx.Query(searchTextFinal, index='swisssearch_fuzzy')
         except IOError:  # pragma: no cover
             raise exc.HTTPGatewayTimeout()
@@ -131,11 +131,7 @@ class Search(SearchValidation):
 
         if len(searchList) != 0:
             try:
-                if self.typeInfo == 'locations_preview':
-                    temp = self.sphinx.Query(searchTextFinal, index='swisssearch_preview')
-                else:
-                    temp = self.sphinx.Query(searchTextFinal, index='swisssearch')
-
+                temp = self.sphinx.Query(searchTextFinal, index='swisssearch')
             except IOError:  # pragma: no cover
                 raise exc.HTTPGatewayTimeout()
             temp = temp['matches'] if temp is not None else temp

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -10,7 +10,7 @@ class TestSearchServiceView(TestsBase):
         self.assertIn('detail', attrs)
         self.assertIn('origin', attrs)
         self.assertIn('label', attrs)
-        if type_ in ('locations',  'locations_preview'):
+        if type_ in ('locations'):
             self.assertIn('geom_quadindex', attrs)
             if returnGeometry:
                 self.assertIn('lon', attrs)
@@ -62,7 +62,7 @@ class TestSearchServiceView(TestsBase):
             'type': 'unaccepted'
         }
         resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=400)
-        acceptedTypes = ['locations', 'locations_preview', 'layers', 'featuresearch']
+        acceptedTypes = ['locations', 'layers', 'featuresearch']
         resp.mustcontain("The type parameter you provided is not valid. Possible values are %s" % (', '.join(acceptedTypes)))
 
     def test_searchtext_none_value_layers(self):
@@ -869,22 +869,6 @@ class TestSearchServiceView(TestsBase):
         }
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(len(resp.json['results']), 0)
-        self.assertEqual(resp.json['fuzzy'], 'true')
-        # type : 'locations_preview'
-        params = {
-            'type': 'locations_preview',
-            'searchText': 'Bettingen'
-        }
-        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
-        self.assertGreater(len(resp.json['results']), 0)
-        # Fuzzy results for locations_preview
-        params = {
-            'type': 'locations_preview',
-            'searchText': 'birgma',
-            'lang': 'de'
-        }
-        resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
-        self.assertGreater(len(resp.json['results']), 0)
         self.assertEqual(resp.json['fuzzy'], 'true')
 
     def test_search_lang_param_same_entry(self):


### PR DESCRIPTION
this will remove the transition search type locations_preview, which is not working anymore and is mostly unused now (see kibana).