### PR TITLE
BGDIDIC-984: Revert activate time support / timeseries for pk25

### DIFF
--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -810,8 +810,8 @@ class GridstandTemplate:
     id = Column('gid', BigInteger, primary_key=True)
     tileid = Column('tileid', Unicode)
     lk_name = Column('lk_name', Unicode)
-    datenstand = Column('release', Integer)  # flightyear
-    releasekey = Column('releasekey', Unicode)  # gdwh_releasekey
+    datenstand = Column('release', Integer)
+    releasekey = Column('releasekey', Unicode)
     the_geom = Column(Geometry2D)
 
 
@@ -826,9 +826,7 @@ class GridstandPermiterTemplate:
 
 class GridstandPk25Meta(Base, GridstandTemplate, Vector):
     __bodId__ = 'ch.swisstopo.pixelkarte-pk25.metadata'
-    __tablename__ = 'view_pk25_metadata'
-    __timeInstant__ = 'year'
-    year = Column('year', Unicode)
+    __tablename__ = 'view_gridstand_datenhaltung_pk25_tilecache'
 
 
 register('ch.swisstopo.pixelkarte-pk25.metadata', GridstandPk25Meta)


### PR DESCRIPTION
we have to revert the pk25 timeseries for the next deploy

This reverts commit d2738699e2270caa4e1ee6baf5ca77e7c3d6b81d.