### PR TITLE
show all exact search results before wildcard search

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -133,12 +133,10 @@ class Search(SearchValidation):
             try:
                 # standard wildcard search
                 self.sphinx.AddQuery(searchTextFinal, index='swisssearch')
-                # exact search, first 10 results
-                self.sphinx.SetLimits(0, 10)
+                # exact search with priority
                 searchText = '@detail ^%s' % ' '.join(self.searchText)
                 self.sphinx.AddQuery(searchText, index='swisssearch')
                 # reset settings
-                self.sphinx.SetLimits(0, limit)
 
                 temp = self.sphinx.RunQueries()
 


### PR DESCRIPTION
@davidoesch @gjn
**new search behaviour**
instead of 10 results of exact prefix match search, all the results of exact prefix search will be prepended to the wildcard search results.

[Testlink](https://mf-chsdi3.dev.bgdi.ch/dev_ltclm_esel/shorten/810052d6fc)
search for 
* ``esel``
* ``loch``
* ``quartier``
