### PR TITLE
Fixing CI manual build and versioning

### DIFF
--- a/buildspec-py3.yml
+++ b/buildspec-py3.yml
@@ -35,7 +35,7 @@ phases:
       - echo "Installing kubectl"
       - curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/amd64/kubectl
       - chmod +x ./kubectl
-      - mkdir -p $HOME/bin && cp ./kubectl $HOME/bin/kubectl && export PATH=$PATH:$HOME/bin
+      - mkdir -p $HOME/bin && mv ./kubectl $HOME/bin/kubectl && export PATH=$PATH:$HOME/bin
       - kubectl version --short --client
       - echo "Configure AWS profile swisstopo-bgdi-dev"
       - sts=$(aws sts assume-role --role-arn "arn:aws:iam::839910802816:role/kubernetes-codebuild-dev" --role-session-name "swisstopo-bgdi-dev")
@@ -56,7 +56,7 @@ phases:
           # NOTE: For manual build trigger, CODEBUILD_WEBHOOK_HEAD_REF is not set therefore get
           # the branch name from git command. This is a bit hacky but did not find any other solution
           echo CODEBUILD_RESOLVED_SOURCE_VERSION=${CODEBUILD_RESOLVED_SOURCE_VERSION}
-          export GIT_BRANCH=$(git describe --all | awk '{gsub("remotes/origin/|origin/|heads/|refs/heads/", ""); print $1}')
+          export GIT_BRANCH=$(git show-ref --heads | grep $(git --no-pager show --format=%H) | head -1 | awk '{gsub("refs/heads/", ""); print $2}')
         fi
       - export GIT_BASE_BRANCH="${CODEBUILD_WEBHOOK_BASE_REF#refs/heads/}"
       - export GIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -51,6 +51,7 @@ class TestsBase(TestCase):
 
     def setUp(self):
         from pyramid.paster import get_app, get_appsettings
+        os.environ['TEST_APP'] = '1'
         dir_path = os.path.dirname(os.path.realpath(__file__))
         inifile = os.path.realpath(os.path.join(dir_path, '../..', 'development.ini'))
         app = get_app(inifile)


### PR DESCRIPTION
The docker image was build with the dirty label due to the installation of
kubectl locally inside the repo. This has been fixed by moving kubectl to
~/bin instead of copying.

Manual build on master branch did not pushed the docker image on ECR, because
the `git describe` command returns the tag instead of the ref.