### PR TITLE
Removed useless service-alti apache config

### DIFF
--- a/apache/wsgi-py3.conf.in
+++ b/apache/wsgi-py3.conf.in
@@ -118,12 +118,6 @@ WSGIScriptAliasMatch ^${APACHE_ENTRY_PATH}/ ${WSGI_APP}
     WSGIApplicationGroup %{GLOBAL}
 </Directory>
 
-# Some services are not "free": control is done at varnish level
-<LocationMatch ^${APACHE_ENTRY_PATH}/rest/(height|profile)>
-   Order Deny,Allow
-   Allow from all
-</LocationMatch>
-
 
 # kml file downloads
 AliasMatch ^${APACHE_ENTRY_PATH}/kml/(map\.geo\.admin\.ch_KML_\d+\.kml)$ ${KML_TEMP_DIR}/$1

--- a/buildspec-py3.yml
+++ b/buildspec-py3.yml
@@ -56,7 +56,8 @@ phases:
         else
           # NOTE: For manual build trigger, CODEBUILD_WEBHOOK_HEAD_REF is not set therefore get
           # the branch name from git command. This is a bit hacky but did not find any other solution
-          export GIT_BRANCH=$(git show-ref --heads | grep $(git --no-pager show --format=%H) | head -1 | awk '{gsub("refs/heads/", ""); print $2}')
+          echo CODEBUILD_RESOLVED_SOURCE_VERSION=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+          export GIT_BRANCH=$(git describe --all | awk '{gsub("remotes/origin/|origin/|heads/|refs/heads/", ""); print $1}')
         fi
       - export GIT_BASE_BRANCH="${CODEBUILD_WEBHOOK_BASE_REF#refs/heads/}"
       - export GIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)


### PR DESCRIPTION
This apache config is a left over for when service-alti was still part of chsdi3.