### PR TITLE
publish esid as stable id

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -3235,14 +3235,13 @@ register('ch.swisstopo.swissimage-product.metadata', SwissimageHistMetadata)
 
 
 class AmtlichesStrassenverzeichnis(Base, Vector):
-    __tablename__ = 'streetnames'
+    __tablename__ = 'streetnames_tooltip'
     __table_args__ = ({'schema': 'vd', 'autoload': False})
     __template__ = 'templates/htmlpopup/strassenverzeichnis.mako'
     __bodId__ = 'ch.swisstopo.amtliches-strassenverzeichnis'
     __label__ = 'label'
     __queryable_attributes__ = ['label', 'plzo', 'gdename', 'gdenr', 'type']
-    id = Column('bgdi_id', Integer, primary_key=True)
-    esid = Column('esid', Integer)
+    id = Column('esid', Integer, primary_key=True)
     label = Column('label', Unicode)
     plzo = Column('plzo', Unicode)
     gdename = Column('gdename', Unicode)

--- a/chsdi/templates/htmlpopup/strassenverzeichnis.mako
+++ b/chsdi/templates/htmlpopup/strassenverzeichnis.mako
@@ -1,12 +1,13 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
+    <% c['stable_id'] = True %>
     <%
     validated = 'yesText' if c['attributes']['validated'] == 1 else 'noText'
     official = 'yesText' if c['attributes']['official'] == 1 else 'noText'
     %>
 
-    <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.esid')}</td>                 <td>${c['attributes']['esid'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.esid')}</td>                 <td>${c['featureId']}</td></tr>
     <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.label')}</td>                 <td>${c['attributes']['label'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.plzo')}</td>                 <td>${c['attributes']['plzo'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('ch.swisstopo.amtliches-strassenverzeichnis.gdenr')}</td>                 <td>${c['attributes']['gdenr'] or '-'}</td></tr>


### PR DESCRIPTION
according to the data owner esid is a stable identifier.
replaces https://github.com/geoadmin/mf-chsdi3/pull/3409
triggered by https://jira.swisstopo.ch/browse/BGDIDI_KB-2024

[Testlink](https://mf-chsdi3.dev.bgdi.ch/feature_strassenverzeichnis/shorten/892e8336bd)
note: the link to object link wont work in the testlink. it is a hardcoded link using the root chsdi on dev and not the feature branch.