### PR TITLE
BGDIDIC-1393: lubis bilder st gallen

### DIFF
--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -102,7 +102,7 @@ viewer_url = get_viewer_url(request, params)
 % if 'contact_image_url' in c['attributes'] and c['attributes']['contact_image_url']:
 <tr>
   <td class="cell-left">${_('tt_lubis_url_canton')}</td>
-  <td><a href="${c['attributes']['contact_image_url']}" target="_blank">${c['attributes']['contact_image_url']}</a></td>
+  <td><a href="${c['attributes']['contact_image_url']}" target="_blank">${_('tt_lubis_url_canton')}</td>
 </tr>
 % endif
 


### PR DESCRIPTION
add new timestamps 2009 / 2018 kanton st gallen
[Testlink](https://mf-geoadmin3.dev.bgdi.ch/index.html?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-grau&layers_timestamp=20181231&wmts_url=//service-proxywms.dev.bgdi.ch&layers=ch.swisstopo.lubis-luftbilder-dritte-kantone&E=2744489.16&N=1250033.85&zoom=4&time=2018&api_url=//mf-chsdi3.dev.bgdi.ch/data-BGDIDIC-1393-lubis-sg)