### PR TITLE
Limiting featureIds number pro request

### DIFF
--- a/chsdi/lib/validation/features.py
+++ b/chsdi/lib/validation/features.py
@@ -59,6 +59,8 @@ class HtmlPopupServiceValidation(BaseFeaturesValidation):
     def featureIds(self, value):
         if value is not None:
             self._featureIds = value.split(',')
+            if len(self._featureIds) > int(self.request.registry.settings['max_featureids_request']):
+                raise HTTPBadRequest('Too many featureIds')
         else:
             raise HTTPBadRequest('Please provide featureIds')  # pragma: no cover
 

--- a/production.ini.in
+++ b/production.ini.in
@@ -58,6 +58,7 @@ vector_bucket = ${vector_bucket}
 datageoadminhost = ${datageoadminhost}
 opentrans_api_key = ${opentrans_api_key}
 empty_geotables = ch.bav.sachplan-infrastruktur-schifffahrt_anhoerung,ch.bfe.sachplan-uebertragungsleitungen_anhoerung,ch.blw.emapis-bewaesserung,ch.blw.emapis-elektrizitaetsversorgung,ch.blw.emapis-milchleitung,ch.blw.emapis-seilbahnen,ch.vbs.sachplan-infrastruktur-militaer_anhoerung,ch.sem.sachplan-asyl_anhoerung,ch.astra.sachplan-infrastruktur-strasse_anhoerung,ch.bav.sachplan-infrastruktur-schiene_anhorung
+max_featureids_request = 20
 
 shortener.allowed_hosts = ${shortener_allowed_hosts}
 shortener.allowed_domains = ${shortener_allowed_domains}

--- a/tests/integration/test_features_service.py
+++ b/tests/integration/test_features_service.py
@@ -261,6 +261,12 @@ class TestFeaturesView(TestsBase):
         self.assertEqual(resp.json['feature']['id'], featureId)
         self.assertEsrijsonFeature(resp.json['feature'], 21781)
 
+    def test_feature_too_many_featuresids(self):
+        bodId = 'ch.bafu.bundesinventare-bln'
+        featureIds = ','.join(map(str, range(50)))
+        resp = self.testapp.get('/rest/services/ech/MapServer/%s/%s' % (bodId, featureIds), status=400)
+        resp.mustcontain('Too many featureIds')
+
     def test_feature_valid_topic_all(self):
         bodId = 'ch.bafu.bundesinventare-bln'
         featureId = self.getRandomFeatureId(bodId)


### PR DESCRIPTION
for `features service`, limit number of id in a single request to something

Too many
http://mf-chsdi3.dev.bgdi.ch/mom_max_ids/rest/services/api/MapServer/ch.bafu.nabelstationen/1,2,3,4,5,6,7,8,9,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2

OK (two features)
http://mf-chsdi3.dev.bgdi.ch/mom_max_ids/rest/services/api/MapServer/ch.bafu.nabelstationen/RIG,LAU