### PR TITLE
Correct default cache-control header

### DIFF
--- a/rc_prod
+++ b/rc_prod
@@ -23,5 +23,5 @@ export WSGI_PROCESSES=4
 export WSGI_THREADS=30
 export CMSGEOADMINHOST=https://cms.geo.admin.ch
 export LINKEDDATAHOST=https://ld.geo.admin.ch
-expor CACHE_CONTROL="max-age=1800, public"
+export CACHE_CONTROL="max-age=1800, public"
 export DYNAMIC_TRANSLATION=1


### PR DESCRIPTION
Typo preventing setting the correct cache control header