### PR TITLE
[WIP] Identify to return real geojson

### DIFF
--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -31,7 +31,9 @@ WSGIPassAuthorization On
 # Compress also geojson
 <IfModule mod_deflate.c>
    <IfModule mod_filter.c>
+       <Location ${apache_entry_path}>
        AddOutputFilterByType DEFLATE application/geo+json
+       </Location>
    </IfModule>
 </IfModule>
 

--- a/apache/wsgi.conf.in
+++ b/apache/wsgi.conf.in
@@ -28,6 +28,14 @@ WSGIPassAuthorization On
   Header set X-UA-Compatible "IE=Edge"
 </IfModule>
 
+# Compress also geojson
+<IfModule mod_deflate.c>
+   <IfModule mod_filter.c>
+       AddOutputFilterByType DEFLATE application/geo+json
+   </IfModule>
+</IfModule>
+
+
 # Redirect old main/wsgi stuff
 RedirectMatch permanent ^/main/wsgi/(.*)$ /$1
 RedirectMatch permanent ^${apache_entry_path}/iipimage/(.*)$ ${apache_entry_path}/luftbilder/$1

--- a/chsdi/lib/validation/identify.py
+++ b/chsdi/lib/validation/identify.py
@@ -62,6 +62,7 @@ class IdentifyServiceValidation(BaseFeaturesValidation):
         self.limit = request.params.get('limit')
         self.order = request.params.get('order')
         self.layerDefs = request.params.get('layerDefs')
+        self.geometryFormat = request.params.get('geometryFormat', 'geojson')
 
     @property
     def where(self):

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -42,9 +42,16 @@ def identify_oereb(request):
     return _identify_oereb(request)
 
 
+@view_config(route_name='identify', renderer='geojson', request_param='geometryFormat=GeoJSON')
+def identify_real_geojson(request):
+    features = _identify(request)['results']
+
+    return {"type": "FeatureCollection", "features": features}
+
+
 @view_config(route_name='identify', renderer='geojson', request_param='geometryFormat=geojson')
 def identify_geojson(request):
-    return _identify(request)
+    return _identify(request)['results']
 
 
 @view_config(route_name='identify', renderer='esrijson')

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -42,22 +42,20 @@ def identify_oereb(request):
     return _identify_oereb(request)
 
 
-@view_config(route_name='identify', renderer='geojson', request_param='geometryFormat=GeoJSON')
-def identify_real_geojson(request):
-    features = _identify(request)['results']
-
-    return {"type": "FeatureCollection", "features": features}
-
-
 @view_config(route_name='identify', renderer='geojson', request_param='geometryFormat=geojson')
 def identify_geojson(request):
-    return _identify(request)['results']
+    return {'results': _identify(request)}
 
 
-@view_config(route_name='identify', renderer='esrijson')
+@view_config(route_name='identify', renderer='esrijson', request_param='geometryFormat=esrijson')
 def identify_esrijson(request):
-    return _identify(request)
+    return {'results': _identify(request)}
 
+
+@view_config(route_name='identify', renderer='geojson')
+def identify_real_geojson(request):
+    features = _identify(request)
+    return {"type": "FeatureCollection", "features": features}
 
 @view_config(route_name='feature', renderer='geojson',
              request_param='geometryFormat=geojson')
@@ -208,7 +206,7 @@ def _identify_oereb(request):
 
 def _identify(request):
     params = IdentifyServiceValidation(request)
-    response = {'results': []}
+    response = None
     scale = None
     # Determine layer types
     # Grid layers are serverless
@@ -251,7 +249,7 @@ def _identify(request):
                 layersDB.append({layerBodId: models})
     featuresGrid = _identify_grid(params, layersGrid)
     featuresDB = _identify_db(params, layersDB)
-    response['results'] = featuresGrid + featuresDB
+    response = featuresGrid + featuresDB
     return response
 
 


### PR DESCRIPTION
The `identify`service returns a bogus `geojson` when param `geometryFormat=geojson` (see https://github.com/geoadmin/mf-chsdi3/issues/3371).


**real GeoJSON**
Apparently, `geometryFormat` is always set in logs. So this PR proposes toreturn real GeoJSON by default (`geometryFormat` not set), instead of the unused EsriJSON. This should not break anything
[geometryFormat=None](https://mf-chsdi3.int.bgdi.ch/real_geojson/rest/services/ech/MapServer/identify?geometryType=esriGeometryEnvelope&geometry=630000,245000,645000,265000&imageDisplay=500,600,96&layers=all:ch.bafu.bundesinventare-bln&mapExtent=548945.5,147956,549402,148103.5&tolerance=1)

Another as [WSG84](https://mf-chsdi3.int.bgdi.ch/real_geojson/rest/services/ech/MapServer/identify?geometryType=esriGeometryEnvelope&geometry=7,44,8,46&imageDisplay=500,600,96&layers=all:ch.bafu.bundesinventare-bln&mapExtent=7,44,8,46&tolerance=1&sr=4326)

**bogus GeoJSON**
As for now...
[geometryFormat=geojson](https://mf-chsdi3.int.bgdi.ch/real_geojson/rest/services/ech/MapServer/identify?geometryType=esriGeometryEnvelope&geometry=630000,245000,645000,265000&imageDisplay=500,600,96&layers=all:ch.bafu.bundesinventare-bln&mapExtent=548945.5,147956,549402,148103.5&tolerance=1&geometryFormat=geojson)

**ESRI JSON**
Never used outside `map.geo.admin.ch?
[geometryFormat=esrijson](https://mf-chsdi3.int.bgdi.ch/real_geojson/rest/services/ech/MapServer/identify?geometryType=esriGeometryEnvelope&geometry=630000,245000,645000,265000&imageDisplay=500,600,96&layers=all:ch.bafu.bundesinventare-bln&mapExtent=548945.5,147956,549402,148103.5&tolerance=1&geometryFormat=esrijson)

Alternatively, we could set a new  `route`, but with more meaningful `path` and `parameters`

TODO. Test to fix