### PR TITLE
BGDIINF_SB-2481: install apache mod_deflate in docker to enable compression

### DIFF
--- a/25-mf-chsdi3.conf.in
+++ b/25-mf-chsdi3.conf.in
@@ -31,7 +31,7 @@
 
   ## Logging
   ErrorLogFormat "[%{cu}t] level=%l request_id=%L pid_tid=%P/%T - %M"
-  ErrorLogFormat request "[%{cu}t] level=%l request_id=%L headers: User-Agent=\"%{User-Agent}i\" Referer=\"%{Referer}i\" Origin=\"%{Origin}i\""
+  ErrorLogFormat request "[%{cu}t] level=%l request_id=%L headers: User-Agent=\"%{User-Agent}i\" Referer=\"%{Referer}i\" Origin=\"%{Origin}i\" Accept-Language=\"%{Accept-Language}i\" Accept-Encoding=\"%{Accept-Encoding}i\"  Accept=\"%{Accept}i\""
   ErrorLog /dev/stdout
   CustomLog /dev/stdout "[%{%Y-%m-%dT%T}t.%{usec_frac}t] level=info request_id=%L \"%r\" status=%>s remote=%h duration=%{ms}T query=%q
   LogLevel ${APACHE_LOG_LEVEL}

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN echo "ServerName localhost" | tee /etc/apache2/conf-available/fqdn.conf \
         auth_basic \
         authz_groupfile \
         autoindex \
+        deflate \
         dir \
         env \
         expires \


### PR DESCRIPTION
Compression was already configured but mod_deflate not installed.

Also add some useful headers in logging

This PR needs also https://github.com/geoadmin/infra-terraform-bgdi-dev/pull/63 and https://github.com/geoadmin/infra-terraform-bgdi/pull/68 in order to work properly