### PR TITLE
ltclm cadastral tooltip

### DIFF
--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -12098,6 +12098,9 @@ msgstr "Mineral rights"
 msgid "cwm_realestate_type_default"
 msgstr "Land and buildings"
 
+msgid "cwm_realestate_type_default"
+msgstr "Land and buildings"
+
 msgid "cyan"
 msgstr "cyan"
 

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -12098,9 +12098,6 @@ msgstr "Mineral rights"
 msgid "cwm_realestate_type_default"
 msgstr "Land and buildings"
 
-msgid "cwm_realestate_type_default"
-msgstr "Land and buildings"
-
 msgid "cyan"
 msgstr "cyan"
 

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -3273,6 +3273,10 @@ class CadastralWebMap(Base, Vector):
     __label__ = 'ak'
     id = Column('id', Integer, primary_key=True)
     ak = Column('ak', Unicode)
+    number = Column('number', Unicode)
+    identnd = Column('identnd', Unicode)
+    egris_egrid = Column('egris_egrid', Unicode)
+    realestate_type = Column('realestate_type', Integer)
     the_geom = Column(Geometry2D)
 
 register('ch.kantone.cadastralwebmap-farbe', CadastralWebMap)
@@ -3289,6 +3293,10 @@ class CadastralWebMapOpenData(Base, Vector):
     bfsnr = Column('bfsnr', Integer)
     ak = Column('ak', Unicode)
     name = Column('name', Unicode)
+    number = Column('number', Unicode)
+    identnd = Column('identnd', Unicode)
+    egris_egrid = Column('egris_egrid', Unicode)
+    realestate_type = Column('realestate_type', Integer)
     the_geom = Column(Geometry2D)
 
 register('ch.swisstopo-vd.amtliche-vermessung', CadastralWebMapOpenData)

--- a/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
@@ -58,7 +58,6 @@
     % else:
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td>${_('Canton has provided no link to portal')}</td></tr>
     % endif
-    <tr><td class="cell-left">${_('cwm_identnd')}</td><td>${c['attributes']['identnd'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('cwm_number')}</td><td>${c['attributes']['number'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('cwm_egris_egrid')}</td><td>${c['attributes']['egris_egrid'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('cwm_realestate_type')}</td><td>${_('cwm_realestate_type_{}'.format(c['attributes']['realestate_type']) if c['attributes']['realestate_type'] >=0 else '-')}</td></tr>

--- a/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
@@ -61,6 +61,6 @@
     <tr><td class="cell-left">${_('cwm_identnd')}</td><td>${c['attributes']['identnd'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('cwm_number')}</td><td>${c['attributes']['number'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('cwm_egris_egrid')}</td><td>${c['attributes']['egris_egrid'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('cwm_realestate_type')}</td><td>${_('cwm_realestate_type_{}'.format(c['attributes']['realestate_type']) if c['attributes']['realestate_type'] else '-')}</td></tr>
+    <tr><td class="cell-left">${_('cwm_realestate_type')}</td><td>${_('cwm_realestate_type_{}'.format(c['attributes']['realestate_type']) if c['attributes']['realestate_type'] >=0 else '-')}</td></tr>
 </%def>
 

--- a/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
@@ -60,6 +60,6 @@
     % endif
     <tr><td class="cell-left">${_('cwm_number')}</td><td>${c['attributes']['number'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('cwm_egris_egrid')}</td><td>${c['attributes']['egris_egrid'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('cwm_realestate_type')}</td><td>${_('cwm_realestate_type_{}'.format(c['attributes']['realestate_type']) if c['attributes']['realestate_type'] >=0 else '-')}</td></tr>
+    <tr><td class="cell-left">${_('cwm_realestate_type')}</td><td>${_('cwm_realestate_type_{}'.format(c['attributes']['realestate_type']) if c['attributes']['realestate_type'] >=0 else 'cwm_realestate_type_default')}</td></tr>
 </%def>
 

--- a/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
@@ -58,4 +58,9 @@
     % else:
         <tr><td class="cell-left">${_('link to canton geoportal')}</td><td>${_('Canton has provided no link to portal')}</td></tr>
     % endif
+    <tr><td class="cell-left">${_('cwm_identnd')}</td><td>${c['attributes']['identnd'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('cwm_number')}</td><td>${c['attributes']['number'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('cwm_egris_egrid')}</td><td>${c['attributes']['egris_egrid'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('cwm_realestate_type')}</td><td>${_('cwm_realestate_type_{}'.format(c['attributes']['realestate_type']) if c['attributes']['realestate_type'] else '-')}</td></tr>
 </%def>
+


### PR DESCRIPTION
this will add the following attributes (see https://github.com/geoadmin/mf-chsdi3/issues/3372):
* number
* identnd
* egris_egrid
* realestate_type

to identify/htmlpopup of these layers:

* ch.kantone.cadastralwebmap-farbe
* ch.swisstopo-vd.amtliche-vermessung

[Testlink](https://s.geo.admin.ch/8789fb5a44)