### PR TITLE
Try to solve strange issue with empty base.ini.in and push master.latest docker image tag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,15 +69,15 @@ ARG GIT_DIRTY=unknown
 ARG VERSION=unknown
 ARG AUTHOR=unknown
 
-LABEL git.hash=$GIT_HASH
-LABEL git.branch=$GIT_BRANCH
-LABEL git.dirty=$GIT_DIRTY
-LABEL version=$VERSION
-LABEL author=$AUTHOR
+LABEL git.hash=${GIT_HASH}
+LABEL git.branch=${GIT_BRANCH}
+LABEL git.dirty=${GIT_DIRTY}
+LABEL version=${VERSION}
+LABEL author=${AUTHOR}
 
-# Substitute the version in the pylons configuration. Note because envsubst cannot do in place
-# substitution we use the tee tool to do the in place substitution.
-RUN APP_VERSION=$VERSION envsubst '${APP_VERSION}' < base.ini.in | tee base.ini.in > /dev/null
+# Substitute the version in the pylons configuration.
+ENV APP_VERSION=${VERSION}
+RUN sed -i 's/${APP_VERSION}/'${APP_VERSION}'/g' base.ini.in
 
 # NOTE: Here below we cannot use environment variable with ENTRYPOINT using the `exec` form.
 # The ENTRYPOINT `exec` form is required in order to use the docker-entrypoint.sh as first

--- a/base.ini.in
+++ b/base.ini.in
@@ -7,7 +7,7 @@
 
 [app:main]
 use = egg:chsdi
-app_version=${APP_VERSION}
+app_version = ${APP_VERSION}
 entry_path = ${APACHE_ENTRY_PATH}
 available_languages = de fr it en rm
 
@@ -50,7 +50,7 @@ install_directory = ${CURRENT_DIRECTORY}
 host = ${HOST}
 apache_base_path = ${APACHE_BASE_PATH}
 apache_entry_path = ${APACHE_ENTRY_PATH}
-kml_temp_dir=${KML_TEMP_DIR}
+kml_temp_dir = ${KML_TEMP_DIR}
 public_bucket_host = ${PUBLIC_BUCKET_HOST}
 vector_bucket = ${VECTOR_BUCKET}
 datageoadminhost = ${DATAGEOADMINHOST}

--- a/buildspec-py3.yml
+++ b/buildspec-py3.yml
@@ -164,8 +164,6 @@ phases:
           echo "=========== Pushing image ========="
           echo "Push image ${DOCKER_IMG_TAG}"
           docker push ${DOCKER_IMG_TAG}
-        fi
-        if [[ "${GIT_BRANCH}" == develop-* ]]; then
           echo "Push latest image ${DOCKER_IMG_TAG_LATEST}"
           docker push ${DOCKER_IMG_TAG_LATEST}
         fi


### PR DESCRIPTION
One docker image built by the CI had an empty base.ini.in file. Checking the logs of the CI build did not revealed any issues that could have resulted to an empty base.ini.in file. However this file was built with `envsubst` and `tee` program using a pipe and `>/dev/null` so some error could have been missing. A CI build retry solved the issue.
    
So here I'm trying to do the envsubst with `sed -i` command with the hope that if this for any reason would fail, it would provide some useful information and stop the build process.