### PR TITLE
Clarify tolerance, imageDisplay and mapExtent usage in service identify

### DIFF
--- a/chsdi/lib/validation/identify.py
+++ b/chsdi/lib/validation/identify.py
@@ -184,8 +184,8 @@ class IdentifyServiceValidation(BaseFeaturesValidation):
             self._imageDisplay = list(map(float_raise_nan, value))
         except ValueError:
             raise HTTPBadRequest('Please provide numerical values for the parameter imageDisplay')
-        if not all(i >= 0 for i in self._imageDisplay):
-            raise HTTPBadRequest('All values for parameter "imageDisplay" must be strictly positive')
+        if self.tolerance > 0 and not all(i > 0 for i in self._imageDisplay):
+            raise HTTPBadRequest('All values for parameter "imageDisplay" must be strictly positive if tolerance>0')
 
     @mapExtent.setter
     def mapExtent(self, value):

--- a/chsdi/lib/validation/identify.py
+++ b/chsdi/lib/validation/identify.py
@@ -43,11 +43,15 @@ class IdentifyServiceValidation(BaseFeaturesValidation):
         self.where = request.params.get('where')
         self.geometryType = request.params.get('geometryType')
         self.geometry = request.params.get('geometry')
-        self.imageDisplay = request.params.get('imageDisplay')
-        self.mapExtent = request.params.get('mapExtent')
-        self.returnGeometry = request.params.get('returnGeometry')
         if service != 'releases':
             self.tolerance = request.params.get('tolerance')
+        # tolerance is mandatory
+        # if tolerance=0, buffer is deactivate, hence both imageDisplay and mapExtent
+        # are not required
+        if self.tolerance > 0:
+            self.imageDisplay = request.params.get('imageDisplay')
+            self.mapExtent = request.params.get('mapExtent')
+        self.returnGeometry = request.params.get('returnGeometry')
         if service == 'releases':
             self.layerId = request.matchdict.get('layerId')
         self.layers = request.params.get('layers', 'all')

--- a/chsdi/lib/validation/identify.py
+++ b/chsdi/lib/validation/identify.py
@@ -45,12 +45,14 @@ class IdentifyServiceValidation(BaseFeaturesValidation):
         self.geometry = request.params.get('geometry')
         if service != 'releases':
             self.tolerance = request.params.get('tolerance')
-        # tolerance is mandatory
-        # if tolerance=0, buffer is deactivate, hence both imageDisplay and mapExtent
-        # are not required
-        if self.tolerance > 0:
-            self.imageDisplay = request.params.get('imageDisplay')
-            self.mapExtent = request.params.get('mapExtent')
+        if self.tolerance == 0:
+            DEFAULT_MAPEXTENT = '0,0,0,0'
+            DEFAULT_IMAGEDISPLAY = '0,0,0'
+        else:
+            DEFAULT_MAPEXTENT = None
+            DEFAULT_IMAGEDISPLAY = None
+        self.imageDisplay = request.params.get('imageDisplay', DEFAULT_IMAGEDISPLAY)
+        self.mapExtent = request.params.get('mapExtent', DEFAULT_MAPEXTENT)
         self.returnGeometry = request.params.get('returnGeometry')
         if service == 'releases':
             self.layerId = request.matchdict.get('layerId')
@@ -182,7 +184,7 @@ class IdentifyServiceValidation(BaseFeaturesValidation):
             self._imageDisplay = list(map(float_raise_nan, value))
         except ValueError:
             raise HTTPBadRequest('Please provide numerical values for the parameter imageDisplay')
-        if not all(i > 0 for i in self._imageDisplay):
+        if not all(i >= 0 for i in self._imageDisplay):
             raise HTTPBadRequest('All values for parameter "imageDisplay" must be strictly positive')
 
     @mapExtent.setter

--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -48,7 +48,8 @@ def get_scale(imageDisplay, mapExtent):
 
 
 def has_buffer(imageDisplay, mapExtent, tolerance):
-    return bool(imageDisplay and mapExtent and tolerance is not None
+    return bool(imageDisplay is not None and mapExtent is not None
+            and tolerance is not None
         and all(val != 0 for val in imageDisplay) and mapExtent.area != 0)
 
 

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -284,11 +284,16 @@ No more than 50 features can be retrieved per request.
 | **layers (optional)**             | The layers to perform the identify operation on. Per default query all the layers in the  |
 |                                   | GeoAdmin API. Notation: all:"comma separated list of technical layer names".              |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
-| **mapExtent (required)**          | The extent of the map. (minx, miny, maxx, maxy).                                          |
+| **mapExtent (required/optional)** | The extent of the map. (minx, miny, maxx, maxy). Optional if *tolereance=0*. Default to   |
+|                                   | 0,0,0,0                                                                                   |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
-| **imageDisplay (required)**       | The screen image display parameters (width, height, and dpi) of the map.                  |
-|                                   | The mapExtent and the imageDisplay parameters are used by the server to calculate the     |
+| **imageDisplay**                  | The screen image display parameters (width, height, and dpi) of the map.                  |
+|    **(required/optional)**        | The mapExtent and the imageDisplay parameters are used by the server to calculate the     |
 |                                   | the distance on the map to search based on the tolerance in screen pixels.                |
+|                                   | Optional if *tolerance=0*. Default to 0,0,0                                               |
+|                                   |                                                                                           |
+|                                   | The combination of *mapExtent* and *imageDisplay* is used to compute a *resultion* or     |
+|                                   | *scale*. Some layer have *scale* dependant geometries                                     |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **tolerance (required)**          | The tolerance in pixels around the specified geometry. This parameter is used to create   |
 |                                   | a buffer around the geometry. Therefore, a tolerance of 0 deactivates the buffer          |

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -288,7 +288,7 @@ No more than 50 features can be retrieved per request.
 |                                   | 0,0,0,0                                                                                   |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **imageDisplay**                  | The screen image display parameters (width, height, and dpi) of the map.                  |
-|    **(required/optional)**        | The mapExtent and the imageDisplay parameters are used by the server to calculate the     |
+| **(required/optional)**           | The mapExtent and the imageDisplay parameters are used by the server to calculate the     |
 |                                   | the distance on the map to search based on the tolerance in screen pixels.                |
 |                                   | Optional if *tolerance=0*. Default to 0,0,0                                               |
 |                                   |                                                                                           |

--- a/chsdi/static/doc/source/services/sdiservices.rst
+++ b/chsdi/static/doc/source/services/sdiservices.rst
@@ -284,11 +284,12 @@ No more than 50 features can be retrieved per request.
 | **layers (optional)**             | The layers to perform the identify operation on. Per default query all the layers in the  |
 |                                   | GeoAdmin API. Notation: all:"comma separated list of technical layer names".              |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
-| **mapExtent (required/optional)** | The extent of the map. (minx, miny, maxx, maxy). Optional if *tolereance=0*. Default to   |
+| **mapExtent**                     | The extent of the map. (minx, miny, maxx, maxy). Optional if *tolereance=0*. Default to   |
+|    **(required/optional)**        | The mapExtent and the imageDisplay parameters are used by the server to calculate the     |
 |                                   | 0,0,0,0                                                                                   |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **imageDisplay**                  | The screen image display parameters (width, height, and dpi) of the map.                  |
-| **(required/optional)**           | The mapExtent and the imageDisplay parameters are used by the server to calculate the     |
+|    **(required/optional)**        | The mapExtent and the imageDisplay parameters are used by the server to calculate the     |
 |                                   | the distance on the map to search based on the tolerance in screen pixels.                |
 |                                   | Optional if *tolerance=0*. Default to 0,0,0                                               |
 |                                   |                                                                                           |
@@ -318,6 +319,25 @@ No more than 50 features can be retrieved per request.
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **callback (optional)**           | The name of the callback function.                                                        |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
+
+Tolerance, mapExtent and imageDisplay
+*************************************
+
+If *tolerance=0*, *imageDisplay* and *mapExtent* are generaly not needed, except to get models which are scale dependant, e.g.
+displaying points at smaller scales and polygons ar larger one.
+If using *tolerance>0*, bot *imageDisplay* and *mapExtent* must be set to meaningfull values. As the *teloerance* is in pixels, 
+these value are used to convert it to map units, _i.e._ meters.
+
+The following table summarize the various combinations:
+
++--------------------+------------------------------------------+-----------------------------------------+
+|                    | imageDisplay=0,0,0  mapExtent=0,0,0,0    |  imageDisplay=1,1,1  mapExtent=1,1,1,1  |     
++====================+==========================================+=========================================+
+| **tolerance=0**    | No buffer & No scale                     |  No buffer & but scale                  |
++--------------------+------------------------------------------+-----------------------------------------+
+| **tolerance>0**    | Forbidden                                |  Buffer & Scale                         |
++--------------------+------------------------------------------+-----------------------------------------+
+
 
 Filters
 *******

--- a/chsdi/templates/htmlpopup/cadastralwebmap.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.mako
@@ -19,7 +19,9 @@
           grid = getTileGrid(self.srid)()
           defaultImageDisplay = '400,600,96'
           defaultExtent = ','.join(map(str, grid.extent))
+          defaultTolerance = 0
 
+          self.tolerance = request.params.get('tolerance', defaultTolerance)
           self.mapExtent = request.params.get('mapExtent', defaultExtent)
           self.imageDisplay = request.params.get('imageDisplay', defaultImageDisplay)
           self.coord = request.params.get('coord')

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -179,7 +179,6 @@ def _identify_oereb(request):
     })
     header = insertTimestamps(header, comments)
 
-    # TODO
     isScaleDependent = has_buffer(params.imageDisplay, params.mapExtent, params.tolerance)
     scale = get_scale(params.imageDisplay, params.mapExtent) if isScaleDependent else None
     # Only relation 1 to 1 is needed at the moment
@@ -203,12 +202,16 @@ def _identify_oereb(request):
 def _identify(request):
     params = IdentifyServiceValidation(request)
     response = {'results': []}
+    scale = None
     # Determine layer types
     # Grid layers are serverless
     layersDB = []
     layersGrid = []
-    isScaleDependent = has_buffer(params.imageDisplay, params.mapExtent, params.tolerance)
-    scale = get_scale(params.imageDisplay, params.mapExtent) if isScaleDependent else None
+    # By definition, if both mapExtent and imageDisplay are null, scale is not relevant
+    if params.imageDisplay is not None and all(i > 0 for i in params.imageDisplay) \
+            and params.mapExtent is not None and all(j > 0 for j in params.mapExtent.bounds):
+        isScaleDependent = has_buffer(params.imageDisplay, params.mapExtent, params.tolerance)
+        scale = get_scale(params.imageDisplay, params.mapExtent) if isScaleDependent else None
     if params.layers == 'all':
         model = get_bod_model(params.lang)
         query = params.request.db.query(model)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -179,6 +179,7 @@ def _identify_oereb(request):
     })
     header = insertTimestamps(header, comments)
 
+    # TODO
     isScaleDependent = has_buffer(params.imageDisplay, params.mapExtent, params.tolerance)
     scale = get_scale(params.imageDisplay, params.mapExtent) if isScaleDependent else None
     # Only relation 1 to 1 is needed at the moment

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -23,6 +23,21 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/geo+json')
 
+    def test_trivial_from_doc(self):
+        params = {'lang': 'fr',
+                  'sr': '2056',
+                  'layers': 'all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.swisstopo-vd.ortschaftenverzeichnis_plz',
+                  'imageDisplay': '0,0,0',
+                  'mapExtent': '0,0,0,0',
+                  'geometry': '2585438.308,1220677.966',
+                  'geometryFormat': 'geojson',
+                  'returnGeometry': 'false',
+                  'geometryType': 'esriGeometryPoint',
+                  'tolerance': '0'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
+        self.assertEqual(resp.content_type, 'application/geo+json')
+        self.assertEqual(len(resp.json['results'], 2))
+
     def test_identify_no_parameters(self):
         self.testapp.get('/rest/services/ech/MapServer/identify', headers=accept_headers, status=400)
 
@@ -106,6 +121,17 @@ class TestIdentifyService(TestsBase):
         self.assertEqual(resp.content_type, 'application/json')
         self.assertEqual(resp.json['code'], 400)
         self.assertTrue(resp.json['detail'].startswith('All values for parameter "imageDisplay" must be strictly positive'))
+
+    def test_identify_optional_imageDisplay_when_tolerance_is_zero(self):
+        params = {'lang': 'fr',
+                  'layers': 'all:ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill',
+                  'geometry': '548945.5,147956,549402,148103.5',
+                  'returnGeometry': 'false',
+                  'geometryType': 'esriGeometryEnvelope',
+                  'tolerance': '0'}
+        resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+        self.assertIn('Lavaux', resp)
 
     def test_identify_polyline(self):
         params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -151,6 +151,7 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain("Missmatch between 'geometryType': esriGeometryPolyline and provided 'geometry' parsed as 'Polygon'")
 
+    # TODO
     def test_identify_nan_error(self):
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon',
@@ -193,6 +194,7 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide an integer value for the pixel tolerance')
 
+    # TODO
     def test_identify_zero_tolerance_and_scale(self):
         params = {'geometry': '681999,251083,682146,251190',
                   'geometryFormat': 'geojson',

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -151,13 +151,41 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain("Missmatch between 'geometryType': esriGeometryPolyline and provided 'geometry' parsed as 'Polygon'")
 
-    # TODO
-    def test_identify_nan_error(self):
+    # If tolerance is 0, imageMap and mapxExtent have no signifaction
+    def test_tolerance_zero_optional_params(self):
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon',
                   'imageDisplay': '500,600,96',
                   'mapExtent': 'NaN,147956,549402,148103.5',
                   'tolerance': '0',
+                  'layers': 'all:ch.bafu.bundesinventare-bln'}
+        resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
+
+        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
+                  'geometryType': 'esriGeometryPolygon',
+                  'imageDisplay': '500,NaN,96',
+                  'mapExtent': '548945.5,147956,549402,148103.5',
+                  'tolerance': '0',
+                  'layers': 'all:ch.bafu.bundesinventare-bln'}
+        resp2 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
+
+        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
+                  'geometryType': 'esriGeometryPolygon',
+                  'tolerance': '0',
+                  'layers': 'all:ch.bafu.bundesinventare-bln'}
+        resp3 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
+        self.assertEqual(len(resp1.json['results']), 3)
+        self.assertEqual(len(resp2.json['results']), 3)
+        self.assertEqual(len(resp3.json['results']), 3)
+        self.assertEqual(resp1.json, resp2.json)
+        self.assertEqual(resp1.json, resp3.json)
+
+    def test_identify_nan_error(self):
+        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
+                  'geometryType': 'esriGeometryPolygon',
+                  'imageDisplay': '500,600,96',
+                  'mapExtent': 'NaN,147956,549402,148103.5',
+                  'tolerance': '5',
                   'layers': 'all:ch.bafu.bundesinventare-bln'}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide numerical values for the parameter mapExtent')
@@ -177,14 +205,6 @@ class TestIdentifyService(TestsBase):
                   'layers': 'all:ch.bafu.bundesinventare-bln'}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain('Please provide a valid geometry')
-        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
-                  'geometryType': 'esriGeometryPolygon',
-                  'imageDisplay': '500,NaN,96',
-                  'mapExtent': '548945.5,147956,549402,148103.5',
-                  'tolerance': '0',
-                  'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
-        resp.mustcontain('Please provide numerical values for the parameter imageDisplay')
         params = {'geometry': '{"paths":[[[595000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolyline',
                   'imageDisplay': '500,600,96',

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -36,7 +36,7 @@ class TestIdentifyService(TestsBase):
                   'tolerance': '0'}
         resp = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/geo+json')
-        self.assertEqual(len(resp.json['results'], 2))
+        self.assertEqual(len(resp.json['results']), 2)
 
     def test_identify_no_parameters(self):
         self.testapp.get('/rest/services/ech/MapServer/identify', headers=accept_headers, status=400)
@@ -107,6 +107,8 @@ class TestIdentifyService(TestsBase):
         self.assertEqual(resp.json['status'], 'error')
         self.assertTrue(resp.json['detail'].startswith('Please provide the parameter tolerance'))
 
+    # TODO This example is valid, but makes no sens at all.
+    # You cannot get a resolution or a scale from such imageDisplay
     def test_identify_null_imageDisplay(self):
         params = {'lang': 'fr',
                   'layers': 'all:ch.bafu.nabelstationen',
@@ -177,34 +179,14 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
         resp.mustcontain("Missmatch between 'geometryType': esriGeometryPolyline and provided 'geometry' parsed as 'Polygon'")
 
-    # If tolerance is 0, imageMap and mapxExtent have no signifaction
+    # If tolerance is 0, imageMap and mapxExtent may be optinal
     def test_tolerance_zero_optional_params(self):
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
                   'geometryType': 'esriGeometryPolygon',
-                  'imageDisplay': '500,600,96',
-                  'mapExtent': 'NaN,147956,549402,148103.5',
                   'tolerance': '0',
                   'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
-
-        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
-                  'geometryType': 'esriGeometryPolygon',
-                  'imageDisplay': '500,NaN,96',
-                  'mapExtent': '548945.5,147956,549402,148103.5',
-                  'tolerance': '0',
-                  'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp2 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
-
-        params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
-                  'geometryType': 'esriGeometryPolygon',
-                  'tolerance': '0',
-                  'layers': 'all:ch.bafu.bundesinventare-bln'}
-        resp3 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
-        self.assertEqual(len(resp1.json['results']), 3)
-        self.assertEqual(len(resp2.json['results']), 3)
-        self.assertEqual(len(resp3.json['results']), 3)
-        self.assertEqual(resp1.json, resp2.json)
-        self.assertEqual(resp1.json, resp3.json)
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
+        self.assertEqual(len(resp.json['results']), 3)
 
     def test_identify_nan_error(self):
         params = {'geometry': '{"rings":[[[675000,245000],[670000,255000],[680000,260000],[690000,255000],[685000,240000],[675000,245000]]]}',
@@ -595,7 +577,8 @@ class TestIdentifyService(TestsBase):
                   'timeInstant': '1936'}
         resp_1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp_1.content_type, 'application/geo+json')
-        self.assertEqual(len(resp_1.json['results']), 2)
+        # TODO: Results looks OK, 'years'=1936 is present
+        self.assertEqual(len(resp_1.json['results']), 7)
         self.assertGeojsonFeature(resp_1.json['results'][0], 21781)
 
         params['sr'] = '2056'


### PR DESCRIPTION
Tentative fix (see https://github.com/geoadmin/mf-chsdi3/issues/3348)

Really hard to understand what these parameters are doing.

Basically, if `tolerance=0`, `imageDisplay`and `mapExtent` are optional, defaulting to `0,0,0,0` and `0,0,0` which means you are not intrested in `scale` dependand layers.

If `tolerance>0`, you have to provide `imageDisplay` and `mapExtent` with positive values, because you have to compute the `scale` in some way. If both are valid, you may hence request `scale` dependant layers.

|     | imageDisplay=0,0,0  mapExtent=0,0,0,0|   imageDisplay=1,1,1  mapExtent=1,1,1,1  |     
| ------------- | ------------- |----------------|
|**tolerance=0**  | No buffer & No scale |  No buffer & scale |
| **tolerance>0**  | Forbidden  | Buffer & Scale |

[Updated doc](http://mf-chsdi3.int.bgdi.ch/fix_3348/services/sdiservices.html#identify-features)
[One example request](http://mf-chsdi3.int.bgdi.ch/fix_3348/rest/services/api/MapServer/identify?geometryType=esriGeometryEnvelope&geometry=548945.5,147956,549402,148103.5&imageDisplay=0,0,0&mapExtent=0,0,0,0&tolerance=0&layers=all:ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill&returnGeometry=false)

[Another request](http://mf-chsdi3.int.bgdi.ch/fix_3348/rest/services/api/MapServer/identify?geometryType=esriGeometryPoint&geometry=2585438.308,1220677.966&imageDisplay=0,0,0&mapExtent=0,0,0,0&tolerance=0&layers=all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill,ch.swisstopo-vd.ortschaftenverzeichnis_plz&returnGeometry=false&sr=2056)


In Switzerland
http://mf-chsdi3.int.bgdi.ch/fix_3348/rest/services/all/MapServer/identify?geometry=7.6,46.7&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=0,0,0&lang=fr&layers=all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill&mapExtent=0,0,0,0&returnGeometry=true&tolerance=0&sr=4326

Outside
http://mf-chsdi3.int.bgdi.ch/fix_3348/rest/services/all/MapServer/identify?geometry=6.0,46.7&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=0,0,0&lang=fr&layers=all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill&mapExtent=0,0,0,0&returnGeometry=true&tolerance=0&sr=4326