### PR TITLE
Adding support for WebMercator with identify_grid function (Windrose)

### DIFF
--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -378,8 +378,8 @@ class TestIdentifyService(TestsBase):
         self.assertGeojsonFeature(resp_2.json['results'][0], 3857)
         self.assertEqual(resp.json['results'][0]['id'], resp_2.json['results'][0]['id'])
         params['sr'] = '4326'
-        params['geometry'] = reproject_to_srid(params['geometry'], 2056, 4326)
-        params['mapExtent'] = reproject_to_srid(params['mapExtent'], 2056, 4326)
+        params['geometry'] = reproject_to_srid(params['geometry'], 3857, 4326, 6)
+        params['mapExtent'] = reproject_to_srid(params['mapExtent'], 3857, 4326, 6)
         resp_2 = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp_2.content_type, 'application/geo+json')
         self.assertGeojsonFeature(resp_2.json['results'][0], 4326)

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -370,6 +370,20 @@ class TestIdentifyService(TestsBase):
         self.assertEqual(resp_2.content_type, 'application/geo+json')
         self.assertGeojsonFeature(resp_2.json['results'][0], 2056)
         self.assertEqual(resp.json['results'][0]['id'], resp_2.json['results'][0]['id'])
+        params['sr'] = '3857'
+        params['geometry'] = reproject_to_srid(params['geometry'], 2056, 3857)
+        params['mapExtent'] = reproject_to_srid(params['mapExtent'], 2056, 3857)
+        resp_2 = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
+        self.assertEqual(resp_2.content_type, 'application/geo+json')
+        self.assertGeojsonFeature(resp_2.json['results'][0], 3857)
+        self.assertEqual(resp.json['results'][0]['id'], resp_2.json['results'][0]['id'])
+        params['sr'] = '4326'
+        params['geometry'] = reproject_to_srid(params['geometry'], 2056, 4326)
+        params['mapExtent'] = reproject_to_srid(params['mapExtent'], 2056, 4326)
+        resp_2 = self.testapp.get('/rest/services/ech/MapServer/identify', params=params, headers=accept_headers, status=200)
+        self.assertEqual(resp_2.content_type, 'application/geo+json')
+        self.assertGeojsonFeature(resp_2.json['results'][0], 4326)
+        self.assertEqual(resp.json['results'][0]['id'], resp_2.json['results'][0]['id'])
 
     @skipUnless(s3_tests, "Requires AWS S3 access")
     def test_identify_valid_envelope_on_grid(self):


### PR DESCRIPTION
this is required for https://github.com/geoadmin/web-mapviewer/pull/28 to work properly 

[Edit by momo]

Test on : http://mf-chsdi3.int.bgdi.ch/feature_BGDIINF_SB-1636_identify_grid_mercator/

[Demo](http://mf-chsdi3.int.bgdi.ch/feature_BGDIINF_SB-1636_identify_grid_mercator/rest/services/ech/MapServer/identify?layers=all:ch.bfe.windenergie-geschwindigkeit_h75&sr=3857&geometry=863078.1471059697,5824278.363468439&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=1315,1297,96&mapExtent=838218.94,5826192.47,875670.14,5863131.03&limit=10&tolerance=10&returnGeometry=true&lang=en)