### PR TITLE
Feature bgdiinf sb 1527 fix weighting of exact search result

### DIFF
--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -216,7 +216,8 @@ class Search(SearchValidation):
                 # waldhofstrasse 1 -> weight 100
                 # waldhofstrasse 1.1 -> weight 1
                 for result in exact_results:
-                    if result['attrs']['detail'].startswith('%s ' % (' '.join(self.searchText))):
+                    if result['attrs']['detail'].startswith('%s ' % (' '.join(self.searchText))) or \
+                       result['attrs']['detail'] == ' '.join(self.searchText):
                         result['weight'] += 99
                 merged_results = exact_results + wildcard_results
             else:

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -187,16 +187,16 @@ class Search(SearchValidation):
             try:
                 # wildcard search only if more than one character in searchtext
                 if len(' '.join(self.searchText)) > 1 or self.bbox:
-                    # standard wildcard search
+                    # wildcard search
                     self.sphinx.AddQuery(searchTextFinal, index='swisssearch')
 
-                # exact search, first 10 results
-                searchText = '@detail ^%s' % ' '.join(self.searchText)
+                # exact search use default ranking for exact search
+                searchText = '@detail "^%s"' % (' '.join(self.searchText))
+                self.sphinx.SetRankingMode(sphinxapi.SPH_RANK_PROXIMITY_BM25)
                 self.sphinx.AddQuery(searchText, index='swisssearch')
 
-                # reset settings
+                # reset settingss
                 temp = self.sphinx.RunQueries()
-
                 # In case RunQueries doesn't return results (reason unknown)
                 # related to issue
                 if temp is None:
@@ -205,12 +205,22 @@ class Search(SearchValidation):
             except IOError:  # pragma: no cover
                 raise exc.HTTPGatewayTimeout()
 
-            temp_merged = temp[0].get('matches', []) + temp[1].get('matches', []) if len(temp) == 2 else temp[0].get('matches', [])
+            wildcard_results = temp[0].get('matches', [])
+            merged_results = []
 
-            # remove duplicate results, exact search results have priority over wildcard search results
+            if len(temp) == 2:
+                # we have results from both queries (exact + wildcard)
+                # prepend exact search results to wildcard search result
+                exact_results = temp[1].get('matches', [])
+                merged_results = exact_results + wildcard_results
+            else:
+                # we have results from one or no query
+                merged_results = wildcard_results
+
+            # remove duplicate from sphinx results, exact search results have priority over wildcard search results
             temp = []
             seen = []
-            for d in temp_merged:
+            for d in merged_results:
                 if d['id'] not in seen:
                     temp.append(d)
                     seen.append(d['id'])


### PR DESCRIPTION
This issue has been initially introduced with the combination of exact and wildcard search in swisssearch in a multi-query [1].
The multi query has been introduced, specified and updated here:
#3073
#3148

With this multi search search we have introduced a bug that has been first reported here:
https://github.com/geoadmin/mf-chsdi3/issues/3573

The main reason for the bug was the wrong combination of the two result objects in python code and the wrong ranking of the results.

**1st fix:**
A first attempt to solve the issue was not complete:
https://github.com/geoadmin/mf-chsdi3/pull/3575
There were still some exact match results when searching for single words to far down in the results, p.e. Esel, Rotten, Loch .

**2nd fix**
The second attempt fixed this and did a clean prepend of exact match before wildcard match results, but the weighting of the results was still wrong:
https://github.com/geoadmin/mf-chsdi3/pull/3581

This pr is building on top of these two fixes and is setting the correct weighting for exact match results. Until now both results of the multi query (exact and wildcard) have been weighted / ranked with the same sphinx ranker: SPH_RANK_WORDCOUNT

With this pr the exact match results will be weighted with the default rankig method: SPH_RANK_PROXIMITY_BM25

This will result in exact match results having a much higher weight than wildcard match results. 

[Testlink](https://mf-chsdi3.dev.bgdi.ch/feature_BGDIINF_SB-1527/shorten/8d7d65425b)
examples:
https://mf-chsdi3.dev.bgdi.ch/feature_BGDIINF_SB-1527/rest/services/ech/SearchServer?sr=2056&searchText=rotten&lang=de&type=locations
https://mf-chsdi3.dev.bgdi.ch/feature_BGDIINF_SB-1527/2012090912/rest/services/ech/SearchServer?sr=2056&searchText=dorfstrasse%201%205442%20Fislisbach&lang=de&type=locations


[1] http://sphinxsearch.com/docs/current/multi-queries.html