### PR TITLE
SB_BGDIINF_SB-2488 bugfix ; solving crashes on sdi services queries with SR 4326 and 3857

### DIFF
--- a/chsdi/models/bod.py
+++ b/chsdi/models/bod.py
@@ -245,10 +245,10 @@ class ServiceMetadataEn(Base, ServiceMetadata):
 def computeHeader(mapName, srid):
     gagrid = getTileGrid(srid)()
     minZoom = 0
-    maxZoom = 28
+    maxZoom = len(gagrid.RESOLUTIONS)
     dpi = 90.7
     lods = []
-    for zoom in range(minZoom, maxZoom + 1):
+    for zoom in range(minZoom, maxZoom):
         lods.append(
             {'level': zoom,
              'resolution': gagrid.getResolution(zoom),


### PR DESCRIPTION
This is a cherry picked commit from the current develop branch.

The new implementation avoid out of bounds array reading which was causing the crashes.