### PR TITLE
BGDIINF_SB-1789: TLS not needed to connect the local MTA

### DIFF
--- a/chsdi/views/feedback.py
+++ b/chsdi/views/feedback.py
@@ -72,8 +72,6 @@ def feedback(context, request):
 
         mailServer = smtplib.SMTP('127.0.0.1', 25)
         mailServer.ehlo()
-        mailServer.starttls()
-        mailServer.ehlo()
         # Recipients and sender are always the same
         mailServer.sendmail(to, to, msg.as_string())
         mailServer.close()


### PR DESCRIPTION
To be able to get rid of snakeoil when connection the local MTA