### PR TITLE
BGDIINF_SB-2468: Fixed _get_feature from VECTOR_BUCKET crash

### DIFF
--- a/chsdi/models/s3_client.py
+++ b/chsdi/models/s3_client.py
@@ -42,7 +42,6 @@ def get_file_from_bucket(bucket_name, file_name):
         error_tpl = "Bucket (%s) or file (%s) not valids. \n%s"
         log.error(error_tpl % (bucket_name, file_name, e))
         raise exc.HTTPInternalServerError(error_tpl % (anonymize_string(bucket_name, length = 5), file_name, e))
-        return e
     return response
 
 


### PR DESCRIPTION
When reading a feature from the VECTOR_BUCKET and if the feature doesn't have
a geometry (like for example the
tooltip/ch.bfe.windenergie-geschwindigkeit_h50/default/20181001/1027/1561/data.json
the service crashed with a 500.

The issue was that the _get_feature_grid() method would trigger a KeyError in
this case and that originally (before commit ac1a4a38b7a6b026f1342d145526c4c744fc1d2c)
in that case the exception was ignored.

Now we don't catch anymore broad exception which is a very bad practice. In
case of an S3 error, which should not happen will let the app crash. We can
latter if this happens too often due to S3 instability, add a retry mechanisme.

Also the original KeyError exception has been fixed, now if no geometry is
available in the feature, then we don't try to add a bbox.