### PR TITLE
set uuid as primary key

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -3055,7 +3055,7 @@ class SwisstneBase:
     __table_args__ = ({'schema': 'tlm', 'autoload': False})
     __bodId__ = 'ch.swisstopo.swisstne-base'
     __label__ = 'id'
-    id = Column('bgdi_id', Unicode, primary_key=True)
+    id = Column('uuid', Unicode, primary_key=True)
     the_geom = Column(Geometry2D)
 
 


### PR DESCRIPTION
In order for the click on the SphinxSearch results to work, the same column must be used as the primary key in CHSDI.