### PR TITLE
Api default version to 4.4.2

### DIFF
--- a/chsdi/static/doc/source/api/quickstart.rst
+++ b/chsdi/static/doc/source/api/quickstart.rst
@@ -73,14 +73,14 @@ One can use different versions of GeoAdmin Api using the version parameter.
 
   <script src="http://api3.geo.admin.ch/loader.js?lang=en&version=3.18.2" type="text/javascript"></script>
 
-Default version is based on ol version 3.6.0.
+Default version is based on ol version 4.4.2.
 
 Available versions are (which are all based on ol3 releases):
 
 - 3.6.0  (LV03)
 - 3.18.2 (LV03)
 - 4.3.2  (LV03)
-- 4.4.2  (LV95)
+- 4.4.2  (LV95) **default**
 
 .. warning::
    Only the latest version is supported. Previous versions are given as courtesy and may be using layers and

--- a/chsdi/views/loader.py
+++ b/chsdi/views/loader.py
@@ -21,8 +21,8 @@ def loadjs(request):
     if vip is True:
         public_bucket_host = public_bucket_host.replace('public', 'public-cdn')
 
-    # If version not provided fallback to the first entry
-    version_str = request.params.get('version', available_versions[0])
+    # If version not provided fallback to the latest entry
+    version_str = request.params.get('version', available_versions[-1])
     # If provided make sure the version exists
     if version_str not in available_versions:
         raise HTTPNotFound(

--- a/tests/integration/test_loader.py
+++ b/tests/integration/test_loader.py
@@ -4,42 +4,45 @@ from tests.integration import TestsBase
 
 
 class TestLoaderJs(TestsBase):
+    default_version = '4.4.2'
 
     def test_loaderjs(self):
         resp = self.testapp.get('/loader.js', status=200)
         self.assertTrue(resp.content_type, 'application/javascript')
-        resp.mustcontain('resources/api/3.6.0/ga.js')
-        resp.mustcontain('resources/api/3.6.0/ga.css')
-        resp.mustcontain('resources/api/3.6.0/EPSG21781.js')
-        resp.mustcontain('resources/api/3.6.0/EPSG2056.js')
-        resp.mustcontain('proj4.js')
+        resp.mustcontain('resources/api/{}/ga.js'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/ga.css'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/EPSG21781.js'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/EPSG2056.js'.format(self.default_version))
         resp.mustcontain('proj4.js')
 
     def test_loaderjs_lang(self):
-        resp = self.testapp.get('/loader.js', params={'lang': 'en'}, status=200)
+        resp = self.testapp.get('/loader.js', params={'lang': 'fr'}, status=200)
         self.assertTrue(resp.content_type, 'application/javascript')
-        resp.mustcontain('resources/api/3.6.0/ga.js')
-        resp.mustcontain('resources/api/3.6.0/ga.css')
-        resp.mustcontain('resources/api/3.6.0/EPSG21781.js')
-        resp.mustcontain('resources/api/3.6.0/EPSG2056.js')
+        resp.mustcontain('resources/api/{}/ga.js'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/ga.css'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/EPSG21781.js'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/EPSG2056.js'.format(self.default_version))
         resp.mustcontain('proj4.js')
+        # We use french, as word in English or German maybe found in layers'attributes.
+        self.assertTrue(resp.body.count('eau') >= 1)
 
     def test_loaderjs_debug(self):
         resp = self.testapp.get('/loader.js', params={'mode': 'debug'}, status=200)
         self.assertTrue(resp.content_type, 'application/javascript')
-        resp.mustcontain('resources/api/3.6.0/ga-debug.js')
-        resp.mustcontain('resources/api/3.6.0/ga.css')
-        resp.mustcontain('resources/api/3.6.0/EPSG21781.js')
-        resp.mustcontain('resources/api/3.6.0/EPSG2056.js')
+        resp.mustcontain('resources/api/{}/ga-debug.js'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/ga.css'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/EPSG21781.js'.format(self.default_version))
+        resp.mustcontain('resources/api/{}/EPSG2056.js'.format(self.default_version))
         resp.mustcontain('proj4.js')
 
     def test_loaderjs_version(self):
-        resp = self.testapp.get('/loader.js', params={'version': '3.18.2'}, status=200)
+        version = '3.18.2'
+        resp = self.testapp.get('/loader.js', params={'version': version}, status=200)
         self.assertTrue(resp.content_type, 'application/javascript')
-        resp.mustcontain('resources/api/3.18.2/ga.js')
-        resp.mustcontain('resources/api/3.18.2/ga.css')
-        resp.mustcontain('resources/api/3.18.2/EPSG21781.js')
-        resp.mustcontain('resources/api/3.18.2/EPSG2056.js')
+        resp.mustcontain('resources/api/{}/ga.js'.format(version))
+        resp.mustcontain('resources/api/{}/ga.css'.format(version))
+        resp.mustcontain('resources/api/{}/EPSG21781.js'.format(version))
+        resp.mustcontain('resources/api/{}/EPSG2056.js'.format(version))
         resp.mustcontain('proj4.js')
 
     def test_loaderjs_bad_version(self):


### PR DESCRIPTION
This is a big change. **Please be sure to notify the users before merging**.

Examples (http://api3.geo.admin.ch/api/examples.html) are already using `4.4.2`

User https://mf-chsdi3.int.bgdi.ch/fix_3042/loader.js


Fixes https://github.com/geoadmin/mf-chsdi3/issues/3042