### PR TITLE
Feature igks sb 77 remove queryable attributes

### DIFF
--- a/chsdi/models/vector/bafu.py
+++ b/chsdi/models/vector/bafu.py
@@ -51,7 +51,6 @@ class Hydrogeologischekarte100(Base, Vector):
     __tablename__ = 'hydrogeologische_karte_100'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrogeologische-karte_100'
-    __queryable_attributes__ = ['name', 'pdf_list']
     __template__ = 'templates/htmlpopup/hydrogeologische-karte_100.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -68,7 +67,6 @@ class KarstFliesswege(Base, Vector):
     __template__ = 'templates/htmlpopup/karst-unterirdische_fliesswege.mako'
     __bodId__ = 'ch.bafu.karst-unterirdische_fliesswege'
     __label__ = 'id'
-    __queryable_attributes__ = ['ei_type', 'ei_hdyn']
     id = Column('objectid', Integer, primary_key=True)
     ei_id = Column('ei_id', Unicode)
     ei_hdyn = Column('ei_hdyn', SmallInteger)
@@ -92,7 +90,6 @@ class KarstEinzugsgebieteinheiten(Base, Vector):
     __template__ = 'templates/htmlpopup/karst-einzugsgebietseinheiten.mako'
     __bodId__ = 'ch.bafu.karst-einzugsgebietseinheiten'
     __label__ = 'id'
-    __queryable_attributes__ = ['ub_type', 'ub_flux']
     id = Column('objectid', Integer, primary_key=True)
     ub_name = Column('ub_name', Unicode)
     ub_type = Column('ub_type', SmallInteger)
@@ -117,7 +114,6 @@ class KarstGrundwasservorkommen(Base, Vector):
     __template__ = 'templates/htmlpopup/karst-ausdehnung_grundwasservorkommen.mako'
     __bodId__ = 'ch.bafu.karst-ausdehnung_grundwasservorkommen'
     __label__ = 'id'
-    __queryable_attributes__ = ['nk_type', 'nk_level', 'nk_hdyn']
     id = Column('objectid', Integer, primary_key=True)
     nk_hdyn = Column('nk_hdyn', SmallInteger)
     nk_type = Column('nk_type', SmallInteger)
@@ -141,7 +137,6 @@ class KarstEinzugsgebiete(Base, Vector):
     __template__ = 'templates/htmlpopup/karst-einzugsgebiete.mako'
     __bodId__ = 'ch.bafu.karst-einzugsgebiete'
     __label__ = 'ba_name'
-    __queryable_attributes__ = ['ba_name']
     __returnedGeometry__ = 'the_geom_highlight'
     id = Column('objectid', Integer, primary_key=True)
     ba_id = Column('ba_id', Unicode)
@@ -163,7 +158,6 @@ class KarstQuellenschwinden(Base, Vector):
     __bodId__ = 'ch.bafu.karst-quellen_schwinden'
     __label__ = 'ip_name'
     __returnedGeometry__ = 'the_geom_highlight'
-    __queryable_attributes__ = ['ip_type', 'ip_name', 'ip_qclass', 'ip_reg', 'ip_exp']
     id = Column('objectid', Integer, primary_key=True)
     ip_id = Column('ip_id', Unicode)
     ip_name = Column('ip_name', Unicode)
@@ -200,7 +194,6 @@ class Vec25Gewaessernetz2000(Base, Vector):
     __tablename__ = 'gewaessernetz_2000'
     __table_args__ = ({'schema': 'vec25', 'autoload': False})
     __bodId__ = 'ch.bafu.vec25-gewaessernetz_2000'
-    __queryable_attributes__ = ['gwlnr', 'gewissnr', 'name', 'objectval']
     __template__ = 'templates/htmlpopup/vec25-gewaessernetz_2000.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -217,7 +210,6 @@ class Untersuchungsgebiete(Base, Vector):
     __tablename__ = 'hydrologie_untersuchungsgebiete'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-untersuchungsgebiete'
-    __queryable_attributes__ = ['name', 'max_hoe', 'min_hoe', 'mit_hoe', 'antv_ab86', 'einzugsgebietsflaeche', 'regimtyp']
     __template__ = 'templates/htmlpopup/hug.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -240,7 +232,6 @@ class Hochwassergrenzwertpegel(Base, Vector):
     __tablename__ = 'hochwassergrenzwertpegel'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-hochwassergrenzwertpegel'
-    __queryable_attributes__ = ['name', 'hoehe', 'einzugsgebietsflaeche', 'nummer', 'fluss', 'm_ende', 'm_beginn']
     __template__ = 'templates/htmlpopup/hochwassergrenzwertpegel.mako'
     __extended_info__ = True
     __label__ = 'name'
@@ -264,7 +255,6 @@ class AtlasKantonaleMessstationen(Base, Vector):
     __tablename__ = 'hydro_atlas_kant_messstationen'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologischer-atlas_kantonale-messstationen'
-    __queryable_attributes__ = ['hoehe', 'betriebsbeginn', 'einzugsgebietsflaeche', 'nummer', 'vergletscherung', 'bilanzgebietsnummer']
     __template__ = 'templates/htmlpopup/atlas_kantonale_messstationen.mako'
     __extended_info__ = True
     __label__ = 'name'
@@ -288,7 +278,6 @@ class Daueruntersuchung_fliessgewaesser(Base, Vector):
     __tablename__ = 'hydro_duntersuchung_fliessgewaesser'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-daueruntersuchung_fliessgewaesser'
-    __queryable_attributes__ = ['name', 'hoehe', 'betriebsbeginn', 'einzugsgebietsflaeche', 'mittlerehoehe', 'vergletscherung', 'stationierung', 'flussgebiet']
     __template__ = 'templates/htmlpopup/daueruntersuchung_fliessgewaesser.mako'
     __extended_info__ = True
     __label__ = 'name'
@@ -315,7 +304,6 @@ class Vec25Seen(Base, Vector):
     __tablename__ = 'seen'
     __table_args__ = ({'schema': 'vec25', 'autoload': False})
     __bodId__ = 'ch.bafu.vec25-seen'
-    __queryable_attributes__ = ['gewaesserkennzahl', 'name', 'seetyp', 'ausgleichsbecken', 'reguliert', 'seeflaeche_km2', 'inhalt_see_mio_m3', 'nutzinhalt_mio_m3', 'tiefe_see_m', 'hoehenlage_muem', 'uferlaenge_m', 'gwlnr']
     __template__ = 'templates/htmlpopup/vec25_seen.mako'
     __extended_info__ = True
     __label__ = 'name'
@@ -342,7 +330,6 @@ class HydroAtlasFlussgebiete(Base, Vector):
     __tablename__ = 'atlas_flussgebiete'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologischer-atlas_flussgebiete'
-    __queryable_attributes__ = ['nummer', 'name', 'shape_area', 'umfang']
     __template__ = 'templates/htmlpopup/atlas_flussgebiete.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -360,7 +347,6 @@ class HydroAtlasBilanzgebiete(Base, Vector):
     __tablename__ = 'atlas_bilanzgebiete'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologischer-atlas_bilanzgebiete'
-    __queryable_attributes__ = ['name', 'flussgebiet', 'shape_area']
     __template__ = 'templates/htmlpopup/atlas_bilanzgebiete.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -378,7 +364,6 @@ class HydroAtlasBasisgebiete(Base, Vector):
     __tablename__ = 'atlas_basisgebiete'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologischer-atlas_basisgebiete'
-    __queryable_attributes__ = ['gebietskennzahl', 'bemerkung', 'flussgebiet', 'max_hoe', 'min_hoe', 'mit_hoe', 'mit_ns', 's_w_ns', 'jahrtemp_g', 'winttemp_g', 'shape_area']
     __template__ = 'templates/htmlpopup/atlas_basisgebiete.mako'
     __extended_info__ = True
     __label__ = 'nummer'
@@ -404,7 +389,6 @@ class Niedrigwasserstatistik(Base, Vector):
     __tablename__ = 'niedrigwasserstatistik'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-niedrigwasserstatistik'
-    __queryable_attributes__ = ['name']
     __template__ = 'templates/htmlpopup/niedrigwasserstatistik.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -421,7 +405,6 @@ class TypFliessgewaesser(Base, Vector):
     __tablename__ = 'typisierung_fliessgewaesser'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.typisierung-fliessgewaesser'
-    __queryable_attributes__ = ['objectid_gwn25', 'grosserfluss', 'biogeo', 'hoehe', 'abfluss', 'gefaelle', 'geo', 'code', 'gewaessertyp', 'aehnlichkeit']
     __template__ = 'templates/htmlpopup/fliessgewaesser_typ.mako'
     __extended_info__ = True
     __label__ = 'objectid_gwn25'
@@ -478,8 +461,6 @@ class MittlereAbfluesse(Base, Vector):
     __tablename__ = 'mittlere_abfluesse'
     __table_args__ = ({'schema': 'wasser', 'autoload': False})
     __bodId__ = 'ch.bafu.mittlere-abfluesse'
-    __queryable_attributes__ = ['mqn_jahr', 'mqn_jan', 'mqn_feb', 'mqn_mar', 'mqn_apr', 'mqn_mai', 'mqn_jun', 'mqn_jul',
-                                'mqn_aug', 'mqn_sep', 'mqn_okt', 'mqn_nov', 'mqn_dez', 'regimetyp', 'regimenummer', 'abflussvar']
     __template__ = 'templates/htmlpopup/mittlere_abfluesse.mako'
     __extended_info__ = True
     __label__ = 'regimenummer'
@@ -509,7 +490,6 @@ class MittlereAbfluesseZukunft(Base, Vector):
     __tablename__ = 'mittlere_abfluesse_zukunft'
     __table_args__ = ({'schema': 'wasser', 'autoload': False})
     __bodId__ = 'ch.bafu.mittlere-abfluesse_zukunft'
-    __queryable_attributes__ = ['place', 'water_name']
     __template__ = 'templates/htmlpopup/mittlere_abfluesse_zukunft.mako'
     __label__ = 'place'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -568,7 +548,6 @@ class FeststoffeGeschiebemessnetz(Base, Vector):
     __tablename__ = 'geschiebemessnetz'
     __table_args__ = ({'schema': 'wasser', 'autoload': False})
     __bodId__ = 'ch.bafu.feststoffe-geschiebemessnetz'
-    __queryable_attributes__ = ['gsch_n', 'lk', 'lage', 'fn', 'hmax', 'hmin', 'hmed', 'exp', 'form', 'geologie', 'platz', 'fluss', 'station', 'institut', 'amt']
     __template__ = 'templates/htmlpopup/geschiebemessnetz.mako'
     __extended_info__ = True
     __label__ = 'fluss'
@@ -692,7 +671,6 @@ class HydroQ347(Base, Vector):
     __tablename__ = 'hydro_q347'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-q347'
-    __queryable_attributes__ = ['basisid', 'lhg', 'gewaesser', 'flaeche', 'q_84_93', 'qp', 'p', 'qmod']
     __template__ = 'templates/htmlpopup/hydro_q347.mako'
     __extended_info__ = True
     __label__ = 'gewaesser'
@@ -719,7 +697,6 @@ class HugStationen(Base, Vector):
     __tablename__ = 'hydrologie_untersuchungsgebiete_stationen'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-untersuchungsgebiete_stationen'
-    __queryable_attributes__ = ['name', 'hoehe', 'betriebsbeginn', 'einzugsgebietsflaeche', 'flussgebiet']
     __template__ = 'templates/htmlpopup/hug_stationen.mako'
     __label__ = 'name'
     id = Column('geodb_oid', Integer, primary_key=True)
@@ -753,7 +730,6 @@ class StrukturgueteHochrheinLinkesufer(Base, Vector):
     __tablename__ = 'strukturguete_hochrhein'
     __table_args__ = ({'schema': 'wasser', 'autoload': False})
     __bodId__ = 'ch.bafu.strukturguete-hochrhein_linkesufer'
-    __queryable_attributes__ = ['lumfeld', 'rumfeld', 'lufer', 'rufer', 'sohle']
     __template__ = 'templates/htmlpopup/strukturguete_hochrhein.mako'
     __label__ = 'id'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -772,7 +748,6 @@ class StrukturgueteHochrheinLinkesumfeld(Base, Vector):
     __tablename__ = 'strukturguete_hochrhein'
     __table_args__ = ({'schema': 'wasser', 'autoload': False, 'extend_existing': True})
     __bodId__ = 'ch.bafu.strukturguete-hochrhein_linkesumfeld'
-    __queryable_attributes__ = ['lumfeld', 'rumfeld', 'lufer', 'rufer', 'sohle']
     __template__ = 'templates/htmlpopup/strukturguete_hochrhein.mako'
     __label__ = 'id'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -791,7 +766,6 @@ class StrukturgueteHochrheinRechtesumfeld(Base, Vector):
     __tablename__ = 'strukturguete_hochrhein'
     __table_args__ = ({'schema': 'wasser', 'autoload': False, 'extend_existing': True})
     __bodId__ = 'ch.bafu.strukturguete-hochrhein_rechtesumfeld'
-    __queryable_attributes__ = ['lumfeld', 'rumfeld', 'lufer', 'rufer', 'sohle']
     __template__ = 'templates/htmlpopup/strukturguete_hochrhein.mako'
     __label__ = 'id'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -810,7 +784,6 @@ class StrukturgueteHochrheinRechtesufer(Base, Vector):
     __tablename__ = 'strukturguete_hochrhein'
     __table_args__ = ({'schema': 'wasser', 'autoload': False, 'extend_existing': True})
     __bodId__ = 'ch.bafu.strukturguete-hochrhein_rechtesufer'
-    __queryable_attributes__ = ['lumfeld', 'rumfeld', 'lufer', 'rufer', 'sohle']
     __template__ = 'templates/htmlpopup/strukturguete_hochrhein.mako'
     __label__ = 'id'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -829,7 +802,6 @@ class StrukturgueteHochrheinSohle(Base, Vector):
     __tablename__ = 'strukturguete_hochrhein'
     __table_args__ = ({'schema': 'wasser', 'autoload': False, 'extend_existing': True})
     __bodId__ = 'ch.bafu.strukturguete-hochrhein_sohle'
-    __queryable_attributes__ = ['lumfeld', 'rumfeld', 'lufer', 'rufer', 'sohle']
     __template__ = 'templates/htmlpopup/strukturguete_hochrhein.mako'
     __label__ = 'id'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -848,8 +820,6 @@ class GewaesserschutzBadewasserqualitaet(Base, Vector):
     __tablename__ = 'baqua'
     __table_args__ = ({'schema': 'wasser', 'autoload': False})
     __bodId__ = 'ch.bafu.gewaesserschutz-badewasserqualitaet'
-    __queryable_attributes__ = ['id', 'bwname', 'groupid', 'nwunitname', 'rbdsuname',
-                                'gemeinde', 'canton', 'bwatercat', 'qualitaet_eua']
     __template__ = 'templates/htmlpopup/gewaesserschutz_badewasserqualitaet.mako'
     __extended_info__ = True
     __label__ = 'bwname'
@@ -929,7 +899,6 @@ class Temperaturmessnetz(Base, Vector):
     __tablename__ = 'temperaturmessnetz'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-wassertemperaturmessstationen'
-    __queryable_attributes__ = ['id', 'name']
     __template__ = 'templates/htmlpopup/temperaturmessnetz.mako'
     __label__ = 'name'
     id = Column('nr', Integer, primary_key=True)
@@ -945,11 +914,6 @@ class GewaesserschutzTemplate:
     __template__ = 'templates/htmlpopup/klaeranlagen.mako'
     __extended_info__ = True
     __label__ = 'name'
-    __queryable_attributes__ = ['nummer', 'name', 'ort', 'name_vorfluter', 'gewiss_nr', 'reinigungstyp', 'abw_tagesmittel', 'abw_tagesspitze',
-                                'spitzenbelastung_regen', 'rohabwasser_tag', 'frischschlamm_tag', 'stabilisierter_schlamm_tag', 'bsb5anteil',
-                                'bsb5absolut', 'csbanteil', 'csbabsolut', 'docanteil', 'docabsolut', 'nh4_nanteil', 'nh4_nabsolut', 'nh4_n_ganzjaehrig',
-                                'nanteil', 'nabsolut', 'n_abwassertemperatur', 'gesamtpanteil', 'gesamtpabsolut', 'gesamt_ungel_stoffe_absolut',
-                                'andere_stoffe', 'kanton', 'vsa_kategorie', 'ausbaugroesse_egw', 'anzahl_nat_einwohner', 'jahr_nat_einwohner', 'abwasseranteil_q347', 'gwlnr']
     id = Column('nummer', Integer, primary_key=True)
     name = Column('name', Unicode)
     rechtswert = Column('rechtswert', Integer)
@@ -1153,7 +1117,6 @@ class Gewaesserzustandst (Base, Vector):
     __tablename__ = 'dbgz'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-gewaesserzustandsmessstationen'
-    __queryable_attributes__ = ['nr', 'name', 'gewaesser']
     __template__ = 'templates/htmlpopup/gewaesserzustandsmessstationen.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1240,7 +1203,6 @@ class AU(Base, Vector):
     __tablename__ = 'auen'
     __table_args__ = ({'schema': 'bundinv', 'autoload': False})
     __bodId__ = 'ch.bafu.bundesinventare-auen'
-    __queryable_attributes__ = ['objnummer', 'name']
     __template__ = 'templates/htmlpopup/auen.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1261,7 +1223,6 @@ class AU_A2(Base, Vector):
     __tablename__ = 'auen_anhang2'
     __table_args__ = ({'schema': 'bundinv', 'autoload': False})
     __bodId__ = 'ch.bafu.bundesinventare-auen_anhang2'
-    __queryable_attributes__ = ['objnummer', 'name']
     __template__ = 'templates/htmlpopup/auen_anhang2.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1282,7 +1243,6 @@ class AuenVegetationAlpin(Base, Vector):
     __tablename__ = 'auen_vegetation_alpin'
     __table_args__ = ({'schema': 'bundinv', 'autoload': False})
     __bodId__ = 'ch.bafu.bundesinventare-auen_vegetation_alpin'
-    __queryable_attributes__ = ['objnummer', 'objname', 'vegetation']
     __template__ = 'templates/htmlpopup/auen_vegetation_alpin.mako'
     __label__ = 'objname'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1325,7 +1285,6 @@ class AlpinAuenAusserhalbBundesinventar(Base, Vector):
     __tablename__ = 'alpinauen'
     __table_args__ = ({'schema': 'schutzge', 'autoload': False})
     __bodId__ = 'ch.bafu.auen-ausserhalb_bundesinventar_alpin'
-    __queryable_attributes__ = ['name']
     __template__ = 'templates/htmlpopup/auen_ausserhalb_bundinv_alpin.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1350,7 +1309,6 @@ class AuenVegetationsKarten(Base, Vector):
     __tablename__ = 'auen_vegetationskarte'
     __table_args__ = ({'schema': 'flora', 'autoload': False})
     __bodId__ = 'ch.bafu.auen-vegetationskarten'
-    __queryable_attributes__ = ['obj_nummer', 'name', 'kartierjahr', 'primaervegetation_de', 'primaervegetation_fr', 'primaervegetation_it']
     __template__ = 'templates/htmlpopup/auen_veg.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1372,7 +1330,6 @@ class BLN(Base, Vector):
     __tablename__ = 'bln_v2'
     __table_args__ = ({'schema': 'bundinv', 'autoload': False})
     __bodId__ = 'ch.bafu.bundesinventare-bln'
-    __queryable_attributes__ = ['bln_name']
     __template__ = 'templates/htmlpopup/bln.mako'
     __label__ = 'bln_name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1414,7 +1371,6 @@ class JB(Base, Vector):
     __tablename__ = 'jb'
     __table_args__ = ({'schema': 'bundinv', 'autoload': False})
     __bodId__ = 'ch.bafu.bundesinventare-jagdbanngebiete'
-    __queryable_attributes__ = ['jb_name']
     __template__ = 'templates/htmlpopup/jb.mako'
     __label__ = 'jb_name'  # Composite labels
     id = Column('gid', Integer, primary_key=True)
@@ -1520,7 +1476,6 @@ class Flachmoore(Base, Vector):
     __table_args__ = ({'schema': 'bundinv', 'autoload': False})
     __bodId__ = 'ch.bafu.bundesinventare-flachmoore'
     __template__ = 'templates/htmlpopup/flachmoore.mako'
-    __queryable_attributes__ = ['objnummer']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -2046,7 +2001,6 @@ class Wrzselect(Base, Vector):
     __table_args__ = ({'schema': 'wrzportal', 'autoload': False})
     __bodId__ = 'ch.bafu.wrz-jagdbanngebiete_select'
     __template__ = 'templates/htmlpopup/wrz_select.mako'
-    __queryable_attributes__ = ['kanton', 'jb_name', 'beschlussjahr', 'schutzs_de', 'schutzs_fr', 'schutzs_it']
     __label__ = 'jb_name'
     id = Column('bgdi_id', Integer, primary_key=True)
     jb_name = Column('jb_name', Unicode)
@@ -2134,7 +2088,6 @@ class Wildtier(Base, Vector):
     __bodId__ = 'ch.bafu.fauna-wildtierkorridor_national'
     __template__ = 'templates/htmlpopup/wildtierkorridor.mako'
     __label__ = 'objnummer'
-    __queryable_attributes__ = ['name', 'objnummer', 'zustand_de', 'zustand_fr', 'zustand_it']
     id = Column('bgdi_id', Integer, primary_key=True)
     objnummer = Column('objnummer', Unicode)
     name = Column('name', Unicode)
@@ -2292,7 +2245,6 @@ class Hochwasserstatistik(Base, Vector):
     __tablename__ = 'hochwasserstatistik'
     __table_args__ = ({'schema': 'hydrologie', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrologie-hochwasserstatistik'
-    __queryable_attributes__ = ['name']
     __template__ = 'templates/htmlpopup/hochwasserstatistik.mako'
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -2310,7 +2262,6 @@ class HydrogeologieMarkierversuche(Base, Vector):
     __table_args__ = ({'schema': 'hydrogeolog', 'autoload': False})
     __bodId__ = 'ch.bafu.hydrogeologie-markierversuche'
     __template__ = 'templates/htmlpopup/hydrogeologie_markierversuche.mako'
-    __queryable_attributes__ = ['ort', 'milieu', 'markierstoff']
     __label__ = 'id'
     id = Column('id', Integer, primary_key=True)
     nummer_ein = Column('nummer_ein', Integer)
@@ -2331,7 +2282,6 @@ class LandesForstInventarWaldMischGrad(Base, Vector):
     __table_args__ = ({'schema': 'wald', 'autoload': False})
     __bodId__ = 'ch.bafu.landesforstinventar-waldmischungsgrad'
     __template__ = 'templates/htmlpopup/landesforstinventar-waldmischgrad.mako'
-    __queryable_attributes__ = ['datenstand']
     __label__ = 'datenstand'
     id = Column('bgdi_id', Integer, primary_key=True)
     datenstand = Column('datenstand', Integer)
@@ -2344,7 +2294,6 @@ class LandesForstInventarVegetation:
     __tablename__ = 'vegetationshoehenmodell'
     __table_args__ = ({'schema': 'wald', 'autoload': False, 'extend_existing': True})
     __template__ = 'templates/htmlpopup/landesforstinventar-vegetationshoehenmodell.mako'
-    __queryable_attributes__ = ['datenstand']
     __label__ = 'datenstand'
     id = Column('bgdi_id', Integer, primary_key=True)
     datenstand = Column('datenstand', Integer)

--- a/chsdi/models/vector/bak.py
+++ b/chsdi/models/vector/bak.py
@@ -26,7 +26,6 @@ class IsosOrtsbild(Base, IsosBase, Vector):
     __tablename__ = 'isos_ortsbild'
     __bodId__ = 'ch.bak.bundesinventar-schuetzenswerte-ortsbilder'
     __label__ = 'name'
-    __queryable_attributes__ = ['id', 'name']
     __minscale__ = 50001
 
 
@@ -34,7 +33,6 @@ class IsosOrtsbildPerimeter(Base, IsosBase, Vector):
     __tablename__ = 'view_isos_perimeter'
     __bodId__ = 'ch.bak.bundesinventar-schuetzenswerte-ortsbilder'
     __label__ = 'name'
-    __queryable_attributes__ = ['id', 'name']
     __maxscale__ = 50000
     __minscale__ = 25001
 
@@ -68,7 +66,6 @@ register('ch.bak.bundesinventar-schuetzenswerte-ortsbilder', IsosOrtsbildHinweis
 
 class IsosFotoBase(IsosBase):
     __bodId__ = 'ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos'
-    __queryable_attributes__ = ['id', 'name']
     __label__ = 'name'
 
 

--- a/chsdi/models/vector/evd.py
+++ b/chsdi/models/vector/evd.py
@@ -22,7 +22,6 @@ class Bodeneignung:
 class Kulturtyp(Base, Bodeneignung, Vector):
     __template__ = 'templates/htmlpopup/bodeneignung-kulurtyp.mako'
     __bodId__ = 'ch.blw.bodeneignung-kulturtyp'
-    # __queryable_attributes__ = ['farbe']
     __label__ = 'symb_color'
     symb_color = Column('symb_color', Unicode)
 
@@ -240,7 +239,6 @@ class UrsprungsbezeichnungenFleisch(Base, Vector):
     __tablename__ = 'ursprungsbezeichnungen_fleisch'
     __table_args__ = ({'schema': 'blw', 'autoload': False})
     __bodId__ = 'ch.blw.ursprungsbezeichnungen-fleisch'
-    __queryable_attributes__ = ['objektcode', 'objekt_d', 'objekt_f', 'objekt_i']
     __template__ = 'templates/htmlpopup/ursprungsbezeichnungen.mako'
     __label__ = 'objektcode'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -257,7 +255,6 @@ class UrsprungsbezeichnungenKaese(Base, Vector):
     __tablename__ = 'ursprungsbezeichnungen_kaese'
     __table_args__ = ({'schema': 'blw', 'autoload': False})
     __bodId__ = 'ch.blw.ursprungsbezeichnungen-kaese'
-    __queryable_attributes__ = ['objektcode', 'objekt_d', 'objekt_f', 'objekt_i']
     __template__ = 'templates/htmlpopup/ursprungsbezeichnungen.mako'
     __label__ = 'objektcode'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -274,7 +271,6 @@ class UrsprungsbezeichnungenKonditoreiwaren(Base, Vector):
     __tablename__ = 'ursprungsbezeichnungen_konditoreiwaren'
     __table_args__ = ({'schema': 'blw', 'autoload': False})
     __bodId__ = 'ch.blw.ursprungsbezeichnungen-konditoreiwaren'
-    __queryable_attributes__ = ['objektcode', 'objekt_d', 'objekt_f', 'objekt_i']
     __template__ = 'templates/htmlpopup/ursprungsbezeichnungen.mako'
     __label__ = 'objektcode'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -291,7 +287,6 @@ class UrsprungsbezeichnungenPflanzen(Base, Vector):
     __tablename__ = 'ursprungsbezeichnungen_pflanzen'
     __table_args__ = ({'schema': 'blw', 'autoload': False})
     __bodId__ = 'ch.blw.ursprungsbezeichnungen-pflanzen'
-    __queryable_attributes__ = ['objektcode', 'objekt_d', 'objekt_f', 'objekt_i']
     __template__ = 'templates/htmlpopup/ursprungsbezeichnungen.mako'
     __label__ = 'objektcode'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -308,7 +303,6 @@ class UrsprungsbezeichnungenSpirituosen(Base, Vector):
     __tablename__ = 'ursprungsbezeichnungen_spirituosen'
     __table_args__ = ({'schema': 'blw', 'autoload': False})
     __bodId__ = 'ch.blw.ursprungsbezeichnungen-spirituosen'
-    __queryable_attributes__ = ['objektcode', 'objekt_d', 'objekt_f', 'objekt_i']
     __template__ = 'templates/htmlpopup/ursprungsbezeichnungen.mako'
     __label__ = 'objektcode'
     id = Column('bgdi_id', Integer, primary_key=True)

--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -28,7 +28,6 @@ class FixpunkteLfp1(Base, Vector):
     __table_args__ = ({'schema': 'fpds', 'autoload': False})
     __template__ = 'templates/htmlpopup/fixpunkte.mako'
     __bodId__ = 'ch.swisstopo.fixpunkte-lfp1'
-    __queryable_attributes__ = ['id']
     __label__ = 'id'
     id = Column('pointid', Unicode, primary_key=True)
     punktname = Column('punktname', Unicode)
@@ -53,7 +52,6 @@ class FixpunkteLfp2(Base, Vector):
     __table_args__ = ({'schema': 'fpds', 'autoload': False})
     __template__ = 'templates/htmlpopup/fixpunkte.mako'
     __bodId__ = 'ch.swisstopo.fixpunkte-lfp2'
-    __queryable_attributes__ = ['id']
     __label__ = 'id'
     id = Column('pointid', Unicode, primary_key=True)
     nbident = Column('nbident', Unicode)
@@ -78,7 +76,6 @@ class FixpunkteHfp1(Base, Vector):
     __table_args__ = ({'schema': 'fpds', 'autoload': True})
     __template__ = 'templates/htmlpopup/fixpunkte.mako'
     __bodId__ = 'ch.swisstopo.fixpunkte-hfp1'
-    __queryable_attributes__ = ['id', 'bgdi_label']
     __label__ = 'id'
     id = Column('pointid', Unicode, primary_key=True)
     bgdi_label = Column('bgdi_label', Unicode)
@@ -104,7 +101,6 @@ class FixpunkteHfp2(Base, Vector):
     __table_args__ = ({'schema': 'fpds', 'autoload': True})
     __template__ = 'templates/htmlpopup/fixpunkte.mako'
     __bodId__ = 'ch.swisstopo.fixpunkte-hfp2'
-    __queryable_attributes__ = ['id']
     __label__ = 'id'
     id = Column('pointid', Unicode, primary_key=True)
     nbident = Column('nbident', Unicode)

--- a/chsdi/models/vector/lubis.py
+++ b/chsdi/models/vector/lubis.py
@@ -41,7 +41,6 @@ class LuftbilderBase:
 class LuftbilderSwisstopoFarbe(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_swisstopo_color'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder_farbe'
-    __queryable_attributes__ = ['id', 'ort']
     image_height = Column('image_height', Integer)
     image_width = Column('image_width', Integer)
 
@@ -51,7 +50,6 @@ register('ch.swisstopo.lubis-luftbilder_farbe', LuftbilderSwisstopoFarbe)
 class LuftbilderSwisstopoIr(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_swisstopo_ir'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder_infrarot'
-    __queryable_attributes__ = ['id', 'ort']
     image_height = Column('image_height', Integer)
     image_width = Column('image_width', Integer)
 
@@ -61,7 +59,6 @@ register('ch.swisstopo.lubis-luftbilder_infrarot', LuftbilderSwisstopoIr)
 class LuftbilderSwisstopoSw(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_swisstopo_bw'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder_schwarzweiss'
-    __queryable_attributes__ = ['id', 'ort', 'filmart', 'bgdi_flugjahr']
     image_height = Column('image_height', Integer)
     image_width = Column('image_width', Integer)
 
@@ -71,7 +68,6 @@ register('ch.swisstopo.lubis-luftbilder_schwarzweiss', LuftbilderSwisstopoSw)
 class LuftbilderDritteFirmen(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_dritte_firmen'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder-dritte-firmen'
-    __queryable_attributes__ = ['id', 'ort', 'filmart', 'bgdi_flugjahr']
     contact = Column('contact', Unicode)
     contact_email = Column('contact_email', Unicode)
     contact_web = Column('contact_web', Unicode)
@@ -83,7 +79,6 @@ register('ch.swisstopo.lubis-luftbilder-dritte-firmen', LuftbilderDritteFirmen)
 class LuftbilderDritteKantone(Base, LuftbilderBase, Vector):
     __tablename__ = 'luftbilder_dritte_kantone'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder-dritte-kantone'
-    __queryable_attributes__ = ['id', 'ort', 'filmart', 'bgdi_flugjahr']
     contact = Column('contact', Unicode)
     contact_email = Column('contact_email', Unicode)
     contact_web = Column('contact_web', Unicode)
@@ -97,7 +92,6 @@ class Bildstreifen(Base, Vector):
     __table_args__ = ({'schema': 'ads40', 'autoload': False})
     __template__ = 'templates/htmlpopup/lubis_bildstreifen.mako'
     __bodId__ = 'ch.swisstopo.lubis-bildstreifen'
-    __queryable_attributes__ = ['id']
     __returnedGeometry__ = 'the_geom_footprint'
     __timeInstant__ = 'bgdi_flugjahr'
     __extended_info__ = True
@@ -135,7 +129,6 @@ class LuftbilderSchraegaufnahmen(Base, Vector):
     __extended_info__ = True
     # Composite labels
     __label__ = 'flightdate'
-    __queryable_attributes__ = ['id', 'bgdi_flugjahr', 'medium_format']
     id = Column('ebkey', Unicode, primary_key=True)
     inventory_number = Column('inventory_number', Unicode)
     flightdate = Column('flightdate', Unicode)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -237,7 +237,6 @@ class DosisleistungTerrestrisch(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/dosisleistung_terrestrisch.mako'
     __bodId__ = 'ch.swisstopo.geologie-dosisleistung-terrestrisch'
-    __queryable_attributes__ = ['contour']
     __label__ = 'contour'
     id = Column('bgdi_id', Integer, primary_key=True)
     contour = Column('contour', Numeric)
@@ -279,7 +278,6 @@ class Landesschwerenetz(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/landesschwerenetz.mako'
     __bodId__ = 'ch.swisstopo.landesschwerenetz'
-    __queryable_attributes__ = ['nr_lsn2004', 'name', 'type']
     __label__ = 'label_tt'
     id = Column('bgdi_id', Integer, primary_key=True)
     nr_lsn2004 = Column('nr_lsn2004', Unicode)
@@ -308,7 +306,6 @@ class LandesschwerenetzExt(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/landesschwerenetz.mako'
     __bodId__ = 'ch.swisstopo.landesschwerenetz'
-    __queryable_attributes__ = ['nr_lsn2004', 'name', 'type']
     __maxscale__ = 3000
     __label__ = 'label_tt'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -338,7 +335,6 @@ class GravimetrischerAtlasMesspunkte(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/gravimetrischer_atlas_messpunkte.mako'
     __bodId__ = 'ch.swisstopo.geologie-gravimetrischer_atlas.messpunkte'
-    __queryable_attributes__ = ['stationnam']
     __label__ = 'stationnam'
     id = Column('bgdi_id', Integer, primary_key=True)
     stationnam = Column('stationnam', Unicode)
@@ -407,7 +403,6 @@ register(GeologieGeowege.__bodId__, GeologieGeowege)
 class ShopProductClass:
     __template__ = 'templates/htmlpopup/shop_product.mako'
     __label__ = 'id'
-    __queryable_attributes__ = ['release']
     id = Column('pk_product', Unicode, primary_key=True)
     scale = Column('scale', Integer)
     release = Column('release', Integer)
@@ -558,7 +553,6 @@ register('ch.swisstopo.segelflugkarte.metadata', SegelFlug300DigitalMeta)
 
 class ShopProductGroupClass(ShopProductClass):
     __label__ = 'number'
-    __queryable_attributes__ = ['number', 'name_de', 'name_fr', 'name_it', 'name_en', 'release']
     number = Column('s_map_number', Unicode)
     name_de = Column('s_title_de', Unicode)
     name_fr = Column('s_title_fr', Unicode)
@@ -710,7 +704,6 @@ class SwissboundariesBezirk(Base, Vector):
     __table_args__ = ({'schema': 'tlm', 'autoload': False})
     __template__ = 'templates/htmlpopup/swissboundaries_bezirk.mako'
     __bodId__ = 'ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill'
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -725,7 +718,6 @@ class SwissboundariesGemeinde(Base, Vector):
     __table_args__ = ({'schema': 'tlm', 'autoload': False})
     __template__ = 'templates/htmlpopup/swissboundaries_gemeinde.mako'
     __bodId__ = 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill'
-    __queryable_attributes__ = ['gemname', 'id']
     __label__ = 'gemname'
     id = Column('id', Integer, primary_key=True)
     gemname = Column('gemname', Unicode)
@@ -743,7 +735,6 @@ class SwissboundariesKanton(Base, Vector):
     __table_args__ = ({'schema': 'tlm', 'autoload': False})
     __template__ = 'templates/htmlpopup/swissboundaries_kanton.mako'
     __bodId__ = 'ch.swisstopo.swissboundaries3d-kanton-flaeche.fill'
-    __queryable_attributes__ = ['id', 'ak', 'name']
     __label__ = 'name'
     id = Column('kantonsnr', Integer, primary_key=True)
     ak = Column('ak', Unicode)
@@ -981,7 +972,6 @@ class Vec200Namedlocation(Base, Vector):
     __table_args__ = ({'autoload': False})
     __template__ = 'templates/htmlpopup/vec200_namedlocation.mako'
     __bodId__ = 'ch.swisstopo.vec200-names-namedlocation'
-    __queryable_attributes__ = ['objname1', 'id']
     # Composite labels coalesce(objname1,'')||' '||coalesce(objname2,'')
     __label__ = 'objname1'
     id = Column('gtdboid', Unicode, primary_key=True)
@@ -1344,7 +1334,6 @@ class GeologieBohrungenTiefer500(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/bohrungen_tiefer_500.mako'
     __bodId__ = 'ch.swisstopo.geologie-bohrungen_tiefer_500'
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     __extended_info__ = True
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1415,7 +1404,6 @@ class GeologieGeothermischePotenzialstudien(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/geothermische_potenzialstudien.mako'
     __bodId__ = 'ch.swisstopo.geologie-geothermische_potenzialstudien_regional'
-    __queryable_attributes__ = ['autor', 'titel_de', 'titel_fr', 'titel_en', 'titel_it', 'titel_rm']
     __label__ = 'kanton'
     __extended_info__ = True
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -1461,7 +1449,6 @@ class TiefenGeothermieProjekte(Base, Vector):
     __bodId__ = 'ch.swisstopo.geologie-tiefengeothermie_projekte'
     __label__ = 'name'
     __extended_info__ = True
-    __queryable_attributes__ = ['name', 'status_de', 'status_fr', 'status_en', 'system_de', 'system_fr', 'system_en']
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
     owner = Column('owner', Unicode)
@@ -1639,7 +1626,6 @@ class GeologieGeotechnikZiegeleien1907(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/ziegeleien_1907.mako'
     __bodId__ = 'ch.swisstopo.geologie-geotechnik-ziegeleien_1907'
-    __queryable_attributes__ = ['ziegelei_2']
     __label__ = 'ziegelei_2'
     id = Column('id', Integer, primary_key=True)
     ziegelei_2 = Column('ziegelei_2', Unicode)
@@ -1792,7 +1778,6 @@ class GeologieRohstoffeIndustrieminerale(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_industrieminerale.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-industrieminerale'
-    __queryable_attributes__ = ['obname', 'obnamealt', 'imkinds', 'edrskinds']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -1812,7 +1797,6 @@ class GeologieRohstoffeKohlenBitumenErdgas(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_kohlen_bitumen_erdgas.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas'
-    __queryable_attributes__ = ['obname', 'obnamealt', 'erkinds', 'ederkinds']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -1832,7 +1816,6 @@ class GeologieRohstoffeVererzungen(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_vererzungen.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-vererzungen'
-    __queryable_attributes__ = ['obname']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -1852,7 +1835,6 @@ class GeologieRohstoffeNaturwerksteineAbbau(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_naturwerksteine_abbau.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-naturwerksteine_abbau'
-    __queryable_attributes__ = ['obname', 'tckind', 'ltkinds', 'emkinds', 'stkind']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -1872,7 +1854,6 @@ class GeologieRohstoffeGebrocheneGesteine(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_gebrochene_gesteine.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-gebrochene_gesteine_abbau'
-    __queryable_attributes__ = ['obname', 'tckind', 'ltkinds', 'emkinds']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -1892,7 +1873,6 @@ class GeologieRohstoffeSalzAbbauVerarbeitung(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_salz_abbau_verarbeitung.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-salz_abbau_verarbeitung'
-    __queryable_attributes__ = ['obname', 'obnamealt', 'ockind', 'emkinds', 'ltkind', 'pckind']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -1915,7 +1895,6 @@ class GeologieRohstoffeGipsAbbauVerarbeitung(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_gips_abbau_verarbeitung.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-gips_abbau_verarbeitung'
-    __queryable_attributes__ = ['obname', 'ockind', 'emkinds', 'ltkinds', 'edltkinds', 'pckind']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -1938,7 +1917,6 @@ class GeologieRohstoffeZementAbbauVerarbeitung(Base, Vector):
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/rohstoffe_zement_abbau_verarbeitung.mako'
     __bodId__ = 'ch.swisstopo.geologie-rohstoffe-zement_abbau_verarbeitung'
-    __queryable_attributes__ = ['obname', 'ockind', 'emkinds', 'ltkinds', 'edltkinds', 'pckind']
     __label__ = 'obname'
     id = Column('obid', Integer, primary_key=True)
     obname = Column('obname', Unicode)
@@ -2238,7 +2216,6 @@ class VerschiebungsvektorenTsp1(Base, Vector):
     __table_args__ = ({'schema': 'geodaesie', 'autoload': False})
     __template__ = 'templates/htmlpopup/verschiebungsvektoren_tps1.mako'
     __bodId__ = 'ch.swisstopo.verschiebungsvektoren-tsp1'
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     fid = Column('id', Integer)
@@ -2261,7 +2238,6 @@ class VerschiebungsvektorenTsp2(Base, Vector):
     __table_args__ = ({'schema': 'geodaesie', 'autoload': False})
     __template__ = 'templates/htmlpopup/verschiebungsvektoren_tps2.mako'
     __bodId__ = 'ch.swisstopo.verschiebungsvektoren-tsp2'
-    __queryable_attributes__ = ['name', 'id']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     fid = Column('id', Integer)
@@ -2299,7 +2275,6 @@ class PLZOrtschaften(Base, Vector):
     __table_args__ = ({'schema': 'vd', 'autoload': False})
     __template__ = 'templates/htmlpopup/gabmo_plz.mako'
     __bodId__ = 'ch.swisstopo-vd.ortschaftenverzeichnis_plz'
-    __queryable_attributes__ = ['plz', 'langtext']
     __label__ = 'plz'
     id = Column('os_uuid', Unicode, primary_key=True)
     plz = Column('plz', Integer)
@@ -2444,7 +2419,6 @@ class TransformationBezugsrahmenHoehePunkte(Base, Vector):
     __template__ = 'templates/htmlpopup/transformation_bezugsrahmen_hoehe.mako'
     __bodId__ = 'ch.swisstopo.transformation-bezugsrahmen_hoehe'
     __label__ = 'name'
-    __queryable_attributes__ = ['name']
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
     y = Column('y', Numeric)
@@ -2488,7 +2462,6 @@ class HebungsratenLine(Base, Vector):
     __table_args__ = ({'schema': 'geodaesie', 'autoload': False})
     __template__ = 'templates/htmlpopup/hebungsraten.mako'
     __bodId__ = 'ch.swisstopo.hebungsraten'
-    __queryable_attributes__ = []
     __label__ = 'contour'
     id = Column('bgdi_id', Integer, primary_key=True)
     contour = Column('contour', Numeric)
@@ -2500,7 +2473,6 @@ class HebungsratenPunkt(Base, Vector):
     __table_args__ = ({'schema': 'geodaesie', 'autoload': False})
     __template__ = 'templates/htmlpopup/hebungsraten.mako'
     __bodId__ = 'ch.swisstopo.hebungsraten'
-    __queryable_attributes__ = ['ord_nr', 'ort']
     __label__ = 'ord_nr'
     id = Column('bgdi_id', Integer, primary_key=True)
     ord_nr = Column('ord_nr', Unicode)
@@ -2609,7 +2581,6 @@ register('ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke', SteineH
 class GisGeolBase:
     __template__ = 'templates/htmlpopup/gisgeol.mako'
     __table_args__ = ({'schema': 'geol', 'autoload': False})
-    __queryable_attributes__ = ['sgd_nr', 'orig_id', 'title', 'author', 'aux_info', 'doccreation']
     __label__ = 'title'
     __extended_info__ = True
     __timeInstant__ = 'year'
@@ -2704,7 +2675,6 @@ class Geocover:
 
 class GeocoverBase(Geocover):
     __label__ = 'description_de'
-    __queryable_attributes__ = []
     __maxscale__ = 70000
     id = Column('bgdi_id', Integer, primary_key=True)
     description_de = Column('description_de', Unicode)
@@ -2835,7 +2805,6 @@ class Ga25Features(Ga25Atlas):
     basisdatensatz = Column('basisdatensatz', Unicode)
     description = Column('description', Unicode)
     __maxscale__ = 70000
-    __queryable_attributes__ = []
 
 
 class Ga25LineAux(Base, Ga25Features, Vector):

--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -17,7 +17,6 @@ class Nsa(Base, Vector):
     __template__ = 'templates/htmlpopup/nsa.mako'
     __bodId__ = 'ch.astra.nationalstrassenachsen'
     __label__ = 'id'
-    __queryable_attributes__ = ['strassennummer', 'name']
     id = Column('bgdi_id', Integer, primary_key=True)
     eigentuemer = Column('eigentuemer', Unicode)
     segmentname = Column('segmentname', Unicode)
@@ -40,7 +39,6 @@ class SchienennetzPoint(Base, Vector):
     __template__ = 'templates/htmlpopup/schienennetz_point.mako'
     __bodId__ = 'ch.bav.schienennetz'
     __label__ = 'nom_point'
-    __queryable_attributes__ = ['numero', 'nom_point', 'abreviation']
     id = Column('xtf_id', Integer, primary_key=True)
     xtf_id_tooltip = Column('xtf_id_tooltip', Unicode)
     numero = Column('numero', Integer)
@@ -57,7 +55,6 @@ class SchienennetzSegment(Base, Vector):
     __template__ = 'templates/htmlpopup/schienennetz_segment.mako'
     __bodId__ = 'ch.bav.schienennetz'
     __label__ = 'nom_segment'
-    __queryable_attributes__ = ['nom_segment']
     id = Column('id', Integer, primary_key=True)
     xtf_id_tooltip = Column('xtf_id_tooltip', Unicode)
     numeroet = Column('numeroet', Integer)
@@ -159,7 +156,6 @@ class OevHaltestellenZoom1(Base, OevHaltestellen, Vector):
     __maxscale__ = 3000
     __label__ = 'name'
     __extended_info__ = True
-    __queryable_attributes__ = ['id', 'name']
     __returnedGeometry__ = 'the_geom_point'
     id = Column('nummer', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -181,7 +177,6 @@ class OevHaltestellenZoom2(Base, OevHaltestellen, Vector):
     __minscale__ = 3000
     __label__ = 'name'
     __extended_info__ = True
-    __queryable_attributes__ = ['id', 'name']
     __returnedGeometry__ = 'the_geom_point'
     id = Column('nummer', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -261,7 +256,6 @@ class IVSNat(Base, Vector):
     __table_args__ = ({'schema': 'astra', 'autoload': False})
     __template__ = 'templates/htmlpopup/ivs_nat.mako'
     __bodId__ = 'ch.astra.ivs-nat'
-    __queryable_attributes__ = ['ivs_slaname', 'ivs_nummer', 'ivs_signatur']
     __label__ = 'id'
     id = Column('nat_id', Integer, primary_key=True)
     ivs_slaname = Column('ivs_slaname', Unicode)
@@ -285,7 +279,6 @@ class IVSNatVerlaeufe(Base, Vector):
     __table_args__ = ({'schema': 'astra', 'autoload': False})
     __template__ = 'templates/htmlpopup/ivs_nat.mako'
     __bodId__ = 'ch.astra.ivs-nat-verlaeufe'
-    __queryable_attributes__ = ['ivs_slaname', 'ivs_nummer', 'ivs_signatur']
     __label__ = 'id'
     id = Column('nat_id', Integer, primary_key=True)
     ivs_slaname = Column('ivs_slaname', Unicode)
@@ -309,7 +302,6 @@ class IVSRegLoc(Base, Vector):
     __table_args__ = ({'schema': 'astra', 'autoload': False})
     __template__ = 'templates/htmlpopup/ivs_nat.mako'
     __bodId__ = 'ch.astra.ivs-reg_loc'
-    __queryable_attributes__ = ['ivs_slaname', 'ivs_nummer', 'ivs_signatur']
     __label__ = 'ivs_nummer'
     id = Column('reg_loc_id', Integer, primary_key=True)
     ivs_slaname = Column('ivs_slaname', Unicode)
@@ -350,7 +342,6 @@ class Zaehlstellenregloc(Base, Vector):
     __table_args__ = ({'schema': 'astra', 'autoload': False})
     __template__ = 'templates/htmlpopup/verkehrszaehlstellen.mako'
     __bodId__ = 'ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal'
-    __queryable_attributes__ = ['id', 'zaehlstellen_bezeichnung']
     __extended_info__ = True
     __label__ = 'zaehlstellen_bezeichnung'
     id = Column('nr', Integer, primary_key=True)
@@ -383,7 +374,6 @@ class Zaehstellenueber(Base, Vector):
     __table_args__ = ({'schema': 'astra', 'autoload': False})
     __template__ = 'templates/htmlpopup/verkehrszaehlstellen.mako'
     __bodId__ = 'ch.astra.strassenverkehrszaehlung_messstellen-uebergeordnet'
-    __queryable_attributes__ = ['id', 'zaehlstellen_bezeichnung']
     __extended_info__ = True
     __label__ = 'zaehlstellen_bezeichnung'
     id = Column('nr', Integer, primary_key=True)
@@ -612,7 +602,6 @@ class KatasterBelasteterStandorte(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/kataster_belasteter_standorte_oev.mako'
     __bodId__ = 'ch.bav.kataster-belasteter-standorte-oev'
-    __queryable_attributes__ = ['katasternummer']
     __label__ = 'id'
     id = Column('vflz_id', Integer, primary_key=True)
     katasternummer = Column('katasternummer', Unicode)
@@ -637,7 +626,6 @@ class AbgeltungWasserkraftnutzung(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/abgeltungwasserkraftnutzung.mako'
     __bodId__ = 'ch.bfe.abgeltung-wasserkraftnutzung'
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('objectnumber', Integer, primary_key=True)
     area = Column('area', Numeric)
@@ -693,7 +681,6 @@ class Energieberatungsstellen (Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/energieberatungsstellen.mako'
     __bodId__ = 'ch.bfe.energieberatungsstellen'
-    __queryable_attributes__ = ['name', 'management']
     __label__ = 'name'
     id = Column('xtf_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -732,7 +719,6 @@ class Energiestaedte(Base, Vector):
     __template__ = 'templates/htmlpopup/energiestaedte.mako'
     __bodId__ = 'ch.bfe.energiestaedte'
     __extended_info__ = True
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -755,7 +741,6 @@ class EnergiestaedteRegionen(Base, Vector):
     __template__ = 'templates/htmlpopup/energiestaedte_energieregionen.mako'
     __bodId__ = 'ch.bfe.energiestaedte-energieregionen'
     __extended_info__ = True
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -787,7 +772,6 @@ class Energiestaedte2000wattAreale(Base, Vector):
     __template__ = 'templates/htmlpopup/energiestaedte_2000watt_areale.mako'
     __bodId__ = 'ch.bfe.energiestaedte-2000watt-areale'
     __extended_info__ = True
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -813,7 +797,6 @@ class Energieforschung(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/energieforschung.mako'
     __bodId__ = 'ch.bfe.energieforschung'
-    __queryable_attributes__ = ['title_de', 'title_fr', 'title_it', 'title_en']
     __label__ = 'title_de'
     id = Column('bgdi_id', Integer, primary_key=True)
     title_de = Column('title_de', Unicode)
@@ -847,7 +830,6 @@ class FernWaermeAngebot(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/fernwaerme_angebot.mako'
     __bodId__ = 'ch.bfe.fernwaerme-angebot'
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -1045,7 +1027,6 @@ class StauanlagenBundesaufsicht(Base, Vector):
     __template__ = 'templates/htmlpopup/stauanlagenbundesaufsicht.mako'
     __bodId__ = 'ch.bfe.stauanlagen-bundesaufsicht'
     __extended_info__ = True
-    __queryable_attributes__ = ['damname', 'damtype_de', 'damtype_fr', 'damtype_en']
     __label__ = 'damname'
     id = Column('dam_stabil_id', Integer, primary_key=True)
     damname = Column('damname', Unicode)
@@ -1078,7 +1059,6 @@ class Wpsm (Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/wpsm.mako'
     __bodId__ = 'ch.bfe.wpsm-qualifizierte_firmen'
-    __queryable_attributes__ = ['company', 'contactperson']
     __label__ = 'company'
     id = Column('xtf_id', Integer, primary_key=True)
     company = Column('company', Unicode)
@@ -1116,7 +1096,6 @@ class WindenergieanlagenFacility(Base, Vector):
     __template__ = 'templates/htmlpopup/windenergieanlagen_facility.mako'
     __bodId__ = 'ch.bfe.windenergieanlagen'
     __extended_info__ = True
-    __queryable_attributes__ = ['fac_name']
     __label__ = 'fac_name'
     id = Column('fac_id', Unicode, primary_key=True)
     fac_name = Column('fac_name', Unicode)
@@ -1144,7 +1123,6 @@ class WindenergieanlagenTurbine(Base, Vector):
     __template__ = 'templates/htmlpopup/windenergieanlagen_turbine.mako'
     __bodId__ = 'ch.bfe.windenergieanlagen'
     __extended_info__ = True
-    __queryable_attributes__ = ['fac_name']
     __label__ = 'tur_year'
     id = Column('tur_id', Unicode, primary_key=True)
     fac_name = Column('fac_name', Unicode)
@@ -1191,7 +1169,6 @@ class BakomNotruf112Fest(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_fn_112.mako'
     __bodId__ = 'ch.bakom.notruf-112_festnetz'
-    __queryable_attributes__ = ['festnetz_112', 'fn_addresse_112']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     festnetz_112 = Column('festnetz_112', Unicode)
@@ -1207,7 +1184,6 @@ class BakomNotruf117Fest(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_fn_117.mako'
     __bodId__ = 'ch.bakom.notruf-117_festnetz'
-    __queryable_attributes__ = ['festnetz_117', 'fn_addresse_117']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     festnetz_117 = Column('festnetz_117', Unicode)
@@ -1223,7 +1199,6 @@ class BakomNotruf118Fest(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_fn_118.mako'
     __bodId__ = 'ch.bakom.notruf-118_festnetz'
-    __queryable_attributes__ = ['festnetz_118', 'fn_addresse_118']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     festnetz_118 = Column('festnetz_118', Unicode)
@@ -1239,7 +1214,6 @@ class BakomNotruf143Fest(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_fn_143.mako'
     __bodId__ = 'ch.bakom.notruf-143_festnetz'
-    __queryable_attributes__ = ['festnetz_143', 'fn_addresse_143']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     festnetz_143 = Column('festnetz_143', Unicode)
@@ -1253,7 +1227,6 @@ register('ch.bakom.notruf-143_festnetz', BakomNotruf143Fest)
 class BakomNotrufBase:
     __table_args__ = ({'schema': 'bakom', 'autoload': False, 'extend_existing': True})
     __tablename__ = 'notruf'
-    __queryable_attributes__ = []
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     the_geom = Column(Geometry2D)
@@ -1276,7 +1249,6 @@ class BakomNotruf144Fest(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_fn_144.mako'
     __bodId__ = 'ch.bakom.notruf-144_festnetz'
-    __queryable_attributes__ = ['festnetz_144', 'fn_addresse_144']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     festnetz_144 = Column('festnetz_144', Unicode)
@@ -1304,7 +1276,6 @@ class BakomNotruf147Fest(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_fn_147.mako'
     __bodId__ = 'ch.bakom.notruf-147_festnetz'
-    __queryable_attributes__ = ['festnetz_147', 'fn_addresse_147']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     festnetz_147 = Column('festnetz_147', Unicode)
@@ -1332,7 +1303,6 @@ class BakomNotruf112Mobil(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_mo_112.mako'
     __bodId__ = 'ch.bakom.notruf-112_mobilnetz'
-    __queryable_attributes__ = ['mobile_112', 'mo_addresse_112']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     mobile_112 = Column('mobile_112', Unicode)
@@ -1348,7 +1318,6 @@ class BakomNotruf117Mobil(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_mo_117.mako'
     __bodId__ = 'ch.bakom.notruf-117_mobilnetz'
-    __queryable_attributes__ = ['mobile_117', 'mo_addresse_117']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     mobile_117 = Column('mobile_117', Unicode)
@@ -1364,7 +1333,6 @@ class BakomNotruf118Mobil(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_mo_118.mako'
     __bodId__ = 'ch.bakom.notruf-118_mobilnetz'
-    __queryable_attributes__ = ['mobile_118', 'mo_addresse_118']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     mobile_118 = Column('mobile_118', Unicode)
@@ -1380,7 +1348,6 @@ class BakomNotruf144Mobil(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_mo_144.mako'
     __bodId__ = 'ch.bakom.notruf-144_mobilnetz'
-    __queryable_attributes__ = ['mobile_144', 'mo_addresse_144']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     mobile_144 = Column('mobile_144', Unicode)
@@ -1396,7 +1363,6 @@ class BakomNotruf147Mobil(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_mo_147.mako'
     __bodId__ = 'ch.bakom.notruf-147_mobilnetz'
-    __queryable_attributes__ = ['mobile_147', 'mo_addresse_147']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     mobile_147 = Column('mobile_147', Unicode)
@@ -1412,7 +1378,6 @@ class BakomNotruf143Mobil(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_mo_143.mako'
     __bodId__ = 'ch.bakom.notruf-143_mobilnetz'
-    __queryable_attributes__ = ['mobile_143', 'mo_addresse_143']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     mobile_143 = Column('mobile_143', Unicode)
@@ -1428,7 +1393,6 @@ class BakomNotruf112Sat(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/notruf_sa_112.mako'
     __bodId__ = 'ch.bakom.notruf-112_satellit'
-    __queryable_attributes__ = ['satellit_112', 'sa_addresse_112']
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     satellit_112 = Column('satellit_112', Unicode)
@@ -1442,20 +1406,6 @@ register('ch.bakom.notruf-112_satellit', BakomNotruf112Sat)
 class BakomNotruf(Base, BakomNotrufBase, Vector):
     __template__ = 'templates/htmlpopup/notruf.mako'
     __bodId__ = 'ch.bakom.notruf'
-    __queryable_attributes__ = ['mobile_112', 'mo_addresse_112',
-                                'mobile_117', 'mo_addresse_117',
-                                'mobile_118', 'mo_addresse_118',
-                                'mobile_144', 'mo_addresse_144',
-                                'mobile_147', 'mo_addresse_147',
-                                'mobile_143', 'mo_addresse_147',
-                                'mobile_143', 'mo_addresse_143',
-                                'satellit_112', 'sa_addresse_112',
-                                'festnetz_112', 'fn_addresse_112',
-                                'festnetz_117', 'fn_addresse_117',
-                                'festnetz_118', 'fn_addresse_118',
-                                'festnetz_143', 'fn_addresse_143',
-                                'festnetz_144', 'fn_addresse_144',
-                                'festnetz_147', 'fn_addresse_147']
     __extended_info__ = True
     name = Column('name', Unicode)
     mobile_112 = Column('mobile_112', Unicode)
@@ -1506,7 +1456,6 @@ class BakomNotruf112Zentral(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False, 'extend_existing': True})
     __template__ = 'templates/htmlpopup/notruf_zentral_112.mako'
     __bodId__ = 'ch.bakom.notruf-112_zentral'
-    __queryable_attributes__ = []
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     gemeinde_112 = Column('gemeinde_112', Unicode)
@@ -1526,7 +1475,6 @@ class BakomNotruf117Zentral(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False, 'extend_existing': True})
     __template__ = 'templates/htmlpopup/notruf_zentral_117.mako'
     __bodId__ = 'ch.bakom.notruf-117_zentral'
-    __queryable_attributes__ = []
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     gemeinde_117 = Column('gemeinde_117', Unicode)
@@ -1544,7 +1492,6 @@ class BakomNotruf118Zentral(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False, 'extend_existing': True})
     __template__ = 'templates/htmlpopup/notruf_zentral_118.mako'
     __bodId__ = 'ch.bakom.notruf-118_zentral'
-    __queryable_attributes__ = []
     __label__ = 'id'
     id = Column('bfs_nummer', Integer, primary_key=True)
     gemeinde_118 = Column('gemeinde_118', Unicode)
@@ -1563,7 +1510,6 @@ class Bakomfernsehsender(Base, Vector):
     __template__ = 'templates/htmlpopup/bakomfernsehsender.mako'
     __bodId__ = 'ch.bakom.radio-fernsehsender'
     __extended_info__ = True
-    __queryable_attributes__ = ['name', 'code']
     __label__ = 'code'
     id = Column('id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -1596,7 +1542,6 @@ class Bakomtv(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/bakomtv.mako'
     __bodId__ = 'ch.bakom.versorgungsgebiet-tv'
-    __queryable_attributes__ = ['prog']
     __label__ = 'prog'
     id = Column('gid', Integer, primary_key=True)
     prog = Column('prog', Unicode)
@@ -1610,7 +1555,6 @@ class Bakomukw(Base, Vector):
     __table_args__ = ({'schema': 'bakom', 'autoload': False})
     __template__ = 'templates/htmlpopup/bakomukw.mako'
     __bodId__ = 'ch.bakom.versorgungsgebiet-ukw'
-    __queryable_attributes__ = ['prog']
     __label__ = 'prog'
     id = Column('gid', Integer, primary_key=True)
     prog = Column('prog', Unicode)
@@ -2041,7 +1985,6 @@ class SachPGFacilities(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/sgt_facilities.mako'
     __bodId__ = 'ch.bfe.sachplan-geologie-tiefenlager'
-    __queryable_attributes__ = ['facptname_de', 'facptname_fr', 'facptname_it']
     # Translatable labels in fr, it
     __label__ = 'facptname_de'
     id = Column('facpt_id', Integer, primary_key=True)
@@ -2068,7 +2011,6 @@ class SachPGPlanning(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/sgt_planning_pt.mako'
     __bodId__ = 'ch.bfe.sachplan-geologie-tiefenlager'
-    __queryable_attributes__ = ['pmname_de', 'pmname_fr', 'pmname_it']
     # Translatable labels in fr, it
     __label__ = 'pmname_de'
     id = Column('pmpt_id', Integer, primary_key=True)
@@ -2100,7 +2042,6 @@ class SachPGAreaPlanningNotMT6(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/sgt_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-geologie-tiefenlager'
-    __queryable_attributes__ = ['pmname_de', 'pmname_fr', 'pmname_it']
     # Translatable labels in fr, it
     __label__ = 'pmname_de'
     id = Column('pmarea_id', Integer, primary_key=True)
@@ -2131,7 +2072,6 @@ class SachPGAreaPlanningMT6(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/sgt_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-geologie-tiefenlager'
-    __queryable_attributes__ = ['pmname_de', 'pmname_fr', 'pmname_it']
     # Translatable labels in fr, it
     __label__ = 'pmname_de'
     id = Column('pmarea_id', Integer, primary_key=True)
@@ -2507,7 +2447,6 @@ class SisFacilitiesA(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schiene_anhorung'
     __template__ = 'templates/htmlpopup/sis_facilities.mako'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -2540,7 +2479,6 @@ class SisPlanningA(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sis_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schiene_anhorung'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -2579,7 +2517,6 @@ class SisAngaben(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sis_angaben.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schiene_ausgangslage'
-    __queryable_attributes__ = ['name', 'description_fr', 'description_it', 'description_de']
     __label__ = 'name'
     id = Column('anlage_id', Unicode, primary_key=True)
     name = Column('name', Unicode)
@@ -2605,7 +2542,6 @@ class SisPlanningRasterA(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sis_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schiene_anhorung'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -2644,7 +2580,6 @@ class SisFacilitiesK(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sis_facilities.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schiene_kraft'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -2677,7 +2612,6 @@ class SisPlanningK(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sis_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schiene_kraft'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
     facname_de = Column('facname_de', Unicode)
@@ -2715,7 +2649,6 @@ class SisPlanningRasterK(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sis_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schiene_kraft'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -2754,7 +2687,6 @@ class KbsZivilflugpl(Base, Vector):
     __table_args__ = ({'schema': 'bazl', 'autoload': False})
     __template__ = 'templates/htmlpopup/kataster_belasteter_standorte_zivflpl.mako'
     __bodId__ = 'ch.bazl.kataster-belasteter-standorte-zivilflugplaetze'
-    __queryable_attributes__ = ['katasternummer']
     __label__ = 'katasternummer'
     id = Column('vflz_id', Integer, primary_key=True)
     katasternummer = Column('katasternummer', Unicode)
@@ -2789,7 +2721,6 @@ class AnlageSchienengueterverkehr:
     __table_args__ = ({'schema': 'bav', 'autoload': False, 'extend_existing': True})
     __template__ = 'templates/htmlpopup/anlagen_schienengueterverkehr.mako'
     __bodId__ = 'ch.bav.anlagen-schienengueterverkehr'
-    __queryable_attributes__ = ['dst_nr', 'name', 'dst_abk']
     __label__ = 'name'
     __returnedGeometry__ = 'the_geom_point'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -3018,7 +2949,6 @@ class SifFacilitiesA(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schifffahrt_anhoerung'
     __template__ = 'templates/htmlpopup/sif_facilities.mako'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3051,7 +2981,6 @@ class SifFacilitiesK(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schifffahrt_kraft'
     __template__ = 'templates/htmlpopup/sif_facilities.mako'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3084,7 +3013,6 @@ class SifPlanningA(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sif_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schifffahrt_anhoerung'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3123,7 +3051,6 @@ class SifPlanningK(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sif_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schifffahrt_kraft'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3162,7 +3089,6 @@ class SifPlanningRasterA(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sif_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schifffahrt_anhoerung'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3201,7 +3127,6 @@ class SifPlanningRasterK(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sif_planning.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schifffahrt_kraft'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it', 'doc_title']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3240,7 +3165,6 @@ class SifAusgangslage(Base, Vector):
     __table_args__ = ({'schema': 'bav', 'autoload': False})
     __template__ = 'templates/htmlpopup/sif_angaben.mako'
     __bodId__ = 'ch.bav.sachplan-infrastruktur-schifffahrt_ausgangslage'
-    __queryable_attributes__ = ['name', 'description_fr', 'description_it', 'description_de']
     __label__ = 'name'
     id = Column('anlage_id', Unicode, primary_key=True)
     name = Column('name', Unicode)
@@ -3405,7 +3329,6 @@ class SuelFacAnhorung(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_anhoerung'
     __template__ = 'templates/htmlpopup/suel_facilities.mako'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3438,7 +3361,6 @@ class SuelPlAnhorung(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/suel_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_anhoerung'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it']
     # Translatable labels in fr, it
     __label__ = 'plname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3477,7 +3399,6 @@ class SuelFacRAnhorung(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/suel_facilities.mako'
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_anhoerung'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3512,7 +3433,6 @@ class SuelPlRAnhorung(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/suel_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_anhoerung'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it']
     # Translatable labels in fr, it
     __label__ = 'plname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3551,7 +3471,6 @@ class SuelFacKraft(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/suel_facilities.mako'
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_kraft'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3584,7 +3503,6 @@ class SuelPlKraft(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/suel_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_kraft'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it']
     __label__ = 'plname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
     facname_de = Column('facname_de', Unicode)
@@ -3622,7 +3540,6 @@ class SuelFacRKraft(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/suel_facilities.mako'
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_kraft'
-    __queryable_attributes__ = ['facname_de', 'facname_fr', 'facname_it']
     # Translatable labels in fr, it
     __label__ = 'facname_de'
     id = Column('stabil_id', Unicode, primary_key=True)
@@ -3657,7 +3574,6 @@ class SuelPlRKraft(Base, Vector):
     __table_args__ = ({'schema': 'bfe', 'autoload': False})
     __template__ = 'templates/htmlpopup/suel_planning.mako'
     __bodId__ = 'ch.bfe.sachplan-uebertragungsleitungen_kraft'
-    __queryable_attributes__ = ['plname_de', 'plname_fr', 'plname_it']
     # Translatable labels in fr, it
     __label__ = 'plname_de'
     id = Column('stabil_id', Unicode, primary_key=True)

--- a/chsdi/models/vector/vbs.py
+++ b/chsdi/models/vector/vbs.py
@@ -11,7 +11,6 @@ Base = bases['vbs']
 class Kulturgueter:
     __table_args__ = ({'schema': 'babs', 'autoload': False})
     __template__ = 'templates/htmlpopup/kgs.mako'
-    __queryable_attributes__ = ['zkob']
     __extended_info__ = True
     __label__ = 'zkob'
     id = Column('kgs_nr', Integer, primary_key=True)
@@ -142,7 +141,6 @@ class Retablierungsstellen(Base, Vector):
     __table_args__ = ({'schema': 'militaer', 'autoload': False})
     __template__ = 'templates/htmlpopup/retablierungsstellen.mako'
     __bodId__ = 'ch.vbs.retablierungsstellen'
-    __queryable_attributes__ = ['name']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -157,7 +155,6 @@ class Armeelogistikcenter(Base, Vector):
     __table_args__ = ({'schema': 'militaer', 'autoload': False})
     __template__ = 'templates/htmlpopup/armeelogistikcenter.mako'
     __bodId__ = 'ch.vbs.armeelogistikcenter'
-    __queryable_attributes__ = ['name', 'abkuerzung']
     __label__ = 'name'
     id = Column('bgdi_id', Integer, primary_key=True)
     name = Column('name', Unicode)
@@ -174,7 +171,6 @@ class BundestankstellenBebeco:
     __table_args__ = ({'schema': 'militaer', 'autoload': False, 'extend_existing': True})
     __template__ = 'templates/htmlpopup/bundestankstellen.mako'
     __bodId__ = 'ch.vbs.bundestankstellen-bebeco'
-    __queryable_attributes__ = ['ort', 'standort', 'adresse', 'plz', 'produkt_de', 'produkt_fr', 'produkt_it']
     __label__ = 'ort'
     __returnedGeometry__ = 'the_geom_point'
     id = Column('bgdi_id', Integer, primary_key=True)
@@ -215,7 +211,6 @@ class LogistikraeumeArmeelogistikcenter(Base, Vector):
     __table_args__ = ({'schema': 'militaer', 'autoload': False})
     __template__ = 'templates/htmlpopup/logistikraeume.mako'
     __bodId__ = 'ch.vbs.logistikraeume-armeelogistikcenter'
-    __queryable_attributes__ = ['kanton', 'region']
     __label__ = 'kanton'
     id = Column('bgdi_id', Integer, primary_key=True)
     kanton = Column('kantone', Unicode)
@@ -230,7 +225,6 @@ class Waldschaden(Base, Vector):
     __table_args__ = ({'schema': 'wascha', 'autoload': False})
     __template__ = 'templates/htmlpopup/waldschadenkarte.mako'
     __bodId__ = 'ch.vbs.waldschadenkarte'
-    __queryable_attributes__ = ['lauf_nr', 'jahr_schad', 'gde_name', 'lokalname', 'x_koord', 'y_koord']
     __label__ = 'lauf_nr'
     id = Column('bgdi_id', Integer, primary_key=True)
     the_geom = Column(Geometry2D)
@@ -355,7 +349,6 @@ class KatasterBelasteterStandorteMilitaer(Base, Vector):
     __table_args__ = ({'schema': 'militaer', 'autoload': False})
     __template__ = 'templates/htmlpopup/kataster_belasteter_standorte_militaer.mako'
     __bodId__ = 'ch.vbs.kataster-belasteter-standorte-militaer'
-    __queryable_attributes__ = ['katasternummer']
     __label__ = 'katasternummer'
     id = Column('bgdi_id', Integer, primary_key=True)
     katasternummer = Column('katasternummer', Unicode)

--- a/tests/integration/test_identify_service.py
+++ b/tests/integration/test_identify_service.py
@@ -757,16 +757,16 @@ class TestIdentifyService(TestsBase):
 
     def test_identify_query_null(self):
         params = {'geometryFormat': 'geojson',
-                  'layers': 'all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp',
-                  'where': 'andere_stoffe is null'}
+                  'layers': 'all:ch.bazl.luftfahrthindernis',
+                  'where': 'abortionaccomplished is null'}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/geo+json')
         self.assertGeojsonFeature(resp.json['results'][0], 21781)
 
     def test_identify_query_not_null(self):
         params = {'geometryFormat': 'geojson',
-                  'layers': 'all:ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp',
-                  'where': 'andere_stoffe is not null'}
+                  'layers': 'all:ch.bazl.luftfahrthindernis',
+                  'where': 'totallength is not null'}
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/geo+json')
         self.assertGeojsonFeature(resp.json['results'][0], 21781)
@@ -851,10 +851,9 @@ class TestIdentifyService(TestsBase):
         self.assertGeojsonFeature(resp.json['results'][0], 21781)
 
     def test_identify_query_offset(self):
-        params = {'layers': 'all:ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill',
+        params = {'layers': 'all:ch.swisstopo.amtliches-strassenverzeichnis',
                   'returnGeometry': 'false',
-                  'timeInstant': '2015',
-                  'where': 'gemname ilike \'%a%\''}
+                  'where': 'gdename ilike \'%a%\''}
         resp_1 = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         params.update({'offset': '2'})
         self.assertNotIn('geometry', resp_1.json['results'][0])
@@ -941,14 +940,14 @@ class TestIdentifyService(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=400)
 
     def test_identify_quer_spatial_filters_scale_dep(self):
-        params = {'layers': 'all:ch.bav.haltestellen-oev',
-                  'geometry': '643952.5,164121.24999999997',
+        params = {'layers': 'all:ch.bfe.solarenergie-eignung-daecher',
+                  'geometry': '2642877.792491166,1130728.3764497258',
                   'geometryFormat': 'geojson',
                   'geometryType': 'esriGeometryPoint',
-                  'imageDisplay': '1641,867,96',
-                  'mapExtent': '533750,136249.99999999994,550250,174249.99999999997',
-                  'tolerance': '5',
-                  'where': 'name ilike \'%dietikon%\''
+                  'imageDisplay': '1102,948,96',
+                  'mapExtent': '2642758.5675955135,1130581.5290043117,2643074.110592108,1130852.9761556475',
+                  'tolerance': '10',
+                  'where': 'building_id = 2521433'
                   }
         resp = self.testapp.get('/rest/services/all/MapServer/identify', params=params, headers=accept_headers, status=200)
         self.assertEqual(resp.content_type, 'application/geo+json')

--- a/tests/integration/test_layers_service.py
+++ b/tests/integration/test_layers_service.py
@@ -206,8 +206,8 @@ class TestMapServiceView(TestsBase):
         resp = self.testapp.get('/rest/services/all/MapServer/layersConfig', status=200)
         self.assertEqual(resp.content_type, 'application/json')
         jsonData = resp.json
-        self.assertIn('ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp', jsonData)
-        layer = jsonData['ch.bafu.gewaesserschutz-klaeranlagen_reinigungstyp']
+        self.assertIn('ch.swisstopo.amtliches-strassenverzeichnis', jsonData)
+        layer = jsonData['ch.swisstopo.amtliches-strassenverzeichnis']
         self.assertIn('queryableAttributes', layer)
         self.assertGreater(len(layer['queryableAttributes']), 0)
         # Should not have
@@ -250,7 +250,7 @@ class TestMapServiceView(TestsBase):
     def test_layer_attributes_multi_models(self):
         resp = self.testapp.get('/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft', status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        self.assertEqual(len(resp.json['fields']), 3)
+        self.assertEqual(len(resp.json['fields']), 33)
 
     def test_features_attributes_multi_models(self):
         resp = self.testapp.get('/rest/services/api/MapServer/ch.bav.sachplan-infrastruktur-schiene_kraft/attributes/plname_de', status=200)


### PR DESCRIPTION
this will remove attribute search from unused layers:
as discussed and decided in https://jira.swisstopo.ch/browse/IGKS_SB-77

the queryable_attributes property has been removed from all but the following layers:

- ch.astra.unfaelle-*
- ch.bazl.luftfahrthindernis 
- ch.bfe.ladestellen-elektromobilitaet
- ch.bafu.wrz-wildruhezonen_portal
- ch.swisstopo.amtliches-gebaeudeadressverzeichnis
- ch.swisstopo.amtliches-strassenverzeichnis
- ch.bfe.solarenergie-eignung-fassaden
- ch.bfe.solarenergie-eignung-daecher

