### PR TITLE
Extended query for strassenverzeichnis

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -3158,7 +3158,6 @@ class AmtlichesStrassenverzeichnis(Base, Vector):
     __template__ = 'templates/htmlpopup/strassenverzeichnis.mako'
     __bodId__ = 'ch.swisstopo.amtliches-strassenverzeichnis'
     __label__ = 'label'
-    __extended_info__ = True
     __queryable_attributes__ = ['label', 'plzo', 'gdename', 'gdenr', 'type']
     id = Column('bgdi_id', Integer, primary_key=True)
     esid = Column('esid', Integer)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -3158,6 +3158,8 @@ class AmtlichesStrassenverzeichnis(Base, Vector):
     __template__ = 'templates/htmlpopup/strassenverzeichnis.mako'
     __bodId__ = 'ch.swisstopo.amtliches-strassenverzeichnis'
     __label__ = 'label'
+    __extended_info__ = True
+    __queryable_attributes = ['label', 'plzo', 'gdename', 'gdenr', 'type']
     id = Column('bgdi_id', Integer, primary_key=True)
     esid = Column('esid', Integer)
     label = Column('label', Unicode)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -3159,7 +3159,7 @@ class AmtlichesStrassenverzeichnis(Base, Vector):
     __bodId__ = 'ch.swisstopo.amtliches-strassenverzeichnis'
     __label__ = 'label'
     __extended_info__ = True
-    __queryable_attributes = ['label', 'plzo', 'gdename', 'gdenr', 'type']
+    __queryable_attributes__ = ['label', 'plzo', 'gdename', 'gdenr', 'type']
     id = Column('bgdi_id', Integer, primary_key=True)
     esid = Column('esid', Integer)
     label = Column('label', Unicode)

--- a/chsdi/templates/htmlpopup/strassenverzeichnis.mako
+++ b/chsdi/templates/htmlpopup/strassenverzeichnis.mako
@@ -14,8 +14,3 @@
     <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.type')}</td>                 <td>${_(c['attributes']['type'] or '-')}</td></tr>
     <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.status')}</td>                 <td>${_(c['attributes']['status'] or '-')}</td></tr>
 </%def>
-
-<%def name="extended_info(c, lang)">
-
-  <h1>TODO</h1>
-</%def>

--- a/chsdi/templates/htmlpopup/strassenverzeichnis.mako
+++ b/chsdi/templates/htmlpopup/strassenverzeichnis.mako
@@ -15,3 +15,7 @@
     <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.status')}</td>                 <td>${_(c['attributes']['status'] or '-')}</td></tr>
 </%def>
 
+<%def name="extended_info(c, lang)">
+
+  <h1>TODO</h1>
+</%def>


### PR DESCRIPTION
Trying to address https://github.com/geoadmin/mf-chsdi3/issues/3104

[Demo](https://mf-chsdi3.dev.bgdi.ch/strassen_query/shorten/815225b98f)

Queryable attributes are: "plzo","type","gdenr","gdename","label"

Possible values: https://mf-chsdi3.dev.bgdi.ch/strassen_query/rest/services/api/MapServer/ch.swisstopo.amtliches-strassenverzeichnis


**Examples:**

**Bahnhofstrasse (many)**
https://mf-chsdi3.dev.bgdi.ch/strassen_query/rest/services/all/MapServer/identify?geometryFormat=geojson&imageDisplay=1367,900,96&lang=en&layers=all:ch.swisstopo.amtliches-strassenverzeichnis&mapExtent=2598894.75,1199352.08,2600261.75,1200252.08&returnGeometry=false&sr=2056&tolerance=5&where=label+ilike+%27%25Bahnhofstrasse%25%27

**Bahnhofstrasse and Thun**

https://mf-chsdi3.dev.bgdi.ch/strassen_query/rest/services/all/MapServer/identify?geometryFormat=geojson&imageDisplay=1367,900,96&lang=en&layers=all:ch.swisstopo.amtliches-strassenverzeichnis&mapExtent=2598894.75,1199352.08,2600261.75,1200252.08&returnGeometry=false&sr=2056&tolerance=5&where=label+ilike+%27%25Bahnhofstrasse%25%27+and+plzo+ilike+%27%25Thun%25%27