### PR TITLE
BGDIINF_SB-2449: fix nosetests and mako issues (python3/pyhton2)

### DIFF
--- a/chsdi/templates/htmlpopup/aktuelle_erdbeben.mako
+++ b/chsdi/templates/htmlpopup/aktuelle_erdbeben.mako
@@ -4,15 +4,16 @@
 <%
     import requests
     request = context.get('request')
-    defaultCoord = ['600000', '200000']
-    defaultBbox = ['600000', '200000', '650000', '250000']
+    defaultCoord = [600000.0, 200000.0]
+    defaultBbox = [600000.0, 200000.0, 650000.0, 250000.0]
+    defaultImageDisplay = [0, 0, 0]
     topic = request.matchdict.get('map')
     baseUrl = request.registry.settings['api_url']
 
     # generate getfeatureinfo request
-    coord_x, coord_y = [float(x) for x in request.params['coord'].split(",")] if request.params['coord'] else defaultCoord
-    bbox_xmin, bbox_ymin, bbox_xmax, bbox_ymax = [float(x) for x in request.params['mapExtent'].split(",")] if request.params['mapExtent'] else defaultBbox
-    imageDisplay = [int(x) for x in request.params['imageDisplay'].split(",")]
+    coord_x, coord_y = [float(x) for x in request.params['coord'].split(",")] if request.params.get('coord', False) else defaultCoord
+    bbox_xmin, bbox_ymin, bbox_xmax, bbox_ymax = [float(x) for x in request.params['mapExtent'].split(",")] if request.params.get('mapExtent', False) else defaultBbox
+    imageDisplay = [int(x) for x in request.params['imageDisplay'].split(",")] if request.params.get('imageDisplay', False) else defaultImageDisplay
     getfeatureinfo_x = int(((coord_x - bbox_xmin)/(bbox_xmax-bbox_xmin))*imageDisplay[0])
     getfeatureinfo_y = int(((bbox_ymax - coord_y)/(bbox_ymax-bbox_ymin))*imageDisplay[1])
 
@@ -28,7 +29,7 @@
         r = requests.get(url)
         response = r.content.decode('utf-8')
         # Consider any status other than 2xx as error or mapserver 200 responses with MapServer Message in body
-        if not r.status_code // 100 == 2 or "MapServer Message" in r.content:
+        if not r.status_code == 200 or "MapServer Message" in response:
             response = "invalid service repsonse:<br/>response: {}<br/>http status: {}<br/>Url: {}".format(response, r.status_code, url)
     except requests.exceptions.RequestException as e:
         # A serious problem happened, like an SSLError or InvalidURL

--- a/chsdi/templates/htmlpopup/aktuelle_erdbeben.mako
+++ b/chsdi/templates/htmlpopup/aktuelle_erdbeben.mako
@@ -28,7 +28,7 @@
     try:
         r = requests.get(url)
         response = r.content.decode('utf-8')
-        # Consider any status other than 2xx as error or mapserver 200 responses with MapServer Message in body
+        # Consider any status other than 200 as error or mapserver 200 responses with MapServer Message in body
         if not r.status_code == 200 or "MapServer Message" in response:
             response = "invalid service repsonse:<br/>response: {}<br/>http status: {}<br/>Url: {}".format(response, r.status_code, url)
     except requests.exceptions.RequestException as e:

--- a/chsdi/templates/htmlpopup/biogeoreg.mako
+++ b/chsdi/templates/htmlpopup/biogeoreg.mako
@@ -2,7 +2,7 @@
 
 <%def name="table_body(c, lang)">
   <%
-    lang = lang if lang in ('fr','it','en') else 'de'
+    lang = lang if lang in ('fr','it') else 'de'
     regionname_text = 'regionname_%s' % lang
     unterregionname_text = 'unterregionname_%s' % lang
   %>

--- a/chsdi/templates/htmlpopup/kernkraftwerke.mako
+++ b/chsdi/templates/htmlpopup/kernkraftwerke.mako
@@ -32,6 +32,12 @@
         decontamination_phase = c['attributes']['decontamination_phase'].split('##');
         dismantling_phase = c['attributes']['dismantling_phase'].split('##');
 
+        # Python3's range is Python2's xrange
+        try:
+          xrange
+        except NameError:
+          xrange = range
+
     %>
     <script>
         $(document).ready(function(){
@@ -60,15 +66,15 @@
     % for reactor_i in xrange(0, c['attributes']['reactors']):
         <tr></tr>
         <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.reactor_name')}</th>      <td><strong>${reactor_name[reactor_i]}</strong></td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.life_phase_de')}</th>      <td>${life_phase[lang_i][reactor_i]}</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.reactor_type_de')}</th>      <td>${reactor_type[lang_i][reactor_i]}</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.cooling_type_de')}</th>      <td>${cooling_type[lang_i][reactor_i]}</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.nominal_thermal_output')}</th>      <td>${nominal_thermal_output[reactor_i]} MW</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.gross_el_output')}</th>      <td>${gross_el_output[reactor_i]} MWe</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.net_el_output')}</th>      <td>${net_el_output[reactor_i]} MWe</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.construction_phase')}</th>      <td>${construction_phase[reactor_i]}</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.operation_phase')}</th>      <td>${operation_phase[reactor_i]}</td></tr>
-        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.decontamination_phase')}</th>      <td>${decontamination_phase[reactor_i]}</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.life_phase_de')}</th>      <td>${list(life_phase)[lang_i][reactor_i]}</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.reactor_type_de')}</th>      <td>${list(reactor_type)[lang_i][reactor_i]}</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.cooling_type_de')}</th>      <td>${list(cooling_type)[lang_i][reactor_i]}</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.nominal_thermal_output')}</th>      <td>${list(nominal_thermal_output)[reactor_i]} MW</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.gross_el_output')}</th>      <td>${list(gross_el_output)[reactor_i]} MWe</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.net_el_output')}</th>      <td>${list(net_el_output)[reactor_i]} MWe</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.construction_phase')}</th>      <td>${list(construction_phase)[reactor_i]}</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.operation_phase')}</th>      <td>${list(operation_phase)[reactor_i]}</td></tr>
+        <tr><th class="cell-left">${_('ch.bfe.kernkraftwerke.decontamination_phase')}</th>      <td>${list(decontamination_phase)[reactor_i]}</td></tr>
     % endfor
     </table>
     <div class="thumbnail-container">

--- a/chsdi/templates/htmlpopup/kernkraftwerke.mako
+++ b/chsdi/templates/htmlpopup/kernkraftwerke.mako
@@ -33,6 +33,7 @@
         dismantling_phase = c['attributes']['dismantling_phase'].split('##');
 
         # Python3's range is Python2's xrange
+        # TODO python2 clean-up
         try:
           xrange
         except NameError:

--- a/chsdi/templates/htmlpopup/kgs.mako
+++ b/chsdi/templates/htmlpopup/kgs.mako
@@ -24,9 +24,9 @@
             from urllib2 import urlopen
             csv_file = urlopen(csv_url)
             reader = csv.reader(csv_file, delimiter =';')  # creates the reader object
-            csv_file.close()
             next(reader) # Skip header
             pic_list = [map(lambda x: x.decode("utf-8"), row) for row in reader if int(row[0]) == c['featureId']]
+            csv_file.close()
         except ImportError:
             # Python3 fallback
             from urllib.request import urlopen

--- a/chsdi/templates/htmlpopup/kgs.mako
+++ b/chsdi/templates/htmlpopup/kgs.mako
@@ -15,7 +15,7 @@
     <%
         c['stable_id'] = True
         objarts = c['attributes']['objektart'].split(',')
-        gemeinde_ehemalig = c['attributes']['gemeinde_ehemalig'] if c['attributes']['gemeinde_ehemalig'].startswith("(") else "("+c['attributes']['gemeinde_ehemalig']+")"
+        gemeinde_ehemalig = c['attributes']['gemeinde_ehemalig'] if str(c['attributes']['gemeinde_ehemalig']).startswith("(") else "("+c['attributes']['gemeinde_ehemalig']+")"
         import csv
         dataGeoAdminHost = request.registry.settings['datageoadminhost']
         csv_url = "https://" + dataGeoAdminHost + "/" + c['layerBodId']  + "/image/meta.txt"

--- a/chsdi/templates/htmlpopup/kgs.mako
+++ b/chsdi/templates/htmlpopup/kgs.mako
@@ -20,6 +20,7 @@
         dataGeoAdminHost = request.registry.settings['datageoadminhost']
         csv_url = "https://" + dataGeoAdminHost + "/" + c['layerBodId']  + "/image/meta.txt"
         csv_file = None
+        # TODO python2 clean-up
         try:
             from urllib2 import urlopen
             csv_file = urlopen(csv_url)

--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -115,7 +115,7 @@ viewer_url = get_viewer_url(request, params)
   </td>
 </tr>
 
-% elif c['attributes'].get('doi_link', '-').startswith('http'):
+% elif str(c['attributes'].get('doi_link', '-')).startswith('http'):
 <tr>
   <td class="cell-left">${_('tt_lubis_Quickview')}</td>
   <td><a href="${c['attributes']['doi_link']}" target="_blank">${c['attributes']['doi_link']}</a></td></tr>

--- a/chsdi/templates/htmlpopup/lubis.mako
+++ b/chsdi/templates/htmlpopup/lubis.mako
@@ -6,7 +6,7 @@ import datetime
 from pyramid.url import route_url
 import chsdi.lib.helpers as h
 import markupsafe
-# Python2/3
+# TODO python2 clean-up
 try:
     from urllib import urlencode
 except ImportError:

--- a/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
+++ b/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
@@ -49,6 +49,7 @@ def get_viewer_url(request, params):
         'rotation': params[7]
     }
     # Python2/3
+    # TODO python2 clean-up
     if six.PY3:
       return h.make_agnostic(route_url('luftbilder', request)) + '?' + urllib.parse.urlencode(f)
     else:

--- a/chsdi/templates/htmlpopup/lubis_terra.mako
+++ b/chsdi/templates/htmlpopup/lubis_terra.mako
@@ -53,6 +53,7 @@ def get_viewer_url(request, params):
         'rotation': params[7]
     }
     # Python2/3
+    # TODO python2 clean-up
     if six.PY3:
       return h.make_agnostic(route_url('luftbilder', request)) + '?' + urllib.parse.urlencode(f)
     else:

--- a/chsdi/templates/htmlpopup/ngamapping.mako
+++ b/chsdi/templates/htmlpopup/ngamapping.mako
@@ -9,7 +9,7 @@
             urlarr = c['attributes']['fdaurl'].split(';')
             aliasdict = dict(zip(aliasarr, urlarr))
         %>
-        % for key in sorted(aliasdict.iterkeys(), key=unicode.lower):
+        % for key in sorted(aliasdict):
             <tr><td><a href="${aliasdict[key] or '-'}" target="_blank">${key or '-'}</a></td></tr>
 	    % endfor
     % else:

--- a/chsdi/templates/htmlpopup/windenergieanlagen_facility.mako
+++ b/chsdi/templates/htmlpopup/windenergieanlagen_facility.mako
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-<%inherit file="base.mako"/> 
+<%inherit file="base.mako"/>
 
 <%def name="table_body(c, lang)">
 <tr>
@@ -15,7 +15,7 @@
   <td>${c['attributes']['fac_type_it'] or '-'}</td>
  % else:
   <td>${c['attributes']['fac_type_de'] or '-'}</td>
- %endif 
+ %endif
   </td>
 </tr>
 </%def>
@@ -39,7 +39,7 @@
  for tur in treeturb:
      turid=tur[0].text
      name=tur[1].text
-     alti=tur[2].text 
+     alti=tur[2].text
      leis = tur[3].text
      bauj = tur[4].text
      manu = tur[5].text
@@ -53,8 +53,8 @@
 %>
 <%
    import locale
-   locale.setlocale(locale.LC_ALL, 'fr_CH.utf-8')
-%>   
+   locale.setlocale(locale.LC_ALL, 'de_CH.utf8')
+%>
 <h3>${_('windenergieangaben')}</h3>
 <table class="table-with-border kernkraftwerke-extended" cellpadding="5">
   <tr>
@@ -110,7 +110,7 @@ src="http://www.uvek-gis.admin.ch/BFE/bilder/ch.bfe.windenergieanlagen/chart_${c
 % else:
 <h3> - </h3>
 % endif
-<h3> ${_('windturbinenangaben')}</h3>       
+<h3> ${_('windturbinenangaben')}</h3>
 <table class="table-with-border kernkraftwerke-extended" cellpadding="1">
    <colgroup>
       <col width=13%>

--- a/chsdi/templates/htmlpopup/zeitreihen.mako
+++ b/chsdi/templates/htmlpopup/zeitreihen.mako
@@ -41,6 +41,7 @@ def get_viewer_url(request, params):
         'release_year': params[6]
     }
     # Python2/3
+    # TODO python2 clean-up
     if six.PY3:
       return h.make_agnostic(route_url('historicalmaps', request)) + '?' + urllib.parse.urlencode(f)
     else:


### PR DESCRIPTION
goal: htmlpopup and extendedhtml nosetests are passing for all the 475 layers in frankfurt with RDS frankfurt and in ireland

thanks to the latest changes/improvement in the makefile.frankfurt (thank you @ltshb ) the nosetests are now working / running for htmlpopup tests. I had to add a small fix to the test_layers.py file, until now  htmlpopup issues have not been reported correctly by the nosetests.

we have the following **issues in the htmlpopup and extendedTooltip tests in ireland and in frankfurt**:
- [x] tests.e2e.test_layers.test_all_htmlpopups('ch.bafu.biogeographische_regionen', '1', False)
- [x] tests.e2e.test_layers.test_all_htmlpopups('ch.babs.kulturgueter', '259', True)
the **issue in frankfurt** will be fixed when we have data.geo.admin.ch in all stagings, for now we have to use ``'https://data.geo.admin.ch/ch.babs.kulturgueter/image/meta.txt' instead of 'https://sys-data.dev.bgdi.ch/ch.babs.kulturgueter/image/meta.txt' `` the issue in ireland with python 2 still has to be fixed 
- [x] tests.e2e.test_layers.test_all_htmlpopups('ch.bafu.gefahren-aktuelle_erdbeben', '1', False)
- [x] tests.e2e.test_layers.test_all_htmlpopups('ch.swisstopo.lubis-luftbilder-dritte-firmen', '20073090540899', True)
fixed with https://github.com/geoadmin/mf-chsdi3/pull/3919

we have the following **issues introduced by the migration to frankfurt (python3)**:
- [x] tests.e2e.test_layers.test_all_htmlpopups('ch.bfe.kernkraftwerke', '1', True)
- [x] tests.e2e.test_layers.test_all_htmlpopups('ch.bakom.anbieter-eigenes_festnetz', '868431', False)
- [x] tests.e2e.test_layers.test_all_htmlpopups('ch.bfe.windenergieanlagen', 'facility_COL', True)

cc @rebert 


```
SKIP: Skiping htmlPopup test for /rest/services/all/MapServer/ch.bafu.biogeographische_regionen/1/htmlPopup?callback=cb_&lang=en error:

Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 59, in render_body
    ${self.table_body(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/biogeoreg.mako", line 10, in render_table_body
    <tr><td class="cell-left">${_('ch.bafu.biogeographische_regionen.regionname')}</td><td>${c['attributes'][regionname_text] or '-'}</td></tr>
KeyError: 'regionname_en'

SKIP: Skiping extendedHtmlPopup for /rest/services/all/MapServer/ch.babs.kulturgueter/259/extendedHtmlPopup?callback=cb_&lang=de error:
-- issue in frankfurt

Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 52, in render_body
    ${self.extended_info(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/kgs.mako", line 33, in render_extended_info
    csv_file = urlopen(csv_url).read().decode('utf-8')
  File "/usr/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.7/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/lib/python3.7/urllib/request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.7/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.7/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
HTTPError: HTTP Error 403: Forbidden

--issue in ireland (python2)
Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python2.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python2.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python2.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python2.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python2.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 52, in render_body
    ${self.extended_info(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/kgs.mako", line 28, in render_extended_info
    next(reader) # Skip header
  File "/usr/lib/python2.7/socket.py", line 530, in next
    line = self.readline()
  File "/usr/lib/python2.7/socket.py", line 447, in readline
    data = self._sock.recv(self._rbufsize)
AttributeError: 'NoneType' object has no attribute 'recv'

SKIP: Skiping htmlPopup test for /rest/services/all/MapServer/ch.bafu.gefahren-aktuelle_erdbeben/1/htmlPopup?callback=cb_&lang=de error:

Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 59, in render_body
    ${self.table_body(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/aktuelle_erdbeben.mako", line 13, in render_table_body
    coord_x, coord_y = [float(x) for x in request.params['coord'].split(",")] if request.params['coord'] else defaultCoord
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/webob/multidict.py", line 344, in __getitem__
    raise KeyError(key)
KeyError: 'coord'

SKIP: Skiping extendedHtmlPopup for /rest/services/all/MapServer/ch.bfe.kernkraftwerke/1/extendedHtmlPopup?callback=cb_&lang=de error:

Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 52, in render_body
    ${self.extended_info(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/kernkraftwerke.mako", line 60, in render_extended_info
    % for reactor_i in xrange(0, c['attributes']['reactors']):
TypeError: 'Undefined' object is not callable

SKIP: Skiping htmlPopup test for /rest/services/all/MapServer/ch.swisstopo.lubis-luftbilder-dritte-firmen/20073090540899/htmlPopup?callback=cb_&lang=de error:

Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 59, in render_body
    ${self.table_body(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/lubis.mako", line 118, in render_table_body
    % elif c['attributes'].get('doi_link', '-').startswith('http'):
AttributeError: 'NoneType' object has no attribute 'startswith'

SKIP: Skiping htmlPopup test for /rest/services/all/MapServer/ch.bakom.anbieter-eigenes_festnetz/868431/htmlPopup?callback=cb_&lang=de error:

Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 59, in render_body
    ${self.table_body(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/ngamapping.mako", line 12, in render_table_body
    % for key in sorted(aliasdict.iterkeys(), key=unicode.lower):
AttributeError: 'dict' object has no attribute 'iterkeys'

SKIP: Skiping extendedHtmlPopup for /rest/services/all/MapServer/ch.bfe.windenergieanlagen/facility_COL/extendedHtmlPopup?callback=cb_&lang=de error:

Traceback (most recent call last):
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/template.py", line 482, in render_unicode
    self, self.callable_, args, data, as_unicode=True
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 883, in _render
    **_kwargs_for_callable(callable_, data)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/mf-chsdi3/.venv/lib/python3.7/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 52, in render_body
    ${self.extended_info(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/windenergieanlagen_facility.mako", line 56, in render_extended_info
    locale.setlocale(locale.LC_ALL, 'fr_CH.utf-8')
  File "/usr/lib/python3.7/locale.py", line 604, in setlocale
    return _setlocale(category, locale)
Error: unsupported locale setting




```