### PR TITLE
BGDIINF_SB-2488 bugfix : sdi services crashes on queries with specific SRID

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -328,7 +328,7 @@ def computeHeader(mapName, srid):
     maxZoom = len(gagrid.RESOLUTIONS)
     dpi = 90.7
     lods = []
-    for zoom in range(minZoom, maxZoom + 1):
+    for zoom in range(minZoom, maxZoom):
         lods.append(
             {'level': zoom,
              'resolution': gagrid.getResolution(zoom),

--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -325,7 +325,7 @@ class ServiceMetadataEn(Base, ServiceMetadata):
 def computeHeader(mapName, srid):
     gagrid = getTileGrid(srid)()
     minZoom = 0
-    maxZoom = 28
+    maxZoom = len(gagrid.RESOLUTIONS)
     dpi = 90.7
     lods = []
     for zoom in range(minZoom, maxZoom + 1):


### PR DESCRIPTION
Issue BGDIINF_SB-2488 : sdi service crashes on queries with SRID 3857 and 4326
Jira ticket : https://jira.swisstopo.ch/browse/BGDIINF_SB-2488

Cause of the problem :

The function aggregating the informations about all zoom levels was
checking through all zoom levels (0 to 28), but the problematic SRID
had less than 28 zoom level, encountering a problem within an assertion
which crashed the whole function.

Mitigation :

We use the RESOLUTION table length from the geoadmin tilegrid object
created with the srid, ensuring we no longer can try to access zoom
levels that are not available for a specific srid.