### PR TITLE
PB-130: HTTP 405 when method not allowed.

### DIFF
--- a/apache/25-mf-chsdi3.conf.in
+++ b/apache/25-mf-chsdi3.conf.in
@@ -54,4 +54,9 @@ ErrorLog /dev/stdout
   # ServerAlias mf-chsdi3.prod.bgdi.ch
   # ServerAlias s.geo.admin.ch
   SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+
+  # WSGI response on OPTIONS is an empty body
+  # no need to zip an empty body
+  RewriteCond %{REQUEST_METHOD} OPTIONS
+  RewriteRule ^(.*)$ $1 [PT,E=no-gzip:1]
 </VirtualHost>


### PR DESCRIPTION
- OPTIONS: empty responses are not being zipped anymore `content-length: 0`

- HTTP 405 on not in GET HEAD OPTIONS