### PR TITLE
BGDIDIC-935 - fix wrong boolean translation

### DIFF
--- a/chsdi/templates/htmlpopup/gebaeuderegister.mako
+++ b/chsdi/templates/htmlpopup/gebaeuderegister.mako
@@ -70,7 +70,7 @@
       if value is None:
         return '-'
       else:
-        return 'yesText' if value == 1 else 'noText'
+        return 'yesText' if value == '1' else 'noText'
 
 %>
   <table>


### PR DESCRIPTION
should be deployed with the next technical deploy.
[testlink](https://mf-chsdi3.dev.bgdi.ch/feature_BGDIDIC-935_fix_mako/shorten/8d02470361)