### PR TITLE
Add parent constructor to CadastralWebMapParams

### DIFF
--- a/chsdi/templates/htmlpopup/cadastralwebmap.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.mako
@@ -15,6 +15,7 @@
 
   class CadastralWebMapParams(IdentifyServiceValidation):
       def __init__(self, request):
+          IdentifyServiceValidation.__init__(self, request)
           self.srid = request.params.get('sr', '21781')
           grid = getTileGrid(self.srid)()
           defaultImageDisplay = '400,600,96'

--- a/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap_opendata.mako
@@ -22,6 +22,7 @@
   
   class CadastralWebMapParams(IdentifyServiceValidation):
       def __init__(self, request):
+          IdentifyServiceValidation.__init__(self, request)
           self.srid = request.params.get('sr', '21781')
           grid = getTileGrid(self.srid)()
           defaultExtent = ','.join(map(str, grid.extent))


### PR DESCRIPTION
calling the parent's constructor to initialize variables, solving root cause for issue 3386

I did not check if other classes within makos could have the same problem yet.