### PR TITLE
Hotfix deploy config

### DIFF
--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -23,4 +23,5 @@ content = IncludeOptional /var/www/vhosts/mf-chsdi3/private/chsdi/apache/*.conf
 int = ip-10-220-6-131.eu-west-1.compute.internal
 
 prod = ip-10-220-4-115.eu-west-1.compute.internal,
-       ip-10-220-5-66.eu-west-1.compute.internal
+       ip-10-220-5-66.eu-west-1.compute.internal,
+       ip-10-220-6-199.eu-west-1.compute.internal


### PR DESCRIPTION
we have a new host for the ogd golive.
vhosts have been synced by c2c already.
https://jira.camptocamp.com/servicedesk/customer/portal/5/INF-6383
