### PR TITLE
Expose some attributes from third party source (identify)

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2428,22 +2428,22 @@ class OerebkatasterZoom1(Base, Oerebkataster, Vector):
         return "{}{}{},{}".format(self.oereb_webservice, path_xml, center.x, center.y)
 
     @hybrid_property
-    def egrids(self):
+    def _egrids(self):
         list_egrid = []
         try:
-            response = requests.get(self._oereb_xml_url)
+            response = requests.get(self._oereb_xml_url, timeout=5)
             if response.status_code == 200:
                 root = et.fromstring(response.text)
                 list_egrid = root.findall('{http://schemas.geo.admin.ch/V_D/OeREB/1.0/Extract}egrid')
         except BaseException:
-            pass
+            return []
         return [e.text for e in list_egrid]
 
     @hybrid_property
     def pdfs(self):
         if self._is_oereb_webservice:
             path_pdf = sanitize_url("{}/extract/reduced/pdf/".format(self.oereb_webservice))
-            return ['{0}{1}'.format(path_pdf, i) for i in self.egrids]
+            return ['{0}{1}'.format(path_pdf, i) for i in self._egrids]
         return []
 
 

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -328,6 +328,7 @@ def _identify_db(params, layerBodIds):
             break
         else:
             features.append(_process_feature(feature, params))
+
     return features
 
 

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -735,6 +735,27 @@ class TestIdentifyService(TestsBase):
                   'geometryFormat': 'interlis'}
         self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
 
+    # This model has hybrid_properties that are normally not exposed
+    def test_identify_oerebkatasterzoom1(self):
+
+        params = {'geometry': '2601796.375,1200283.125',
+            'geometryFormat': 'geojson',
+            'geometryType': 'esriGeometryPoint',
+            'imageDisplay': '1059,907,96',
+            'lang': 'en',
+            'layers': 'all:ch.swisstopo-vd.stand-oerebkataster',
+            'limit': 10,
+            'mapExtent': '2601618.350028069,1200166.769096322,2601883.100028069,1200393.519096322',
+            'returnGeometry': 'true',
+            'sr': 2056,
+            'tolerance': '10'
+                  }
+
+        resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
+        self.assertEqual(resp.content_type, 'application/geo+json')
+        self.assertIn('pdfs', resp.json['results'][0]['properties'].keys())
+        self.assertIn(resp.json['results'][0]['properties']['egris_egrid'], " ".join(resp.json['results'][0]['properties']['pdfs']))
+
     def test_identify_query_time(self):
         params = {'geometryFormat': 'geojson',
                   'layers': 'all:ch.bazl.luftfahrthindernis',


### PR DESCRIPTION
A purely constructed attribute *PDF* is added to the model _OerebkatasterZoom1(_  (https://github.com/geoadmin/mf-chsdi3/blob/data/chsdi/models/vector/stopo.py#L2402-L2410). The link is read from a request XML documents somewhere from a canton service (yes, via http request)

It basically exposes an attribute which does not exist in the DB table into the **identify** JSON. As it uses the _geometry_ to compute it's location, it won't work if the parameter **returnGeometry=false** is set

This PR should not exists in the first place, as it opens the door for any excess

**identify** (with this PR)
https://mf-chsdi3.int.bgdi.ch/feature_BGDIINF_SB-1301/rest/services/all/MapServer/identify?geometry=2601796.375,1200283.125&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1059,907,96&lang=en&layers=all:ch.swisstopo-vd.stand-oerebkataster&limit=10&mapExtent=2601618.350028069,1200166.769096322,2601883.100028069,1200393.519096322&returnGeometry=true&sr=2056&tolerance=10

without PR
https://mf-chsdi3.int.bgdi.ch/rest/services/all/MapServer/identify?geometry=2601796.375,1200283.125&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1059,907,96&lang=en&layers=all:ch.swisstopo-vd.stand-oerebkataster&limit=10&mapExtent=2601618.350028069,1200166.769096322,2601883.100028069,1200393.519096322&returnGeometry=true&sr=2056&tolerance=10


**htmlPopup**
https://mf-chsdi3.int.bgdi.ch/rest/services/ech/MapServer/ch.swisstopo-vd.stand-oerebkataster/845825/htmlPopup?coord=2601796.375,1200283.125&imageDisplay=1059,907,96&lang=en&mapExtent=2601618.350028069,1200166.769096322,2601883.100028069,1200393.519096322&sr=2056

See https://jira.swisstopo.ch/browse/BGDIINF_SB-1301 for rational