### PR TITLE
do not remove dots within the words in search Text

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -151,7 +151,8 @@ def format_search_text(input_str):
 def format_locations_search_text(input_str):
     if input_str is None:
         return input_str
-    input_str = input_str.replace('.', '')
+    # only remove trailing and leading dots
+    input_str = ' '.join([w.strip('.') for w in input_str.split()])
     return format_search_text(input_str)
 
 


### PR DESCRIPTION
customers have complaint that 
`` Leigruebstrasse 2.1 `` cannot be found in swisssearch.

this change will modifiy the function format_locations_search_text and remove dots only from the word boundaries.
p.e.
``pl. du Midi 12.1`` will be converted into ``pl du Midi 12.1``

see helpdesk: Customer feedback ID : 2019091909150848
[testlink](https://mf-chsdi3.dev.bgdi.ch/dev_ltclm_fix_search/shorten/8497becd66)