### PR TITLE
New Pylons app setting files 

### DIFF
--- a/Makefile.frankfurt
+++ b/Makefile.frankfurt
@@ -162,6 +162,11 @@ autolint:
 	@echo "${GREEN}Auto correction of python files...${RESET}";
 	${AUTOPEP8} --in-place --aggressive --aggressive --verbose --ignore=${PEP8_IGNORE} $(PYTHON_FILES)
 
+# FIXME add the rss and css compilation	
+.PHONY: doc
+doc: 
+	@echo "${GREEN}Building the documentation...${RESET}";
+	cd chsdi/static/doc && ../../../${SPHINX} -W -b html source build || exit 1 ;
 
 
 # TODO: still needed?

--- a/Makefile.frankfurt
+++ b/Makefile.frankfurt
@@ -84,6 +84,7 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo "- lint/autolint      Python code quality assurance"
+	@echo "- image              Build the project localy (with tag := $(DOCKER_IMG_LOCAL_TAG))"
 	@echo "- clean              Remove generated files"
 	@echo "- cleanall           Remove all the build artefacts"
 	@echo
@@ -107,9 +108,44 @@ setup: .venv
 		test -d "$(INSTALL_DIRECTORY)" || $(SYSTEM_PYTHON_CMD) -m venv $(INSTALL_DIRECTORY); \
 		${PIP} install $(PIP_QUIET) --upgrade pip==21.2.4 setuptools --index-url ${PYPI_URL} ;
 		${PIP} install $(PIP_QUIET) -r requirements-py3.txt --index-url ${PYPI_URL}  -e .
+		
+.PHONY: environ
+environ:
+	$(call build_templates)
+# FIXME: nosetests is still using development.ini
+define build_templates
+	export DOCKER_IMG_LOCAL_TAG=${DOCKER_IMG_LOCAL_TAG} && \
+	export CURRENT_DIR=${CURRENT_DIR} && \
+	envsubst < base.ini.in > base.ini && \
+	envsubst < dev.ini.in > dev.ini && \
+	envsubst < base.ini.in > production.ini && \
+	envsubst < dev.ini.in > development.ini && \
+	envsubst < local.ini.in > local.ini && \
+	envsubst < apache/wsgi-py3.conf.in > apache/wsgi.conf && \
+	envsubst <  apache/application.wsgi.in > apache/application.wsgi && \
+	envsubst < docker-compose.yml.in > docker-compose.yml && \
+	envsubst < 25-mf-chsdi3.conf.in > 25-mf-chsdi3.conf
+endef
+
+
+.PHONY: serve
+serve:  guard-DEPLOY_TARGET guard-OPENTRANS_API_KEY guard-PGUSER guard-PGPASSWORD guard-GIT_HASH_SHORT guard-APACHE_PORT
+	PYTHONPATH=${PYTHONPATH} ${PSERVE} local.ini --reload
+
+.PHONY: shell
+shell:
+	PYTHONPATH=${PYTHONPATH} ${PSHELL} local.ini
+
+.PHONY: test
+test:
+	PYTHONPATH=${PYTHONPATH} ${NOSE} --verbosity=2  --cover-erase  tests/ -e .*e2e.*
+
+.PHONY: testci
+testci:
+	mkdir -p junit-reports/{integration,functional}
+	PYTHONPATH=${PYTHONPATH} ${NOSE} --with-xunit --xunit-file=junit-reports/functional/nosetest.xml   tests/functional -e .*e2e.*
+	PYTHONPATH=${PYTHONPATH} ${NOSE} --with-xunit --xunit-file=junit-reports/integration/nosetest.xml  tests/integration -e .*e2e.*
 	
-
-
 .PHONY: teste2e
 teste2e:
 	PYTHONPATH=${PYTHONPATH} ${NOSE} tests/e2e/

--- a/base.ini.in
+++ b/base.ini.in
@@ -1,0 +1,112 @@
+###
+# pylons app configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+#
+# This is the base config for the pylons app on docker/k8s/frankfurt infrastructure
+#
+
+[app:main]
+use = egg:chsdi
+app_version = ${APP_VERSION}
+entry_path = ${APACHE_ENTRY_PATH}
+available_languages = de fr it en rm
+
+pyramid.reload_templates = false
+pyramid.debug_authorization = false
+pyramid.debug_notfound = false
+pyramid.debug_routematch = false
+pyramid.prevent_http_cache = false
+pyramid.default_locale_name = de
+pyramid.includes = pyramid_tm
+
+# SQLAlchemy database URL
+sqlalchemy.are.url = postgresql://${DBHOST}:${DBPORT}/are_${DBSTAGING}
+sqlalchemy.bafu.url = postgresql://${DBHOST}:${DBPORT}/bafu_${DBSTAGING}
+sqlalchemy.bak.url = postgresql://${DBHOST}:${DBPORT}/bak_${DBSTAGING}
+sqlalchemy.bod.url = postgresql://${DBHOST}:${DBPORT}/bod_${DBSTAGING}
+sqlalchemy.dritte.url = postgresql://${DBHOST}:${DBPORT}/dritte_${DBSTAGING}
+sqlalchemy.edi.url = postgresql://${DBHOST}:${DBPORT}/edi_${DBSTAGING}
+sqlalchemy.evd.url = postgresql://${DBHOST}:${DBPORT}/evd_${DBSTAGING}
+sqlalchemy.kogis.url = postgresql://${DBHOST}:${DBPORT}/kogis_${DBSTAGING}
+sqlalchemy.stopo.url = postgresql://${DBHOST}:${DBPORT}/stopo_${DBSTAGING}
+sqlalchemy.uvek.url = postgresql://${DBHOST}:${DBPORT}/uvek_${DBSTAGING}
+sqlalchemy.uvek_solarkataster.url = postgresql://${DBHOST}:${DBPORT}/uvek_solarkataster_${DBSTAGING}
+sqlalchemy.vbs.url = postgresql://${DBHOST}:${DBPORT}/vbs_${DBSTAGING}
+sqlalchemy.zeitreihen.url = postgresql://${DBHOST}:${DBPORT}/zeitreihen_${DBSTAGING}
+sqlalchemy.lubis.url = postgresql://${DBHOST}:${DBPORT}/lubis_${DBSTAGING}
+sqlalchemy.diemo.url = postgresql://${DBHOST}:${DBPORT}/diemo_${DBSTAGING}
+
+# Mako specific
+mako.directories = chsdi:templates
+
+geodata_staging = ${GEODATA_STAGING}
+sphinxhost = ${SPHINXHOST}
+wmshost = ${WMSHOST}
+wmts_public_host = ${WMTS_PUBLIC_HOST}
+geoadminhost = ${GEOADMINHOST}
+linkeddatahost = ${LINKEDDATAHOST}
+api_url = ${API_URL}
+install_directory = ${CURRENT_DIRECTORY}
+host = ${HOST}
+apache_base_path = ${APACHE_BASE_PATH}
+apache_entry_path = ${APACHE_ENTRY_PATH}
+kml_temp_dir=${KML_TEMP_DIR}
+http_proxy = ${HTTP_PROXY}
+public_bucket_host = ${PUBLIC_BUCKET_HOST}
+vector_bucket = ${VECTOR_BUCKET}
+datageoadminhost = ${DATAGEOADMINHOST}
+opentrans_api_key = ${OPENTRANS_API_KEY}
+empty_geotables = ch.bav.sachplan-infrastruktur-schifffahrt_anhoerung,ch.bfe.sachplan-uebertragungsleitungen_anhoerung,ch.blw.emapis-bewaesserung,ch.blw.emapis-elektrizitaetsversorgung,ch.blw.emapis-milchleitung,ch.blw.emapis-seilbahnen,ch.vbs.sachplan-infrastruktur-militaer_anhoerung,ch.sem.sachplan-asyl_anhoerung,ch.astra.sachplan-infrastruktur-strasse_anhoerung,ch.bav.sachplan-infrastruktur-schiene_anhorung
+max_featureids_request = 20
+
+# Use the BOD directly, no .po./mo files
+dynamic_translation = ${DYNAMIC_TRANSLATION}
+
+###
+# wsgi server configuration
+###
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 6543
+
+###
+# logging configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, chsdi, sqlalchemy
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_chsdi]
+level = INFO
+handlers = console
+qualname = chsdi
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handlers]
+keys = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = INFO
+formatter = generic
+
+[formatters]
+keys = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/dev.ini.in
+++ b/dev.ini.in
@@ -1,0 +1,71 @@
+###
+# pylons app configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+#
+# Use this file exclusively on docker/frankfurt/python3 and k8s dev environment
+
+[app:main]
+use = config:base.ini
+app_version = ${APP_VERSION}
+
+pyramid.reload_templates = true
+pyramid.debug_authorization = true
+pyramid.debug_notfound = true
+pyramid.debug_routematch = true
+pyramid.prevent_http_cache = true
+pyramid.includes =
+    pyramid_debugtoolbar
+mako.imports =
+    import logging
+
+# By default, the toolbar only appears for clients from IP addresses
+# '127.0.0.1' and '::1'.
+debugtoolbar.hosts = 0.0.0.0/0
+
+###
+# wsgi server configuration
+###
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = ${SERVER_PORT}
+
+###
+# logging configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, chsdi, sqlalchemy
+
+[logger_root]
+level = DEBUG
+handlers = console
+
+[logger_chsdi]
+level = DEBUG
+handlers = console
+qualname = chsdi
+
+[logger_sqlalchemy]
+level = INFO
+handlers = console
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handlers]
+keys = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = DEBUG
+formatter = generic
+
+[formatters]
+keys = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/development.ini.in
+++ b/development.ini.in
@@ -1,7 +1,9 @@
 ###
-# app configuration
+# pylons app configuration
 # http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
-###
+#
+# development (both local and dev) setting for the pylons app.
+# Use this file only in the legacy infrastructure (python2/vhost/ireland)
 
 [app:main]
 use = config:production.ini

--- a/local.ini.in
+++ b/local.ini.in
@@ -1,0 +1,83 @@
+###
+# pylons app configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+#
+# Use this file exclusively on docker/frankfurt/python3 and local development
+
+[app:main]
+use = config:base.ini
+app_version = ${APP_VERSION}
+
+pyramid.reload_templates = true
+pyramid.debug_authorization = true
+pyramid.debug_notfound = true
+pyramid.debug_routematch = true
+pyramid.prevent_http_cache = true
+pyramid.includes =
+    pyramid_debugtoolbar
+mako.imports =
+    import logging
+
+# By default, the toolbar only appears for clients from IP addresses
+# '127.0.0.1' and '::1'.
+debugtoolbar.hosts = 0.0.0.0/0
+
+###
+# wsgi server configuration
+###
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = ${SERVER_PORT}
+
+###
+# logging configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, chsdi, sqlalchemy
+
+[logger_root]
+level = DEBUG
+handlers = console
+
+[logger_chsdi]
+level = DEBUG
+handlers = console
+qualname = chsdi
+
+[logger_sqlalchemy]
+level = INFO
+handlers = console
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handlers]
+keys = console, file, sqlfile
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = DEBUG
+formatter = generic
+
+[handler_file]
+class = FileHandler
+level = INFO
+formatter = generic
+args = ('${CURRENT_DIR}/app.log', 'w')
+
+[handler_sqlfile]
+class = FileHandler
+level = INFO
+formater = generic
+args = ('${CURRENT_DIR}/appsql.log', 'w')
+
+[formatters]
+keys = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/production.ini.in
+++ b/production.ini.in
@@ -1,7 +1,10 @@
 ###
-# app configuration
+# pylons app configuration
 # http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
-###
+#
+# production (generally int and prod) settings for the pylons app.
+# Use this file only in the legacy infrastructure (python2/vhost/ireland)
+
 
 [app:main]
 use = egg:chsdi


### PR DESCRIPTION
Leave the legacy Pylons app settings `development.ini` and `production.ini` as is.

The new settings files (WIP) `base.ini` and `local.ini` (for, hem, local development) only need `envsubst` and are using the envars directly, without the `mako` black magic.

Normally
`export $(cat local.env) && make -f Makefile.frankfurt setup environ serve`  should serve the application (at least the static files and pgsql part) on the `HTTP_SERVER` defined port.
