### PR TITLE
PB-1319: corrected timestamp formats and adapted format_time() to fix erroneous 1h offset for departure times

### DIFF
--- a/chsdi/lib/opentransapi/opentransapi.py
+++ b/chsdi/lib/opentransapi/opentransapi.py
@@ -39,13 +39,12 @@ class OpenTrans:
         self.url = open_trans_url  # URL of API
         self.station_id = None
 
-    def get_departures(self, station_id, number_results=5, request_dt_time=False):
-        if not request_dt_time:
-            # Note: according to https://opentransportdata.swiss/de/cookbook/ojpstopeventrequest/
-            # the timestamps used in the OJPStopEventRequest should preferably be in UTC
-            # and MUST include the seconds, in order to prevent their code from trying to interpret
-            # the given times as a form of local time!
-            request_dt_time = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
+    def get_departures(self, station_id, number_results=5):
+        # Note: according to https://opentransportdata.swiss/de/cookbook/ojpstopeventrequest/
+        # the timestamps used in the OJPStopEventRequest should preferably be in UTC
+        # and MUST include the seconds, in order to prevent their code from trying to interpret
+        # the given times as a form of local time!
+        request_dt_time = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
         self.station_id = station_id
         api_response_xml = self.send_post(station_id, request_dt_time, number_results)  # UTC!
         results = self.xml_to_array(api_response_xml)

--- a/chsdi/lib/opentransapi/opentransapi.py
+++ b/chsdi/lib/opentransapi/opentransapi.py
@@ -18,12 +18,16 @@ def format_time(str_date_time):
     # - timezone offsets, e.g. "+01:00"
     # - sometimes the returned timestamps have an unexpected number of
     #   fractional seconds, e.g. 7 instead of 6, should be handled, too
+    local_tz = timezone('Europe/Zurich')
     date_time = isoparse(str_date_time)
 
-    # Convert to local timezone explicitly
-    local_tz = timezone('Europe/Zurich')  # Replace with your local timezone
-    local_date_time = date_time.astimezone(local_tz)
+    # If for some reason we receive a timezone-naive timestamp, we assume it is a
+    # local time
+    if date_time.tzinfo is None:
+        date_time = date_time.replace(tzinfo=local_tz)
 
+    # Convert to local timezone explicitly
+    local_date_time = date_time.astimezone(local_tz)
     # Return time in local time, as needed.
     return local_date_time.strftime('%d/%m/%Y %H:%M')
 

--- a/chsdi/lib/opentransapi/opentransapi.py
+++ b/chsdi/lib/opentransapi/opentransapi.py
@@ -38,12 +38,12 @@ class OpenTrans:
     def get_departures(self, station_id, number_results=5, request_dt_time=False):
         if not request_dt_time:
             # Note: according to https://opentransportdata.swiss/de/cookbook/ojpstopeventrequest/
-            # the timestamps used in the OJPStopEventRequest should preferably be in Zulu time
+            # the timestamps used in the OJPStopEventRequest should preferably be in UTC
             # and MUST include the seconds, in order to prevent their code from trying to interpret
             # the given times as a form of local time!
             request_dt_time = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
         self.station_id = station_id
-        api_response_xml = self.send_post(station_id, request_dt_time, number_results)  # zulu times!
+        api_response_xml = self.send_post(station_id, request_dt_time, number_results)  # UTC!
         results = self.xml_to_array(api_response_xml)
         return results
 
@@ -97,7 +97,7 @@ class OpenTrans:
         # Hence it MUST NOT be changed!
 
         # Further ATTENTION:
-        # Timestamps used for RequestTimestamp and DepArrTime MUST be in Zulu time, see:
+        # Timestamps used for RequestTimestamp and DepArrTime MUST be in UTC, see:
         # https://opentransportdata.swiss/de/cookbook/ojpstopeventrequest/
         payload = f"""<?xml version="1.0" encoding="UTF-8"?>
         <OJP xmlns='http://www.vdv.de/ojp' xmlns:siri='http://www.siri.org.uk/siri' version='2.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.vdv.de/ojp ../../../../OJP4/OJP.xsd'>

--- a/chsdi/lib/opentransapi/opentransapi.py
+++ b/chsdi/lib/opentransapi/opentransapi.py
@@ -11,7 +11,7 @@ import re
 def format_time(str_date_time):
     # Though the documentation of the OJP 2.0 API is not too verbose on this point (see:
     # https://opentransportdata.swiss/de/cookbook/ojpstopeventrequest/), it seems, the
-    # timestamps are always handeled in some form of ISO 8601 datetime format.
+    # timestamps are always returned in some form of ISO 8601 datetime format.
     # Using isoparse() should be able to handle all the needed cases, e.g.
     # - "Z" as timezone designator
     # - timezone offsets, e.g. "+01:00"

--- a/tests/integration/test_opentransapi.py
+++ b/tests/integration/test_opentransapi.py
@@ -54,6 +54,12 @@ class TestOpenTransApi(TestsBase):
         self.assertEqual(results[0]["destinationName"], "Hogwarts")
         self.assertEqual(results[0]["destinationId"], "ch:1:sloid:91178::3")
 
+        # assert, that several timestamp formats are correctly handled and transformed into the
+        # correct local time
+        self.assertEqual(format_time("2024-11-19T08:52:00Z"), "19/11/2024 08:52")
+        self.assertEqual(format_time("2024-11-19T08:52:00.1234567"), "19/11/2024 08:52")
+        self.assertEqual(format_time("2024-11-19T08:52:00+01:00"), "19/11/2024 08:52")
+
     @requests_mock.Mocker()
     def test_stationboard_nonexisting_station(self, mock_requests):
         now = datetime.now(timezone('Europe/Zurich')).isoformat(timespec="microseconds")

--- a/tests/integration/test_opentransapi.py
+++ b/tests/integration/test_opentransapi.py
@@ -54,10 +54,12 @@ class TestOpenTransApi(TestsBase):
         self.assertEqual(results[0]["destinationName"], "Hogwarts")
         self.assertEqual(results[0]["destinationId"], "ch:1:sloid:91178::3")
 
+    def test_format_time(self):
         # assert, that several timestamp formats are correctly handled and transformed into the
         # correct local time
-        self.assertEqual(format_time("2024-11-19T08:52:00Z"), "19/11/2024 08:52")
-        self.assertEqual(format_time("2024-11-19T08:52:00.1234567"), "19/11/2024 08:52")
+        self.assertEqual(format_time("2024-11-19T08:52:00Z"), "19/11/2024 09:52")
+        self.assertEqual(format_time("2024-11-19T09:52:00.123456789"), "19/11/2024 09:52")
+        self.assertEqual(format_time("2024-11-19T08:52:00.123456789Z"), "19/11/2024 09:52")
         self.assertEqual(format_time("2024-11-19T08:52:00+01:00"), "19/11/2024 08:52")
 
     @requests_mock.Mocker()


### PR DESCRIPTION
Currently during several steps of timestamp handling and conversions, the displayed departure times in the viewer are 1 hour off. The new format_time() should be more robust and also corresponsing tests are added.

Furthermore, according to https://opentransportdata.swiss/de/cookbook/ojpstopeventrequest/ the timestamps
used in OJPStopEventRequests should be in Zulu time, to prevent their code from trying
to interpret the given times as local times.
This is now implemented correctly and a few test for timestamp conversions are added.