### PR TITLE
BGDIINF_SB-2328: small fixed in Makefile.frankfurt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ apache/wsgi.conf
 apache/application.wsgi
 apache/tomcat-print.conf
 chsdi.egg-info
+chsdi/locale
 chsdi/static/doc/build/
 chsdi/static/css/extended.min.css
 chsdi/static/css/blueimp-gallery.min.css

--- a/Makefile.frankfurt
+++ b/Makefile.frankfurt
@@ -184,7 +184,7 @@ translate: .venv
 	 ${PYTHON} setup.py extract_messages
 	 for lng in ${AVAILABLE_LANGUAGES}; do \
 		${PYTHON} setup.py init_catalog -l $$lng; \
-	done; 
+	done;
 	${PYTHON} setup.py compile_catalog
 
 
@@ -192,14 +192,14 @@ local.ini: local.ini.in base.ini guard-ENV_FILE guard-OPENTRANS_API_KEY guard-PG
 	$(call setup_env,$(ENV_FILE))
 	export CURRENT_DIRECTORY=${CURRENT_DIRECTORY} && \
 	${ENVSUBST} <  $< > $@
-	
 
-base.ini: base.ini.in 
+
+base.ini: base.ini.in
 	${ENVSUBST} <  $< > $@
 	cp $@ production.ini
 
 .PHONY: serve
-serve:  local.ini 
+serve:  local.ini
 	PYTHONPATH=${PYTHONPATH} ${PSERVE} local.ini --reload
 
 .PHONY: shell
@@ -212,7 +212,7 @@ dockerlogin:
 
 
 .PHONY: dockerbuild
-dockerbuild: guard-OPENTRANS_API_KEY guard-PGUSER guard-PGPASSWORD guard-VERSION guard-APACHE_PORT
+dockerbuild: guard-OPENTRANS_API_KEY guard-PGUSER guard-PGPASSWORD guard-APACHE_PORT
 	docker build \
 		--build-arg GIT_HASH="$(GIT_COMMIT_HASH)" \
 		--build-arg GIT_BRANCH="$(GIT_BRANCH)" \
@@ -222,14 +222,14 @@ dockerbuild: guard-OPENTRANS_API_KEY guard-PGUSER guard-PGPASSWORD guard-VERSION
 
 
 .PHONY: dockerrun
-dockerrun: guard-ENV_FILE guard-OPENTRANS_API_KEY guard-PGUSER guard-PGPASSWORD guard-VERSION guard-APACHE_PORT
+dockerrun: guard-ENV_FILE guard-OPENTRANS_API_KEY guard-PGUSER guard-PGPASSWORD guard-APACHE_PORT
 	docker run \
 		-it \
         	-p ${APACHE_PORT}:${APACHE_PORT} \
                 --env-file=${ENV_FILE} \
                 --env PGUSER=${PGUSER} --env PGPASSWORD=${PGPASSWORD} \
 		--env OPENTRANS_API_KEY=${OPENTRANS_API_KEY} \
-		--env APP_VERSION=${VERSION} \
+		--env APP_VERSION="$(GIT_TAG)" \
 		$(DOCKER_IMG_LOCAL_TAG)
 
 .PHONY: test

--- a/PYTHON3.md
+++ b/PYTHON3.md
@@ -19,12 +19,12 @@ The required environement variables are set in `.env.default`
  
 Build the Pylons settings files and run the local `waitress`server
 
-    make -f Makefile.frankfurt environ server
+    make -f Makefile.frankfurt environ serve
     
 You may want to customize the variables. Copy the file `.env.default` as `.ven.mine`,
 change the variables you want and use them with
 
-    ENV_FILE=.env.mine make -f Makefile.frankfurt environ server
+    ENV_FILE=.env.mine make -f Makefile.frankfurt environ serve
     
 
 N.B. Some variables must be set manually, namely `PGUSER`, `PGPWASSPORD`, `OPENTRANS_API_KEY`


### PR DESCRIPTION
The guard-Version was removed from the targets dockerbuild and dockerrun, as the git tag is used for the VERSION variable.
No need to guard- the git tag, as it is either set to the correct value or to unknown, but will not be undefined.