### PR TITLE
BGDIDIC-1792: switched lfp1 datasource to fida system

### DIFF
--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -31,6 +31,7 @@ class FixpunkteLfp1(Base, Vector):
     __label__ = 'id'
     id = Column('pointid', Unicode, primary_key=True)
     punktname = Column('punktname', Unicode)
+    nbident = Column('nbident', Unicode)
     status = Column('status', Unicode)
     nummer = Column('nummer', Unicode)
     n95 = Column('n95', Numeric)

--- a/chsdi/models/vector/kogis.py
+++ b/chsdi/models/vector/kogis.py
@@ -25,22 +25,24 @@ register('ch.swisstopo.fixpunkte-agnes', Agnes)
 
 class FixpunkteLfp1(Base, Vector):
     __tablename__ = 'punkt_lage_lfp1'
-    __table_args__ = ({'schema': 'fpds', 'autoload': False})
-    __template__ = 'templates/htmlpopup/fixpunkte.mako'
+    __table_args__ = ({'schema': 'fida', 'autoload': False})
+    __template__ = 'templates/htmlpopup/fixpunkte_fida.mako'
     __bodId__ = 'ch.swisstopo.fixpunkte-lfp1'
     __label__ = 'id'
     id = Column('pointid', Unicode, primary_key=True)
     punktname = Column('punktname', Unicode)
-    nummer = Column('nummer', Unicode)
     status = Column('status', Unicode)
-    nbident = Column('nbident', Unicode)
-    x03 = Column('x03', Numeric)
-    y03 = Column('y03', Numeric)
+    nummer = Column('nummer', Unicode)
     n95 = Column('n95', Numeric)
     e95 = Column('e95', Numeric)
     h02 = Column('h02', Numeric)
+    proto_url = Column('proto_url', Unicode)
     zugang = Column('zugang', Unicode)
-    url = Column('url', Unicode)
+    ordnung = Column('ordnung', Unicode)
+    l_gen_lv95 = Column('l_gen_lv95', Numeric)
+    h_gen_lv95 = Column('h_gen_lv95', Numeric)
+    l_zuv_lv95 = Column('l_zuv_lv95', Unicode)
+    h_zuv_lv95 = Column('l_zuv_lv95', Unicode)
     bgdi_created = Column('bgdi_created', Unicode)
     the_geom = Column(Geometry2D)
 

--- a/chsdi/templates/htmlpopup/fixpunkte_fida.mako
+++ b/chsdi/templates/htmlpopup/fixpunkte_fida.mako
@@ -6,6 +6,7 @@
 %>
     <% c['stable_id'] = True %>
     <tr><td class="cell-left">${_(nummer)}</td>         <td>${c['featureId']}</td></tr>
+    <tr><td class="cell-left">${_('punktname')}</td>      <td>${c['attributes']['punktname'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('status_fida')}</td>      <td>${c['attributes']['status'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('fp_E95_N95')}</td>     <td>${c['attributes']['e95'] or '-'} / ${c['attributes']['n95'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('fp_H02')}</td>         <td>${c['attributes']['h02'] or '-'}</td></tr>

--- a/chsdi/templates/htmlpopup/fixpunkte_fida.mako
+++ b/chsdi/templates/htmlpopup/fixpunkte_fida.mako
@@ -9,6 +9,6 @@
     <tr><td class="cell-left">${_('punktname')}</td>      <td>${c['attributes']['punktname'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('status_fida')}</td>      <td>${c['attributes']['status'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('fp_E95_N95')}</td>     <td>${c['attributes']['e95'] or '-'} / ${c['attributes']['n95'] or '-'}</td></tr>
-    <tr><td class="cell-left">${_('fp_H02')}</td>         <td>${c['attributes']['h02'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('fp_H02_fida')}</td>         <td>${c['attributes']['h02'] or '-'}</td></tr>
     <tr><td class="cell-left">${_('protokoll')}</td>      <td><a href="${c['attributes']['proto_url'] or '-'}" target="_blank">${_('protokoll')}</a></td></tr>
 </%def>

--- a/chsdi/templates/htmlpopup/fixpunkte_fida.mako
+++ b/chsdi/templates/htmlpopup/fixpunkte_fida.mako
@@ -1,0 +1,13 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    nummer = c['layerBodId'] + '.' + 'id'
+%>
+    <% c['stable_id'] = True %>
+    <tr><td class="cell-left">${_(nummer)}</td>         <td>${c['featureId']}</td></tr>
+    <tr><td class="cell-left">${_('status_fida')}</td>      <td>${c['attributes']['status'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('fp_E95_N95')}</td>     <td>${c['attributes']['e95'] or '-'} / ${c['attributes']['n95'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('fp_H02')}</td>         <td>${c['attributes']['h02'] or '-'}</td></tr>
+    <tr><td class="cell-left">${_('protokoll')}</td>      <td><a href="${c['attributes']['proto_url'] or '-'}" target="_blank">${_('protokoll')}</a></td></tr>
+</%def>


### PR DESCRIPTION
Adapt model and htmlpopup to new attributes datasource fida.
[Testlink](https://mf-chsdi3.dev.bgdi.ch/feature_BGDIDIC-1792_fida/shorten/94d14f69ed)