### PR TITLE
Fix for python3

### DIFF
--- a/chsdi/lib/validation/identify.py
+++ b/chsdi/lib/validation/identify.py
@@ -187,7 +187,8 @@ class IdentifyServiceValidation(BaseFeaturesValidation):
             self._imageDisplay = list(map(float_raise_nan, value))
         except ValueError:
             raise HTTPBadRequest('Please provide numerical values for the parameter imageDisplay')
-        if self.tolerance > 0 and not all(i > 0 for i in self._imageDisplay):
+        # Python3 None > 0 --> TypeError
+        if self.tolerance is not None and self.tolerance > 0 and not all(i > 0 for i in self._imageDisplay):
             raise HTTPBadRequest('All values for parameter "imageDisplay" must be strictly positive if tolerance>0')
 
     @mapExtent.setter


### PR DESCRIPTION
`None > 0` which is valid in `Python2`, gives a `TypeError` in `Python3`

You have to run the tests locally as no CI will do:
`USE_PYTHON3=1 make test`
