### PR TITLE
remove unsupported lang

### DIFF
--- a/chsdi/templates/htmlpopup/bakom_standorte_mobilfunkanlagen.mako
+++ b/chsdi/templates/htmlpopup/bakom_standorte_mobilfunkanlagen.mako
@@ -2,7 +2,7 @@
 
 <%def name="table_body(c, lang)">
     <%
-        lang = lang if lang in ('fr','it','rm','en') else 'de'
+        lang = lang if lang in ('fr','it','en') else 'de'
         typ_text = 'typ_%s' %lang
         power_text = 'power_%s' %lang
         techno_text = 'techno_%s' %lang


### PR DESCRIPTION
e2e test are failing in the current milestone deploy:

```
Traceback (most recent call last):
  File "/home/ltclm/.local/share/virtualenvs/mf-chsdi3-rPHPdC_d/lib/python3.9/site-packages/pyramid_mako/__init__.py", line 148, in __call__
    result = template.render_unicode(**system)
  File "/home/ltclm/.local/share/virtualenvs/mf-chsdi3-rPHPdC_d/lib/python3.9/site-packages/mako/template.py", line 444, in render_unicode
    return runtime._render(
  File "/home/ltclm/.local/share/virtualenvs/mf-chsdi3-rPHPdC_d/lib/python3.9/site-packages/mako/runtime.py", line 874, in _render
    _render_context(
  File "/home/ltclm/.local/share/virtualenvs/mf-chsdi3-rPHPdC_d/lib/python3.9/site-packages/mako/runtime.py", line 916, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/home/ltclm/.local/share/virtualenvs/mf-chsdi3-rPHPdC_d/lib/python3.9/site-packages/mako/runtime.py", line 943, in _exec_template
    callable_(context, *args, **kwargs)
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/base.mako", line 59, in render_body
    ${self.table_body(c, lang)}
  File "/home/ltclm/mf-chsdi3/chsdi/templates/htmlpopup/bakom_standorte_mobilfunkanlagen.mako", line 19, in render_table_body
    <td>${c['attributes'][typ_text] or '-'}</td>
KeyError: 'typ_rm'
```

rm is not supported in the model