### PR TITLE
restore original order of multi query results

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -187,16 +187,15 @@ class Search(SearchValidation):
             try:
                 # wildcard search only if more than one character in searchtext
                 if len(' '.join(self.searchText)) > 1 or self.bbox:
-                    # standard wildcard search
+                    # wildcard search
                     self.sphinx.AddQuery(searchTextFinal, index='swisssearch')
 
-                # exact search, first 10 results
-                searchText = '@detail ^%s' % ' '.join(self.searchText)
+                # exact search
+                searchText = '@detail "^%s"' % (' '.join(self.searchText))
                 self.sphinx.AddQuery(searchText, index='swisssearch')
 
-                # reset settings
+                # reset settingss
                 temp = self.sphinx.RunQueries()
-
                 # In case RunQueries doesn't return results (reason unknown)
                 # related to issue
                 if temp is None:
@@ -205,12 +204,22 @@ class Search(SearchValidation):
             except IOError:  # pragma: no cover
                 raise exc.HTTPGatewayTimeout()
 
-            temp_merged = temp[0].get('matches', []) + temp[1].get('matches', []) if len(temp) == 2 else temp[0].get('matches', [])
+            wildcard_results = temp[0].get('matches', [])
+            merged_results = []
 
-            # remove duplicate results, exact search results have priority over wildcard search results
+            if len(temp) == 2:
+                # we have results from both queries (exact + wildcard)
+                # prepend exact search results to wildcard search result
+                exact_results = temp[1].get('matches', [])
+                merged_results = exact_results + wildcard_results
+            else:
+                # we have results from one or no query
+                merged_results = wildcard_results
+
+            # remove duplicate from sphinx results, exact search results have priority over wildcard search results
             temp = []
             seen = []
-            for d in temp_merged:
+            for d in merged_results:
                 if d['id'] not in seen:
                     temp.append(d)
                     seen.append(d['id'])


### PR DESCRIPTION
a side effect has been introduced with the fix or this issue:
https://github.com/geoadmin/mf-chsdi3/issues/3573

the position of exact search results of single words (p.e. Esel, Rotten, Loch, etc., ...) has been changed.

the result order of the sphinx multi query (exact and wildcard) has been broken.
the multi query has been introduced, specified and updated here:
https://github.com/geoadmin/mf-chsdi3/pull/3073
https://github.com/geoadmin/mf-chsdi3/pull/3148


[Testlink](https://mf-chsdi3.dev.bgdi.ch/feature_BGDIINF_SB-1453/shorten/8d0b4800f8)