### PR TITLE
[WIP] Test tests.integration.test_layers.test_all_identify fails

### DIFF
--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -20,7 +20,7 @@ Geometry2D = GeometryChsdi(geometry_type='GEOMETRY', dimension=2, srid=2056)
 Geometry3D = GeometryChsdi(geometry_type='GEOMETRYZ', dimension=3, srid=2056)
 
 
-MAX_FEATURE_GEOMETRY_SIZE = 1e6
+MAX_FEATURE_GEOMETRY_SIZE = 3e6
 
 DEFAULT_OUPUT_SRID = 21781
 


### PR DESCRIPTION
tests.integration.test_layers.test_all_identify(u'ch.swisstopo.swissalti3d.metadata',) because the geometry is too large.

**Context:**
Since the perimeter of the product swissalti3d changed, the shop layer is larger than the defined MAX_FEATURE_GEOMETRY_SIZE. The geometry is essential to calculate the exact prize of the product (whole Switzerland and over the boarder = CHF 112248.70).

**Propositions:**
1. Change of MAX_FEATURE_GEOMETRY_SIZE
2. Layer exception in tests
3. Change of the Feature Geometry (this has to be coordinated with the people from sale) 
4. **Marcels proposition** https://github.com/geoadmin/mf-chsdi3/pull/3304 (last but not least)