### PR TITLE
Fixing pool pre ping default value.

### DIFF
--- a/chsdi/models/__init__.py
+++ b/chsdi/models/__init__.py
@@ -22,8 +22,10 @@ def initialize_sql(settings):
             pool_recycle=20,
             pool_size=20,
             max_overflow=-1,
-            pool_pre_ping=bool(strtobool(settings.get("sqlalchemy.pool_pre_ping", "False"))),
-            isolation_level=settings.get("sqlalchemy.isolation_level", "READ COMMITTED"),
+            pool_pre_ping=bool(strtobool(
+                settings["sqlalchemy.pool_pre_ping"] if settings["sqlalchemy.pool_pre_ping"] else "False")
+            ),
+            isolation_level=settings["sqlalchemy.isolation_level"] if settings["sqlalchemy.isolation_level"] else "READ COMMITTED",
             connect_args={"connect_timeout": 10}
         )
         engines[db] = engine


### PR DESCRIPTION
When no pool pre ping environment variable is defined then the config
`sqlalchemy.pool_pre_ping` is an empty string.