### PR TITLE
remove host 10-220-6-199

### DIFF
--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -23,5 +23,4 @@ content = IncludeOptional /var/www/vhosts/mf-chsdi3/private/chsdi/apache/*.conf
 int = ip-10-220-6-131.eu-west-1.compute.internal
 
 prod = ip-10-220-4-115.eu-west-1.compute.internal,
-       ip-10-220-5-66.eu-west-1.compute.internal,
-       ip-10-220-6-199.eu-west-1.compute.internal
+       ip-10-220-5-66.eu-west-1.compute.internal


### PR DESCRIPTION
from slack
```
Hej @simon.sehier
We decided to ask you to remove instance 10-220-6-199 from the backend. The two other instances will (hopefully) be enough. Meanwhile we will decide what we want to do with this....
Could you tell us, when this has been done?
BR
Tobias
FYI: @Marc Monnerat @Marcel Clausen @Christoph Boecklin
```