### PR TITLE
set uuid as primary key

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -3054,9 +3054,8 @@ register(FixpunkteHfp2.__bodId__, FixpunkteHfp2)
 class SwisstneBase:
     __table_args__ = ({'schema': 'tlm', 'autoload': False})
     __bodId__ = 'ch.swisstopo.swisstne-base'
-    __label__ = 'uuid'
+    __label__ = 'id'
     id = Column('bgdi_id', Unicode, primary_key=True)
-    uuid = Column('uuid', Unicode)
     the_geom = Column(Geometry2D)
 
 

--- a/chsdi/templates/htmlpopup/swisstne_base_line.mako
+++ b/chsdi/templates/htmlpopup/swisstne_base_line.mako
@@ -3,7 +3,7 @@
 <%def name="table_body(c, lang)">
     <tr>
       <td class="cell-left">${_('ch.swisstopo.swisstne-base.uuid')}</td>
-      <td>${c['attributes']['uuid'] or '-'}</td>
+      <td>${c['featureId'] or '-'}</td>
     </tr>
     <tr>
       <td class="cell-left">${_('ch.swisstopo.swisstne-base.from_node_uuid')}</td>

--- a/chsdi/templates/htmlpopup/swisstne_base_point.mako
+++ b/chsdi/templates/htmlpopup/swisstne_base_point.mako
@@ -3,7 +3,7 @@
 <%def name="table_body(c, lang)">
     <tr>
       <td class="cell-left">${_('ch.swisstopo.swisstne-base.uuid')}</td>
-      <td>${c['attributes']['uuid'] or '-'}</td>
+      <td>${c['featureId'] or '-'}</td>
     </tr>
 </%def>
 

--- a/chsdi/templates/htmlpopup/swisstne_base_poly.mako
+++ b/chsdi/templates/htmlpopup/swisstne_base_poly.mako
@@ -7,7 +7,7 @@
   %>
   <tr>
     <td class="cell-left">${_('ch.swisstopo.swisstne-base.uuid')}</td>
-    <td>${c['attributes']['uuid'] or '-'}</td>
+    <td>${c['featureId'] or '-'}</td>
   </tr>
   <tr>
     <td class="cell-left">${_('ch.swisstopo.swisstne-base.type')}</td>


### PR DESCRIPTION
In order for the click on the SphinxSearch results to work, the same column must be used as the primary key in CHSDI.