### PR TITLE
Return a valid geojson

### DIFF
--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -51,7 +51,13 @@ def identify_esrijson(request):
 @view_config(route_name='feature', renderer='geojson',
              request_param='geometryFormat=geojson')
 def view_get_feature_geojson(request):
-    return _get_feature_service(request)
+
+    feats = _get_feature_service(request)
+    features = [dict(f, **{'type': 'Feature'}) for f in feats]
+    if (len(features)) == 1:
+        feature = features[0]['feature']
+        return feature
+    return features
 
 
 @view_config(route_name='feature', renderer='esrijson')
@@ -323,7 +329,8 @@ def _get_feature_service(request):
         else:
             features.append(feature)
     if len(features) == 1:
-        return features[0]
+        feature = features[0]
+        feature['type'] = 'Feature'
     return features
 
 

--- a/tests/integration/test_features_service.py
+++ b/tests/integration/test_features_service.py
@@ -258,40 +258,40 @@ class TestFeaturesView(TestsBase):
         featureId = self.getRandomFeatureId(bodId)
         resp = self.testapp.get('/rest/services/ech/MapServer/%s/%s' % (bodId, featureId), status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['feature']['id'], featureId)
-        self.assertEsrijsonFeature(resp.json['feature'], 21781)
+        self.assertEqual(resp.json['features'][0]['feature']['id'], featureId)
+        self.assertEsrijsonFeature(resp.json['features'][0]['feature'], 21781)
 
     def test_feature_valid_topic_all(self):
         bodId = 'ch.bafu.bundesinventare-bln'
         featureId = self.getRandomFeatureId(bodId)
         resp = self.testapp.get('/rest/services/all/MapServer/%s/%s' % (bodId, featureId), status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['feature']['id'], featureId)
-        self.assertEsrijsonFeature(resp.json['feature'], 21781)
+        self.assertEqual(resp.json['features'][0]['feature']['id'], featureId)
+        self.assertEsrijsonFeature(resp.json['features'][0]['feature'], 21781)
 
     def test_feature_geojson(self):
         bodId = 'ch.bafu.bundesinventare-bln'
         featureId = self.getRandomFeatureId(bodId)
         resp = self.testapp.get('/rest/services/ech/MapServer/%s/%s' % (bodId, featureId), params={'geometryFormat': 'geojson'}, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['feature']['id'], featureId)
-        self.assertGeojsonFeature(resp.json['feature'], 21781)
+        self.assertEqual(resp.json['id'], featureId)
+        self.assertGeojsonFeature(resp.json, 21781)
 
     def test_feature_geojson_nogeom(self):
         bodId = 'ch.bafu.bundesinventare-bln'
         featureId = self.getRandomFeatureId(bodId)
         resp = self.testapp.get('/rest/services/ech/MapServer/%s/%s' % (bodId, featureId), params={'geometryFormat': 'geojson', 'returnGeometry': 'false'}, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['feature']['id'], featureId)
-        self.assertGeojsonFeature(resp.json['feature'], 21781, hasGeometry=False)
+        self.assertEqual(resp.json['id'], featureId)
+        self.assertGeojsonFeature(resp.json, 21781, hasGeometry=False)
 
     def test_feature_geojson_geom(self):
         bodId = 'ch.bafu.bundesinventare-bln'
         featureId = self.getRandomFeatureId(bodId)
         resp = self.testapp.get('/rest/services/ech/MapServer/%s/%s' % (bodId, featureId), params={'geometryFormat': 'geojson', 'returnGeometry': 'true'}, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(resp.json['feature']['id'], featureId)
-        self.assertGeojsonFeature(resp.json['feature'], 21781)
+        self.assertEqual(resp.json['id'], featureId)
+        self.assertGeojsonFeature(resp.json, 21781)
 
     @skip("Apparently, there is no too big data anymore")
     def test_too_large_feature_only_attributes(self):
@@ -344,7 +344,8 @@ class TestFeaturesView(TestsBase):
         featureId = self.getRandomFeatureId(bodId)
         resp = self.testapp.get('/rest/services/all/MapServer/%s/%s' % (bodId, featureId), params={'geometryFormat': 'geojson'}, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertIn('geometry', resp.json['feature'])
+        self.assertIn('geometry', resp.json)
+        self.assertIn('properties', resp.json)
 
     def test_htmlpopup_invalid_srid(self):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bafu.bundesinventare-bln/362/htmlPopup', params={'sr': '111'}, status=400)


### PR DESCRIPTION
:bomb: As already stated, this is a [breaking change](https://github.com/geoadmin/mf-chsdi3/pull/3135/files#diff-b0865f5af44bf58b4964c43b60561529). I won't merge it.

As EPSG:4326 GeoJSON

http://mf-chsdi3.int.bgdi.ch/identify_geojson/rest/services/api/MapServer/ch.swisstopo.fixpunkte-agnes/HUTT?geometryFormat=geojson&sr=4326

http://mf-chsdi3.int.bgdi.ch/identify_geojson/rest/services/api/MapServer/ch.swisstopo.fixpunkte-agnes/HUTT,NEUC?geometryFormat=geojson&sr=4326


See https://github.com/geoadmin/mf-chsdi3/issues/3020