### PR TITLE
stop mf-chsdi3 error log flooding with invalid search text

### DIFF
--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -153,6 +153,8 @@ def format_locations_search_text(input_str):
         return input_str
     # only remove trailing and leading dots
     input_str = ' '.join([w.strip('.') for w in input_str.split()])
+    # remove double quotation marks
+    input_str = input_str.replace('"', '')
     return format_search_text(input_str)
 
 

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -182,7 +182,7 @@ class Search(SearchValidation):
             except IOError:  # pragma: no cover
                 raise exc.HTTPGatewayTimeout()
 
-            temp_merged = temp[1]['matches'] + temp[0]['matches'] if len(temp) == 2 else temp[0]['matches']
+            temp_merged = temp[1].get('matches', []) + temp[0].get('matches', []) if len(temp) == 2 else temp[0].get('matches', [])
 
             # remove duplicate results, exact search results have priority over wildcard search results
             temp = []

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -182,7 +182,7 @@ class Search(SearchValidation):
                 # In case RunQueries doesn't return results (reason unknown)
                 # related to issue
                 if temp is None:
-                    raise ValueError("no results from sphinx service (%s)" % self.sphinx._error)
+                    raise exc.HTTPServiceUnavailable('no results from sphinx service (%s)' % self.sphinx._error)
 
             except IOError:  # pragma: no cover
                 raise exc.HTTPGatewayTimeout()

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -179,6 +179,11 @@ class Search(SearchValidation):
                 # reset settings
                 temp = self.sphinx.RunQueries()
 
+                # In case RunQueries doesn't return results (reason unknown)
+                # related to issue
+                if temp is None:
+                    raise ValueError("no results from sphinx service (%s)" % self.sphinx._error)
+
             except IOError:  # pragma: no cover
                 raise exc.HTTPGatewayTimeout()
 


### PR DESCRIPTION
this will stop the flooding of mf-chsdi3 error logs when invalid search queries are sent to search service like:
```
http://localhost:9076/rest/services/api/SearchServer?sr=2056&searchText="Arbon&lang=fr&type=locations
```

it is also fixing query strings by removing double quotes from the input parameter

[Testlink](http://mf-chsdi3.dev.bgdi.ch/dev_ltclm_fix_search_errors/rest/services/api/SearchServer?sr=2056&searchText=%22Arbon&lang=fr&type=locations)

triggered by https://jira.swisstopo.ch/browse/BGDIINF_SB-895