### PR TITLE
Configurable DynamoDB tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ APACHE_ENTRY_PATH := $(shell if [ '$(APACHE_BASE_PATH)' = 'main' ]; then echo ''
 DATAGEOADMINHOST ?= data.geo.admin.ch
 SHORTENER_ALLOWED_DOMAINS := admin.ch, swisstopo.ch, bgdi.ch
 SHORTENER_ALLOWED_HOSTS ?=
+# A single table for dev, int and prod. Different name for each build test
+SHORTENER_TABLE_NAME ?= shorturl
 PYPI_URL ?= https://pypi.org/simple/
 GITHUB_LAST_COMMIT=$(shell curl -s  https://api.github.com/repos/geoadmin/mf-chsdi3/commits | jq -r '.[0].sha')
 
@@ -64,7 +66,8 @@ LAST_SHOP_URL := $(call lastvalue,shop-url)
 LAST_HOST := $(call lastvalue,host)
 LAST_GEOADMIN_FILE_STORAGE_BUCKET := $(call lastvalue,geoadmin-file-storage-bucket)
 LAST_PUBLIC_BUCKET_HOST  := $(call lastvalue,public-bucket-host)
-LAST_SHORTENER_ALLOWED_HOSTS := $(call lastvalue,allowed-hosts)
+LAST_SHORTENER_ALLOWED_HOSTS := $(call lastvalue,shortener-allowed-hosts)
+LAST_SHORTENER_TABLE_NAME := $(call lastvalue,shortener-table-name)
 LAST_VECTOR_BUCKET := $(call lastvalue,vector-bucket)
 LAST_DATAGEOADMINHOST := $(call lastvalue,datageoadminhost)
 LAST_CMSGEOADMINHOST := $(call lastvalue,cmsgeoadminhost)
@@ -474,6 +477,7 @@ production.ini: production.ini.in \
                 .venv/last-linkeddatahost \
                 .venv/last-opentrans-api-key \
                 .venv/last-shortener-allowed-domains \
+                .venv/last-shortener-table-name \
                 guard-OPENTRANS_API_KEY
 	@echo "${GREEN}Creating production.ini...${RESET}";
 	${MAKO_CMD} \
@@ -499,6 +503,7 @@ production.ini: production.ini.in \
 		--var "geoadmin_file_storage_bucket=$(GEOADMIN_FILE_STORAGE_BUCKET)" \
 		--var "public_bucket_host=$(PUBLIC_BUCKET_HOST)" \
 		--var "shortener_allowed_hosts=$(SHORTENER_ALLOWED_HOSTS)" \
+		--var "shortener_table_name=$(SHORTENER_TABLE_NAME)" \
 		--var "vector_bucket=$(VECTOR_BUCKET)" \
 		--var "datageoadminhost=$(DATAGEOADMINHOST)" \
 		--var "cmsgeoadminhost=$(CMSGEOADMINHOST)" \
@@ -630,6 +635,9 @@ chsdi/static/css/extended.min.css: chsdi/static/less/extended.less
 
 .venv/last-shortener-allowed-hosts::
 	$(call cachelastvariable,$@,$(SHORTENER_ALLOWED_HOSTS),$(LAST_SHORTENER_ALLOWED_HOSTS),shortener-allowed-hosts)
+
+.venv/last-shortener-table-name::
+	$(call cachelastvariable,$@,$(SHORTENER_TABLE_NAME),$(LAST_SHORTENER_TABLE_NAME),shortener-table-name)
 
 .venv/last-vector-bucket::
 	$(call cachelastvariable,$@,$(VECTOR_BUCKET),$(LAST_VECTOR_BUCKET),vector-bucket)

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ DATAGEOADMINHOST ?= data.geo.admin.ch
 SHORTENER_ALLOWED_DOMAINS := admin.ch, swisstopo.ch, bgdi.ch
 SHORTENER_ALLOWED_HOSTS ?=
 # A single table for dev, int and prod. Different name for each build test
+GEOADMIN_FILE_STORAGE_TABLE ?= geoadmin-file-storage
 SHORTENER_TABLE_NAME ?= shorturl
 PYPI_URL ?= https://pypi.org/simple/
 GITHUB_LAST_COMMIT=$(shell curl -s  https://api.github.com/repos/geoadmin/mf-chsdi3/commits | jq -r '.[0].sha')
@@ -65,6 +66,7 @@ LAST_API_URL := $(call lastvalue,api-url)
 LAST_SHOP_URL := $(call lastvalue,shop-url)
 LAST_HOST := $(call lastvalue,host)
 LAST_GEOADMIN_FILE_STORAGE_BUCKET := $(call lastvalue,geoadmin-file-storage-bucket)
+LAST_GEOADMIN_FILE_STORAGE_TABLE := $(call lastvalue,geoadmin-file-storage-table)
 LAST_PUBLIC_BUCKET_HOST  := $(call lastvalue,public-bucket-host)
 LAST_SHORTENER_ALLOWED_HOSTS := $(call lastvalue,shortener-allowed-hosts)
 LAST_SHORTENER_TABLE_NAME := $(call lastvalue,shortener-table-name)
@@ -469,6 +471,7 @@ production.ini: production.ini.in \
                 .venv/last-kml-temp-dir \
                 .venv/last-http-proxy \
                 .venv/last-geoadmin-file-storage-bucket \
+                .venv/last-geoadmin-file-storage-table \
                 .venv/last-public-bucket-host \
                 .venv/last-shortener-allowed-hosts \
                 .venv/last-vector-bucket \
@@ -501,6 +504,7 @@ production.ini: production.ini.in \
 		--var "kml_temp_dir=$(KML_TEMP_DIR)" \
 		--var "http_proxy=$(HTTP_PROXY)" \
 		--var "geoadmin_file_storage_bucket=$(GEOADMIN_FILE_STORAGE_BUCKET)" \
+		--var "geoadmin_file_storage_table=$(GEOADMIN_FILE_STORAGE_TABLE)" \
 		--var "public_bucket_host=$(PUBLIC_BUCKET_HOST)" \
 		--var "shortener_allowed_hosts=$(SHORTENER_ALLOWED_HOSTS)" \
 		--var "shortener_table_name=$(SHORTENER_TABLE_NAME)" \
@@ -629,6 +633,9 @@ chsdi/static/css/extended.min.css: chsdi/static/less/extended.less
 
 .venv/last-geoadmin-file-storage-bucket::
 	$(call cachelastvariable,$@,$(GEOADMIN_FILE_STORAGE_BUCKET),$(LAST_GEOADMIN_FILE_STORAGE_BUCKET),geoadmin-file-storage-bucket)
+
+.venv/last-geoadmin-file-storage-table::
+	$(call cachelastvariable,$@,$(GEOADMIN_FILE_STORAGE_TABLE),$(LAST_GEOADMIN_FILE_STORAGE_TABLE),geoadmin-file-storage-table)
 
 .venv/last-public-bucket-host::
 	$(call cachelastvariable,$@,$(PUBLIC_BUCKET_HOST),$(LAST_PUBLIC_BUCKET_HOST),public-bucket-host)

--- a/chsdi/views/admin.py
+++ b/chsdi/views/admin.py
@@ -15,8 +15,9 @@ LIMIT = 50
 def admin_kml(context, request):
     settings = request.registry.settings
     bucket_name = settings.get('geoadmin_file_storage_bucket')
+    table_name = settings.get('geoadmin_file_storage_table')
     api_url = settings.get('api_url')
-    files = kml_load(api_url=api_url, bucket_name=bucket_name)
+    files = kml_load(api_url=api_url, bucket_name=bucket_name, table_name=table_name)
     kmls = {'files': files, 'count': len(files), 'bucket': api_url, 'host': settings.get('geoadminhost')}
 
     response = render_to_response(
@@ -26,10 +27,10 @@ def admin_kml(context, request):
     return response
 
 
-def kml_load(api_url='//api3.geo.admin.ch', bucket_name=None):
+def kml_load(api_url='//api3.geo.admin.ch', bucket_name=None, table_name=None):
     now = datetime.datetime.now()
     date = now.strftime('%Y-%m-%d')
-    table = get_dynamodb_table(table_name='geoadmin-file-storage')
+    table = get_dynamodb_table(table_name=table_name)
     fileids = []
     results = table.query(Limit=LIMIT * 4,
                           IndexName='bucketTimestampIndex',

--- a/chsdi/views/files.py
+++ b/chsdi/views/files.py
@@ -10,7 +10,7 @@ from chsdi.lib.decorators import requires_authorization, validate_kml_input
 class FileView(FilesHandler):
 
     def __init__(self, request):
-        self.dynamodb_table_name = request.registry.settings['geoadmin-file-storage']
+        self.dynamodb_table_name = request.registry.settings['geoadmin_file_storage_table']
         self.bucket_key_name = 'geoadmin_file_storage_bucket'
         self.bucket_name = request.registry.settings['geoadmin_file_storage_bucket']
         self.default_mime_type = 'application/vnd.google-earth.kml+xml'

--- a/chsdi/views/files.py
+++ b/chsdi/views/files.py
@@ -10,7 +10,7 @@ from chsdi.lib.decorators import requires_authorization, validate_kml_input
 class FileView(FilesHandler):
 
     def __init__(self, request):
-        self.dynamodb_table_name = 'geoadmin-file-storage'
+        self.dynamodb_table_name = request.registry.settings['geoadmin-file-storage']
         self.bucket_key_name = 'geoadmin_file_storage_bucket'
         self.bucket_name = request.registry.settings['geoadmin_file_storage_bucket']
         self.default_mime_type = 'application/vnd.google-earth.kml+xml'

--- a/chsdi/views/shortener.py
+++ b/chsdi/views/shortener.py
@@ -57,10 +57,12 @@ def shortener(request):
         # Index restriction in DynamoDB
         url_short = 'toolong'
     else:  # pragma: no cover
-        url_short = check_url(url, request.registry.settings)
+        settings = request.registry.settings
+        url_short = check_url(url, settings)
+        table_name = settings.get('shortener.table_name')
         # DynamoDB v2 high-level abstraction
         try:
-            table = get_dynamodb_table(table_name='shorturl')
+            table = get_dynamodb_table(table_name=table_name)
         except Exception as e:
             raise exc.HTTPInternalServerError('Error during connection %s' % e)
         url_short = _add_item(table, url)

--- a/production.ini.in
+++ b/production.ini.in
@@ -54,6 +54,7 @@ apache_entry_path = ${apache_entry_path}
 kml_temp_dir=${kml_temp_dir}
 http_proxy = ${http_proxy}
 geoadmin_file_storage_bucket = ${geoadmin_file_storage_bucket}
+geoadmin_file_storage_table = ${geoadmin_file_storage_table}
 public_bucket_host = ${public_bucket_host}
 vector_bucket = ${vector_bucket}
 datageoadminhost = ${datageoadminhost}

--- a/production.ini.in
+++ b/production.ini.in
@@ -63,6 +63,7 @@ max_featureids_request = 20
 
 shortener.allowed_hosts = ${shortener_allowed_hosts}
 shortener.allowed_domains = ${shortener_allowed_domains}
+shortener.table_name = ${shortener_table_name}
 
 ###
 # wsgi server configuration


### PR DESCRIPTION
This PR should not change anything.

To run integration tests in CodeBuild, we need custom DynamoDB tables.
We have two tables `shorturl` for the _shorturl service_ (with one table for `dev`, `int` and `prod`) and
`geoadmin-filestorage` for the _file service_ and the _glstyle service_ (again, only one table, but three buckets!)


See https://jira.swisstopo.ch/browse/BGDIINF_SB-965