### PR TITLE
Ltfoa fix strassenverzeichnis tooltip

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -15314,6 +15314,12 @@ msgstr "Häufigkeit (%)"
 msgid "tt_bfe_hinweis"
 msgstr "Hinweis zur Unsicherheit der Modellierung"
 
+msgid "tt_bfe_hinweis_text"
+msgstr "Diese Daten sind nicht für die Beurteilung eines Standorts geeignet. Dafür sind Windmessungen notwendig."
+
+msgid "tt_bfe_hinweis_wa"
+msgstr "Hinweis"
+
 msgid "tt_bfe_hoehe_gelaende"
 msgstr "Höhe Gelände"
 

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -15314,6 +15314,12 @@ msgstr "Frequency (%)"
 msgid "tt_bfe_hinweis"
 msgstr "Note concerning the uncertainty of modelling"
 
+msgid "tt_bfe_hinweis_text"
+msgstr "These data do not qualify for the assessment of a wind energy site. For this purpose a wind measurement is required."
+
+msgid "tt_bfe_hinweis_wa"
+msgstr "Please Note"
+
 msgid "tt_bfe_hoehe_gelaende"
 msgstr "Altitude"
 

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -15314,6 +15314,12 @@ msgstr "Häufigkeit (%)"
 msgid "tt_bfe_hinweis"
 msgstr "Hinweis zur Unsicherheit der Modellierung"
 
+msgid "tt_bfe_hinweis_text"
+msgstr "Diese Daten sind nicht für die Beurteilung eines Standorts geeignet. Dafür sind Windmessungen notwendig."
+
+msgid "tt_bfe_hinweis_wa"
+msgstr "Hinweis"
+
 msgid "tt_bfe_hoehe_gelaende"
 msgstr "Höhe Gelände"
 

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -15314,6 +15314,12 @@ msgstr "Fréquence (%)"
 msgid "tt_bfe_hinweis"
 msgstr "Remarque concernant l’incertitude de la modélisation"
 
+msgid "tt_bfe_hinweis_text"
+msgstr "Ces données ne permettent pas d’évaluer correctement les qualités d’un site. Pour ce faire des mesures de vent ciblées sont indispensables."
+
+msgid "tt_bfe_hinweis_wa"
+msgstr "Avertissement"
+
 msgid "tt_bfe_hoehe_gelaende"
 msgstr "Altitude"
 

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -15314,6 +15314,12 @@ msgstr "Frequenza (%)"
 msgid "tt_bfe_hinweis"
 msgstr "Nota sull’incertezza della modellazione"
 
+msgid "tt_bfe_hinweis_text"
+msgstr "Questi dati non sono appropriati per la valutazione di un’ubicazione. Per una valutazione sono necessarie delle misurazioni del vento."
+
+msgid "tt_bfe_hinweis_wa"
+msgstr "Avvertimento"
+
 msgid "tt_bfe_hoehe_gelaende"
 msgstr "Altitudine"
 

--- a/chsdi/templates/htmlpopup/strassenverzeichnis.mako
+++ b/chsdi/templates/htmlpopup/strassenverzeichnis.mako
@@ -1,6 +1,7 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
+    <% c['stable_id'] = True %>
     <%
     validated = 'yesText' if c['attributes']['validated'] == 1 else 'noText'
     official = 'yesText' if c['attributes']['official'] == 1 else 'noText'

--- a/chsdi/templates/htmlpopup/windatlas50.mako
+++ b/chsdi/templates/htmlpopup/windatlas50.mako
@@ -35,12 +35,8 @@ props = c['attributes']
 </style>
 <!-- html output -->
     <tr>
-      <th class="cell-left">${_('tt_bfe_hoehe_ueber_grund')}</th>
-      <td>${altitude or '-'} m</td>
-    </tr>
-    <tr>
-      <th class="cell-left">${_('tt_bfe_koordinaten')}</th>
-      <td>${center}</td>
+      <th class="cell-left">${_('tt_bfe_hinweis_wa')}</th>
+      <td>${_('tt_bfe_hinweis_text')}</td>
     </tr>
     <tr>
       <th class="cell-left">${_('tt_bfe_hoehe_gelaende')}</th>
@@ -204,6 +200,10 @@ table#windrichtung  td.align-right {
 
 <body>
 <table class="table-with-border kernkraftwerke-extended">
+  <tr>
+    <th class="cell-left">${_('tt_bfe_hinweis_wa')}</th>
+    <td>${_('tt_bfe_hinweis_text')}</td>
+  </tr>
   <tr>
     <th class="cell-left">${_('tt_bfe_hoehe_ueber_grund')}</th>
     <td>${altitude or '-'} m</td>


### PR DESCRIPTION
This PR activates the "link to objekt" element in the strassenverzeichnis tooltip
[test](https://mf-geoadmin3.dev.bgdi.ch/index.html?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fltfoa&layers=ch.swisstopo.amtliches-strassenverzeichnis&layers_opacity=0.85&E=2586184.13&N=1219785.30&zoom=9)