### PR TITLE
Hotfix BGDIINF_SB-1097 set vary header

### DIFF
--- a/chsdi/views/wmtscapabilities.py
+++ b/chsdi/views/wmtscapabilities.py
@@ -103,4 +103,13 @@ class WMTSCapabilites(MapNameValidation):
             wmts,
             request=self.request)
         response.content_type = 'text/xml'
+
+        # Notify caching systems that the content of the response
+        # varies depending on the protocol used (i.e. http or https)
+        # The original protocol used by the client is stored in X-Forwarded-Proto
+        # header by the ALB
+        # Note: vary header in Pyramid needs to be a list
+        # https://docs.pylonsproject.org/projects/pyramid/en/latest/api/response.html#pyramid.response.Response.vary
+        response.vary = ['X-Forwarded-Proto']
+
         return response


### PR DESCRIPTION
This fixes https://jira.swisstopo.ch/browse/BGDIINF_SB-1097
deployed on int, can be tested with 
`curl -s --head https://mf-chsdi3.int.bgdi.ch/hotfix_BGDIINF_SB-1097_set_vary_header/1.0.0/WMTSCapabilities.xml` and `curl -s --head http://mf-chsdi3.int.bgdi.ch/hotfix_BGDIINF_SB-1097_set_vary_header/1.0.0/WMTSCapabilities.xml` respectively (cache is now 'filled' for 30 min)