### PR TITLE
BGDIINF_SB_2418: added short comment in .env.default

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -16,6 +16,7 @@ GEODATA_STAGING=test
 HOST=sys-api3.dev.bgdi.ch
 HTTP_PROXY=http://ec2-52-28-118-239.eu-central-1.compute.amazonaws.com:80
 INSTALLDIR=/var/www/vhosts/mf-chsdi3/private/chsdi
+# FIXME: KML_TEMP_DIR can probably be removed in context of https://jira.swisstopo.ch/browse/BGDIINF_SB-2456
 KML_TEMP_DIR=/var/local/print/kml
 LINKEDDATAHOST=https://ld.geo.admin.ch
 MODWSGI_CONFIG=development.ini


### PR DESCRIPTION
`KML_TEMP_DIR` env var in .env.default can probably be deleted in context of
https://jira.swisstopo.ch/browse/BGDIINF_SB-2456. Hence a short comment has been added
to .env.default