### PR TITLE
[WIP] Updating last_access timestamp when getting a file

### DIFF
--- a/tests/integration/test_file_storage.py
+++ b/tests/integration/test_file_storage.py
@@ -121,6 +121,15 @@ class TestFileView(TestsBase):
         self.assertTrue(resp.json['status'], 'updated')
         self.assertEqual(admin_id, resp.json['adminId'])
 
+    # KML in S3 are served directly by varnish
+    def test_get_kml(self):
+        resp = self.testapp.post('/files', VALID_KML, headers=self.headers, status=200)
+        file_id = resp.json['fileId']
+
+        resp = self.testapp.get('/files/%s' % file_id, headers=self.headers, status=200)
+        self.assertTrue(resp.headers['Content-Type'], 'application/vnd.google-earth.kml+xml; charset=UTF-8')
+        self.assertEqual(resp.text, VALID_KML)
+
     def test_forked_kml(self):
         resp = self.testapp.post('/files', VALID_KML, headers=self.headers, status=200)
         admin_id = resp.json['adminId']


### PR DESCRIPTION
Currently, files are served directly by varnish/S3.
In order to update the last_access timestamp, we have to use the service.

See #1808