### PR TITLE
Exclude geojson layer from tooltips layer (docu only)

### DIFF
--- a/chsdi/static/doc/source/api/faq/index.rst
+++ b/chsdi/static/doc/source/api/faq/index.rst
@@ -104,7 +104,8 @@ The following list contains all the free accessible layers:
 Which layers have a tooltip?
 ****************************
 
-Not all the layers have a tooltip. Below, you can find the complete list all the layers that have a tooltip:
+Not all the layers have a tooltip. The complete list of layer using the `htmlPopup <../../services/sdiservices.html#htmlpopup-resource>`_ service is 
+the following. Note: some vector layer (GeoJSON) have a client-only tooltip and are not using this service:
 
 .. raw:: html
 

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -176,7 +176,7 @@ def faqlist(request):
         if 'parentLayerId' not in lyr and not k.endswith('_3d'):
             if k not in translations:
                 translations[k] = request.translate(k)
-            if 'tooltip' in lyr and lyr['tooltip']:
+            if 'tooltip' in lyr and lyr['tooltip'] and 'type' in lyr and lyr['type'] not in ('geojson',):
                 tooltipLayers.append(k)
             if 'queryableAttributes' in lyr and lyr['queryableAttributes']:
                 queryableLayers.append(k)


### PR DESCRIPTION
`GeoJSON` have a client-side only tooltip and are hence not callable through the `identify` service. This PR corrects the doc, which is misleading (via `google-group GeoADMIN`)