### PR TITLE
remove ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata 

### DIFF
--- a/chsdi/locale/de/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/de/LC_MESSAGES/chsdi.po
@@ -1508,6 +1508,9 @@ msgstr "Mountainbikeland Schweiz"
 msgid "ch.astra.mountainbikeland.attribut_c"
 msgstr "Route"
 
+msgid "ch.astra.mountainbikeland-sperrungen_umleitungen"
+msgstr "Sperrungen Mountainbike"
+
 msgid "ch.astra.nationalstrassenachsen"
 msgstr "Nationalstrassenachsen"
 
@@ -1720,6 +1723,9 @@ msgstr "Skatingland Schweiz"
 
 msgid "ch.astra.skatingland.attribut_c"
 msgstr "Route"
+
+msgid "ch.astra.skatingland-sperrungen_umleitungen"
+msgstr "Sperrungen Skating"
 
 msgid "ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal"
 msgstr "Zählstellen (regional)"
@@ -2239,6 +2245,9 @@ msgstr "Veloland Schweiz"
 
 msgid "ch.astra.veloland.attribut_c"
 msgstr "Route"
+
+msgid "ch.astra.veloland-sperrungen_umleitungen"
+msgstr "Sperrungen Velo"
 
 msgid "ch.astra.wanderland"
 msgstr "Wanderland"
@@ -8960,9 +8969,6 @@ msgstr "Name"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.number"
 msgstr "Nummer"
 
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata"
-msgstr "Einteilung Geologische Generalkarte 200 Papier"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.name"
 msgstr "Name"
 
@@ -8980,9 +8986,6 @@ msgstr "Name"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.number"
 msgstr "Nummer"
-
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.release"
-msgstr "Ausgabejahr"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.release"
 msgstr "Ausgabejahr"
@@ -11731,9 +11734,6 @@ msgstr "Gemeindeinformationen"
 
 msgid "ch.swisstopo-vd.geometa-grundbuch"
 msgstr "Grundbuchinformationen"
-
-msgid "ch.swisstopo-vd.geometa-los"
-msgstr "Gebiete in Arbeit"
 
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Nachführungsgeometer/in"

--- a/chsdi/locale/en/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/en/LC_MESSAGES/chsdi.po
@@ -1508,6 +1508,9 @@ msgstr "Mountainbiking in Switzerland"
 msgid "ch.astra.mountainbikeland.attribut_c"
 msgstr "Route"
 
+msgid "ch.astra.mountainbikeland-sperrungen_umleitungen"
+msgstr "Sperrungen Mountainbike"
+
 msgid "ch.astra.nationalstrassenachsen"
 msgstr "Axis of national routes"
 
@@ -1720,6 +1723,9 @@ msgstr "Skating in Switzerland"
 
 msgid "ch.astra.skatingland.attribut_c"
 msgstr "Route"
+
+msgid "ch.astra.skatingland-sperrungen_umleitungen"
+msgstr "Sperrungen Skating"
 
 msgid "ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal"
 msgstr "Traffic census (regional)"
@@ -2239,6 +2245,9 @@ msgstr "Cycling in Switzerland"
 
 msgid "ch.astra.veloland.attribut_c"
 msgstr "Route"
+
+msgid "ch.astra.veloland-sperrungen_umleitungen"
+msgstr "Sperrungen Velo"
 
 msgid "ch.astra.wanderland"
 msgstr "Hiking in Switzerland"
@@ -8960,9 +8969,6 @@ msgstr "Name"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.number"
 msgstr "Number"
 
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata"
-msgstr "Division general geological map 200 Paper"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.name"
 msgstr "Name"
 
@@ -8980,9 +8986,6 @@ msgstr "Name"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.number"
 msgstr "Number"
-
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.release"
-msgstr "Edition"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.release"
 msgstr "Edition"
@@ -11731,9 +11734,6 @@ msgstr "Information about Municipality"
 
 msgid "ch.swisstopo-vd.geometa-grundbuch"
 msgstr "Land registry information"
-
-msgid "ch.swisstopo-vd.geometa-los"
-msgstr "Cadastral surveying lots."
 
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Cadastral surveyor"

--- a/chsdi/locale/fi/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fi/LC_MESSAGES/chsdi.po
@@ -1508,6 +1508,9 @@ msgstr "La Svizra cun velo da muntogna"
 msgid "ch.astra.mountainbikeland.attribut_c"
 msgstr "Route"
 
+msgid "ch.astra.mountainbikeland-sperrungen_umleitungen"
+msgstr "Sperrungen Mountainbike"
+
 msgid "ch.astra.nationalstrassenachsen"
 msgstr "Axas da las vias naziunalas"
 
@@ -1720,6 +1723,9 @@ msgstr "La Svizra cun skates"
 
 msgid "ch.astra.skatingland.attribut_c"
 msgstr "Route"
+
+msgid "ch.astra.skatingland-sperrungen_umleitungen"
+msgstr "Sperrungen Skating"
 
 msgid "ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal"
 msgstr "Dumbraziun traffic (regiunal)"
@@ -2239,6 +2245,9 @@ msgstr "La Svizra cun velo"
 
 msgid "ch.astra.veloland.attribut_c"
 msgstr "Route"
+
+msgid "ch.astra.veloland-sperrungen_umleitungen"
+msgstr "Sperrungen Velo"
 
 msgid "ch.astra.wanderland"
 msgstr "La Svizra a pe"
@@ -8960,9 +8969,6 @@ msgstr "Name"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.number"
 msgstr "Nummer"
 
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata"
-msgstr "Div. charta geol. gen. 200 Stampa"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.name"
 msgstr "Name"
 
@@ -8980,9 +8986,6 @@ msgstr "Name"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.number"
 msgstr "Nummer"
-
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.release"
-msgstr "Ausgabejahr"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.release"
 msgstr "Ausgabejahr"
@@ -11731,9 +11734,6 @@ msgstr "Infurmaziuns vischnanca"
 
 msgid "ch.swisstopo-vd.geometa-grundbuch"
 msgstr "Infurmaziuns register funsil"
-
-msgid "ch.swisstopo-vd.geometa-los"
-msgstr "Territoris en lavur"
 
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Geometer-revisur"

--- a/chsdi/locale/fr/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/fr/LC_MESSAGES/chsdi.po
@@ -1508,6 +1508,9 @@ msgstr "la Suisse à VTT"
 msgid "ch.astra.mountainbikeland.attribut_c"
 msgstr "Itinéraires"
 
+msgid "ch.astra.mountainbikeland-sperrungen_umleitungen"
+msgstr "to do"
+
 msgid "ch.astra.nationalstrassenachsen"
 msgstr "Axes des routes nationales"
 
@@ -1720,6 +1723,9 @@ msgstr "La Suisse en rollers"
 
 msgid "ch.astra.skatingland.attribut_c"
 msgstr "Itinéraires"
+
+msgid "ch.astra.skatingland-sperrungen_umleitungen"
+msgstr "to do"
 
 msgid "ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal"
 msgstr "Postes de comptage (régional)"
@@ -2239,6 +2245,9 @@ msgstr "La Suisse à vélo"
 
 msgid "ch.astra.veloland.attribut_c"
 msgstr "Itinéraires"
+
+msgid "ch.astra.veloland-sperrungen_umleitungen"
+msgstr "to do"
 
 msgid "ch.astra.wanderland"
 msgstr "La Suisse à pied"
@@ -8960,9 +8969,6 @@ msgstr "Nom"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.number"
 msgstr "Numéro"
 
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata"
-msgstr "Découpage carte géologique générale 200 Papier"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.name"
 msgstr "Nom"
 
@@ -8980,9 +8986,6 @@ msgstr "Nom"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.number"
 msgstr "Numéro"
-
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.release"
-msgstr "Édition"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.release"
 msgstr "Édition"
@@ -11731,9 +11734,6 @@ msgstr "Informations sur la commune"
 
 msgid "ch.swisstopo-vd.geometa-grundbuch"
 msgstr "Information sur le registre foncier"
-
-msgid "ch.swisstopo-vd.geometa-los"
-msgstr "Secteurs en travaux"
 
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Géomètre-conservateur"

--- a/chsdi/locale/it/LC_MESSAGES/chsdi.po
+++ b/chsdi/locale/it/LC_MESSAGES/chsdi.po
@@ -1508,6 +1508,9 @@ msgstr "La Svizzera in mountain bike"
 msgid "ch.astra.mountainbikeland.attribut_c"
 msgstr "Percorsi"
 
+msgid "ch.astra.mountainbikeland-sperrungen_umleitungen"
+msgstr "to do"
+
 msgid "ch.astra.nationalstrassenachsen"
 msgstr "Asse delle strade nazionali"
 
@@ -1720,6 +1723,9 @@ msgstr "La Svizzera in skating"
 
 msgid "ch.astra.skatingland.attribut_c"
 msgstr "Percorsi"
+
+msgid "ch.astra.skatingland-sperrungen_umleitungen"
+msgstr "to do"
 
 msgid "ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal"
 msgstr "Stazioni di conteggio (regionale)"
@@ -2239,6 +2245,9 @@ msgstr "La Svizzera in bici"
 
 msgid "ch.astra.veloland.attribut_c"
 msgstr "Percorsi"
+
+msgid "ch.astra.veloland-sperrungen_umleitungen"
+msgstr "to do"
 
 msgid "ch.astra.wanderland"
 msgstr "La Svizzera a piedi"
@@ -8960,9 +8969,6 @@ msgstr "Nome"
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.number"
 msgstr "Numero"
 
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata"
-msgstr "Divisione carta geologica generale 200 Stampa"
-
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.name"
 msgstr "Nome"
 
@@ -8980,9 +8986,6 @@ msgstr "Nome"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.number"
 msgstr "Numero"
-
-msgid "ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata.release"
-msgstr "Edizione"
 
 msgid "ch.swisstopo.geologie-generalkarte-ggk200.release"
 msgstr "Edizione"
@@ -11731,9 +11734,6 @@ msgstr "Informazioni sul Comune"
 
 msgid "ch.swisstopo-vd.geometa-grundbuch"
 msgstr "Informazioni del registro fondiario"
-
-msgid "ch.swisstopo-vd.geometa-los"
-msgstr "Aree con lavori in corso"
 
 msgid "ch.swisstopo-vd.geometa-nfgeom"
 msgstr "Geometra revisore"

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -671,14 +671,6 @@ class GeolSpezialKarteMetadata(Base, ShopProductGroupClass, Vector):
 register('ch.swisstopo.geologie-spezialkarten_schweiz_papier.metadata', GeolSpezialKarteMetadata)
 
 
-class GeolGeneralKarteMetadata(Base, ShopProductGroupClass, Vector):
-    __table_args__ = ({'schema': 'geol', 'autoload': False})
-    __tablename__ = 'view_gridstand_ggk'
-    __bodId__ = 'ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata'
-
-register('ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata', GeolGeneralKarteMetadata)
-
-
 class GeolGenKarteGGK200Meta(Base, ShopProductGroupClass, Vector):
     __tablename__ = 'view_gridstand_ggk_shop'
     __table_args__ = ({'schema': 'geol', 'autoload': False})


### PR DESCRIPTION
ch.swisstopo.geologie-generalkarte-ggk200_papier.metadata has been deprecated and removed from bod and data.