### PR TITLE
Fixing logging for Kibana

### DIFF
--- a/chsdi/logging_tweens.py
+++ b/chsdi/logging_tweens.py
@@ -10,7 +10,7 @@ def logging_context_tween(handler, registry):
             "request": {
                 "method": request.method,
                 "path": request.path,
-                "queryString": request.query_string,
+                "query_string": request.query_string,
                 "headers": dict(request.headers),
                 "payload": helpers.get_payload(request)
             }

--- a/chsdi/subscribers.py
+++ b/chsdi/subscribers.py
@@ -100,7 +100,7 @@ def log_response(event):
             extra={
                 "duration": time.time() - started_at if started_at else '',
                 "response": {
-                    "status_code": event.response.status,
+                    "status_code": event.response.status_code,
                     "headers": {h[0]: h[1] for h in event.response.headerlist},
                     "payload": helpers.get_payload(event.response)
                 }


### PR DESCRIPTION
In Kibana the request.statusCode field is used as integer and not as string.

Also changed the query_string nomenclature to be consistent.

K8s logging needs to be changed see https://github.com/geoadmin/infra-kubernetes/pull/286