### PR TITLE
BGDIDIC-983: new metageometries for pk25/50/100, remove shop attributes from several swisstopo layer

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2943,12 +2943,13 @@ class HiksSiegfriedTa25Metadata(Base, Vector):
 register('ch.swisstopo.hiks-siegfried-ta25.metadata', HiksSiegfriedTa25Metadata)
 
 
-class HiksSiegfriedTa50Metadata(Base, ShopStandardClass, Vector):
+class HiksSiegfriedTa50Metadata(Base, Vector):
     __tablename__ = 'view_gridstand_siegfried_ta50_shop'
+    __template__ = 'templates/htmlpopup/dufour_meta.mako'
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __bodId__ = 'ch.swisstopo.hiks-siegfried-ta50.metadata'
-    number = Column('s_map_number', Unicode)
-    scale = Column('scale', Integer)
+    id = Column('kbnum', Integer, primary_key=True)
+    name = Column('kbbez', Unicode)
     the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.hiks-siegfried-ta50.metadata', HiksSiegfriedTa50Metadata)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2931,12 +2931,13 @@ class HiksDufourMetadata(Base, Vector):
 register('ch.swisstopo.hiks-dufour.metadata', HiksDufourMetadata)
 
 
-class HiksSiegfriedTa25Metadata(Base, ShopStandardClass, Vector):
+class HiksSiegfriedTa25Metadata(Base, Vector):
     __tablename__ = 'view_gridstand_siegfried_ta25_shop'
+    __template__ = 'templates/htmlpopup/dufour_meta.mako'
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __bodId__ = 'ch.swisstopo.hiks-siegfried-ta25.metadata'
-    number = Column('s_map_number', Unicode)
-    scale = Column('scale', Integer)
+    id = Column('kbnum', Integer, primary_key=True)
+    name = Column('kbbez', Unicode)
     the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.hiks-siegfried-ta25.metadata', HiksSiegfriedTa25Metadata)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -1097,20 +1097,6 @@ class GridstandPk200Meta(Base, GridstandTemplate, Vector):
 register('ch.swisstopo.pixelkarte-pk200.metadata', GridstandPk200Meta)
 
 
-class GridstandSwissimage(Base, ShopStandardClass, Vector):
-    __tablename__ = 'view_gridstand_datenhaltung_swissimage_tilecache'
-    __table_args__ = ({'schema': 'datenstand', 'autoload': False})
-    __bodId__ = 'ch.swisstopo.images-swissimage.metadata'
-    __label__ = 'lk25_name'
-    id = Column('tilenumber', Unicode, primary_key=True)
-    tileid = Column('tileid', Unicode)
-    lk25_name  = Column('lk25_name', Unicode)
-    datenstand = Column('datenstand', Unicode)
-    the_geom = Column(Geometry2D)
-
-register('ch.swisstopo.images-swissimage.metadata', GridstandSwissimage)
-
-
 class GridstandSwissimageDop10(Base, Vector):
     __tablename__ = 'view_gridstand_datenhaltung_swissimage_dop10_tilecache'
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -508,14 +508,6 @@ class ShopProductGroupClass(ShopProductClass):
     name_en = Column('s_title_en', Unicode)
 
 
-class SkitourenkarteMetadata(Base, ShopProductGroupClass, Vector):
-    __table_args__ = ({'schema': 'datenstand', 'autoload': False})
-    __tablename__ = 'view_gridstand_lkski_shop'
-    __bodId__ = 'ch.swisstopo.skitourenkarte-50.metadata'
-
-register('ch.swisstopo.skitourenkarte-50.metadata', SkitourenkarteMetadata)
-
-
 class Landeskarte25PapierMetadata(Base, ShopProductGroupClass, Vector):
     __table_args__ = ({'schema': 'public', 'autoload': False})
     __tablename__ = 'lk25_papier'

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -1043,7 +1043,9 @@ register('ch.swisstopo.dreiecksvermaschung', Dreiecksvermaschung)
 class GridstandTemplate:
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __label__ = 'lk_name'
-    id = Column('kbnum', Unicode, primary_key=True)
+    __template__ = 'templates/htmlpopup/gridstand.mako'
+    id = Column('gid', BigInteger, primary_key=True)
+    tileid = Column('tileid', Unicode)
     lk_name = Column('lk_name', Unicode)
     datenstand = Column('release', Integer)
     the_geom = Column(Geometry2D)
@@ -1057,10 +1059,10 @@ class GridstandPermiterTemplate:
 
 # PK 25
 
-class GridstandPk25Meta(Base, GridstandTemplate, ShopStandardClass, Vector):
+
+class GridstandPk25Meta(Base, GridstandTemplate, Vector):
     __bodId__ = 'ch.swisstopo.pixelkarte-pk25.metadata'
     __tablename__ = 'view_gridstand_datenhaltung_pk25_tilecache'
-    tileid = Column('tileid', Unicode)
 
 
 register('ch.swisstopo.pixelkarte-pk25.metadata', GridstandPk25Meta)
@@ -1068,10 +1070,9 @@ register('ch.swisstopo.pixelkarte-pk25.metadata', GridstandPk25Meta)
 # PK 50
 
 
-class GridstandPk50Meta(Base, GridstandTemplate, ShopStandardClass, Vector):
+class GridstandPk50Meta(Base, GridstandTemplate, Vector):
     __bodId__ = 'ch.swisstopo.pixelkarte-pk50.metadata'
     __tablename__ = 'view_gridstand_datenhaltung_pk50_tilecache'
-    tileid = Column('tileid', Unicode)
 
 
 register('ch.swisstopo.pixelkarte-pk50.metadata', GridstandPk50Meta)
@@ -1079,33 +1080,21 @@ register('ch.swisstopo.pixelkarte-pk50.metadata', GridstandPk50Meta)
 # PK 100
 
 
-class GridstandPk100Meta(Base, GridstandTemplate, ShopStandardClass, Vector):
+class GridstandPk100Meta(Base, GridstandTemplate, Vector):
     __bodId__ = 'ch.swisstopo.pixelkarte-pk100.metadata'
     __tablename__ = 'view_gridstand_datenhaltung_pk100_tilecache'
-    tileid = Column('tileid', Unicode)
 
 register('ch.swisstopo.pixelkarte-pk100.metadata', GridstandPk100Meta)
 
 # PK 200
 
 
-class GridstandPk200Meta(Base, GridstandTemplate, ShopStandardClass, Vector):
+class GridstandPk200Meta(Base, GridstandTemplate, Vector):
     __bodId__ = 'ch.swisstopo.pixelkarte-pk200.metadata'
     __tablename__ = 'view_gridstand_datenhaltung_pk200_tilecache'
-    tileid = Column('tileid', Unicode)
+    id = Column('kbnum', Unicode, primary_key=True)
 
 register('ch.swisstopo.pixelkarte-pk200.metadata', GridstandPk200Meta)
-
-# PK 500
-
-
-class GridstandPk500(Base, ShopProductClass, Vector):
-    __tablename__ = 'view_gridstand_datenhaltung_pk500_tilecache_shop'
-    __table_args__ = ({'schema': 'datenstand', 'autoload': False})
-    __bodId__ = 'ch.swisstopo.pixelkarte-farbe-pk500.noscale'
-
-
-register('ch.swisstopo.pixelkarte-farbe-pk500.noscale', GridstandPk500)
 
 
 class GridstandSwissimage(Base, ShopStandardClass, Vector):

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2919,12 +2919,13 @@ class Lotabweichungen(Base, Vector):
 register('ch.swisstopo.lotabweichungen', Lotabweichungen)
 
 
-class HiksDufourMetadata(Base, ShopStandardClass, Vector):
+class HiksDufourMetadata(Base, Vector):
     __tablename__ = 'view_gridstand_dufour_shop'
+    __template__ = 'templates/htmlpopup/dufour_meta.mako'
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __bodId__ = 'ch.swisstopo.hiks-dufour.metadata'
-    number = Column('s_map_number', Unicode)
-    scale = Column('scale', Integer)
+    id = Column('kbnum', Integer, primary_key=True)
+    name = Column('kbbez', Unicode)
     the_geom = Column(Geometry2D)
 
 register('ch.swisstopo.hiks-dufour.metadata', HiksDufourMetadata)

--- a/chsdi/templates/htmlpopup/dufour_meta.mako
+++ b/chsdi/templates/htmlpopup/dufour_meta.mako
@@ -1,0 +1,6 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+    <tr><td class="cell-left">${_('ch.swisstopo.lk25-papierkarte.metadata.number')}</td>       <td>${c['attributes']['label']}</td></tr>
+    <tr><td class="cell-left">${_('ch.swisstopo.lk25-papierkarte.metadata.name_de')}</td>      <td>${c['attributes']['name']}</td></tr>
+</%def>

--- a/chsdi/templates/htmlpopup/gridstand.mako
+++ b/chsdi/templates/htmlpopup/gridstand.mako
@@ -1,0 +1,7 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+    <tr><td class="cell-left">${_('ch.swisstopo.images-swissimage.metadata.name_de')}</td>      <td>${c['attributes']['lk_name']}</td></tr>
+    <tr><td class="cell-left">${_('ch.swisstopo.swissimage-product.metadata.kbnum')}</td>       <td>${c['attributes']['tileid']}</td></tr>
+    <tr><td class="cell-left">${_('ch.swisstopo.swissimage-product.metadata.flightyear')}</td>  <td>${c['attributes']['datenstand']}</td></tr>
+</%def>

--- a/tests/integration/test_features_service.py
+++ b/tests/integration/test_features_service.py
@@ -774,7 +774,7 @@ class TestReleasesService(TestsBase):
 
     def test_layer_without_releases(self):
         params = {'imageDisplay': '500,600,96', 'mapExtent': '611399.9999999999,158650,690299.9999999999,198150'}
-        self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.images-swissimage.metadata/releases', params=params, status=400)
+        self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.pixelkarte-farbe/releases', params=params, status=400)
 
     def test_unknown_layers(self):
         params = {'imageDisplay': '500,600,96', 'mapExtent': '611399.9999999999,158650,690299.9999999999,198150'}


### PR DESCRIPTION
change geometry source for the following meta layers:
* ch.swisstopo.pixelkarte-farbe-pk25.noscale
* ch.swisstopo.pixelkarte-farbe-pk50.noscale
* ch.swisstopo.pixelkarte-farbe-pk100.noscale

remove shop logic / features from
* ch.swisstopo.pixelkarte-farbe-pk200.noscale
* ch.swisstopo.pixelkarte-farbe-pk500.noscale

finalize decomissioning:
* ch.swisstopo.images-swissimage.metadata
* ch.swisstopo.skitourenkarte-50.metadata

[testlink](https://mf-chsdi3.dev.bgdi.ch/data-BGDIDIC-983-smr-metageometries/shorten/97069ebb76)

other prs to be merged and deployed together with these changes:
wms-mapfile_include: https://github.com/geoadmin/wms-mapfile_include/pull/754
bgdi-scripts / automata: https://github.com/geoadmin/bgdi-scripts/pull/1114


Post deploy tasks:
- [ ] `drop view datenstand.view_gridstand_lkski_shop`
- [ ]  `drop view stopo_master.datenstand.view_gridstand_datenhaltung_swissimage_tilecache`

- [ ]  view_gridstand_dufour_shop
```SQL
DROP VIEW datenstand.view_gridstand_dufour_shop;

CREATE OR REPLACE VIEW datenstand.view_gridstand_dufour_shop
 AS
         SELECT base.bgdi_id,
            ( SELECT string_agg(child.kbnum, ' + '::text) AS string_agg
                   FROM grid_tk100 child
                  WHERE child.bgdi_id = base.bgdi_id OR child.parent_id_shop = base.bgdi_id) AS kbnum,
            base.kbbez,
            st_multi(( SELECT st_union(child.the_geom) AS st_union
                   FROM grid_tk100 child
                  WHERE child.bgdi_id = base.bgdi_id OR child.parent_id_shop = base.bgdi_id)) AS the_geom
           FROM grid_tk100 base
          WHERE base.parent_id_shop IS NULL;

ALTER TABLE datenstand.view_gridstand_dufour_shop
    OWNER TO postgres;

GRANT ALL ON TABLE datenstand.view_gridstand_dufour_shop TO postgres;
GRANT SELECT ON TABLE datenstand.view_gridstand_dufour_shop TO "www-data";
```

- [ ] view_gridstand_siegfried_ta25_shop
```SQL
DROP VIEW datenstand.view_gridstand_siegfried_ta25_shop;

CREATE OR REPLACE VIEW datenstand.view_gridstand_siegfried_ta25_shop
 AS
 SELECT bgdi_id,
	kbnum,
    kbbez, 
    the_geom
   FROM grid_ta25;

ALTER TABLE datenstand.view_gridstand_siegfried_ta25_shop
    OWNER TO postgres;

GRANT ALL ON TABLE datenstand.view_gridstand_siegfried_ta25_shop TO postgres;
GRANT SELECT ON TABLE datenstand.view_gridstand_siegfried_ta25_shop TO "www-data";
GRANT ALL ON TABLE datenstand.view_gridstand_siegfried_ta25_shop TO pgkogis;
```

- [ ] view_gridstand_siegfried_ta50_shop
```SQL
DROP VIEW datenstand.view_gridstand_siegfried_ta50_shop;

CREATE OR REPLACE VIEW datenstand.view_gridstand_siegfried_ta50_shop
 AS
 SELECT 
    bgdi_id,
    kbnum,
    kbbez,
    the_geom
   FROM grid_ta50 WHERE parent_id IS NULL OR parent_id = 46;

ALTER TABLE datenstand.view_gridstand_siegfried_ta50_shop
    OWNER TO postgres;

GRANT ALL ON TABLE datenstand.view_gridstand_siegfried_ta50_shop TO postgres;
GRANT SELECT ON TABLE datenstand.view_gridstand_siegfried_ta50_shop TO "www-data";
GRANT ALL ON TABLE datenstand.view_gridstand_siegfried_ta50_shop TO pgkogis;
```