### PR TITLE
Do not log access log to other_vhosts_access.log

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,4 +1,5 @@
 APACHE_LOG_LEVEL=error
+APACHE_LOG_FMT=%M
 HTTP_PORT=8009
 API_URL=//sys-api3.dev.bgdi.ch
 AWS_DEFAULT_REGION=eu-central-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV GROUP geodata
 
 # Setup default logging levels
 ENV APACHE_LOG_LEVEL=info
-ENV APACHE_LOG_FMT=%M
+ENV APACHE_LOG_FMT="[%{cu}t] [%l] [pid/tid %P/%T] [%m] [ID %L] %M"
 
 # REQUIREMENTS NOTE:
 #  - gettext-base is required for envsubst in docker-entrypoint.sh

--- a/apache/25-mf-chsdi3.conf.in
+++ b/apache/25-mf-chsdi3.conf.in
@@ -3,6 +3,9 @@
 # Managed by Puppet
 # ************************************
 
+# Print the server starting logs to /dev/stdout
+ErrorLog /dev/stdout
+
 <VirtualHost *:${HTTP_PORT}>
   # ServerName mf-chsdi3
 
@@ -33,6 +36,7 @@
   ErrorLogFormat "${APACHE_LOG_FMT}"
   ErrorLog /dev/stdout
   LogLevel ${APACHE_LOG_LEVEL}
+  CustomLog /dev/null common
   ServerSignature Off
 
 


### PR DESCRIPTION
If you don't set `CostomLog` in your vhost config, by default access log are
logged into other_vhosts_access.log file.
    
Also set the global `ErrorLog` to stdout in order to have the apache starting
logs in stdout instead of error.log file.

In deployment used a more meaning full log format for apache. Application
logs are logged directly into a file. For local development application logs
are logged to stdout therefore only use %M in apache.