### PR TITLE
BGDIINF_SB-2328: Put all logs to stdout

### DIFF
--- a/25-mf-chsdi3.conf.in
+++ b/25-mf-chsdi3.conf.in
@@ -32,7 +32,7 @@
   ## Logging
   ServerSignature Off
   LogLevel ${APACHE_LOG_LEVEL}
-  ErrorLog /dev/stderr
+  ErrorLog /dev/stdout
   CustomLog /dev/stdout  combined
 
   ## Script alias directives

--- a/apache/default.conf.in
+++ b/apache/default.conf.in
@@ -7,7 +7,7 @@
     DocumentRoot /var/www/html
 
     LogLevel ${APACHE_LOG_LEVEL}
-    ErrorLog /proc/self/fd/2
+    ErrorLog /dev/stdout
     # CustomLog /dev/null combined
     CustomLog /dev/stdout  combined
 
@@ -18,7 +18,7 @@
     RewriteCond %{REQUEST_URI} !^/checker
     RewriteRule ^/(.*)  http://127.0.0.1:${WSGI_PORT}/$1  [P]
     ProxyPassReverse / http://127.0.0.1:${WSGI_PORT}/
-        
+
 
 </VirtualHost>
 

--- a/development.ini.in
+++ b/development.ini.in
@@ -12,7 +12,7 @@ pyramid.debug_authorization = true
 pyramid.debug_notfound = true
 pyramid.debug_routematch = true
 pyramid.prevent_http_cache = true
-pyramid.includes = 
+pyramid.includes =
     pyramid_debugtoolbar
 mako.imports =
     import logging
@@ -37,9 +37,18 @@ port = ${SERVER_PORT}
 [loggers]
 keys = root, chsdi, sqlalchemy
 
+[logger_root]
+level = DEBUG
+handlers = console
+
+[logger_chsdi]
+level = DEBUG
+handlers = console
+qualname = chsdi
+
 [logger_sqlalchemy]
 level = INFO
-handlers =
+handlers = console
 qualname = sqlalchemy.engine
 # "level = INFO" logs SQL queries.
 # "level = DEBUG" logs SQL queries and results.
@@ -48,22 +57,10 @@ qualname = sqlalchemy.engine
 [handlers]
 keys = console, file, sqlfile
 
-[formatters]
-keys = generic
-
-[logger_root]
-level = DEBUG
-handlers = console
-
-[logger_chsdi]
-level = DEBUG
-handlers = file
-qualname = chsdi
-
 [handler_console]
 class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
+args = (sys.stdout,)
+level = DEBUG
 formatter = generic
 
 [handler_file]
@@ -77,6 +74,9 @@ class = FileHandler
 level = INFO
 formater = generic
 args = ('${CURRENT_DIRECTORY}/appsql.log', 'w')
+
+[formatters]
+keys = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/production.ini.in
+++ b/production.ini.in
@@ -77,9 +77,18 @@ port = 6543
 [loggers]
 keys = root, chsdi, sqlalchemy
 
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_chsdi]
+level = INFO
+handlers = console
+qualname = chsdi
+
 [logger_sqlalchemy]
 level = WARN
-handlers =
+handlers = console
 qualname = sqlalchemy.engine
 # "level = INFO" logs SQL queries.
 # "level = DEBUG" logs SQL queries and results.
@@ -88,23 +97,14 @@ qualname = sqlalchemy.engine
 [handlers]
 keys = console
 
-[formatters]
-keys = generic
-
-[logger_root]
-level = WARN
-handlers = console
-
-[logger_chsdi]
-level = WARN
-handlers =
-qualname = chsdi
-
 [handler_console]
 class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
+args = (sys.stdout,)
+level = INFO
 formatter = generic
+
+[formatters]
+keys = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s


### PR DESCRIPTION
On k8s all logs should be sent to stdout in order to read them from the
k8s log command or even better from the ELK stack.