### PR TITLE
BGDIINF_SB-2486: Moved the new config style url rewrite inside python - #3

### DIFF
--- a/apache/wsgi-py3.conf.in
+++ b/apache/wsgi-py3.conf.in
@@ -37,13 +37,6 @@ RedirectMatch ^${APACHE_ENTRY_PATH}$ ${APACHE_ENTRY_PATH}/
 RewriteRule ^${APACHE_ENTRY_PATH}/\d{4}-\d{2}-\d{2}-rc\d+(?:-[^/]*)?/(.*)$ ${APACHE_ENTRY_PATH}/$1 [E=${APACHE_BASE_PATH}setyearcache:true,PT]
 Header merge Cache-Control "max-age=31536013, public" env=${APACHE_BASE_PATH}setyearcache
 
-# New style config url (see mf-geoadmin3 #4687)
-RewriteRule ^${APACHE_ENTRY_PATH}/configs/(de|fr|it|rm|en)/layersConfig\.json ${APACHE_ENTRY_PATH}/rest/services/all/MapServer/layersConfig?lang=$1 [PT]
-RewriteRule ^${APACHE_ENTRY_PATH}/configs/(de|fr|it|rm|en)/translations\.json ${APACHE_ENTRY_PATH}/rest/services/translations?lang=$1 [PT]
-RewriteRule ^${APACHE_ENTRY_PATH}/configs/(de|fr|it|rm|en)/catalog\.(\w+)\.json ${APACHE_ENTRY_PATH}/rest/services/$2/CatalogServer?lang=$1 [PT]
-RewriteRule ^${APACHE_ENTRY_PATH}/configs/(de|fr|it|rm|en)/services\.json ${APACHE_ENTRY_PATH}/rest/services [PT]
-RewriteRule ^${APACHE_ENTRY_PATH}/configs/services\.json ${APACHE_ENTRY_PATH}/rest/services [PT]
-
 ############  WSGI #################################3
 
 # LoadModule wsgi_module modules/mod_wsgi.so

--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -97,6 +97,15 @@ def main(global_config, **settings):
     config.add_route('faqlist', '/rest/services/{map}/faqlist')
     config.add_route('color', '/color/{r},{g},{b}/{image}')
 
+    # Some new style routes used by the viewer see geoadmin/mf-geoadmin3 PR #4687 and geoadmin/web-mapviewer
+    config.add_route('layersConfig-1', '/configs/{lang:\w\w}/layersConfig.json')
+    config.add_route('translations-1', '/configs/{lang:\w\w}/translations.json')
+    config.add_route('catalog-1', '/configs/{lang:\w\w}/catalog.{map:\w+}.json')
+    # This route is only used by the new viewer geoadmin/web-mapviewer
+    config.add_route('topics-1', '/configs/services.json')
+    # The following route doesn't seems to be used anymore
+    # config.add_route('topics-2', '/configs/{lang:\w\w}/services.json')
+
     # Static route
     config.add_static_route('chsdi', 'static')
 

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -143,11 +143,16 @@ def locale_negotiator(request):
     except IOError:  # pragma: no cover
         raise HTTPRequestTimeout('Request was aborted. Didn\'t receive full request')
 
-    settings = get_current_registry().settings
-    languages = settings['available_languages'].split()
     if lang == 'rm':
         return 'fi'
-    elif lang is None or lang not in languages:
+
+    if lang is None and request.matchdict is not None and 'lang' in request.matchdict:
+        # Fallback to lang url parameter if available (required by the new /configs/ style urls
+        lang = request.matchdict['lang']
+
+    languages = get_current_registry().settings['available_languages'].split()
+
+    if lang not in languages:
         if request.accept_language:
             return request.accept_language.best_match(languages, 'de')
         # the default_locale_name configuration variable

--- a/chsdi/subscribers.py
+++ b/chsdi/subscribers.py
@@ -8,6 +8,7 @@ from pyramid.events import NewRequest
 from pyramid.events import BeforeRender
 from pyramid.events import NewResponse
 from pyramid.events import subscriber
+from pyramid.events import ContextFound
 from pyramid.i18n import get_localizer, TranslationStringFactory
 from chsdi.lib import helpers
 from chsdi.models.bod import get_translations
@@ -53,7 +54,7 @@ def update_localizer(lang, localizer, session):
     return localizer
 
 
-@subscriber(NewRequest)
+@subscriber(ContextFound)
 def add_localizer(event):
     request = event.request
     request._LOCALE_ = helpers.locale_negotiator(request)

--- a/chsdi/views/catalog.py
+++ b/chsdi/views/catalog.py
@@ -107,6 +107,7 @@ class CatalogService(MapNameValidation):
         self.staging = request.registry.settings['geodata_staging']
 
     @view_config(route_name='catalog', renderer='jsonp')
+    @view_config(route_name='catalog-1', renderer='jsonp')
     def catalog(self):
         model = Catalog
         query = self.request.db.query(model)\

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -45,7 +45,12 @@ def metadata(request):
 
 
 @view_config(route_name='layersConfig', renderer='jsonp')
+@view_config(route_name='layersConfig-1', renderer='jsonp')
 def layers_config(request):
+    if 'map' not in request.matchdict:
+        # New /configs/{lang}/layersConfig.json style url don't have a map value
+        # therefore fallback to 'all'
+        request.matchdict['map'] = 'all'
     params = BaseLayersValidation(request)
     query = params.request.db.query(LayersConfig)
     layers = {}

--- a/chsdi/views/topics.py
+++ b/chsdi/views/topics.py
@@ -7,6 +7,7 @@ from chsdi.lib.filters import filter_by_geodata_staging
 
 
 @view_config(route_name='topics', renderer='jsonp')
+@view_config(route_name='topics-1', renderer='jsonp')
 def topics(request):
     model = Topics
     geodataStaging = request.registry.settings['geodata_staging']

--- a/chsdi/views/translations.py
+++ b/chsdi/views/translations.py
@@ -16,6 +16,7 @@ class TranslationService(object):
         self.lang = request.lang
 
     @view_config(route_name='translations', renderer='jsonp')
+    @view_config(route_name='translations-1', renderer='jsonp')
     def translations(self):
         model = Translations
         lang = self.lang


### PR DESCRIPTION
For this support I had to move the `add_localizer()` hook from `NewRequest` to
`ContextFound` event. In the first one no routing is done and we cannot take
the `lang` parameter from the path for the new config style urls, while in the
ContextFound the routing has already be done and the `lang` url parameter has
already been parsed.