### PR TITLE
increase number of sphinx results in bbox search

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -98,16 +98,18 @@ class Search(SearchValidation):
 
     def _swiss_search(self):
         limit = self.limit if self.limit and self.limit <= self.LOCATION_LIMIT else self.LOCATION_LIMIT
-        self.sphinx.SetLimits(0, limit)
 
         # Define ranking mode
         if self.bbox is not None and self.sortbbox:
             coords = self._get_geoanchor_from_bbox()
             self.sphinx.SetGeoAnchor('lat', 'lon', coords[1], coords[0])
             self.sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, '@geodist ASC')
+            limit = 150
         else:
             self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_WORDCOUNT)
             self.sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, 'rank ASC, @weight DESC, num ASC')
+
+        self.sphinx.SetLimits(0, limit)
 
         # Filter by origins if needed
         if self.origins is None:

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -98,7 +98,6 @@ class Search(SearchValidation):
 
     def _swiss_search(self):
         limit = self.limit if self.limit and self.limit <= self.LOCATION_LIMIT else self.LOCATION_LIMIT
-
         # Define ranking mode
         if self.bbox is not None and self.sortbbox:
             coords = self._get_geoanchor_from_bbox()
@@ -168,7 +167,7 @@ class Search(SearchValidation):
         else:
             temp = []
         if temp is not None and len(temp) != 0:
-            self._parse_location_results(temp)
+            self._parse_location_results(temp, limit)
 
     def _layer_search(self):
 
@@ -451,7 +450,7 @@ class Search(SearchValidation):
                     raise exc.HTTPInternalServerError('Error while converting point(x, y) to EPSG:{}'.format(self.srid))
         return res
 
-    def _parse_location_results(self, results):
+    def _parse_location_results(self, results, limit):
         nb_address = 0
         for result in self._yield_matches(results):
             origin = result['attrs']['origin']
@@ -475,6 +474,8 @@ class Search(SearchValidation):
                                                             result['attrs']['geom_st_box2d']):
                     self._parse_locations(result['attrs'])
                     self.results['results'].append(result)
+        if len(self.results['results']) > 0:
+            self.results['results'] = self.results['results'][:limit]
 
     def _parse_feature_results(self, results):
         for idx, result in self._yield_results(results):

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -20,6 +20,7 @@ class Search(SearchValidation):
     LAYER_LIMIT = 30
     FEATURE_LIMIT = 20
     DEFAULT_SRID = 21781
+    BBOX_SEARCH_LIMIT = 150
 
     def __init__(self, request):
         super(Search, self).__init__(request)
@@ -103,7 +104,7 @@ class Search(SearchValidation):
             coords = self._get_geoanchor_from_bbox()
             self.sphinx.SetGeoAnchor('lat', 'lon', coords[1], coords[0])
             self.sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, '@geodist ASC')
-            limit = 150
+            limit = self.BBOX_SEARCH_LIMIT
         else:
             self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_WORDCOUNT)
             self.sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, 'rank ASC, @weight DESC, num ASC')


### PR DESCRIPTION
there is a risk that the object we're looking for is not within the first 50 results of the sphinx search when doing a bbox search.

this pr will increase the number of results in the initial spinx query to 150 in case of bbox search.
the quadindex matching is done in a post-processing on the sphinx query results in the function ``parse_location_results()``. 

[First Query](http://mf-chsdi3.dev.bgdi.ch/dev_ltclm_bbox_search/rest/services/api/SearchServer?searchText=Echallens&origins=parcel&type=locations&bbox=2538177,1165702,2538177,1165702&sr=2056)
[Second Query](http://mf-chsdi3.dev.bgdi.ch/dev_ltclm_bbox_search/rest/services/api/SearchServer?searchText=Echallens&origins=parcel&type=locations&bbox=2538525,1165844,2538525,1165844&sr=2056)

fix for https://github.com/geoadmin/mf-chsdi3/issues/3218