### PR TITLE
Search 'layers' returns GeoJSON

### DIFF
--- a/chsdi/lib/exceptions.py
+++ b/chsdi/lib/exceptions.py
@@ -10,3 +10,11 @@ class HTTPBandwidthLimited(exc.HTTPServerError):
 
 class QueryParseException(Exception):
     pass
+
+
+class CoordinatesTransformationException(Exception):
+    pass
+
+
+class CoordinatesRoundingException(Exception):
+    pass

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -41,7 +41,7 @@ from shapely.ops import transform as shape_transform
 from shapely.wkt import dumps as shape_dumps, loads as shape_loads
 from shapely.geometry.base import BaseGeometry
 from chsdi.lib.parser import WhereParser
-from chsdi.lib.exceptions import QueryParseException
+from chsdi.lib.exceptions import QueryParseException, CoordinatesTransformationException
 import logging
 
 if six.PY3:
@@ -440,12 +440,15 @@ def _transform_coordinates(coordinates, srid_from, srid_to, rounding=True):
         raise ValueError
     new_coords = []
     coords_iter = iter(coordinates)
-    for pnt in zip(coords_iter, coords_iter):
-        new_pnt = _transform_point(pnt, srid_from, srid_to)
-        new_coords += new_pnt
-    if rounding:
-        precision = get_precision_for_proj(srid_to)
-        new_coords = _round_bbox_coordinates(new_coords, precision=precision)
+    try:
+        for pnt in zip(coords_iter, coords_iter):
+            new_pnt = _transform_point(pnt, srid_from, srid_to)
+            new_coords += new_pnt
+        if rounding:
+            precision = get_precision_for_proj(srid_to)
+            new_coords = _round_bbox_coordinates(new_coords, precision=precision)
+    except Exception:
+        raise CoordinatesTransformationException("Cannot transform coordinates {} from {} to {}".format(coordinates, srid_from, srid_to))
     return new_coords
 
 

--- a/chsdi/lib/mortonspacekey.py
+++ b/chsdi/lib/mortonspacekey.py
@@ -20,7 +20,7 @@ class BBox:
         self.maxy = float(maxy)
 
     def __repr__(self):
-        return 'BBox(%s,%s,%s,%s)' % (self.minx, self.miny, self.maxx, self.maxy)
+        return 'BBox({}, {}, {}, {})'.format(*self.bounds)
 
     def __eq__(self, other):
         if (self.minx == other.minx
@@ -35,6 +35,10 @@ class BBox:
 
     def height(self):
         return self.maxy - self.miny
+
+    @property
+    def bounds(self):
+        return [self.minx, self.miny, self.maxx, self.maxy]
 
     def pointAt(self, i):
         if i == 0:

--- a/chsdi/lib/mortonspacekey.py
+++ b/chsdi/lib/mortonspacekey.py
@@ -20,7 +20,7 @@ class BBox:
         self.maxy = float(maxy)
 
     def __repr__(self):
-        return 'BBox({}, {}, {}, {})'.format(*self.bounds)
+        return 'BBox({},{},{},{})'.format(*self.bounds)
 
     def __eq__(self, other):
         if (self.minx == other.minx

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -77,13 +77,15 @@ class Search(SearchValidation):
                 attributes['id'] = item['id']
                 attributes['weight'] = item['weight']
                 if attributes['origin'] != 'layer':
+                    # Already reprojected
                     bounds = parse_box2d(attributes['geom_st_box2d'])
                 else:
-                    bounds = self.quadtree.bbox.bounds
-                try:
-                    bounds = transform_shape(bounds, self.DEFAULT_SRID, self.srid)
-                except ValueError:
-                    pass
+                    try:
+                        # TODO: This is the requested QuadTree, because sphinx layer indices do not have extent
+                        bounds = self.quadtree.bbox.bounds
+                        bounds = transform_shape(bounds, self.DEFAULT_SRID, self.srid)
+                    except ValueError:
+                        raise exc.HTTPInternalServerError("Search error: cannot reproject result to SRID: {}".format(self.srid))
                 bbox = box(*bounds)
                 if features_bbox is None:
                     features_bbox = bbox

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -118,6 +118,34 @@ class TestSearchServiceView(TestsBase):
         self.assertEqual(resp.json['results'][0]['attrs']['lang'], 'de')
         self.assertAttrs('layers', resp.json['results'][0]['attrs'], 21781)
 
+    def test_search_layers_geojson(self):
+        params = {
+            'type': 'layers',
+            'searchText': 'wand',
+            'geometryFormat': 'geojson'
+        }
+        resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
+        self.assertEqual(resp.content_type, 'application/geo+json')
+        self.assertEqual(resp.json['type'], 'FeatureCollection')
+        self.assertEqual(resp.json['bbox'], [420000, 30000, 900000, 510000])
+
+    def test_search_layers_geojson_with_projection(self):
+        projections = {'2056': [2420000.0, 1029999.9, 2900000.0, 1509999.9],
+                       '4326': [5.140299, 45.398122, 11.591428, 49.66641],
+                       '3857': [572215.5, 5684416.9, 1290351.9, 6388703.1],
+                       '21781': [420000, 30000, 900000, 510000]}
+        params = {
+            'type': 'layers',
+            'searchText': 'wand',
+            'geometryFormat': 'geojson'
+        }
+        for sr in list(projections.keys()):
+            params['sr'] = sr
+            resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
+            self.assertEqual(resp.content_type, 'application/geo+json')
+            self.assertEqual(resp.json['type'], 'FeatureCollection')
+            self.assertEqual(resp.json['bbox'], projections[sr])
+
     def test_search_layers_with_cb(self):
         params = {
             'type': 'layers',

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -146,6 +146,24 @@ class TestSearchServiceView(TestsBase):
             self.assertEqual(resp.json['type'], 'FeatureCollection')
             self.assertEqual(resp.json['bbox'], projections[sr])
 
+    def test_search_locations_geojson_with_projection(self):
+        projections = {'2056': [2534437.97, 1150655.173, 2544978.008, 1161554.51],
+                       '4326': [6.58296, 46.503981, 6.721816, 46.602973],
+                       '3857': [732811.8, 5861483.7, 748269.1, 5877508.3],
+                       '21781': [534438.40469522, 150654.771724574, 544978.33190583, 161554.027818952]}
+        params = {
+            'type': 'locations',
+            'searchText': 'lausanne',
+            'geometryFormat': 'geojson',
+            'limit': 1
+        }
+        for sr in list(projections.keys()):
+            params['sr'] = sr
+            resp = self.testapp.get('/rest/services/inspire/SearchServer', params=params, status=200)
+            self.assertEqual(resp.content_type, 'application/geo+json')
+            self.assertEqual(resp.json['type'], 'FeatureCollection')
+            self.assertEqual(resp.json['bbox'], projections[sr])
+
     def test_search_layers_with_cb(self):
         params = {
             'type': 'layers',


### PR DESCRIPTION
Returning a valid `geojson`

The returned `bbox` and `Polygon` do not have a real meaning (it's the default bbox), because we don't have the `layer` extent stored in the `sphinxapi` indices. Feel free to open an issue in https://github.com/geoadmin/service-sphinxsearch/issues if you like.

**Demo**
http://mf-chsdi3.int.bgdi.ch/fix_3351/rest/services/api/SearchServer?searchText=aerial&type=layers&geometryFormat=geojson&sr=3857


Fix https://github.com/geoadmin/mf-chsdi3/issues/3351