### PR TITLE
Option to deactivate translation update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ BODID ?=
 DEPLOY_TARGET ?=
 BRANCH_TO_DELETE ?=
 WMSSCALELEGEND ?=
+UPDATE_TRANSLATION ?= 'true'
 
 # Variables
 USER_SOURCE ?= rc_user
@@ -178,7 +179,7 @@ help:
 	@echo "- deletebranchdev    List deployed branches or delete a deployed branch on dev (BRANCH_TO_DELETE=...)"
 	@echo "- deletebranchint    List deployed branches or delete a deployed branch on int (BRANCH_TO_DELETE=...)"
 	@echo "- updateapi          Updates geoadmin api source code (ol3 fork)"
-	@echo "- deploydev          Deploys master to dev (SNAPSHOT=true to also create a snapshot)"
+	@echo "- deploydev          Deploys master to dev (SNAPSHOT=true to also create a snapshot, UPDATE_TRANSLATION=true|false)"
 	@echo "- updatedev          Updates master to dev, if version has changed (with snapshot)"
 	@echo "- deployint          Deploys a snapshot to integration (SNAPSHOT=201512021146)"
 	@echo "- deployprod         Deploys a snapshot to production (SNAPSHOT=201512021146)"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ deploy process is done.
 
 `make deploydev SNAPSHOT=true`
 
-This updates the source in /var/www... to the latest master branch from github,
+This updates the source in /var/www/vhosts/mf-chsdi3/private/ to the latest master branch from github,
 creates a snapshot and runs nosetests against the test db. The snapshot directory
 will be shown when the script is done. *Note*: you can omit the `-s` parameter if
 you don't want to create a snapshot e.g. for intermediate releases on dev main.

--- a/scripts/deploydev.sh
+++ b/scripts/deploydev.sh
@@ -82,13 +82,18 @@ echo "Deployed branch $GITBRANCH to dev main."
 # create a snapshot
 if [ $CREATE_SNAPSHOT == 'true' ]; then
   # Make sure translations are updated
-  make translate
-  TRANSLATIONS_DIFF=$(git diff)
-  if [ ! -z "$TRANSLATIONS_DIFF" ]; then
-    echo $TRANSLATIONS_DIFF
-    echo "Some translations haven't been updated yet, please update the translations..."
-    echo "Aborting..."
-    exit 1
+  if [ ${UPDATE_TRANSLATION} != 'false' ]; then
+      make translate
+      TRANSLATIONS_DIFF=$(git diff)
+      if [ ! -z "$TRANSLATIONS_DIFF" ]; then
+        echo $TRANSLATIONS_DIFF
+        echo "Some translations haven't been updated yet, please update the translations..."
+        echo "Aborting..."
+        exit 1
+      fi
+  else
+      echo "No updating translations"
+  
   fi
 
   # Deploying snapshot to snapshot directory


### PR DESCRIPTION
For now `make deploydev SNAPSHOT=true` force to update translation.
For code only deploy, it may not necessary to update these translation (translations are from the BOD, statyfied and then committed)

 `make deploydev SNAPSHOT=true UPDATE_TRANSLATION=false`


Or wait until https://github.com/geoadmin/mf-chsdi3/pull/3401 is finished, tested and merged
