### PR TITLE
show doi_link in basic tooltip

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -113,6 +113,13 @@ viewer_url = get_viewer_url(request, params)
     <a href="${viewer_url}" target="_blank"><img src="${preview_url}" alt="quickview"></a>
   </td>
 </tr>
+
+% elif c['attributes'].get('doi_link', '').startswith('http'):
+<tr>
+  <td class="cell-left">${_('tt_lubis_Quickview')}</td>
+  <td><a href="${c['attributes']['doi_link']}" target="_blank">${c['attributes']['doi_link']}</a></td></tr>
+</tr>
+
 % else:
 <tr>
   <td class="cell-left">${_('tt_lubis_Quickview')}</td>


### PR DESCRIPTION
this will show the doi_link attribute as "quickview" link.

[Testlink](https://mf-chsdi3.dev.bgdi.ch/feature_BGDIDIC-645_epics/shorten/8f70a71f54)