### PR TITLE
layerDefs and multiple operators

### DIFF
--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -700,7 +700,7 @@ def _find(request):
                 )
         if where_txt is not None:
             query = query.filter(text(
-                where_txt
+                "({})".format(where_txt)  # operator precedance
             ))
         query = query.limit(MaxFeatures)
         for feature in query:

--- a/tests/integration/test_features_service.py
+++ b/tests/integration/test_features_service.py
@@ -289,7 +289,7 @@ class TestFeaturesView(TestsBase):
         # self.assertEqual(resp1.json['results'], resp2.json['results'])
         for feat in resp2.json['results']:
             self.assertIn(feat['attributes']['gdename'], ['Olten', 'Sattel'])
-            self.assertIn('Studer', feat['attributes'])
+            self.assertIn('Studer', feat['attributes']['label'])
 
     def test_find_filter_with_layerdefs(self):
         params = {'layer': 'ch.swisstopo.amtliches-strassenverzeichnis',


### PR DESCRIPTION
See https://github.com/geoadmin/mf-chsdi3/issues/3267

```
layerDefs={
            "ch.swisstopo.amtliches-strassenverzeichnis": "gdename = 'Olten' or gdename = 'Sattel'"
}

```


Not filtered
https://mf-chsdi3.prod.bgdi.ch/rest/services/all/MapServer/find?returnGeometry=false&layer=ch.swisstopo.amtliches-strassenverzeichnis&searchText=Studerweg&layerDefs=%7B"ch.swisstopo.amtliches-strassenverzeichnis"%3A+"gdename+%3D+%27Olten%27+or+gdename+%3D+%27Sattel%27"%7D&searchField=label


Filtered (this PR)
https://mf-chsdi3.int.bgdi.ch/fix_3267/rest/services/all/MapServer/find?returnGeometry=false&layer=ch.swisstopo.amtliches-strassenverzeichnis&searchText=Studerweg&layerDefs=%7B"ch.swisstopo.amtliches-strassenverzeichnis"%3A+"gdename+%3D+%27Olten%27+or+gdename+%3D+%27Sattel%27"%7D&searchField=label