### PR TITLE
BGDIINF_SB-2451: make code compatible with Python2.7 and Python3.7 at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 *.orig
 .coverage*
 .idea
-.vscode
+./.vscode/
+!./.vscode/settings.json
 .installed.cfg
 .venv/
 .env.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -10,6 +10,8 @@ from papyrus.renderers import GeoJSON
 
 from chsdi.renderers import EsriJSON, CSVRenderer
 from chsdi.models import initialize_sql
+# TODO: clean-up when only Python 3.x and no longer 2.x is in use
+import six
 
 
 def db(request):
@@ -35,7 +37,8 @@ def add_cors_route(config, pattern, service, headers=None, methods=[]):
         response.headers['Access-Control-Allow-Methods'] = ','.join(
             allowed_methods + methods)
         if headers is not None:
-            for k, v in headers.iteritems():
+            # TODO: clean-up when only Python 3.x and no longer 2.x is in use
+            for k, v in six.iteritems(headers):
                 response.headers[k] = v
         return response
 

--- a/chsdi/lib/filters.py
+++ b/chsdi/lib/filters.py
@@ -11,6 +11,7 @@ def full_text_search(query, ormColumns, searchText):
     def ilike_search(col):
         if col is not None:
             return cast(col, Text).ilike('%%%s%%' % searchText)
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     return query.filter(or_(
         *map(ilike_search, ormColumns)
     ))

--- a/chsdi/lib/filters.py
+++ b/chsdi/lib/filters.py
@@ -11,7 +11,6 @@ def full_text_search(query, ormColumns, searchText):
     def ilike_search(col):
         if col is not None:
             return cast(col, Text).ilike('%%%s%%' % searchText)
-    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     return query.filter(or_(
         *map(ilike_search, ormColumns)
     ))

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -10,11 +10,6 @@ import unidecode
 from decimal import Decimal
 from past.utils import old_div
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 from six.moves import zip, reduce, zip_longest
 from itertools import chain
 
@@ -37,7 +32,11 @@ except ImportError:
 import xml.etree.ElementTree as etree
 from pyproj import Proj, transform as proj_transform
 from requests.exceptions import ConnectionError, Timeout, RequestException
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+# TODO: clean-up when only Python 3.x and no longer 2.x is in use
+try:
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+except ImportError:
+    from urllib3.exceptions import InsecureRequestWarning
 from shapely.ops import transform as shape_transform
 from shapely.wkt import dumps as shape_dumps, loads as shape_loads
 from shapely.geometry.base import BaseGeometry
@@ -460,17 +459,12 @@ def float_raise_nan(val):
 
 def parse_box2d(stringBox2D):
     extent = stringBox2D.replace('BOX(', '').replace(')', '').replace(',', ' ')
-    # Python2/3
-    box = map(float, extent.split(' '))
-    if not isinstance(box, list):
-        box = list(box)
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
+    box = list(map(float, extent.split(' ')))
     return box
 
 
-def is_box2d(box2D):
-    # Python2/3
-    if not isinstance(box2D, list):
-        box2D = list(box2D)
+def validate_box2d(box2D):
     # Bottom left to top right only
     if len(box2D) != 4 or box2D[0] > box2D[2] or box2D[1] > box2D[3]:
         raise ValueError('Invalid box2D.')
@@ -478,7 +472,7 @@ def is_box2d(box2D):
 
 
 def center_from_box2d(box2D):
-    box2D = is_box2d(box2D)
+    box2D = validate_box2d(box2D)
     return [
         box2D[0] + ((box2D[2] - box2D[0]) / 2),
         box2D[1] + ((box2D[3] - box2D[1]) / 2)
@@ -537,7 +531,7 @@ def format_scale(scale):
     scale_str = str(scale)
     n = ''
     while len(scale_str) > 3:
-        # Python2/3
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
         scale_prov = old_div(int(float(scale_str)), 1000)
         n = n + "'000"
         scale_str = str(scale_prov)
@@ -563,7 +557,7 @@ def get_loaderjs_url(request, version='3.6.0'):
 
 def decompress_gzipped_string(streaming_body):
     if six.PY2:
-        string_file = StringIO(streaming_body.read())
+        string_file = six.StringIO(streaming_body.read())
         gzip_file = gzip.GzipFile(fileobj=string_file, mode='r', compresslevel=5)
         return gzip_file.read().decode('utf-8')
     else:

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -459,7 +459,6 @@ def float_raise_nan(val):
 
 def parse_box2d(stringBox2D):
     extent = stringBox2D.replace('BOX(', '').replace(')', '').replace(',', ' ')
-    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     box = list(map(float, extent.split(' ')))
     return box
 
@@ -556,6 +555,7 @@ def get_loaderjs_url(request, version='3.6.0'):
 
 
 def decompress_gzipped_string(streaming_body):
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     if six.PY2:
         string_file = six.StringIO(streaming_body.read())
         gzip_file = gzip.GzipFile(fileobj=string_file, mode='r', compresslevel=5)

--- a/chsdi/lib/mortonspacekey.py
+++ b/chsdi/lib/mortonspacekey.py
@@ -179,9 +179,6 @@ class QuadTree:
 
     def _getCommonKey(self, keys):
         res = ''
-        # Python2/3
-        if not isinstance(keys, list):
-            keys = list(keys)
         for i in range(self.levels + 1):
             before = len(res)
             if not reduce(lambda has, k: (has and len(k) > i), keys, True):

--- a/chsdi/lib/parser.py
+++ b/chsdi/lib/parser.py
@@ -74,11 +74,11 @@ class WhereParser(object):
 
     @property
     def tokens(self):
-        return filter(lambda x: x not in ('or', 'and'), self._tokens())
+        return [x for x in self._tokens() if x not in ('or', 'and')]
 
     @property
     def operators(self):
-        return filter(lambda x: x in ('or', 'and'), self._tokens())
+        return [x for x in self._tokens() if x in ('or', 'and')]
 
     def _tokens(self):
         r = []

--- a/chsdi/lib/sphinxapi/sphinxapi.py
+++ b/chsdi/lib/sphinxapi/sphinxapi.py
@@ -463,7 +463,7 @@ class SphinxClient:
 
         self._groupby = attribute
         self._groupfunc = func
-        # Python2/3
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
         self._groupsort = str_bytes(groupsort)
 
     def SetGroupDistinct(self, attribute):
@@ -510,7 +510,7 @@ class SphinxClient:
         """
         self._groupby = ''
         self._groupfunc = SPH_GROUPBY_DAY
-        # Python2/3
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
         self._groupsort = str_bytes('@group desc')
         self._groupdistinct = ''
 
@@ -562,7 +562,7 @@ class SphinxClient:
         req.extend(pack('>L',1)) # id64 range marker
         req.extend(pack('>Q', self._min_id))
         req.extend(pack('>Q', self._max_id))
-        
+
         # filters
         req.extend ( pack ( '>L', len(self._filters) ) )
         for f in self._filters:
@@ -594,7 +594,7 @@ class SphinxClient:
         req.extend ( pack ( '>2L', self._groupfunc, len(self._groupby) ) )
         req.extend ( self._groupby )
         req.extend ( pack ( '>2L', self._maxmatches, len(self._groupsort) ) )
-        # TODO Python2/3
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
         # _groupsort is a str
         req.extend ( self._groupsort )
         req.extend ( pack ( '>LLL', self._cutoff, self._retrycount, self._retrydelay))
@@ -664,7 +664,7 @@ class SphinxClient:
         # req.extend ( pack('>L',len(self._tokenfilterlibrary)) + self._tokenfilterlibrary )
         # req.extend ( pack('>L',len(self._tokenfiltername)) + self._tokenfiltername )
         # req.extend ( pack('>L',len(self._tokenfilteropts)) + self._tokenfilteropts )
-            
+
         # send query, get response
 
         self._reqs.append(req)
@@ -720,7 +720,7 @@ class SphinxClient:
 
                 if status == SEARCHD_WARNING:
                     result['warning'] = message
-                    
+
                 else:
                     result['error'] = message
                     continue
@@ -871,7 +871,7 @@ class SphinxClient:
         if opts.get('allow_empty'):             flags |= 256
         if opts.get('emit_zones'):              flags |= 512
         if opts.get('load_files_scattered'):    flags |= 1024
-        
+
         # mode=0, flags
         req = bytearray()
         req.extend(pack('>2L', 0, flags))
@@ -901,7 +901,7 @@ class SphinxClient:
 
         req.extend(pack('>L', int(opts['limit'])))
         req.extend(pack('>L', int(opts['around'])))
-        
+
         req.extend(pack('>L', int(opts['limit_passages'])))
         req.extend(pack('>L', int(opts['limit_words'])))
         req.extend(pack('>L', int(opts['start_passage_id'])))
@@ -989,7 +989,7 @@ class SphinxClient:
         if mva:
             mva_attr = 1
         for attr in attrs:
-            # TODO Python2/3
+            # TODO: clean-up when only Python 3.x and no longer 2.x is in use
             if six.PY3:
                 attr = attr.encode('utf8')
             req.append(pack('>L', len(attr)) + attr)
@@ -1035,7 +1035,7 @@ class SphinxClient:
         assert (isinstance(hits, int))
 
         # build request
- 
+
         req = bytearray()
         query = str_bytes(query)
         req.extend(pack ( '>L', len(query) ) + query)

--- a/chsdi/lib/validation/search.py
+++ b/chsdi/lib/validation/search.py
@@ -103,8 +103,8 @@ class SearchValidation(MapNameValidation):
             raise HTTPBadRequest("Please provide a search text")
         searchTextList = value.split(' ')
         # Remove empty strings
-        # Python2/3
-        searchTextList = list(filter(None, searchTextList))
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
+        searchTextList = list([_f for _f in searchTextList if _f])
         if ilen(searchTextList) > MAX_SEARCH_TERMS:
             raise HTTPBadRequest("The searchText parameter can not contain more than 10 words")
         self._searchText = searchTextList
@@ -116,7 +116,7 @@ class SearchValidation(MapNameValidation):
             if len(values) != 4:
                 raise HTTPBadRequest("Please provide 4 coordinates in a comma separated list")
             try:
-                # Python 2/3
+                # TODO: clean-up when only Python 3.x and no longer 2.x is in use
                 values = list(map(float_raise_nan, values))
             except ValueError:
                 raise HTTPBadRequest("Please provide numerical values for the parameter bbox")
@@ -202,5 +202,5 @@ class SearchValidation(MapNameValidation):
         if value == 'en':
             value = 'de'
         if value is not None and value not in self.availableLangs:
-            raise HTTPBadRequest('Usupported lang filter %s' % value)
+            raise HTTPBadRequest('Unsupported lang filter %s' % value)
         self._searchLang = value

--- a/chsdi/models/vector/__init__.py
+++ b/chsdi/models/vector/__init__.py
@@ -28,9 +28,6 @@ DEFAULT_OUPUT_SRID = 21781
 
 
 def get_resolution(imageDisplay, mapExtent):
-    # TODO: Python2/3
-    if not isinstance(imageDisplay, list):
-        imageDisplay = list(imageDisplay)
     bounds = mapExtent.bounds
     map_meter_width = abs(bounds[0] - bounds[2])
     map_meter_height = abs(bounds[1] - bounds[3])
@@ -40,9 +37,6 @@ def get_resolution(imageDisplay, mapExtent):
 
 
 def get_scale(imageDisplay, mapExtent):
-    # TODO: Python2/3
-    if not isinstance(imageDisplay, list):
-        imageDisplay = list(imageDisplay)
     resolution = get_resolution(imageDisplay, mapExtent)
     return resolution * 39.37 * imageDisplay[2]
 

--- a/chsdi/renderers.py
+++ b/chsdi/renderers.py
@@ -7,6 +7,8 @@ import datetime
 from sqlalchemy.ext.associationproxy import _AssociationList
 from papyrus.renderers import GeoJSON
 from geojson.codec import PyGFPEncoder
+# TODO: clean-up when only Python 3.x and no longer 2.x is in use
+import six
 
 
 class EsriJSONEncoder(PyGFPEncoder):
@@ -62,8 +64,8 @@ class CSVRenderer(object):
 
     def __call__(self, value, system):
         import csv
-        import StringIO
-        fout = StringIO.StringIO()
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
+        fout = six.StringIO()
         writer = csv.writer(fout, delimiter=';', quoting=csv.QUOTE_ALL)
 
         writer.writerow(value['headers'])

--- a/chsdi/subscribers.py
+++ b/chsdi/subscribers.py
@@ -49,7 +49,7 @@ def add_localizer(event):
     request._LOCALE_ = helpers.locale_negotiator(request)
     localizer = get_localizer(request)
     request.lang = 'rm' if localizer.locale_name == 'fi' else localizer.locale_name
-    # Python2/3
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     if not six.PY3:
         request.lang = request.lang.encode('ascii', 'ignore')
     # The load balancer forwards requests as http, therefore we need to check X-Forwarded-Proto

--- a/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
+++ b/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
@@ -48,8 +48,7 @@ def get_viewer_url(request, params):
         'lang': params[6],
         'rotation': params[7]
     }
-    # Python2/3
-    # TODO python2 clean-up
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     if six.PY3:
       return h.make_agnostic(route_url('luftbilder', request)) + '?' + urllib.parse.urlencode(f)
     else:

--- a/chsdi/templates/htmlpopup/lubis_terra.mako
+++ b/chsdi/templates/htmlpopup/lubis_terra.mako
@@ -52,8 +52,7 @@ def get_viewer_url(request, params):
         'lang': params[6],
         'rotation': params[7]
     }
-    # Python2/3
-    # TODO python2 clean-up
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     if six.PY3:
       return h.make_agnostic(route_url('luftbilder', request)) + '?' + urllib.parse.urlencode(f)
     else:

--- a/chsdi/templates/htmlpopup/zeitreihen.mako
+++ b/chsdi/templates/htmlpopup/zeitreihen.mako
@@ -40,8 +40,7 @@ def get_viewer_url(request, params):
         'lang': params[5],
         'release_year': params[6]
     }
-    # Python2/3
-    # TODO python2 clean-up
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     if six.PY3:
       return h.make_agnostic(route_url('historicalmaps', request)) + '?' + urllib.parse.urlencode(f)
     else:

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -1,14 +1,13 @@
 <%namespace name="lubis_map" file="lubis_map.mako"/>
 
 <%
-from pyramid.url import route_url
-# TODO: clean-up when only Python 3.x and no longer 2.x are in use
-try:
-    from urllib2 import urlopen
-except ImportError:
-    # Python3 fallback
-    from urllib.request import urlopen
-from json import loads
+  from pyramid.url import route_url
+  # TODO: clean-up when only Python 3.x and no longer 2.x are in use
+  try:
+      from urllib2 import urlopen
+  except ImportError:
+      from urllib.request import urlopen
+  from json import loads
 
   c = context
   topic = 'luftbilder'

--- a/chsdi/templates/luftbilder/viewer.mako
+++ b/chsdi/templates/luftbilder/viewer.mako
@@ -1,13 +1,14 @@
 <%namespace name="lubis_map" file="lubis_map.mako"/>
 
 <%
-  from pyramid.url import route_url
-  try:
-      from urllib2 import urlopen
-  except ImportError:
-      # Python3 fallback
-      from urllib.request import urlopen
-  from json import loads
+from pyramid.url import route_url
+# TODO: clean-up when only Python 3.x and no longer 2.x are in use
+try:
+    from urllib2 import urlopen
+except ImportError:
+    # Python3 fallback
+    from urllib.request import urlopen
+from json import loads
 
   c = context
   topic = 'luftbilder'

--- a/chsdi/views/color.py
+++ b/chsdi/views/color.py
@@ -8,7 +8,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.view import view_config
 from pyramid.response import Response
 
-# Python2/3
+# TODO: clean-up when only Python 3.x and no longer 2.x is in use
 if six.PY3:
     from io import BytesIO
 else:

--- a/chsdi/views/downloadkml.py
+++ b/chsdi/views/downloadkml.py
@@ -7,7 +7,8 @@ import json
 import os
 import errno
 import time
-import urllib
+# TODO: clean-up when only Python 3.x and no longer 2.x is in use
+from six.moves.urllib.parse import unquote_plus
 from pyramid.view import view_config
 from pyramid.response import Response
 from pyramid.httpexceptions import (HTTPBadRequest, HTTPInternalServerError)
@@ -51,7 +52,7 @@ class DownloadKML:
             return Response(status=200)
 
         # IE is always URLEncoding the body
-        jsonstring = urllib.unquote_plus(self.request.body)
+        jsonstring = unquote_plus(self.request.body)
 
         try:
             spec = json.loads(jsonstring, encoding=self.request.charset)

--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -34,7 +34,6 @@ from chsdi.lib.helpers import _transform_coordinates, transform_round_geometry
 import logging
 logger = logging.getLogger(__name__)
 
-
 MAX_FEATURES = 201
 
 
@@ -125,7 +124,7 @@ def _prepare_popup_response(params, request, isExtended=False, isIframe=False):
 
     if params.cbName is None:
         return response
-    # Python2/3
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     if six.PY3:
         return response.body.decode('utf8')
     return response.body
@@ -486,7 +485,7 @@ def _get_features_for_filters(params, layerBodIds, maxFeatures=None, where=None)
     ''' Returns a generator function that yields
     a feature. '''
     for layer in layerBodIds:
-        # Python2/3
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
         layerBodId, models = next(six.iteritems(layer))
         # Determine the limit
         limits = [x for x in [maxFeatures, params.limit] if x is not None]

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -49,9 +49,7 @@ def layers_config(request):
     params = BaseLayersValidation(request)
     query = params.request.db.query(LayersConfig)
     layers = {}
-    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     for layer in get_layers_config_for_params(params, query, LayersConfig):
-        # layers = dict(list(layers.items()) + list(layer.items()))
         layers = dict(chain(layers.items(), layer.items()))
 
     return layers
@@ -170,7 +168,6 @@ def faqlist(request):
 
     query = params.request.db.query(LayersConfig)
     for layer in get_layers_config_for_params(params, query, LayersConfig):
-        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
         k = list(layer.keys()).pop()
         lyr = list(layer.values()).pop()
         if 'parentLayerId' not in lyr and not k.endswith('_3d'):

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -49,7 +49,7 @@ def layers_config(request):
     params = BaseLayersValidation(request)
     query = params.request.db.query(LayersConfig)
     layers = {}
-    # Python 2/3
+    # TODO: clean-up when only Python 3.x and no longer 2.x is in use
     for layer in get_layers_config_for_params(params, query, LayersConfig):
         # layers = dict(list(layers.items()) + list(layer.items()))
         layers = dict(chain(layers.items(), layer.items()))
@@ -170,7 +170,7 @@ def faqlist(request):
 
     query = params.request.db.query(LayersConfig)
     for layer in get_layers_config_for_params(params, query, LayersConfig):
-        # Python2/3
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
         k = list(layer.keys()).pop()
         lyr = list(layer.values()).pop()
         if 'parentLayerId' not in lyr and not k.endswith('_3d'):

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -490,7 +490,6 @@ class Search(SearchValidation):
         try:
             box2d = res['geom_st_box2d']
             box_str = box2d[4:-1]
-            # TODO: clean-up when only Python 3.x and no longer 2.x is in use
             b = list(map(float, re.split(' |,', box_str)))
             shape = box(*b)
             bbox = transform_shape(shape, self.DEFAULT_SRID, self.srid).bounds

--- a/chsdi/views/search.py
+++ b/chsdi/views/search.py
@@ -490,7 +490,8 @@ class Search(SearchValidation):
         try:
             box2d = res['geom_st_box2d']
             box_str = box2d[4:-1]
-            b = map(float, re.split(' |,', box_str))
+            # TODO: clean-up when only Python 3.x and no longer 2.x is in use
+            b = list(map(float, re.split(' |,', box_str)))
             shape = box(*b)
             bbox = transform_shape(shape, self.DEFAULT_SRID, self.srid).bounds
             res['geom_st_box2d'] = "BOX({} {},{} {})".format(*bbox)
@@ -503,7 +504,7 @@ class Search(SearchValidation):
         if not self.returnGeometry:
             attrs2Del = ['x', 'y', 'lon', 'lat', 'geom_st_box2d']
             popAtrrs = lambda x: res.pop(x) if x in res else x
-            # Python2/3
+            # TODO: clean-up when only Python 3.x and no longer 2.x is in use
             if six.PY2:
                 map(popAtrrs, attrs2Del)
             else:

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -47,7 +47,8 @@ repoze.lru==0.7
 requests==2.22.0
 Shapely==1.6.4.post2
 simplejson==3.16.0
-six==1.12.0
+ # TODO: clean-up when only Python 3.x and no longer 2.x is in use
+six==1.16.0
 Sphinx==1.8.5
 sphinx-rtd-theme===0.4.3
 SQLAlchemy==1.3.24

--- a/scripts/check_python3_compatibility.sh
+++ b/scripts/check_python3_compatibility.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+PYTHON_FILES=`find ../chsdi/* ../tests/* -path ../chsdi/static -prune -o -path ../chsdi/lib/sphinxapi -prune -o -path ../tests/e2e -prune -o -type f -name "*.py" -print`
+2to3-3.7 -w -n $PYTHON_FILES

--- a/tests/functional/test_helpers.py
+++ b/tests/functional/test_helpers.py
@@ -16,10 +16,8 @@ from shapely.geometry import Point, Polygon
 from shapely.geometry import mapping
 from numpy.testing import assert_almost_equal
 
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin
+# TODO: clean-up when only Python 3.x and no longer 2.x is in use
+from six.moves.urllib.parse import urljoin
 
 
 class Test_Helpers(unittest.TestCase):

--- a/tests/functional/test_mortonspacekey.py
+++ b/tests/functional/test_mortonspacekey.py
@@ -174,4 +174,4 @@ class Test_QuadTree(unittest.TestCase):
         self._test_compare_with_bbox(msk.BBox(660000.1, 30000.1, 899999.9, 269999.9))
         self._test_compare_with_bbox(msk.BBox(660000.1, 30000.1, 899999.1, 269999.1))
 
-        map(lambda x: self._test_compare_with_bbox(self.randBBox()), range(20))
+        list(map(lambda x: self._test_compare_with_bbox(self.randBBox()), list(range(20))))

--- a/tests/integration/test_catalog.py
+++ b/tests/integration/test_catalog.py
@@ -75,7 +75,7 @@ class TestCatalogService(TestsBase):
                     break
 
             if not found:
-                print(node.get('id'))
+                print((node.get('id')))
                 return False
 
             if 'children' in node:
@@ -120,7 +120,7 @@ class TestCatalogService(TestsBase):
                     break
 
             if not found:
-                print(node.get('layerBodId'))
+                print((node.get('layerBodId')))
                 return False
 
             if 'children' in node:

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -432,7 +432,7 @@ class TestSearchServiceView(TestsBase):
         }
         resp = self.testapp.get('/rest/services/ech/SearchServer', params=params, status=200)
         self.assertEqual(resp.content_type, 'application/json')
-        results_addresses = filter(lambda x: x if x['attrs']['origin'] == 'address' else False, resp.json['results'])
+        results_addresses = [x for x in resp.json['results'] if (x if x['attrs']['origin'] == 'address' else False)]
         self.assertLessEqual(ilen(results_addresses), 50)
         self.assertGreater(len(list(resp.json['results'])), 0)
         self.assertAttrs('locations', resp.json['results'][0]['attrs'], 21781)

--- a/tests/integration/test_wmtscapabilities.py
+++ b/tests/integration/test_wmtscapabilities.py
@@ -141,10 +141,8 @@ class TestWmtsCapabilitiesView(TestsBase):
                 assert_almost_equal(float(coords[1]), 20037508.3428, decimal=4)
 
     def test_axis_order(self):
-        try:
-            from urllib.parse import urlparse
-        except ImportError:
-            from urlparse import urlparse
+        # TODO: clean-up when only Python 3.x and no longer 2.x is in use
+        from six.moves.urllib.parse import urlparse
         import xml.etree.ElementTree as etree
 
         for epsg in EPSGS:


### PR DESCRIPTION
For a certain period, the legacy code has to be compatible with both, Python2.7 and 3.7+
2to3-2.7 has been used to identify parts of the code, that needed to be changed. Six has been used to make those
parts compatible with both versions.

- [x] Check and make python modules compatible with both Python versions
- [x] Check and make Mako files compatible with both Python versions
- [x] Check if all `list()` wrapping suggested by `2to3` is really needed
- [x] Check what is Python version specific at code around line 312 in `/chsdi/views/features.py` (there's a `Python 2/3` comment)