### PR TITLE
fix failing e2e tests test_all_ids_mapping

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2534,7 +2534,7 @@ class GeologischerAtlasProfil(Base, Vector):
     __bodId__ = 'ch.swisstopo.geologie-geologischer_atlas_profile'
     __label__ = 'id'
     __extended_info__ = True
-    id = Column('ga25_id', Integer, primary_key=True)
+    id = Column('ga25_id', Unicode, primary_key=True)
     ga25_name = Column('ga25_name', Unicode)
     ga25_no = Column('ga25_no', Integer)
     ga25_edition = Column('ga25_edition', Integer)
@@ -2720,7 +2720,7 @@ class HiksDufourMetadata(Base, Vector):
     __template__ = 'templates/htmlpopup/dufour_meta.mako'
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __bodId__ = 'ch.swisstopo.hiks-dufour.metadata'
-    id = Column('kbnum', Integer, primary_key=True)
+    id = Column('kbnum', Unicode, primary_key=True)
     name = Column('kbbez', Unicode)
     the_geom = Column(Geometry2D)
 
@@ -2732,7 +2732,7 @@ class HiksSiegfriedTa25Metadata(Base, Vector):
     __template__ = 'templates/htmlpopup/dufour_meta.mako'
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __bodId__ = 'ch.swisstopo.hiks-siegfried-ta25.metadata'
-    id = Column('kbnum', Integer, primary_key=True)
+    id = Column('kbnum', Unicode, primary_key=True)
     name = Column('kbbez', Unicode)
     the_geom = Column(Geometry2D)
 
@@ -2744,7 +2744,7 @@ class HiksSiegfriedTa50Metadata(Base, Vector):
     __template__ = 'templates/htmlpopup/dufour_meta.mako'
     __table_args__ = ({'schema': 'datenstand', 'autoload': False})
     __bodId__ = 'ch.swisstopo.hiks-siegfried-ta50.metadata'
-    id = Column('kbnum', Integer, primary_key=True)
+    id = Column('kbnum', Unicode, primary_key=True)
     name = Column('kbbez', Unicode)
     the_geom = Column(Geometry2D)
 

--- a/tests/e2e/test_layers.py
+++ b/tests/e2e/test_layers.py
@@ -158,7 +158,6 @@ class LayersChecker(object):
     def checkLegendImage(self, layer, legendsPath, legendImages):
         if legendImages is None:
             raise SkipTest("Skip checkLegendImage for layer <{}>".format(layer))
-            return False
         for lang in ('de', 'fr', 'it', 'rm', 'en'):
             key = layer + '_' + lang
             images = [l for l in legendImages if l.startswith(key)]
@@ -174,7 +173,7 @@ class LayersChecker(object):
         try:
             assert (models is not None and len(models) > 0), layer
         except AssertionError as error:
-            raise skipTest("Cannot find model for layer {} error: {}".format(layer, error))
+            raise SkipTest("Cannot find model for layer {} error: {}".format(layer, error))
         model = models[0]
         hasFeatures = True
         # Special treatment for non-distributed sphinx indices (single model)

--- a/tests/e2e/test_links.py
+++ b/tests/e2e/test_links.py
@@ -40,6 +40,9 @@ class LinksChecker(TestsBase):
         del self.testapp
         return False
 
+    def runTest(self):
+        pass
+
     def ilinks(self):
         bod_id = 'ch.kantone.cadastralwebmap-farbe'
         ids = [self.getRandomFeatureId(bod_id) for i in range(30)]


### PR DESCRIPTION
fix wrong primary key type mappings, found by e2e test test_all_ids_mapping

FAIL: tests.e2e.test_layers.test_all_ids_mapping(u'ch.swisstopo.hiks-siegfried-ta50.metadata', u'246', <class 'chsdi.models.vector.stopo.HiksSiegfriedTa50Metadata'>, Column('kbnum', Integer(), table=<view_gridstand_siegfried_ta50>, primary_key=True, nullable=False))

FAIL: tests.e2e.test_layers.test_all_ids_mapping(u'ch.swisstopo.geologie-geologischer_atlas_profile', u'GA25_135_Plate_II_Section_5', <class 'chsdi.models.vector.stopo.GeologischerAtlasProfil'>, Column('ga25_id', Integer(), table=<geologischer_atlas_profil>, primary_key=True, nullable=False))

FAIL: tests.e2e.test_layers.test_all_ids_mapping(u'ch.swisstopo.hiks-dufour.metadata', u'006 + 001', <class 'chsdi.models.vector.stopo.HiksDufourMetadata'>, Column('kbnum', Integer(), table=<view_gridstand_dufour>, primary_key=True, nullable=False))

FAIL: tests.e2e.test_layers.test_all_ids_mapping(u'ch.swisstopo.hiks-siegfried-ta25.metadata', u'258', <class 'chsdi.models.vector.stopo.HiksSiegfriedTa25Metadata'>, Column('kbnum', Integer(), table=<view_gridstand_siegfried_ta25>, primary_key=True, nullable=False))