### PR TITLE
BGDIINF_SB-2328: fixing the old sqlalchemy warning

### DIFF
--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -50,7 +50,7 @@ simplejson==3.16.0
 six==1.12.0
 Sphinx==1.8.5
 sphinx-rtd-theme===0.4.3
-SQLAlchemy==1.3.8
+SQLAlchemy==1.3.24
 toml==0.10.0
 transaction==2.4.0
 translationstring==1.3


### PR DESCRIPTION
See https://github.com/sqlalchemy/sqlalchemy/issues/5039, fixed on Jan 18th, 2020

```
/home/ltmom/code/github.com/mf-chsdi3/.venv/lib/python3.7/site-packages/sqlalchemy/dialects/postgresql/base.py:3450: SAWarning: Could not parse CHECK constraint text: 'CHECK (st_isvalid(the_geom))'
  util.warn("Could not parse CHECK constraint text: %r" % src)
```

