### PR TITLE
Fixed mako with versionned urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,12 +65,14 @@ RUN pip3 install -e .
 ARG GIT_HASH=unknown
 ARG GIT_BRANCH=unknown
 ARG GIT_DIRTY=unknown
+ARG GIT_TAG=unknown
 ARG VERSION=unknown
 ARG AUTHOR=unknown
 
 LABEL git.hash=${GIT_HASH}
 LABEL git.branch=${GIT_BRANCH}
 LABEL git.dirty=${GIT_DIRTY}
+LABEL git.tag=${GIT_TAG}
 LABEL version=${VERSION}
 LABEL author=${AUTHOR}
 

--- a/buildspec-py3.yml
+++ b/buildspec-py3.yml
@@ -65,6 +65,12 @@ phases:
           GIT_BRANCH=$(git describe --exact-match --all 2>/dev/null || echo "unknown")
           export GIT_BRANCH=${GIT_BRANCH#heads/}
         fi
+      - |
+        if [[ "${GIT_TAG}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}-rc[0-9]+[[:alnum:]-]*$$ ]]; then
+          export APP_VERSION="${GIT_TAG}"
+        else
+          export APP_VERSION="0000-00-00-rc0-${GIT_HASH_SHORT}"
+        fi
       - |-
         if [ "${GIT_TAG}" = "unknown"  ] ; then
           DOCKER_IMG_TAG="${DOCKER_REGISTRY}/${SERVICE_NAME}:${GIT_BRANCH//\//_}.${GIT_HASH}"
@@ -151,8 +157,9 @@ phases:
         --build-arg GIT_HASH="${GIT_HASH}"
         --build-arg GIT_BRANCH="${GIT_BRANCH}"
         --build-arg GIT_DIRTY="${GIT_DIRTY}"
+        --build-arg GIT_TAG="${GIT_TAG}"
         --build-arg AUTHOR="CI"
-        --build-arg VERSION="${GIT_TAG}"
+        --build-arg VERSION="${APP_VERSION}"
         -t "${DOCKER_IMG_TAG}" -t "${DOCKER_IMG_TAG_LATEST}" .
       - echo Build completed on $(date)
 

--- a/chsdi/static/info.json.in
+++ b/chsdi/static/info.json.in
@@ -1,8 +1,9 @@
 {
-  "python":"${PYTHON_VERSION}",
-  "branch":"${GIT_BRANCH}",
-  "version": "${APP_VERSION}",
+  "python": "${PYTHON_VERSION}",
+  "branch": "${GIT_BRANCH}",
+  "tag": "${GIT_TAG}",
   "dirty": "${GIT_DIRTY}",
+  "version": "${APP_VERSION}",
   "last_commit_short": "${GIT_HASH_SHORT}",
   "last_commit_hash": "${GIT_HASH}",
   "last_commit_date": "${GIT_COMMIT_DATE}",


### PR DESCRIPTION
Some makos uses versionned urls, for those we have an apache rewrite url
that should match an official release version optionally followed by a git
hash.

This might be an issue if the git repository contains tag that don't match
our milestone version scheme. Therefore now we check if the GIT_TAG is valid
and if not we use a dummy version for the APP_VERSION.

This is only an issue on develop-* branches as here we don't do any git tagging on PR merge,  os it might take an invalid tag that has been done manually for any reason. That was the case with the manual tag `LAST_IRELAND_WORKING_SETUP_DEVELOP` that was created during the migration.