### PR TITLE
PB-1269, PB-1241: Fix cross domain policy

### DIFF
--- a/apache/wsgi-py3.conf.in
+++ b/apache/wsgi-py3.conf.in
@@ -35,6 +35,9 @@ RewriteRule ^${APACHE_ENTRY_PATH}/info.json ${APACHE_ENTRY_PATH}/static/info.jso
 
 # Static for cross domain flash/arcgis
 RewriteRule ^${APACHE_ENTRY_PATH}/(crossdomain.xml|clientaccesspolicy.xml) ${APACHE_ENTRY_PATH}/static/$1 [PT]
+<LocationMatch ^${APACHE_ENTRY_PATH}/static/(crossdomain.xml|clientaccesspolicy.xml)>
+    Header set Content-type "text/x-cross-domain-policy"
+</LocationMatch>
 
 # New style config url (see mf-geoadmin3 #4687)
 RewriteRule ^${APACHE_ENTRY_PATH}/configs/(de|fr|it|rm|en)/layersConfig\.json ${APACHE_ENTRY_PATH}/rest/services/all/MapServer/layersConfig?lang=$1 [PT]

--- a/chsdi/response_callbacks.py
+++ b/chsdi/response_callbacks.py
@@ -24,9 +24,3 @@ def add_cors_header(request, response):
     response.headers['Access-Control-Allow-Origin'] = "*"
     response.headers['Access-Control-Allow-Methods'] = request.registry.settings['request_method']
     response.headers['Access-Control-Allow-Headers'] = "*"
-
-
-def add_cross_domain_policy(request, response):
-    # Check if the request is a cross domain policy request
-    if request.path in ['/crossdomain.xml', '/clientaccesspolicy.xml']:
-        response.headers['Content-Type'] = 'text/x-cross-domain-policy'

--- a/chsdi/subscribers.py
+++ b/chsdi/subscribers.py
@@ -11,7 +11,6 @@ from chsdi.lib import helpers
 from chsdi.models.bod import get_translations
 from chsdi.response_callbacks import add_default_cache_control
 from chsdi.response_callbacks import add_cors_header
-from chsdi.response_callbacks import add_cross_domain_policy
 
 
 import logging
@@ -85,7 +84,6 @@ def log_request(event):
 def setup_response_callbacks(event):
     event.request.add_response_callback(add_default_cache_control)
     event.request.add_response_callback(add_cors_header)
-    event.request.add_response_callback(add_cross_domain_policy)
 
 
 @subscriber(NewResponse)


### PR DESCRIPTION
With the removal of Akhet library static files are directly served by Apache
and not anymore by pyramid so the patching of cross domain policy header needs
to be done by apache.

See https://github.com/geoadmin/mf-chsdi3/pull/4498 and https://github.com/geoadmin/mf-chsdi3/pull/4024