### PR TITLE
Checking if geometryType matches geometry in identify request

### DIFF
--- a/chsdi/lib/validation/identify.py
+++ b/chsdi/lib/validation/identify.py
@@ -2,6 +2,8 @@
 
 import json
 import esrijson
+from shapely.geometry.linestring import LineString
+from shapely.geometry.polygon import Polygon
 from pyramid.httpexceptions import HTTPBadRequest
 
 from chsdi.lib.helpers import float_raise_nan
@@ -150,8 +152,12 @@ class IdentifyServiceValidation(BaseFeaturesValidation):
                     self._geometry = esrijson.to_shape({'x': value[0], 'y': value[1]})
                 else:
                     self._geometry = esrijson.to_shape(esrijson.loads(value))
+
             except:
                 raise HTTPBadRequest('Please provide a valid geometry')
+        if (self._geometryType == u'esriGeometryPolyline' and not isinstance(self._geometry, LineString)) \
+                or (self._geometryType == u'esriGeometryPolygon' and not isinstance(self._geometry, Polygon)):
+            raise HTTPBadRequest(u"Missmatch between 'geometryType': {} and provided 'geometry' parsed as '{}'".format(self._geometryType, self._geometry.__class__.__name__))
 
     @imageDisplay.setter
     def imageDisplay(self, value):

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -101,6 +101,28 @@ class TestIdentifyService(TestsBase):
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEsrijsonFeature(resp.json['results'][0], 21781)
 
+    def test_identify_geometry_polyline_missmatch(self):
+        # Geometry is a PolyLine ("paths") and not a Polygon ("rings")!
+        params = {'geometry': '{"paths": [[[2554060, 1198340],[2554060, 1198530],[2554240, 1198530],[2554240, 1198340],[2554060, 1198340]]]}',
+                  'geometryType': 'esriGeometryPolygon',
+                  'imageDisplay': '1920,852,96',
+                  'mapExtent': '420000,350000,900000,30000',
+                  'tolerance': '0',
+                  'layers': 'all:ch.bfs.volkszaehlung-bevoelkerungsstatistik_einwohner'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
+        resp.mustcontain("Missmatch between 'geometryType': esriGeometryPolygon and provided 'geometry' parsed as 'LineString'")
+
+    def test_identify_geometry_polygon_missmatch(self):
+        # Geometry is a Polygon ("rings") and not a Polyline ("paths")!
+        params = {'geometry': '{"rings": [[[2554060, 1198340],[2554060, 1198530],[2554240, 1198530],[2554240, 1198340],[2554060, 1198340]]]}',
+                  'geometryType': 'esriGeometryPolyline',
+                  'imageDisplay': '1920,852,96',
+                  'mapExtent': '420000,350000,900000,30000',
+                  'tolerance': '0',
+                  'layers': 'all:ch.bfs.volkszaehlung-bevoelkerungsstatistik_einwohner'}
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
+        resp.mustcontain("Missmatch between 'geometryType': esriGeometryPolyline and provided 'geometry' parsed as 'Polygon'")
+
     def test_identify_nan_error(self):
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon',


### PR DESCRIPTION
**Demo**
*Wrong type*

`geometryType` is `esriGeometryPolygon` and
`geometry` is parsed and is a `LineString`  (`paths`!!!, should be `rings` for a polygon)

Service return a missmatch error (and not an empty list as [currently](http://api3.geo.admin.ch/rest/services/ech/MapServer/identify?geometry=%7B%22paths%22:%5B%5B%5B2554060,1198340%5D,%5B2554060,1198530%5D,%5B2554240,1198530%5D,%5B2554240,1198340%5D,%5B2554060,1198340%5D%5D%5D%7D&geometryType=esriGeometryPolygon&imageDisplay=1920%2C852%2C96&mapExtent=420000%2C350000%2C900000%2C30000&returnGeometry=false&sr=2056&tolerance=0&layers=all%3Ach.bfs.volkszaehlung-bevoelkerungsstatistik_einwohner) )

http://mf-chsdi3.int.bgdi.ch/mom_identify_poly/rest/services/ech/MapServer/identify?geometry=%7B%22paths%22:%5B%5B%5B2554060,1198340%5D,%5B2554060,1198530%5D,%5B2554240,1198530%5D,%5B2554240,1198340%5D,%5B2554060,1198340%5D%5D%5D%7D&geometryType=esriGeometryPolygon&imageDisplay=1920%2C852%2C96&mapExtent=420000%2C350000%2C900000%2C30000&returnGeometry=false&sr=2056&tolerance=0&layers=all%3Ach.bfs.volkszaehlung-bevoelkerungsstatistik_einwohner

*Correct type*

`geometryType` is `esriGeometryPolygon` and
`geometry` is parsed and is a `Polygon`  (`rings` is correct for a polygon)

Some features are within the polygon, so response is OK.

http://mf-chsdi3.int.bgdi.ch/mom_identify_poly/rest/services/ech/MapServer/identify?geometry=%7B%22rings%22:%5B%5B%5B2554060,1198340%5D,%5B2554060,1198530%5D,%5B2554240,1198530%5D,%5B2554240,1198340%5D,%5B2554060,1198340%5D%5D%5D%7D&geometryType=esriGeometryPolygon&imageDisplay=1920%2C852%2C96&mapExtent=420000%2C350000%2C900000%2C30000&returnGeometry=false&sr=2056&tolerance=0&layers=all%3Ach.bfs.volkszaehlung-bevoelkerungsstatistik_einwohner

See https://github.com/geoadmin/mf-chsdi3/issues/3194