### PR TITLE
BGDIINF_SB-2328: leaving it to the user to source the ENV_FILE before running make targets

### DIFF
--- a/Makefile.frankfurt
+++ b/Makefile.frankfurt
@@ -18,10 +18,6 @@ INSTALL_DIRECTORY := .venv
 # default configuration
 ENV_FILE ?= .env.default
 
-# read all env vars from ENV_FILE and export them all
-include $(ENV_FILE)
-export
-
 # Note the `fi`is a hack for `rm`(which didn't exist for a long time!)
 # https://github.com/geoadmin/mf-chsdi3/blob/966b5471dfad9f9c77ca44a089b81419c4a6311b/chsdi/lib/helpers.py#L140-L142
 AVAILABLE_LANGUAGES := de fr it fi en

--- a/PYTHON3.md
+++ b/PYTHON3.md
@@ -10,11 +10,18 @@ Install
 Use only `Makefile.frankfurt`
 
 
+The required environment variables are set in `.env.default`. They can be
+adapted or you can use a copy of `.env.default`, e.g. `env.mine` and use that
+instead.
+
+```bash
+source .env.local (or .env.mine)
+export ENV_FILE=.env.local (or .env.mine)
+```
+
 Install the python virtual environment (still `virtualenv`at this point)
 
     make -f Makefile.frankfurt setup
-
-The required environement variables are set in `.env.default`
 
  
 Build the Pylons settings files and run the local `waitress`server


### PR DESCRIPTION
To reduce complexity, the sourcing of the ENV_FILE is left to the user, before running Makefile.frankfurt targets.