### PR TITLE
BGDIINF_SB-2475: VECTOR_BUCKET name is now defined when running test target

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -19,7 +19,6 @@ GEODATA_STAGING=test
 HOST=sys-api3.dev.bgdi.ch
 HTTP_PROXY=http://ec2-52-28-118-239.eu-central-1.compute.amazonaws.com:80
 INSTALLDIR=/var/www/vhosts/mf-chsdi3/private/chsdi
-# FIXME: KML_TEMP_DIR can probably be removed in context of https://jira.swisstopo.ch/browse/BGDIINF_SB-2456
 KML_TEMP_DIR=/var/local/print/kml
 LINKEDDATAHOST=https://ld.geo.admin.ch
 MODWSGI_CONFIG=development.ini
@@ -34,3 +33,8 @@ WMTS_PUBLIC_HOST=sys-wmts.dev.bgdi.ch
 WSGI_APP=/var/www/vhosts/mf-chsdi3/private/chsdi/apache/application.wsgi
 WSGI_PROCESSES=1
 WSGI_THREADS=2
+# IMPORTANT: Always put comments in this file to the very botton, i.e. after all
+# env vars are defined. Otherwise a bulk export as in some Makefile targets, e.g.:
+# $(shell cat $(ENV_FILE)), will ignore all variable definitions after the first #!
+# FIXME: KML_TEMP_DIR can probably be removed in context of https://jira.swisstopo.ch/browse/BGDIINF_SB-2456
+

--- a/Makefile.frankfurt
+++ b/Makefile.frankfurt
@@ -128,7 +128,7 @@ help:
 	@echo "- lint/autolint      Python code quality assurance"
 	@echo "- shell              Pylons shell (for debugging)"
 	@echo "- test               Functional and integration nose tests"
-	@echo "- testci             Same as `test` but with specific junit output for the CI"
+	@echo "- unittest-ci        Same as 'test' but with specific junit output for the CI"
 	@echo "- teste2e            End-to-end tests"
 	@echo
 	@echo -e "\033[1mLOCAL SERVER TARGETS\033[0m "


### PR DESCRIPTION
When running the test Makefile.frankfurt target on vhost-dev, the name of the VECTOR_BUCKET was not defined.
This was due to a commenting line in .env.default. The bulk export with `$(shell cat $(ENV_FILE))`  in the test
target ignored all entries after the commenting line. Hence all comment lines should be placed below the last
definition of env vars.