### PR TITLE
Update stopo.py

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2034,7 +2034,7 @@ class OerebkatasterZoom1(Base, Oerebkataster, Vector):
     __tablename__ = 'view_stand_oereb_parcel'
     oereb_webservice = Column('oereb_webservice', Unicode)
     bgdi_status = Column('bgdi_status', Integer)
-    egris_egrid = Column('egris_egrid', Integer)
+    egris_egrid = Column('egris_egrid', Unicode)
     oereb_extract_pdf = Column('oereb_extract_pdf', Unicode)
     oereb_extract_url = Column('oereb_extract_url', Unicode)
     number = Column('number_', Integer)


### PR DESCRIPTION
fix wrong attribute type for egris_egrid in model of layer ch.swisstopo-vd.stand-oerebkataster