### PR TITLE
jsonp encoder for datetime (fixes #3567)

### DIFF
--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import datetime
 from pyramid.config import Configurator
 from pyramid.events import BeforeRender, NewRequest
 from chsdi.subscribers import add_localizer, add_renderer_globals
@@ -59,7 +60,13 @@ def main(global_config, **settings):
     # renderers
     config.add_mako_renderer('.html')
     config.add_mako_renderer('.js')
-    config.add_renderer('jsonp', JSONP(param_name='callback', indent=None, separators=(',', ':')))
+
+    json_renderer = JSONP(param_name='callback', indent=None, separators=(',', ':'))
+
+    def datetime_adapter(obj, request):
+        return obj.isoformat()
+    json_renderer.add_adapter(datetime.datetime, datetime_adapter)
+    config.add_renderer('jsonp', json_renderer)
     config.add_renderer('geojson', GeoJSON(jsonp_param_name='callback'))
     config.add_renderer('esrijson', EsriJSON(jsonp_param_name='callback'))
     config.add_renderer('csv', CSVRenderer)

--- a/chsdi/static/doc/source/releasenotes/index.rst
+++ b/chsdi/static/doc/source/releasenotes/index.rst
@@ -27,6 +27,9 @@ API & applications
 - Bug fixes
 - `Full changelog <https://github.com/geoadmin/mf-chsdi3/compare/r_200916...r_201028>`__
 - Due to maintenance work, the layer ch.swisstopo.geologie-tiefengeothermie-projekte will be temporarily unavailable in CHSDI until the release of December 9th 2020. In the meantime, the layer is still accessible for `download <https://data.geo.admin.ch/ch.swisstopo.geologie-tiefengeothermie_projekte/>`__.
+- Announcement:
+    - The BFS layer ch.bfs.gebaeude_wohnungs_register (Register of Buildings and Dwellings) will extend its data model on all FSDI services (map, api3 and download on data.geo.admin.ch) by this release according to https://www.bfs.admin.ch/bfs/en/home/statistics/catalogues-databases/publications.assetdetail.7008785.html (model description available in German only).
+        - now productive data model: https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bfs.gebaeude_wohnungs_register/9051164_0 
 
 
 `MAP <//map.geo.admin.ch>`__

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -119,7 +119,10 @@ def feature_attributes(request):
             if len(field['values']) < MAX_ATTRIBUTES_VALUES and \
                value not in field['values']:
                 field['values'].append(value)
-                field['values'].sort()
+                try:
+                    field['values'].sort()
+                except Exception:
+                    pass
         return field
 
     for model in models:

--- a/tests/integration/test_layers_service.py
+++ b/tests/integration/test_layers_service.py
@@ -265,3 +265,10 @@ class TestMapServiceView(TestsBase):
 
     def test_layer_attributes_none_modelToQuery(self):
         self.testapp.get('/rest/services/ech/MapServer/ch.swisstopo.geologie-gravimetrischer_atlas_papier.metadata/attributes/wrongAttribute', status=400)
+
+    # Some models have `datetime`type which breaks with the default serializer
+    def test_layer_attributes_datetime(self):
+        resp = self.testapp.get('/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register', status=200)
+        self.assertEqual(resp.content_type, 'application/json')
+        resp = self.testapp.get('/rest/services/api/MapServer/ch.bfs.gebaeude_wohnungs_register', params={'callback': 'cb_'}, status=200)
+        self.assertEqual(resp.content_type, 'application/javascript')


### PR DESCRIPTION
Fix serializing `datetime`

With [this PR](http://mf-chsdi3.int.bgdi.ch/feature_3567/rest/services/api/MapServer/ch.bfs.gebaeude_wohnungs_register) and [without](http://mf-chsdi3.int.bgdi.ch/rest/services/api/MapServer/ch.bfs.gebaeude_wohnungs_register)