### PR TITLE
change lfh datasource to view with new attribute activesince

### DIFF
--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -5745,7 +5745,7 @@ msgid "ch.bazl.luftfahrthindernis.abortionaccomplished"
 msgstr "Durata dell'installazione"
 
 msgid "ch.bazl.luftfahrthindernis.bgdi_activesince"
-msgstr "depuis"
+msgstr "dal"
 
 msgid "ch.bazl.luftfahrthindernis.duration"
 msgstr "Durata dell'installazione"

--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -1270,13 +1270,13 @@ register('ch.bazl.projektierungszonen-flughafenanlagen', ProjFlughafenanlagen)
 
 
 class Luftfahrthindernis(Base, Vector):
-    __tablename__ = 'luftfahrthindernis'
+    __tablename__ = 'view_luftfahrthindernis'
     __table_args__ = ({'schema': 'bazl', 'autoload': False})
     __template__ = 'templates/htmlpopup/luftfahrthindernisse.mako'
     __bodId__ = 'ch.bazl.luftfahrthindernis'
     __extended_info__ = True
     __queryable_attributes__ = ['registrationnumber', 'state', 'maxheightagl',
-                                'topelevationamsl', 'totallength', 'startofconstruction', 'abortionaccomplished']
+                                'topelevationamsl', 'totallength', 'bgdi_activesince', 'abortionaccomplished']
     # Must be equal to the mapped value of the column
     __label__ = 'registrationnumber'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1289,6 +1289,7 @@ class Luftfahrthindernis(Base, Vector):
     topelevationamsl = Column('topelevationamsl', Integer)
     totallength = Column('totallength', Integer)
     startofconstruction = Column('startofconstruction', Date)
+    bgdi_activesince = Column('bgdi_activesince', Date)
     duration = Column('duration', Unicode)
     geomtype = Column('geomtype', Unicode)
     abortionaccomplished = Column('abortionaccomplished', Date)


### PR DESCRIPTION
adds a new attribute for attribute search ``bgdi_activesince``
its in a new view, and it has always the newer date of the the table attributes ``constructionConfirmed``and ``startofConstruction``

see https://jira.swisstopo.ch/browse/BGDIDI_KB-872

[Testlink](https://mf-chsdi3.dev.bgdi.ch/dev_ltclm_lfh/shorten/7fce83f29b)

automated fme workbench, table and view on _master, _dev, _int, _prod have been updated already.
This can be published only by merging and deploying this code .