### PR TITLE
BGDIDIC-2857: use stable id

### DIFF
--- a/chsdi/models/vector/edi.py
+++ b/chsdi/models/vector/edi.py
@@ -452,9 +452,8 @@ class StatistischeGrundeinheitenStufe1(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __bodId__ = 'ch.bfs.statistische-grundeinheiten_stufe1'
     __template__ = 'templates/htmlpopup/bfs_statistische_grundeinheiten_stufe1.mako'
-    __label__ = 'u1_id'
-    id = Column('bgdi_id', Integer, primary_key=True)
-    u1_id = Column('u1_id', Integer)
+    __label__ = 'u1_name'
+    id = Column('u1_id', Integer, primary_key=True)
     u1_name = Column('u1_name', Unicode)
     kt_id = Column('kt_id', Integer)
     u1_typ = Column('u1_typ', Integer)
@@ -472,9 +471,8 @@ class StatistischeGrundeinheitenStufe2(Base, Vector):
     __table_args__ = ({'schema': 'bfs', 'autoload': False})
     __bodId__ = 'ch.bfs.statistische-grundeinheiten_stufe1'
     __template__ = 'templates/htmlpopup/bfs_statistische_grundeinheiten_stufe2.mako'
-    __label__ = 'u2_id'
-    id = Column('bgdi_id', Integer, primary_key=True)
-    u2_id = Column('u2_id', Integer)
+    __label__ = 'u2_name'
+    id = Column('u2_id', Integer, primary_key=True)
     u2_name = Column('u2_name', Unicode)
     kt_id = Column('kt_id', Integer)
     the_geom = Column('the_geom', Geometry2D)

--- a/chsdi/templates/htmlpopup/bfs_statistische_grundeinheiten_stufe1.mako
+++ b/chsdi/templates/htmlpopup/bfs_statistische_grundeinheiten_stufe1.mako
@@ -2,12 +2,14 @@
 
 <%def name="table_body(c,lang)">
     <%
+        c['stable_id'] = True
+
         lang = 'de' if lang in ('de', 'rm', 'en') else 'fr'
         typ = 'typ_%s' % lang
     %>
     <tr>
         <td class="cell-left">${_('ch.bfs.statistische-grundeinheiten_stufe1.u1_id')}</td>
-        <td>${c['attributes']['u1_id'] or '-'}</td>
+        <td>${c['featureId'] or '-'}</td>
     </tr>
     <tr>
         <td class="cell-left">${_('ch.bfs.statistische-grundeinheiten_stufe1.u1_name')}</td>

--- a/chsdi/templates/htmlpopup/bfs_statistische_grundeinheiten_stufe2.mako
+++ b/chsdi/templates/htmlpopup/bfs_statistische_grundeinheiten_stufe2.mako
@@ -1,9 +1,12 @@
 <%inherit file="base.mako"/>
 
 <%def name="table_body(c,lang)">
+    <%
+        c['stable_id'] = True
+    %>
     <tr>
         <td class="cell-left">${_('ch.bfs.statistische-grundeinheiten_stufe2.u2_id')}</td>
-        <td>${c['attributes']['u2_id'] or '-'}</td>
+        <td>${c['featureId'] or '-'}</td>
     </tr>
     <tr>
         <td class="cell-left">${_('ch.bfs.statistische-grundeinheiten_stufe2.u2_name')}</td>


### PR DESCRIPTION
@ltclm Using now this link: http://localhost:8080/#/map?lang=en&center=2660000,1190000&z=1&bgLayer=ch.swisstopo.pixelkarte-farbe&topic=ech&swisssearch=Basic+statistical+units+level+1&layers=ch.bfs.statistische-grundeinheiten_stufe1@features=1606006:1606007:1606008&featureInfo=default

The Link to object points to the old https://mf-geoadmin3.dev.bgdi.ch

Is this a bug?