### PR TITLE
remove double <i> tags in sphinxsearch response

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -4014,7 +4014,7 @@ msgid "ch.bafu.luftreinhaltung-stickstoff_kritischer_eintrag"
 msgstr "CLN Überschreitung"
 
 msgid "ch.bafu.mittlere-abfluesse"
-msgstr "Mittlere Abflüsse (m³/s)"
+msgstr "Mittlere Abflüsse (m³/s) und Regime"
 
 msgid "ch.bafu.mittlere-abfluesse.abflussvar"
 msgstr "Abflussvariabilität (%)"
@@ -4916,6 +4916,24 @@ msgstr "Wasserkraftnutzung - Weitere Entnahme"
 msgid "ch.bafu.wasser-gebietsauslaesse"
 msgstr "Gebietsauslässe"
 
+msgid "ch.bafu.wasser-gebietsauslaesse.adresse"
+msgstr "Adresse (\"Gewässerkilometer\")"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.de_nebenarm"
+msgstr "Gewässertyp"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.ezgnr"
+msgstr "Gesamteinzugsgebiets-Nummer"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gewaessername"
+msgstr "Gewässername"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gwlnr"
+msgstr "Gewässerlaufnummer"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.id"
+msgstr "Identifikator Gebietsauslass"
+
 msgid "ch.bafu.wasser-leitungen"
 msgstr "Zuleitung"
 
@@ -4925,8 +4943,62 @@ msgstr "Wasserrückgabe"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2"
 msgstr "Teileinzugsgebiete 2km2"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.anteil_ch"
+msgstr "Flächenanteil Gesamt-EZG % CH"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_bestockteflaechen"
+msgstr "Bestockte Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_landwirtschaftsflaechen"
+msgstr "Landwirtschaftsflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_siedlungsflaechen"
+msgstr "Siedlungsflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_unproduktiveflaechen"
+msgstr "Unproduktive Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_bebauteflaechen"
+msgstr "Bebaute Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_feuchtflaechen"
+msgstr "Feuchtflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_landwirtschaft"
+msgstr "Landwirtschaft"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_waelder"
+msgstr "Wälder und naturnahe Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_wasserflaechen"
+msgstr "Wasserflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.de_nebenarm"
+msgstr "Hinweis"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_ezg_flussgb"
 msgstr "Flussgebietsname"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_1"
+msgstr "Höhe Gesamteinzugsgebiet [m]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_2"
+msgstr "Bodenbedeckung CH basierend auf der Arealstatistik [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_3"
+msgstr "Bodenbedeckung basierend auf CORINE Land Cover [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_4"
+msgstr "Wegen gewissen Einschränkungen der Grundlagendaten erheben die daraus berechneten Kennzahlen keinen Anspruch auf absolute Präzision."
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ezgnr"
+msgstr "Gesamteinzugsgebiets-Nummer"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gesamtflaeche"
+msgstr "Fläche Gesamteinzugsgebiet [km2]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gewaessername"
+msgstr "Gewässername"
 
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.gwlnr"
 msgstr "Gewässerlaufnummer"
@@ -4934,11 +5006,41 @@ msgstr "Gewässerlaufnummer"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.id"
 msgstr "Teileinzugsgebiets-Nummer"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.max_z"
+msgstr "Maximale Höhe"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.mean_z"
+msgstr "Mittlere Höhe"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.min_z"
+msgstr "Minimale Höhe"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_40"
 msgstr "Teileinzugsgebiete 40km2"
 
 msgid "ch.bafu.wasser-vorfluter"
 msgstr "Abflussregimetyp"
+
+msgid "ch.bafu.wasser-vorfluter.ezgnr"
+msgstr "Gesamteinzugsgebiets-Nummer"
+
+msgid "ch.bafu.wasser-vorfluter.gewaessername"
+msgstr "Gewässername"
+
+msgid "ch.bafu.wasser-vorfluter.gwlnr"
+msgstr "Gewässerlaufnummer"
+
+msgid "ch.bafu.wasser-vorfluter.id"
+msgstr "Identifikator Vorfluterabschnitt"
+
+msgid "ch.bafu.wasser-vorfluter.nebenarm"
+msgstr "Gewässertyp"
+
+msgid "ch.bafu.wasser-vorfluter.oberesende"
+msgstr "Endadresse (’Gewässerkilometer’)"
+
+msgid "ch.bafu.wasser-vorfluter.unteresende"
+msgstr "Anfangsadresse (’Gewässerkilometer’)"
 
 msgid "ch.bafu.wege-wildruhezonen-jagdbanngebiete"
 msgstr "Erlaubte Wege und Routen"
@@ -5840,8 +5942,38 @@ msgstr "Jahr"
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht"
 msgstr "Eisenbahnlärm, zuläss. Immission N"
 
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_es"
+msgstr "Empfindlichkeitsstufe"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_pointofdetermination_t"
+msgstr "Typ des Ermittlungspunktes"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.floor"
+msgstr "Stockwerk des Ermittlungspunkts"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_night"
+msgstr "Max. zul. Pegel (Nacht)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_year"
+msgstr "Verfügungsjahr"
+
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag"
 msgstr "Eisenbahnlärm, zuläss. Immission T"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_es"
+msgstr "Empfindlichkeitsstufe"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_pointofdetermination_t"
+msgstr "Typ des Ermittlungspunktes"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.floor"
+msgstr "Stockwerk des Ermittlungspunkts"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_day"
+msgstr "Max. zul. Pegel (Tag)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_year"
+msgstr "Verfügungsjahr"
 
 msgid "ch.bav.laerm-emissionplan_eisenbahn_2015"
 msgstr "Emissionsplan Eisenbahn 2015"
@@ -7640,9 +7772,6 @@ msgstr "Erosionsrisiko"
 msgid "ch.blw.erosion-fliesswegkarte"
 msgstr "Fliesswegkarte"
 
-msgid "ch.blw.erosion-mit_bergzonen"
-msgstr "Erosionsrisiko qualitativ 2"
-
 msgid "ch.blw.erosion-quantitativ"
 msgstr "Erosionsrisiko Acker quantitativ"
 
@@ -8300,6 +8429,9 @@ msgstr "https://www.sem.admin.ch/sem/de/home.html"
 msgid "ch.swisstopo"
 msgstr "swisstopo"
 
+msgid "ch.swisstopo.amtliches-gebaeudeadressverzeichnis"
+msgstr "Amtliches Gebäudeadressverzeichnis"
+
 msgid "ch.swisstopo.amtliches-strassenverzeichnis"
 msgstr "Amtliches Strassenverzeichnis"
 
@@ -8632,6 +8764,39 @@ msgstr "Das Geoid"
 
 msgid "ch.swisstopo.geologie-geodaesie-isostatische_anomalien"
 msgstr "Isostatische Anomalien 500"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle"
+msgstr "Geologische 3D-Modelle"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.content"
+msgstr "Modellierte Horizonte / Einheiten"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_author"
+msgstr "Autor(en)"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_contracting_entity"
+msgstr "Auftraggeber"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_description"
+msgstr "Externer Link zur Detailbeschreibung"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_documentation"
+msgstr "Externer Link zur Dokumentation"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_portal"
+msgstr "Externer Link zum Fachportal"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.name"
+msgstr "Name"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.purpose"
+msgstr "Zweck"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.remarks"
+msgstr "Bemerkungen"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.year_publication"
+msgstr "Erstellungsjahr"
 
 msgid "ch.swisstopo.geologie-geologische_einheiten-onegeology"
 msgstr "CHE LG DE 1:500k Geologische Einheiten"
@@ -11687,6 +11852,9 @@ msgstr "Sachplan Militär"
 msgid "ch.vbs.sachplan-infrastruktur-militaer_kraft_polygons_raster"
 msgstr "Sachplan Militär"
 
+msgid "ch.vbs.schiessanzeigen"
+msgstr "Schiessanzeigen und Schiessplätze"
+
 msgid "ch.vbs.sperr-gefahrenzonenkarte"
 msgstr "Sperr- und Gefahrenzonenkarte"
 
@@ -11848,6 +12016,33 @@ msgstr "Polygon erfassen"
 
 msgid "ct"
 msgstr "Kt."
+
+msgid "cwm_egris_egrid"
+msgstr "EGRID"
+
+msgid "cwm_number"
+msgstr "Nummer"
+
+msgid "cwm_realestate_type"
+msgstr "Grundstücksart"
+
+msgid "cwm_realestate_type_0"
+msgstr "Baurecht"
+
+msgid "cwm_realestate_type_1"
+msgstr "Quellenrecht"
+
+msgid "cwm_realestate_type_2"
+msgstr "Konzessionsrecht"
+
+msgid "cwm_realestate_type_3"
+msgstr "weitere"
+
+msgid "cwm_realestate_type_4"
+msgstr "Bergwerk"
+
+msgid "cwm_realestate_type_default"
+msgstr "Liegenschaft"
 
 msgid "cyan"
 msgstr "Cyan"
@@ -12769,6 +12964,9 @@ msgstr "Friedhof"
 
 msgid "<i>Gebaeude Einzelhaus</i>"
 msgstr "Gebaeude Einzelhaus"
+
+msgid "<i>Gebaeude</i>"
+msgstr "Gebaeude"
 
 msgid "<i>Gebiet</i>"
 msgstr "Gebiet"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -4014,7 +4014,7 @@ msgid "ch.bafu.luftreinhaltung-stickstoff_kritischer_eintrag"
 msgstr "CLN Exceedance"
 
 msgid "ch.bafu.mittlere-abfluesse"
-msgstr "Mean runoff (m³/s)"
+msgstr "Mean runoff (m³/s) and regime"
 
 msgid "ch.bafu.mittlere-abfluesse.abflussvar"
 msgstr "Abflussvariabilität (%)"
@@ -4916,6 +4916,24 @@ msgstr "Wasserkraftnutzung - Weitere Entnahme"
 msgid "ch.bafu.wasser-gebietsauslaesse"
 msgstr "Area outlets"
 
+msgid "ch.bafu.wasser-gebietsauslaesse.adresse"
+msgstr "Address ('waterbody kilo-metre')"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.de_nebenarm"
+msgstr "Waterbody type"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.ezgnr"
+msgstr "Catchment area number"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gewaessername"
+msgstr "Waterbody name"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gwlnr"
+msgstr "Number of the river"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.id"
+msgstr "Identifier of the area outlet"
+
 msgid "ch.bafu.wasser-leitungen"
 msgstr "Supply"
 
@@ -4925,8 +4943,62 @@ msgstr "Return flows"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2"
 msgstr "2km2 sub catchment areas"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.anteil_ch"
+msgstr "Percentage CH of the total watershed area"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_bestockteflaechen"
+msgstr "Forests and shrubs"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_landwirtschaftsflaechen"
+msgstr "Agricultural areas"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_siedlungsflaechen"
+msgstr "Artificial surfaces"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_unproduktiveflaechen"
+msgstr "Open spaces with little or no vegetation"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_bebauteflaechen"
+msgstr "Artificial surfaces"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_feuchtflaechen"
+msgstr "Wetlands"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_landwirtschaft"
+msgstr "Agricultural areas"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_waelder"
+msgstr "Forest and semi natural areas"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_wasserflaechen"
+msgstr "Water bodies"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.de_nebenarm"
+msgstr "Indication"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_ezg_flussgb"
 msgstr "Name of river basin"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_1"
+msgstr "Altitude catchment area [m]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_2"
+msgstr "Land cover CH based on area statistics [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_3"
+msgstr "Land cover based on CORINE Land Cover [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_4"
+msgstr "Due to certain limitations of the source data, the calcuated indicators cannot claim absolute accuracy."
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ezgnr"
+msgstr "Catchment area number"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gesamtflaeche"
+msgstr "Catchment area size [km2]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gewaessername"
+msgstr "Waterbody name"
 
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.gwlnr"
 msgstr "Number of the river"
@@ -4934,11 +5006,41 @@ msgstr "Number of the river"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.id"
 msgstr "Sub-catchment area number"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.max_z"
+msgstr "Maximum altitude"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.mean_z"
+msgstr "Mean altitude"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.min_z"
+msgstr "Minimum altitude"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_40"
 msgstr "40km2 sub catchment areas"
 
 msgid "ch.bafu.wasser-vorfluter"
 msgstr "Type of flow regime"
+
+msgid "ch.bafu.wasser-vorfluter.ezgnr"
+msgstr "Catchment area number"
+
+msgid "ch.bafu.wasser-vorfluter.gewaessername"
+msgstr "Waterbody name"
+
+msgid "ch.bafu.wasser-vorfluter.gwlnr"
+msgstr "Number of the river"
+
+msgid "ch.bafu.wasser-vorfluter.id"
+msgstr "Identifier of the section of the effluent"
+
+msgid "ch.bafu.wasser-vorfluter.nebenarm"
+msgstr "Waterbody type"
+
+msgid "ch.bafu.wasser-vorfluter.oberesende"
+msgstr "Finish address (’waterbody kilometre’)"
+
+msgid "ch.bafu.wasser-vorfluter.unteresende"
+msgstr "Start address (’waterbody kilometre’)"
 
 msgid "ch.bafu.wege-wildruhezonen-jagdbanngebiete"
 msgstr "Permitted paths and trails"
@@ -5840,8 +5942,38 @@ msgstr "Year"
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht"
 msgstr "Railway noise, perm. immissions N"
 
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_es"
+msgstr "Empfindlichkeitsstufe"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_pointofdetermination_t"
+msgstr "Typ des Ermittlungspunktes"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.floor"
+msgstr "Stockwerk des Ermittlungspunkts"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_night"
+msgstr "Max. zul. Pegel (Nacht)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_year"
+msgstr "Verfügungsjahr"
+
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag"
 msgstr "Railway noise, perm. immissions D"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_es"
+msgstr "Empfindlichkeitsstufe"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_pointofdetermination_t"
+msgstr "Typ des Ermittlungspunktes"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.floor"
+msgstr "Stockwerk des Ermittlungspunkts"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_day"
+msgstr "Max. zul. Pegel (Tag)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_year"
+msgstr "Verfügungsjahr"
 
 msgid "ch.bav.laerm-emissionplan_eisenbahn_2015"
 msgstr "Emissions Plan 2015"
@@ -6438,7 +6570,7 @@ msgid "ch.bazl.projektierungszonen-flughafenanlagen.oereb.text_thema"
 msgstr "Theme"
 
 msgid "ch.bazl.sachplan-infrastruktur-luftfahrt_anhorung"
-msgstr "SAIP consultation"
+msgstr "SIL consultation"
 
 msgid "ch.bazl.sachplan-infrastruktur-luftfahrt_kraft"
 msgstr "SP Aviation infrastructure"
@@ -7640,9 +7772,6 @@ msgstr "Erosion risk"
 msgid "ch.blw.erosion-fliesswegkarte"
 msgstr "Flow-path map"
 
-msgid "ch.blw.erosion-mit_bergzonen"
-msgstr "Erosion risk 2"
-
 msgid "ch.blw.erosion-quantitativ"
 msgstr "Erosion risk crop quantitative"
 
@@ -8300,6 +8429,9 @@ msgstr "https://www.sem.admin.ch/sem/en/home.html"
 msgid "ch.swisstopo"
 msgstr "swisstopo"
 
+msgid "ch.swisstopo.amtliches-gebaeudeadressverzeichnis"
+msgstr "Amtliches Gebäudeadressverzeichnis"
+
 msgid "ch.swisstopo.amtliches-strassenverzeichnis"
 msgstr "Official street index"
 
@@ -8632,6 +8764,39 @@ msgstr "The geoid"
 
 msgid "ch.swisstopo.geologie-geodaesie-isostatische_anomalien"
 msgstr "Isostatic anomalies 500"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle"
+msgstr "3D geological models"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.content"
+msgstr "Modelled horizons / units"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_author"
+msgstr "Author(s)"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_contracting_entity"
+msgstr "Contracting entity"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_description"
+msgstr "External link to detailed description"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_documentation"
+msgstr "External link to documentation"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_portal"
+msgstr "External link to portal"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.name"
+msgstr "Name"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.purpose"
+msgstr "Purpose"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.remarks"
+msgstr "Remarks"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.year_publication"
+msgstr "Year of publication"
 
 msgid "ch.swisstopo.geologie-geologische_einheiten-onegeology"
 msgstr "Geology 1:500 000"
@@ -11687,6 +11852,9 @@ msgstr "Sachplan Militär"
 msgid "ch.vbs.sachplan-infrastruktur-militaer_kraft_polygons_raster"
 msgstr "Sachplan Militär"
 
+msgid "ch.vbs.schiessanzeigen"
+msgstr "Shooting range bulletins and shooting ranges"
+
 msgid "ch.vbs.sperr-gefahrenzonenkarte"
 msgstr "Map of restricted and danger areas"
 
@@ -11848,6 +12016,33 @@ msgstr "Create polygon"
 
 msgid "ct"
 msgstr "Ct."
+
+msgid "cwm_egris_egrid"
+msgstr "EGRID"
+
+msgid "cwm_number"
+msgstr "Number"
+
+msgid "cwm_realestate_type"
+msgstr "Real Estate Type"
+
+msgid "cwm_realestate_type_0"
+msgstr "Distinct and permanent rights"
+
+msgid "cwm_realestate_type_1"
+msgstr "Rights to spring water"
+
+msgid "cwm_realestate_type_2"
+msgstr "Concession rights"
+
+msgid "cwm_realestate_type_3"
+msgstr "other"
+
+msgid "cwm_realestate_type_4"
+msgstr "Mineral rights"
+
+msgid "cwm_realestate_type_default"
+msgstr "Land and buildings"
 
 msgid "cyan"
 msgstr "cyan"
@@ -12768,6 +12963,9 @@ msgid "<i>Friedhof</i>"
 msgstr "Cemetery"
 
 msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Building"
+
+msgid "<i>Gebaeude</i>"
 msgstr "Building"
 
 msgid "<i>Gebiet</i>"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -4916,6 +4916,24 @@ msgstr "Wasserkraftnutzung - Weitere Entnahme"
 msgid "ch.bafu.wasser-gebietsauslaesse"
 msgstr "Sbuccadas intschess idrografics"
 
+msgid "ch.bafu.wasser-gebietsauslaesse.adresse"
+msgstr "Adresse (\"Gewässerkilometer\")"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.de_nebenarm"
+msgstr "Gewässertyp"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.ezgnr"
+msgstr "Gesamteinzugsgebiets-Nummer"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gewaessername"
+msgstr "Gewässername"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gwlnr"
+msgstr "Gewässerlaufnummer"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.id"
+msgstr "Identifikator Gebietsauslass"
+
 msgid "ch.bafu.wasser-leitungen"
 msgstr "Conducts d'affluenza"
 
@@ -4925,8 +4943,62 @@ msgstr "Restituziun d'aua"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2"
 msgstr "Intschess parzials 2km2"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.anteil_ch"
+msgstr "Flächenanteil Gesamt-EZG % CH"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_bestockteflaechen"
+msgstr "Bestockte Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_landwirtschaftsflaechen"
+msgstr "Landwirtschaftsflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_siedlungsflaechen"
+msgstr "Siedlungsflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_unproduktiveflaechen"
+msgstr "Unproduktive Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_bebauteflaechen"
+msgstr "Bebaute Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_feuchtflaechen"
+msgstr "Feuchtflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_landwirtschaft"
+msgstr "Landwirtschaft"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_waelder"
+msgstr "Wälder und naturnahe Flächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_wasserflaechen"
+msgstr "Wasserflächen"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.de_nebenarm"
+msgstr "Hinweis"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_ezg_flussgb"
 msgstr "Flussgebietsname"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_1"
+msgstr "Höhe Gesamteinzugsgebiet [m]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_2"
+msgstr "Bodenbedeckung CH basierend auf der Arealstatistik [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_3"
+msgstr "Bodenbedeckung basierend auf CORINE Land Cover [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_4"
+msgstr "Wegen gewissen Einschränkungen der Grundlagendaten erheben die daraus berechneten Kennzahlen keinen Anspruch auf absolute Präzision."
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ezgnr"
+msgstr "Gesamteinzugsgebiets-Nummer"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gesamtflaeche"
+msgstr "Fläche Gesamteinzugsgebiet [km2]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gewaessername"
+msgstr "Gewässername"
 
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.gwlnr"
 msgstr "Gewässerlaufnummer"
@@ -4934,11 +5006,41 @@ msgstr "Gewässerlaufnummer"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.id"
 msgstr "Teileinzugsgebiets-Nummer"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.max_z"
+msgstr "Maximale Höhe"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.mean_z"
+msgstr "Mittlere Höhe"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.min_z"
+msgstr "Minimale Höhe"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_40"
 msgstr "Intschess parzials 40km2"
 
 msgid "ch.bafu.wasser-vorfluter"
 msgstr "Tip d'urden da deflussiun"
+
+msgid "ch.bafu.wasser-vorfluter.ezgnr"
+msgstr "Gesamteinzugsgebiets-Nummer"
+
+msgid "ch.bafu.wasser-vorfluter.gewaessername"
+msgstr "Gewässername"
+
+msgid "ch.bafu.wasser-vorfluter.gwlnr"
+msgstr "Gewässerlaufnummer"
+
+msgid "ch.bafu.wasser-vorfluter.id"
+msgstr "Identifikator Vorfluterabschnitt"
+
+msgid "ch.bafu.wasser-vorfluter.nebenarm"
+msgstr "Gewässertyp"
+
+msgid "ch.bafu.wasser-vorfluter.oberesende"
+msgstr "Endadresse (’Gewässerkilometer’)"
+
+msgid "ch.bafu.wasser-vorfluter.unteresende"
+msgstr "Anfangsadresse (’Gewässerkilometer’)"
 
 msgid "ch.bafu.wege-wildruhezonen-jagdbanngebiete"
 msgstr "Vias e rutas permessas"
@@ -5840,8 +5942,38 @@ msgstr "Jahr"
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht"
 msgstr "Eisenbahnlärm, zuläss. Immission N"
 
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_es"
+msgstr "Empfindlichkeitsstufe"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_pointofdetermination_t"
+msgstr "Typ des Ermittlungspunktes"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.floor"
+msgstr "Stockwerk des Ermittlungspunkts"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_night"
+msgstr "Max. zul. Pegel (Nacht)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_year"
+msgstr "Verfügungsjahr"
+
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag"
 msgstr "Eisenbahnlärm, zuläss. Immission T"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_es"
+msgstr "Empfindlichkeitsstufe"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_pointofdetermination_t"
+msgstr "Typ des Ermittlungspunktes"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.floor"
+msgstr "Stockwerk des Ermittlungspunkts"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_day"
+msgstr "Max. zul. Pegel (Tag)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_year"
+msgstr "Verfügungsjahr"
 
 msgid "ch.bav.laerm-emissionplan_eisenbahn_2015"
 msgstr "Plan d'emissiuns viafiers 2015"
@@ -7640,9 +7772,6 @@ msgstr "Erosionsrisiko"
 msgid "ch.blw.erosion-fliesswegkarte"
 msgstr "Charta da deflussiun"
 
-msgid "ch.blw.erosion-mit_bergzonen"
-msgstr "Ristga d'erosiun qualitativa 2"
-
 msgid "ch.blw.erosion-quantitativ"
 msgstr "Ristga erosiun terren cultivà quant"
 
@@ -8300,6 +8429,9 @@ msgstr "https://www.sem.admin.ch/sem/de/home.html"
 msgid "ch.swisstopo"
 msgstr "swisstopo"
 
+msgid "ch.swisstopo.amtliches-gebaeudeadressverzeichnis"
+msgstr "Amtliches Gebäudeadressverzeichnis"
+
 msgid "ch.swisstopo.amtliches-strassenverzeichnis"
 msgstr "Register uffizial da las vias"
 
@@ -8633,6 +8765,39 @@ msgstr "Das Geoid"
 msgid "ch.swisstopo.geologie-geodaesie-isostatische_anomalien"
 msgstr "Anomalias isostaticas 500"
 
+msgid "ch.swisstopo.geologie-geologische_3dmodelle"
+msgstr "Geologische 3D-Modelle"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.content"
+msgstr "Modellierte Horizonte / Einheiten"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_author"
+msgstr "Autor(en)"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_contracting_entity"
+msgstr "Auftraggeber"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_description"
+msgstr "Externer Link zur Detailbeschreibung"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_documentation"
+msgstr "Externer Link zur Dokumentation"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_portal"
+msgstr "Externer Link zum Fachportal"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.name"
+msgstr "Name"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.purpose"
+msgstr "Zweck"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.remarks"
+msgstr "Bemerkungen"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.year_publication"
+msgstr "Erstellungsjahr"
+
 msgid "ch.swisstopo.geologie-geologische_einheiten-onegeology"
 msgstr "CHE LG DE 1:500k Geologische Einheiten"
 
@@ -8751,31 +8916,31 @@ msgid "ch.swisstopo.geologie-geologischer_atlas_vector.metadata.s_title_de"
 msgstr "Name"
 
 msgid "ch.swisstopo.geologie-geomol-isotherme_100"
-msgstr "Höhe 100 °C-Isotherme"
+msgstr "Nivel isoterma 100 °C"
 
 msgid "ch.swisstopo.geologie-geomol-isotherme_100.elev"
 msgstr "Höhe 100 °C-Isotherme [m ü.M.]"
 
 msgid "ch.swisstopo.geologie-geomol-isotherme_150"
-msgstr "Höhe 150 °C-Isotherme"
+msgstr "Nivel isoterma 150 °C"
 
 msgid "ch.swisstopo.geologie-geomol-isotherme_150.elev"
 msgstr "Höhe 150 °C-Isotherme [m ü.M.]"
 
 msgid "ch.swisstopo.geologie-geomol-isotherme_60"
-msgstr "Höhe 60 °C-Isotherme"
+msgstr "Nivel isoterma 60 °C"
 
 msgid "ch.swisstopo.geologie-geomol-isotherme_60.elev"
 msgstr "Höhe 60 °C-Isotherme [m ü.M.]"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturmodell_eingangsdaten"
-msgstr "Temperaturmodell - Daten"
+msgstr "Model da temperatura - datas"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturmodell_eingangsdaten.name"
 msgstr "Name"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_muschelkalk"
-msgstr "Temperaturen Top Muschelkalk"
+msgstr "Temperaturas sisum il Muschelkalk"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_muschelkalk.elev"
 msgstr "Höhe Top Muschelkalk [m ü.M.]"
@@ -8784,7 +8949,7 @@ msgid "ch.swisstopo.geologie-geomol-temperatur_top_muschelkalk.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omalm"
-msgstr "Temperaturen Top Oberer Malm"
+msgstr "Temp. sisum il Malm superiur"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omalm.elev"
 msgstr "Höhe Top Oberer Malm [m ü.M.]"
@@ -8793,7 +8958,7 @@ msgid "ch.swisstopo.geologie-geomol-temperatur_top_omalm.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omm"
-msgstr "Temperaturen Top OMM"
+msgstr "Temperaturas sisum la OMM"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omm.elev"
 msgstr "Höhe Top OMM [m ü.M.]"
@@ -8802,37 +8967,37 @@ msgid "ch.swisstopo.geologie-geomol-temperatur_top_omm.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_1000"
-msgstr "Temperaturen 1000 m Tiefe"
+msgstr "Temperaturas profunditad 1000 m"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_1000.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_1500"
-msgstr "Temperaturen 1500 m Tiefe"
+msgstr "Temperaturas profunditad 1500 m"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_1500.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_2000"
-msgstr "Temperaturen 2000 m Tiefe"
+msgstr "Temperaturas profunditad 2000 m"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_2000.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_3000"
-msgstr "Temperaturen 3000 m Tiefe"
+msgstr "Temperaturas profunditad 3000 m"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_3000.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_4000"
-msgstr "Temperaturen 4000 m Tiefe"
+msgstr "Temperaturas profunditad 4000 m"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_4000.pixel_value"
 msgstr "Temperatur [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_500"
-msgstr "Temperaturen 500 m Tiefe"
+msgstr "Temperaturas profunditad 500 m"
 
 msgid "ch.swisstopo.geologie-geomol-temperaturverteilung_500.pixel_value"
 msgstr "Temperatur [°C]"
@@ -8916,7 +9081,7 @@ msgid "ch.swisstopo.geologie-geotechnik-ziegeleien_1995.ziegeleien"
 msgstr "Name der Ziegelei"
 
 msgid "ch.swisstopo.geologie-geothermische_potenzialstudien_regional"
-msgstr "Geothermische Potenzialstudien"
+msgstr "Studis dal potenzial geotermic"
 
 msgid "ch.swisstopo.geologie-geothermische_potenzialstudien_regional.auftraggeber"
 msgstr "Auftraggeber"
@@ -11687,6 +11852,9 @@ msgstr "Sachplan Militär"
 msgid "ch.vbs.sachplan-infrastruktur-militaer_kraft_polygons_raster"
 msgstr "Sachplan Militär"
 
+msgid "ch.vbs.schiessanzeigen"
+msgstr "Schiessanzeigen und Schiessplätze"
+
 msgid "ch.vbs.sperr-gefahrenzonenkarte"
 msgstr "Charta da zonas scumandadas"
 
@@ -11848,6 +12016,33 @@ msgstr "Registrar il poligon"
 
 msgid "ct"
 msgstr "Kt."
+
+msgid "cwm_egris_egrid"
+msgstr "EGRID"
+
+msgid "cwm_number"
+msgstr "Nummer"
+
+msgid "cwm_realestate_type"
+msgstr "Grundstücksart"
+
+msgid "cwm_realestate_type_0"
+msgstr "Baurecht"
+
+msgid "cwm_realestate_type_1"
+msgstr "Quellenrecht"
+
+msgid "cwm_realestate_type_2"
+msgstr "Konzessionsrecht"
+
+msgid "cwm_realestate_type_3"
+msgstr "weitere"
+
+msgid "cwm_realestate_type_4"
+msgstr "Bergwerk"
+
+msgid "cwm_realestate_type_default"
+msgstr "Liegenschaft"
 
 msgid "cyan"
 msgstr "cian"
@@ -12768,6 +12963,9 @@ msgid "<i>Friedhof</i>"
 msgstr "Santeri"
 
 msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Edifizi"
+
+msgid "<i>Gebaeude</i>"
 msgstr "Edifizi"
 
 msgid "<i>Gebiet</i>"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -4014,7 +4014,7 @@ msgid "ch.bafu.luftreinhaltung-stickstoff_kritischer_eintrag"
 msgstr "Dépassement CLN"
 
 msgid "ch.bafu.mittlere-abfluesse"
-msgstr "Débit naturel (m³/s)"
+msgstr "Débit naturel (m³/s) et régime"
 
 msgid "ch.bafu.mittlere-abfluesse.abflussvar"
 msgstr "Variabilité du débit (%)"
@@ -4916,6 +4916,24 @@ msgstr "Force hydraulique - Autres prélèvements"
 msgid "ch.bafu.wasser-gebietsauslaesse"
 msgstr "Exutoires des bassins versants"
 
+msgid "ch.bafu.wasser-gebietsauslaesse.adresse"
+msgstr "Adresse ('kilométrage d’eau')"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.de_nebenarm"
+msgstr "Type de cours d'eau"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.ezgnr"
+msgstr "N° du bassin versant complet"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gewaessername"
+msgstr "Nom du cours d’eau"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gwlnr"
+msgstr "N° du cours d'eau"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.id"
+msgstr "Identificateur de l'exutoire du bassin"
+
 msgid "ch.bafu.wasser-leitungen"
 msgstr "Dérivation"
 
@@ -4925,8 +4943,62 @@ msgstr "Restitution"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2"
 msgstr "Bassins versants partiels 2km2"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.anteil_ch"
+msgstr "Pourcentage CH de la surface du BV entier"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_bestockteflaechen"
+msgstr "Surfaces boisées"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_landwirtschaftsflaechen"
+msgstr "Surfaces agricoles"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_siedlungsflaechen"
+msgstr "Surfaces d'habitat"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_unproduktiveflaechen"
+msgstr "Surfaces improductives"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_bebauteflaechen"
+msgstr "Territoires artificialisés"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_feuchtflaechen"
+msgstr "Zones humides"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_landwirtschaft"
+msgstr "Territoires agricoles"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_waelder"
+msgstr "Forêts et milieux semi-naturels"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_wasserflaechen"
+msgstr "Surfaces en eau"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.de_nebenarm"
+msgstr "Indication"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_ezg_flussgb"
 msgstr "Nom du bassin fluvial"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_1"
+msgstr "Altitude du bassin versant complet [m]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_2"
+msgstr "Couverture du sol CH basée sur la statistique de la superficie [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_3"
+msgstr "Couverture du sol basée sur CORINE Land Cover [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_4"
+msgstr "En raison de certaines limitations des données de base, les indicateurs ainsi calculés ne peuvent prétendre à une précision absolue."
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ezgnr"
+msgstr "N° du bassin versant complet"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gesamtflaeche"
+msgstr "Superficie du bassin versant complet [km2]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gewaessername"
+msgstr "Nom du cours d'eau"
 
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.gwlnr"
 msgstr "No. du cours d'eau"
@@ -4934,11 +5006,41 @@ msgstr "No. du cours d'eau"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.id"
 msgstr "N° du bassin versant partiel"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.max_z"
+msgstr "Altitude maximale"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.mean_z"
+msgstr "Altitude moyenne"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.min_z"
+msgstr "Altitude minimale"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_40"
 msgstr "Bassins versants partiels 40km2"
 
 msgid "ch.bafu.wasser-vorfluter"
 msgstr "Type de régime d'écoulement"
+
+msgid "ch.bafu.wasser-vorfluter.ezgnr"
+msgstr "N° du bassin versant complet"
+
+msgid "ch.bafu.wasser-vorfluter.gewaessername"
+msgstr "Nom du cours d’eau"
+
+msgid "ch.bafu.wasser-vorfluter.gwlnr"
+msgstr "N° du cours d’eau"
+
+msgid "ch.bafu.wasser-vorfluter.id"
+msgstr "Identificateur du tronçon d'effluent"
+
+msgid "ch.bafu.wasser-vorfluter.nebenarm"
+msgstr "Type de cours d'eau"
+
+msgid "ch.bafu.wasser-vorfluter.oberesende"
+msgstr "Adresse d’arrivée (kilométrage d’eau)"
+
+msgid "ch.bafu.wasser-vorfluter.unteresende"
+msgstr "Adresse de départ (kilométrage d’eau)"
 
 msgid "ch.bafu.wege-wildruhezonen-jagdbanngebiete"
 msgstr "Chemins / itinéraires autorisés"
@@ -5840,8 +5942,38 @@ msgstr "Année"
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht"
 msgstr "Bruit ferrov., immissions admiss. N"
 
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_es"
+msgstr "Degré de sensibilité"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_pointofdetermination_t"
+msgstr "Type de point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.floor"
+msgstr "Etage du point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_night"
+msgstr "Immission maximale adm. (nuit)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_year"
+msgstr "Année de la définition"
+
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag"
 msgstr "Bruit ferrov., immissions admiss. J"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_es"
+msgstr "Degré de sensibilité"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_pointofdetermination_t"
+msgstr "Type de point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.floor"
+msgstr "Etage du point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_day"
+msgstr "Immission maximale adm. (jour)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_year"
+msgstr "Année de la définition"
 
 msgid "ch.bav.laerm-emissionplan_eisenbahn_2015"
 msgstr "Plan des émissions en 2015"
@@ -7640,9 +7772,6 @@ msgstr "Risque d`érosion"
 msgid "ch.blw.erosion-fliesswegkarte"
 msgstr "Carte des écoulements"
 
-msgid "ch.blw.erosion-mit_bergzonen"
-msgstr "Risque d’érosion qualitatif 2"
-
 msgid "ch.blw.erosion-quantitativ"
 msgstr "Risque d'érosion ter. arab. quant."
 
@@ -8300,6 +8429,9 @@ msgstr "https://www.sem.admin.ch/sem/fr/home.html"
 msgid "ch.swisstopo"
 msgstr "swisstopo"
 
+msgid "ch.swisstopo.amtliches-gebaeudeadressverzeichnis"
+msgstr "Le répertoire officiel des adresses de bâtiments"
+
 msgid "ch.swisstopo.amtliches-strassenverzeichnis"
 msgstr "Répertoire officiel des rues"
 
@@ -8633,6 +8765,39 @@ msgstr "Le géoïde"
 msgid "ch.swisstopo.geologie-geodaesie-isostatische_anomalien"
 msgstr "Anomalies isostatiques 500"
 
+msgid "ch.swisstopo.geologie-geologische_3dmodelle"
+msgstr "Modèles géologiques 3D"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.content"
+msgstr "Horizons / Unités modélisés"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_author"
+msgstr "Auteur(s)"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_contracting_entity"
+msgstr "Mandant"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_description"
+msgstr "Lien externe vers la description détaillée"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_documentation"
+msgstr "Lien externe vers la documentation"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_portal"
+msgstr "Lien externe vers le portail thématique"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.name"
+msgstr "Nom"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.purpose"
+msgstr "But"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.remarks"
+msgstr "Remarques"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.year_publication"
+msgstr "Année de publication"
+
 msgid "ch.swisstopo.geologie-geologische_einheiten-onegeology"
 msgstr "CHE SGN FR 1:500k Unités Géologiques"
 
@@ -8784,7 +8949,7 @@ msgid "ch.swisstopo.geologie-geomol-temperatur_top_muschelkalk.pixel_value"
 msgstr "Température [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omalm"
-msgstr "Températures Top Malm Supérieur"
+msgstr "Températures Top Malm supérieur"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omalm.elev"
 msgstr "Altitude Top Malm Supérieur [m s.m.]"
@@ -11687,6 +11852,9 @@ msgstr "Plan sectoriel militaire"
 msgid "ch.vbs.sachplan-infrastruktur-militaer_kraft_polygons_raster"
 msgstr "Plan sectoriel militaire"
 
+msgid "ch.vbs.schiessanzeigen"
+msgstr "Avis de tir et places de tir"
+
 msgid "ch.vbs.sperr-gefahrenzonenkarte"
 msgstr "Carte des zones interdites"
 
@@ -11848,6 +12016,33 @@ msgstr "Créer polygone"
 
 msgid "ct"
 msgstr "Ct."
+
+msgid "cwm_egris_egrid"
+msgstr "EGRID"
+
+msgid "cwm_number"
+msgstr "Numero"
+
+msgid "cwm_realestate_type"
+msgstr "Genre Immeuble"
+
+msgid "cwm_realestate_type_0"
+msgstr "Droit de superficie"
+
+msgid "cwm_realestate_type_1"
+msgstr "Droit de source"
+
+msgid "cwm_realestate_type_2"
+msgstr "Droit de concession"
+
+msgid "cwm_realestate_type_3"
+msgstr "autre"
+
+msgid "cwm_realestate_type_4"
+msgstr "mine"
+
+msgid "cwm_realestate_type_default"
+msgstr "Bien-fonds"
 
 msgid "cyan"
 msgstr "cyan"
@@ -12768,6 +12963,9 @@ msgid "<i>Friedhof</i>"
 msgstr "Cimetière"
 
 msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Bâtiment"
+
+msgid "<i>Gebaeude</i>"
 msgstr "Bâtiment"
 
 msgid "<i>Gebiet</i>"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -4014,7 +4014,7 @@ msgid "ch.bafu.luftreinhaltung-stickstoff_kritischer_eintrag"
 msgstr "Superamento CLN"
 
 msgid "ch.bafu.mittlere-abfluesse"
-msgstr "Deflussi medi (m³/s)"
+msgstr "Deflussi medi (m³/s) e regime"
 
 msgid "ch.bafu.mittlere-abfluesse.abflussvar"
 msgstr "Variabilité du débit (%)"
@@ -4916,6 +4916,24 @@ msgstr "Force hydraulique - Autres prélèvements"
 msgid "ch.bafu.wasser-gebietsauslaesse"
 msgstr "Sbocchi dei bacini imbriferi"
 
+msgid "ch.bafu.wasser-gebietsauslaesse.adresse"
+msgstr "Indirizzo (chilometraggio dell’acqua)"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.de_nebenarm"
+msgstr "Tipo del corso d’acqua"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.ezgnr"
+msgstr "N° complete del bacino idrografico completo"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gewaessername"
+msgstr "Nome del corso d’acqua"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.gwlnr"
+msgstr "N° del corso d’acqua"
+
+msgid "ch.bafu.wasser-gebietsauslaesse.id"
+msgstr "Identificatore dello sbocco del bacino idrografico"
+
 msgid "ch.bafu.wasser-leitungen"
 msgstr "Derivazione"
 
@@ -4925,8 +4943,62 @@ msgstr "Restituzione"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2"
 msgstr "Bacini imbriferi 2km2"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.anteil_ch"
+msgstr "Percentuale CH della superficie del bacino imbrifero totale"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_bestockteflaechen"
+msgstr "Superfici boscate"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_landwirtschaftsflaechen"
+msgstr "Superfici agricole"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_siedlungsflaechen"
+msgstr "Superfici d'insediamento"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.as_unproduktiveflaechen"
+msgstr "Superfici improduttive"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_bebauteflaechen"
+msgstr "Superfici artificiali"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_feuchtflaechen"
+msgstr "Zone umide"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_landwirtschaft"
+msgstr "Superfici agricole"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_waelder"
+msgstr "Foresta e aree seminaturali"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.clc_wasserflaechen"
+msgstr "Superfici d'acqua"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.de_nebenarm"
+msgstr "Indicazione"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_ezg_flussgb"
 msgstr "Nome del bacino fluviale:"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_1"
+msgstr "Altitudine del bacino idrografico completo [m]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_2"
+msgstr "Copertura del suolo CH in base alla statistica della superficie [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_3"
+msgstr "Copertura del suolo sulla base di CORINE Land Cover [%]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ext_info_4"
+msgstr "A causa di alcune limitazioni dei dati di base, gli indicatori calcolati non pretendono di essere assolutamente precise."
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.ezgnr"
+msgstr "N° del bacino idrografico completo"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gesamtflaeche"
+msgstr "Superficie del bacino idrografico completo [km2]"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.gewaessername"
+msgstr "Nome del corso acqua"
 
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.gwlnr"
 msgstr "N° del corso d‘acqua"
@@ -4934,11 +5006,41 @@ msgstr "N° del corso d‘acqua"
 msgid "ch.bafu.wasser-teileinzugsgebiete_2.id"
 msgstr "Numero del bacino idrografico"
 
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.max_z"
+msgstr "Altitudine massima"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.mean_z"
+msgstr "Altitudine media"
+
+msgid "ch.bafu.wasser-teileinzugsgebiete_2.min_z"
+msgstr "Altitudine minima"
+
 msgid "ch.bafu.wasser-teileinzugsgebiete_40"
 msgstr "Bacini imbriferi 40 km2"
 
 msgid "ch.bafu.wasser-vorfluter"
 msgstr "Tipo di regime di deflusso"
+
+msgid "ch.bafu.wasser-vorfluter.ezgnr"
+msgstr "N° del bacino idrografico completo"
+
+msgid "ch.bafu.wasser-vorfluter.gewaessername"
+msgstr "Nome del corso d’acqua"
+
+msgid "ch.bafu.wasser-vorfluter.gwlnr"
+msgstr "N° del corso d’acqua"
+
+msgid "ch.bafu.wasser-vorfluter.id"
+msgstr "Identificatore del tratto dell'effluente"
+
+msgid "ch.bafu.wasser-vorfluter.nebenarm"
+msgstr "Tipo del corso d'acqua"
+
+msgid "ch.bafu.wasser-vorfluter.oberesende"
+msgstr "Indirizzo d'arrivo (chilometraggio dell’acqua)"
+
+msgid "ch.bafu.wasser-vorfluter.unteresende"
+msgstr "Indirizzo di partenza (chilometraggio dell’acqua)"
 
 msgid "ch.bafu.wege-wildruhezonen-jagdbanngebiete"
 msgstr "Sentieri /itinerari autorizzati"
@@ -5840,8 +5942,38 @@ msgstr "Anno"
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht"
 msgstr "Rumore dei treni, immissioni cons. N"
 
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_es"
+msgstr "Degré de sensibilité"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.de_pointofdetermination_t"
+msgstr "Type de point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.floor"
+msgstr "Etage du point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_night"
+msgstr "Immission maximale adm. (nuit)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_nacht.lr_max_year"
+msgstr "Année de la définition"
+
 msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag"
 msgstr "Rumore dei treni, immissioni cons. G"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_es"
+msgstr "Degré de sensibilité"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.de_pointofdetermination_t"
+msgstr "Type de point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.floor"
+msgstr "Etage du point de détermination"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_day"
+msgstr "Immission maximale adm. (jour)"
+
+msgid "ch.bav.laermbelastung-eisenbahn_zulaessige_immissionen_tag.lr_max_year"
+msgstr "Année de la définition"
 
 msgid "ch.bav.laerm-emissionplan_eisenbahn_2015"
 msgstr "Piano delle emissioni 2015"
@@ -7640,9 +7772,6 @@ msgstr "Rischio d'erosione"
 msgid "ch.blw.erosion-fliesswegkarte"
 msgstr "Carta delle vie di deflusso"
 
-msgid "ch.blw.erosion-mit_bergzonen"
-msgstr "Rischio erosione qualitativo 2"
-
 msgid "ch.blw.erosion-quantitativ"
 msgstr "Rischio erosione ter. colt. quant."
 
@@ -8300,6 +8429,9 @@ msgstr "https://www.sem.admin.ch/sem/it/home.html"
 msgid "ch.swisstopo"
 msgstr "swisstopo"
 
+msgid "ch.swisstopo.amtliches-gebaeudeadressverzeichnis"
+msgstr "L'elenco ufficiale degli indirizzi degli edifici"
+
 msgid "ch.swisstopo.amtliches-strassenverzeichnis"
 msgstr "Elenco ufficiale delle vie"
 
@@ -8633,6 +8765,39 @@ msgstr "Il geoide"
 msgid "ch.swisstopo.geologie-geodaesie-isostatische_anomalien"
 msgstr "Anomalie isostatiche 500"
 
+msgid "ch.swisstopo.geologie-geologische_3dmodelle"
+msgstr "Modelli geologici 3D"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.content"
+msgstr "Orizzonti e unità modellate"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_author"
+msgstr "Autore(i)"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_contracting_entity"
+msgstr "Mandante"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_description"
+msgstr "Link esterno verso la descrizione dettagliata"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_documentation"
+msgstr "Link esterno verso la documentazione"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.de_link_portal"
+msgstr "Link esterno verso il portale tecnico"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.name"
+msgstr "Nome"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.purpose"
+msgstr "Scopo"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.remarks"
+msgstr "Osservazioni"
+
+msgid "ch.swisstopo.geologie-geologische_3dmodelle.year_publication"
+msgstr "Anno di pubblicazione"
+
 msgid "ch.swisstopo.geologie-geologische_einheiten-onegeology"
 msgstr "Geologia 1:500 000"
 
@@ -8784,7 +8949,7 @@ msgid "ch.swisstopo.geologie-geomol-temperatur_top_muschelkalk.pixel_value"
 msgstr "Temperatura [°C]"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omalm"
-msgstr "Temperature Top Malm Superiore"
+msgstr "Temperature Top Malm superiore"
 
 msgid "ch.swisstopo.geologie-geomol-temperatur_top_omalm.elev"
 msgstr "Elevazione Top Malm Superiore [m s.l.m.]"
@@ -11687,6 +11852,9 @@ msgstr "Piano settoriale militare"
 msgid "ch.vbs.sachplan-infrastruktur-militaer_kraft_polygons_raster"
 msgstr "Piano settoriale militare"
 
+msgid "ch.vbs.schiessanzeigen"
+msgstr "Avviso di tiro e piazze di tiro"
+
 msgid "ch.vbs.sperr-gefahrenzonenkarte"
 msgstr "Carta delle zone soggette a divieti"
 
@@ -11848,6 +12016,33 @@ msgstr "Crea poligono"
 
 msgid "ct"
 msgstr "Ct."
+
+msgid "cwm_egris_egrid"
+msgstr "EGRID"
+
+msgid "cwm_number"
+msgstr "Numero"
+
+msgid "cwm_realestate_type"
+msgstr "Genere Fondo"
+
+msgid "cwm_realestate_type_0"
+msgstr "Dritto di superficie"
+
+msgid "cwm_realestate_type_1"
+msgstr "Dritto di sorgente"
+
+msgid "cwm_realestate_type_2"
+msgstr "Dritto di concessione"
+
+msgid "cwm_realestate_type_3"
+msgstr "altro"
+
+msgid "cwm_realestate_type_4"
+msgstr "miniera"
+
+msgid "cwm_realestate_type_default"
+msgstr "Bene immobile"
 
 msgid "cyan"
 msgstr "Ciano"
@@ -12768,6 +12963,9 @@ msgid "<i>Friedhof</i>"
 msgstr "Cimitero"
 
 msgid "<i>Gebaeude Einzelhaus</i>"
+msgstr "Edificio"
+
+msgid "<i>Gebaeude</i>"
 msgstr "Edificio"
 
 msgid "<i>Gebiet</i>"


### PR DESCRIPTION
The double ``<i>`` entries are due to missing translation of tlm categories.
The sphinxsearch service response ``rest/services/api/SearchServer`` are translated on the backend, only the labels.
With the latest tlm update we have new object categories ``Gebaeude`` without a translation.
I have added the missing translation to the bod and updated the po files of this branch:
```SQL
begin;
INSERT INTO translations (msg_id, de, fr, it, rm, en)
SELECT '<i>Gebaeude</i>', 'Gebaeude', fr, it, rm, en from translations WHERE bgdi_id = 3972;
rollback;
```
short term fix for **https://jira.swisstopo.ch/browse/BGDIINF_SB-982**
we should try to make the function more robust and avoid double tagging:
https://github.com/geoadmin/mf-chsdi3/blob/data/chsdi/views/search.py#L587