### PR TITLE
BGDIDIC-2600 BGDIDIC-2601 use id from the data itself

### DIFF
--- a/chsdi/models/vector/uvek.py
+++ b/chsdi/models/vector/uvek.py
@@ -1492,7 +1492,7 @@ class Bakomtv(Base, Vector):
     __template__ = 'templates/htmlpopup/bakomtv.mako'
     __bodId__ = 'ch.bakom.versorgungsgebiet-tv'
     __label__ = 'prog'
-    id = Column('gid', Integer, primary_key=True)
+    id = Column('zone_id', Integer, primary_key=True)
     prog = Column('prog', Unicode)
     the_geom = Column(Geometry2D)
 
@@ -1505,7 +1505,7 @@ class Bakomukw(Base, Vector):
     __template__ = 'templates/htmlpopup/bakomukw.mako'
     __bodId__ = 'ch.bakom.versorgungsgebiet-ukw'
     __label__ = 'prog'
-    id = Column('gid', Integer, primary_key=True)
+    id = Column('zone_id', Integer, primary_key=True)
     prog = Column('prog', Unicode)
     the_geom = Column(Geometry2D)
 


### PR DESCRIPTION
Use the `zone_id` which is the ID given by the data instead of `gid` which is a generated sequence and has hot much to do with the data.

Note to me:
Add post deploy task to remove the attribute `gid` in the tables