### PR TITLE
Fix TileMatrixSet extent for non Swiss Projection

### DIFF
--- a/chsdi/views/wmtscapabilities.py
+++ b/chsdi/views/wmtscapabilities.py
@@ -13,7 +13,12 @@ from chsdi.lib.filters import filter_by_geodata_staging, filter_by_map_name
 def getDefaultTileMatrixSet(tileMatrixSet):
     tilematrixSet = {}
 
-    gagrid = getTileGrid(int(tileMatrixSet))()
+    tilegridClass = getTileGrid(int(tileMatrixSet))
+    if tileMatrixSet not in ['2056', '21781']:
+        useSwissExtent = False
+    else:
+        useSwissExtent = True
+    gagrid = tilegridClass(useSwissExtent=useSwissExtent)
     minZoom = 0
     maxZoom = len(gagrid.RESOLUTIONS)
     for zoom in range(minZoom, maxZoom):

--- a/tests/integration/test_wmtscapabilities.py
+++ b/tests/integration/test_wmtscapabilities.py
@@ -103,6 +103,19 @@ class TestWmtsCapabilitiesView(TestsBase):
 
             self.assertTrue(set(used_matrices).issubset(defined_matrices))
 
+    def test_maximum_extent_for_non_swiss(self):
+        import xml.etree.ElementTree as etree
+
+        resp = self.testapp.get('/rest/services/api/1.0.0/WMTSCapabilities.xml', params={'epsg': 3857}, status=200)
+
+        root = etree.fromstring(resp.body)
+        tilematrices = root.findall('.//{http://www.opengis.net/wmts/1.0}TileMatrix')
+        for tilematrix in tilematrices:
+            id = tilematrix.find('./{http://www.opengis.net/ows/1.1}Identifier')
+            if id.text == '0':
+                topleft = tilematrix.find('./{http://www.opengis.net/wmts/1.0}TopLeftCorner')
+                assert topleft.text == '-20037508.3428 20037508.3428'
+
     def test_axis_order(self):
         from urlparse import urlparse
         import xml.etree.ElementTree as etree


### PR DESCRIPTION
See #3080 (caused by https://github.com/geoadmin/lib-gatilegrid/compare/0.1.5...0.1.6)


Check with https://mf-chsdi3.int.bgdi.ch/fix_3080/1.0.0/WMTSCapabilities.EPSG.3857.xml and
                   https://mf-chsdi3.int.bgdi.ch/fix_3080/1.0.0/WMTSCapabilities.EPSG.4326.xml

No good:
```
$ gdalinfo   "WMTS:https://mf-chsdi3.int.bgdi.ch/1.0.0/WMTSCapabilities.EPSG.3857.xml,layer=ch.swisstopo.pixelkarte-farbe"
ERROR 1: Invalid dataset dimensions : -65387263 x -44145919
gdalinfo failed - unable to open 'WMTS:https://mf-chsdi3.int.bgdi.ch/1.0.0/WMTSCapabilities.EPSG.3857.xml,layer=ch.swisstopo.pixelkarte-farbe'.
```
This PR

```
 $ gdalinfo   "WMTS:https://mf-chsdi3.int.bgdi.ch/fix_3080/1.0.0/WMTSCapabilities.EPSG.3857.xml,layer=ch.swisstopo.pixelkarte-farbe"
Driver: WMTS/OGC Web Mab Tile Service
Files: none associated
Size is 2362727, 1543585
Coordinate System is:
PROJCS["WGS 84 / Pseudo-Mercator",
    GEOGCS["WGS 84",
      [...]
    AUTHORITY["EPSG","3857"]]
Origin = (572209.086548235267401,6145313.137596352025867)
Pixel Size = (0.298582141737600,-0.298582141737600)
Metadata:
  ABSTRACT=swisstopo erstellt Landeskarten in den Massstäben 1:10‘000 bis 1:1 Million. Der Layer Landeskarten (farbig) nutzt die unterschiedlichen Massstäbe und zeigt die geeignetste Karte in Abhängigkeit der gewählten Zoomstufe an. Der Layer Landeskarte (farbig) dient als Hintergrundkarte im Geoportal des Bundes. Er ist auch in den Geodiensten WMS und WMTS verfügbar.
  TITLE=Landeskarten (farbig)



```
