### PR TITLE
[WIP] do not filter out large geometries with shop layers

### DIFF
--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -157,7 +157,7 @@ class Vector(object):
         return cls.__mapper__.columns[geom_column_name]
 
     def ignore_max_feature_geometry_size_column(cls):
-        return cls.__mapper__columns[cls.__ignore_max_feature_geometry_size__] if hasattr(cls, '__ignore_max_feature_geometry_size__') else False
+        return cls.__mapper__.columns[cls.__ignore_max_feature_geometry_size__] if hasattr(cls, '__ignore_max_feature_geometry_size__') else False
 
     @classmethod
     def primary_key_column(cls):

--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import re
 import geojson
 import esrijson
@@ -87,7 +86,7 @@ class Vector(object):
                         geom = self._shape
                     elif val is not None and \
                             (len(val.data) < MAX_FEATURE_GEOMETRY_SIZE or
-                            self.ignore_max_feature_geometry_size_column()):
+                            self.ignore_max_feature_geometry_size_column):
                         geom = to_shape(val)
                     try:
                         bbox = geom.bounds
@@ -156,6 +155,7 @@ class Vector(object):
         geom_column_name = cls.__returnedGeometry__ if hasattr(cls, '__returnedGeometry__') else 'the_geom'
         return cls.__mapper__.columns[geom_column_name]
 
+    @property
     def ignore_max_feature_geometry_size_column(cls):
         return cls.__mapper__.columns[cls.__ignore_max_feature_geometry_size__] if hasattr(cls, '__ignore_max_feature_geometry_size__') else False
 

--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -87,7 +87,7 @@ class Vector(object):
                         geom = self._shape
                     elif val is not None and \
                             (len(val.data) < MAX_FEATURE_GEOMETRY_SIZE or
-                            'shop_product.mako' in self.__template__):
+                            self.__ignore_max_feature_geometry_size__):
                         geom = to_shape(val)
                     try:
                         bbox = geom.bounds

--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -86,7 +86,8 @@ class Vector(object):
                             len(self._shape) < MAX_FEATURE_GEOMETRY_SIZE:
                         geom = self._shape
                     elif val is not None and \
-                            len(val.data) < MAX_FEATURE_GEOMETRY_SIZE:
+                            (len(val.data) < MAX_FEATURE_GEOMETRY_SIZE or
+                            'shop_product.mako' in self.__template__):
                         geom = to_shape(val)
                     try:
                         bbox = geom.bounds
@@ -96,7 +97,6 @@ class Vector(object):
                       and not isinstance(col.type, GeometryChsdi)):
                     properties[p.key] = val
         properties = self.insert_label(properties)
-
         return id, geom, properties, bbox
 
     def transform_shape(self, geom, srid_to, rounding=True):

--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -87,7 +87,7 @@ class Vector(object):
                         geom = self._shape
                     elif val is not None and \
                             (len(val.data) < MAX_FEATURE_GEOMETRY_SIZE or
-                            self.__ignore_max_feature_geometry_size__):
+                            self.ignore_max_feature_geometry_size_column()):
                         geom = to_shape(val)
                     try:
                         bbox = geom.bounds
@@ -155,6 +155,9 @@ class Vector(object):
     def geometry_column_to_return(cls):
         geom_column_name = cls.__returnedGeometry__ if hasattr(cls, '__returnedGeometry__') else 'the_geom'
         return cls.__mapper__.columns[geom_column_name]
+
+    def ignore_max_feature_geometry_size_column(cls):
+        return cls.__mapper__columns[cls.__ignore_max_feature_geometry_size__] if hasattr(cls, '__ignore_max_feature_geometry_size__') else False
 
     @classmethod
     def primary_key_column(cls):

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2946,6 +2946,7 @@ class SwissAlti3dPerimeter(Base, ShopStandardClass, Vector):
     __tablename__ = 'shop_perimeter_swissalti3d'
     __table_args__ = ({'autoload': False})
     __bodId__ = 'ch.swisstopo.swissalti3d-reliefschattierung'
+    __ignore_max_feature_geometry_size__ = True  # ignore MAX_FEATURE_GEOMETRY_SIZE
     __totalArea__ = 41455.0
     the_geom = Column(Geometry2D)
 
@@ -2984,7 +2985,8 @@ class SwissAlti3dMetadataPerimeter(Base, ShopStandardClass, Vector):
     __tablename__ = 'shop_perimeter_swissalti3d'
     __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
     __bodId__ = 'ch.swisstopo.swissalti3d.metadata'
-    __totalArea__ = 41455.0
+    __ignore_max_feature_geometry_size__ = True  # ignore MAX_FEATURE_GEOMETRY_SIZE
+    __totalArea__ = 42465.8
     the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.swissalti3d.metadata', SwissAlti3dMetadataPerimeter)
@@ -2994,6 +2996,7 @@ class SwissTlm3dMetadataPerimeter(Base, ShopStandardClass, Vector):
     __tablename__ = 'shop_perimeter_swisstlm3d'
     __table_args__ = ({'schema': 'public', 'autoload': False, 'extend_existing': True})
     __bodId__ = 'ch.swisstopo.swisstlm3d.metadata'
+    __ignore_max_feature_geometry_size__ = True  # ignore MAX_FEATURE_GEOMETRY_SIZE
     the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.swisstlm3d.metadata', SwissTlm3dMetadataPerimeter)


### PR DESCRIPTION
a geom size filter has been introduced with:
https://github.com/geoadmin/mf-chsdi3/pull/1621
and modified with:
https://github.com/geoadmin/mf-chsdi3/pull/3019

this pr adds an exception for shop layers.
we have complex geometries and were not allowed to modify (generalize, thin out, ...) because they are used for prize calculations.
