### PR TITLE
BGDIDIC-642: prepare for stac

### DIFF
--- a/chsdi/models/vector/lubis.py
+++ b/chsdi/models/vector/lubis.py
@@ -143,6 +143,7 @@ class LuftbilderSchraegaufnahmen(Base, Vector):
     # Composite labels
     __label__ = 'flightdate'
     id = Column('ebkey', Unicode, primary_key=True)
+    ebkey_old = Column('ebkey_old', Unicode)
     inventory_number = Column('inventory_number', Unicode)
     flightdate = Column('flightdate', Unicode)
     medium_format = Column('medium_format', Unicode)
@@ -167,10 +168,10 @@ class LuftbilderTerrA(Base, Vector):
     __bodId__ = 'ch.swisstopo.lubis-terrestrische_aufnahmen'
     __timeInstant__ = 'bgdi_flugjahr'
     __returnedGeometry__ = 'the_geom_footprint'
-    __timeInstant__ = 'bgdi_flugjahr'
     __extended_info__ = True
     __label__ = 'flugdatum'
     id = Column('inventory_number', Unicode, primary_key=True)
+    inventarnummer_old = Column('inventarnummer_old', Unicode)
     inventarnummer = Column('objectid', Integer)
     image_number = Column('image_number', Integer)
     flugdatum = Column('bgdi_flugdatum', Unicode)

--- a/chsdi/models/vector/lubis.py
+++ b/chsdi/models/vector/lubis.py
@@ -13,7 +13,6 @@ class LuftbilderBase:
     __template__ = 'templates/htmlpopup/lubis.mako'
     __returnedGeometry__ = 'the_geom_footprint'
     __timeInstant__ = 'bgdi_flugjahr'
-    __extended_info__ = True
     __label__ = 'flugdatum'
     id = Column('ebkey', Unicode, primary_key=True)
     filename = Column('filename', Unicode)
@@ -61,6 +60,7 @@ register('ch.swisstopo.lubis-luftbilder_farbe', LuftbilderSwisstopoFarbe)
 
 
 class LuftbilderSwisstopoIr(Base, LuftbilderBaseStac, Vector):
+    __extended_info__ = True
     __tablename__ = 'luftbilder_swisstopo_ir'
     __bodId__ = 'ch.swisstopo.lubis-luftbilder_infrarot'
     image_height = Column('image_height', Integer)

--- a/chsdi/templates/htmlpopup/lubis_terra.mako
+++ b/chsdi/templates/htmlpopup/lubis_terra.mako
@@ -63,57 +63,73 @@ lang = lang if lang in ('fr','it','en') else 'de'
 c['stable_id'] = True
 request = context.get('request')
 
-toposhopscan = 'nein'
-if c['attributes']['filename'] :
-    toposhopscan = 'ja'
-
 aerialimages_data_host = request.registry.settings['aerialimages_data_host']
 tileUrlBasePath = aerialimages_data_host + '/tiles'
 preview_url = determinePreviewUrl(tileUrlBasePath, c['featureId'])
 
-image_width = c['attributes']['image_width'] if 'image_width' in  c['attributes'] else None
-image_height = c['attributes']['image_height'] if 'image_height' in c['attributes'] else None
-image_rotation = 0
-firma = '-'
 
-if image_width is None or image_height is None:
+# set true if featureId comes from stac
+isStac = c['featureId'].startswith('lubis-terrestrische_aufnahmen')
+
+datum = date_to_str(c['attributes']['flugdatum'])
+if isStac:
+  dataGeoAdminHost = request.registry.settings['datageoadminhost']
+  asset_url=f"{dataGeoAdminHost}/{c['layerBodId']}/{c['featureId']}/{c['featureId']}.tif"
+  preview_url=f"{dataGeoAdminHost}/{c['layerBodId']}/{c['featureId']}/{c['featureId']}.jpg"
+  meta_csv_url=f"{dataGeoAdminHost}/{c['layerBodId']}/{c['featureId']}/{c['featureId']}.csv"
+  viewer_url=asset_url
+  tt_lubis_Quickview='tt_lubis_Quickview_stac'
+  url_pdf = dataGeoAdminHost + "/" + c['layerBodId'] + "/pdf/" + c['attributes']['base_uuid'] + '.pdf'
+  pdf = h.resource_exists(url_pdf) or None
+  url_smapshot= "https://smapshot.heig-vd.ch/map/?imageId={}".format(c['attributes']['smapshot_id'])
+# legacy: old ebkeys with fullresviewer in aerialimages bucket
+# this part can be removed when the migration of the aerialimages bucket to stac/data.geo.admin.ch is finished
+else:
+  image_rotation = 0
+  firma = '-'
   wh = h.imagesize_from_metafile(tileUrlBasePath, c['featureId'])
   image_width = wh[1]
   image_height = wh[0]
+  params = (
+      image_width,
+      image_height,
+      _('tt_lubis_ebkey'),
+      c['featureId'],
+      firma,
+      c['layerBodId'],
+      lang,
+      image_rotation)
+  viewer_url = get_viewer_url(request, params)
 
-
-datum = date_to_str(c['attributes']['flugdatum'])
-params = (
-    image_width,
-    image_height,
-    _('tt_lubis_ebkey'),
-    c['featureId'],
-    firma,
-    c['layerBodId'],
-    lang,
-    image_rotation)
-viewer_url = get_viewer_url(request, params)
 %>
-<tr>
-  <td class="cell-left">${_(tt_lubis_ebkey)}</td>
-  <td>${c['attributes']['image_number'] or '-'}</td>
-</tr>
-<tr><td class="cell-left">${_('tt_lubis_inventarnummer')}</td>          <td>${c['attributes']['inventarnummer'] or '-'}</td></tr>
-<tr>
-  <td class="cell-left">${_('ch.swisstopo.lubis-terrestrische_aufnahmen.tt_lubis_aufnahmedatum')}</td>
-  <td>${datum or '-'}</td>
-</tr>
-<tr>
-  <td class="cell-left">${_('tt_lubis_Filmart')}</td>
-  <td>${c['attributes']['filmart'] or '-'}</td>
-</tr>
-
-% if 'contact_image_url' in c['attributes'] and c['attributes']['contact_image_url']:
-<tr>
-  <td class="cell-left">${_('tt_lubis_url_canton')}</td>
-  <td><a href="${c['attributes']['contact_image_url']}" target="_blank">${c['attributes']['contact_image_url']}</a></td>
-</tr>
+% if isStac: # STAC Tooltips
+<tr><td class="cell-left">${_(tt_lubis_ebkey)}</td>                       <td>${c['attributes']['image_number'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('ch.swisstopo.lubis-terrestrische_aufnahmen.tt_lubis_aufnahmedatum')}</td><td>${datum or '-'}</td></tr>
+<tr><td class="cell-left">${_('tt_lubis_bildpfad')}</td>                  <td>${c['attributes']['filename'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('ch.swisstopo.lubis-terrestrische_aufnahmen.operate_name')}</td>      <td>${c['attributes']['ort'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('ch.swisstopo.lubis-terrestrische_aufnahmen.station')}</td>      <td>${c['attributes']['station'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('tt_lubis_schraegaufnahmen_x')}</td>        <td>${c['attributes']['x'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('tt_lubis_schraegaufnahmen_y')}</td>        <td>${c['attributes']['y'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('tt_lubis_Filmart')}</td>                   <td>${c['attributes']['filmart'] or '-'}</td></tr>
+% if pdf:
+<tr><td class="cell-left">${_('link')}</td><td><a href="${url_pdf}" target="_blank">${_('ch.swisstopo.lubis-terrestrische_aufnahmen.expertenlink')} - pdf</a></td></tr>
 % endif
+<tr><td class="cell-left">${_('link')} smapshot</td>                    <td><a href="${url_smapshot}" target="_blank">${_('link')} smapshot</a></td></tr>
+<tr><td class="cell-left">${_("zusatzinfo")}</td>
+  <td>
+    <a href="${meta_csv_url}" target="_blank">${_(f"{c['layerBodId']}.meta_csv_url")}</a>
+  </td>
+</tr>
+<tr><td class="cell-left">${_(tt_lubis_Quickview)}</td>
+  <td>
+    <a href="${viewer_url}" target="_blank"><img src="${preview_url}" alt="quickview"></a>
+  </td>
+</tr>
+% else: # OLD Tooltips with GDWH datasource
+<tr><td class="cell-left">${_(tt_lubis_ebkey)}</td>                       <td>${c['attributes']['image_number'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('tt_lubis_inventarnummer')}</td>            <td>${c['attributes']['inventarnummer'] or '-'}</td></tr>
+<tr><td class="cell-left">${_('ch.swisstopo.lubis-terrestrische_aufnahmen.tt_lubis_aufnahmedatum')}</td><td>${datum or '-'}</td></tr>
+<tr><td class="cell-left">${_('tt_lubis_Filmart')}</td><td>${c['attributes']['filmart'] or '-'}</td></tr>
 
 % if preview_url != "" and image_width != None:
 <tr>
@@ -128,73 +144,34 @@ viewer_url = get_viewer_url(request, params)
   <td>${_('tt_lubis_noQuickview')}</td>
 </tr>
 % endif
-
-% if 'contact_web' in c['attributes']:
-<tr>
-  <th class="cell-left">${_('tt_lubis_bildorder')}</th>
-  <td>
-    ${c['attributes']['contact'] | br }
-    <br/>
-    ${c['attributes']['contact_email']}
-    <br/>
-
-% if  c['attributes']['contact_web'] != '-':
-    <a href="${c['attributes']['contact_web']}" target="_blank">
-% endif
-
-    ${c['attributes']['contact_web']}
-
-% if  c['attributes']['contact_web'] != '-':
-    </a>
-% endif
-
-  </td>
-</tr>
 % endif
 </%def>
 
 
 <%def name="extended_info(c, lang)">
 <%
+# TODO: extended tooltip can be completely removed after the migration to stac
 from chsdi.lib.helpers import resource_exists
 
 c['stable_id'] = True
-if c['layerBodId'] == 'ch.swisstopo.lubis-luftbilder_farbe':
-    imgtype = 1
-elif c['layerBodId'] == 'ch.swisstopo.lubis-luftbilder_infrarot':
-    imgtype = 2
-else:
-    imgtype = 0
-endif
 protocol = request.scheme
 c['baseUrl'] = h.make_agnostic(''.join((protocol, '://', request.registry.settings['geoadminhost'])))
 topic = request.matchdict.get('map')
 lang = request.lang
+
 aerialimages_data_host = request.registry.settings['aerialimages_data_host']
 tileUrlBasePath = aerialimages_data_host + '/tiles'
-
-
 preview_url = determinePreviewUrl(tileUrlBasePath, c['featureId'])
 
-filesize_mb = '-'
-toposhopscan = 'nein'
-filename = c['attributes']['filename']
-if filename:
-    filesize_mb = c['attributes']['filesize_mb']
-    toposhopscan = 'ja'
-endif
+filename = c['attributes']['filename'] or '-'
+filesize_mb = c['attributes']['filesize_mb'] or '-'
 
 datum = date_to_str(c['attributes']['flugdatum'])
-image_width =  c['attributes']['image_width'] if 'image_width' in  c['attributes'] else None
-image_height = c['attributes']['image_height'] if 'image_height' in c['attributes'] else None
 image_rotation = 0
 firma = '-'
-
-if image_width is None or image_height is None:
-  wh = h.imagesize_from_metafile(tileUrlBasePath, c['featureId'])
-  image_width = wh[1]
-  image_height = wh[0]
-
+wh = h.imagesize_from_metafile(tileUrlBasePath, c['featureId'])
+image_width = wh[1]
+image_height = wh[0]
 params = (
     image_width,
     image_height,
@@ -209,11 +186,12 @@ viewer_url = get_viewer_url(request, params)
 dataPath = 'ch.swisstopo.lubis-terrestrische_aufnahmen/'
 dataGeoAdminHost = request.registry.settings['datageoadminhost']
 pdf = None
-
 url_pdf = dataGeoAdminHost + "/" + dataPath + "pdf/" + c['attributes']['base_uuid'] + '.pdf'
 pdf = resource_exists(url_pdf)
 
 url_smapshot= "https://smapshot.heig-vd.ch/map/?imageId={}".format(c['attributes']['smapshot_id'])
+
+isStac = c['featureId'].startswith('lubis-terrestrische_aufnahmen')
 %>
 <title>${_('tt_lubis_ebkey')}: ${c['featureId']}</title>
 
@@ -241,6 +219,7 @@ url_smapshot= "https://smapshot.heig-vd.ch/map/?imageId={}".format(c['attributes
     </tr>
     <tr><th class="cell-left">${_('link')} smapshot</th>         <td><a href="${url_smapshot}" target="_blank">${_('link')} smapshot</a></td></tr>
   </table>
+% if not isStac:
   <br>
 <div class="chsdi-map-container table-with-border">
  <iframe src="${''.join((c['baseUrl'], '/embed.html', '?', c['layerBodId'], '=', str(c['featureId']), '&lang=', lang, '&topic=', topic,'&bgLayer=ch.swisstopo.pixelkarte-grau'))}" width='580' height='300' style="width: 100%;" frameborder='0' style='border:0'></iframe>
@@ -259,7 +238,7 @@ url_smapshot= "https://smapshot.heig-vd.ch/map/?imageId={}".format(c['attributes
 %endif
     }
   </script>
-
+% endif
 </body>
 </%def>
 

--- a/chsdi/templates/htmlpopup/lubis_terra.mako
+++ b/chsdi/templates/htmlpopup/lubis_terra.mako
@@ -11,7 +11,6 @@ import markupsafe
 def br(text):
     return text.replace('\n', markupsafe.Markup('<br />'))
 
-
 def determinePreviewUrl(tileUrlBasePath, ebkey):
 
     tileUrlBasePath = tileUrlBasePath

--- a/tests/integration/test_features_service.py
+++ b/tests/integration/test_features_service.py
@@ -563,10 +563,6 @@ class TestFeaturesView(TestsBase):
         resp = self.testapp.get('/rest/services/ech/MapServer/ch.bakom.radio-fernsehsender/11/extendedHtmlPopup', status=200)
         self.assertEqual(resp.content_type, 'text/html')
 
-    def test_extendedhtmlpopup_valid_lubis(self):
-        resp = self.testapp.get('/rest/services/all/MapServer/ch.swisstopo.lubis-luftbilder_farbe/lubis-luftbilder_farbe_000-277-465/extendedHtmlPopup', status=200)
-        self.assertEqual(resp.content_type, 'text/html')
-
     def test_extendedhtmlpopup_valid_langs(self):
         for lang in ('de', 'fr', 'it', 'rm', 'en'):
             try:


### PR DESCRIPTION
this pr will prepare the models and the mako of
* ch.swisstopo.lubis-luftbilder_infrarot
* ch.swisstopo.lubis-terrestrische_aufnahmen
* ch.swisstopo.lubis-luftbilder_schraegaufnahmen

for the parllel operation of images delivered by stac and the old images.

Once the migration of the aerialimages bucket is finished, the clean-up of the affected models and makos can be done.
* remove extended tooltip
* remove full res related viewer code / embed.html iframes etc.
* standard tooltip only