### PR TITLE
BGDIINF_SB-3047: Removed final resolution from definition

### DIFF
--- a/chsdi/static/doc/source/index.rst
+++ b/chsdi/static/doc/source/index.rst
@@ -81,8 +81,7 @@ Use the GeoAdmin API Forum to ask questions: http://groups.google.com/group/geoa
         1.5,
         1,
         0.5,
-        0.25,
-        0.1
+        0.25
       ];
 
       // adding Swiss projections to proj4 (proj string comming from https://epsg.io/)


### PR DESCRIPTION
When defining higher resolution than the wms provides, OL

queries are answered with a HTTP400 from the WMTS. So this example

has been adapted to the max resoulution of the layer queried