### PR TITLE
BGDIDIC-645

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -114,7 +114,7 @@ viewer_url = get_viewer_url(request, params)
   </td>
 </tr>
 
-% elif c['attributes'].get('doi_link', '').startswith('http'):
+% elif c['attributes']['doi_link'] and c['attributes']['doi_link'].startswith('http'):
 <tr>
   <td class="cell-left">${_('tt_lubis_Quickview')}</td>
   <td><a href="${c['attributes']['doi_link']}" target="_blank">${c['attributes']['doi_link']}</a></td></tr>


### PR DESCRIPTION
fix htmlpopup, correct handling of null values in attribute doi_link
introduced with the integration of ethz images into this layer 8 months ago.
https://github.com/geoadmin/mf-chsdi3/pull/3669