### PR TITLE
BGDIDIC-1841: update link source

### DIFF
--- a/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
+++ b/chsdi/templates/htmlpopup/cadastralwebmap.include.mako
@@ -4,7 +4,7 @@
     % elif c['attributes']['ak'] and c['attributes']['geoportal_url']:
         <tr>
             <td class="cell-left">${_('link to canton geoportal')}</td>
-            <td><a href="http://${c['attributes']['geoportal_url']}" target="_blank">${c['attributes']['ak']}</a></td>
+            <td><a href="${c['attributes']['geoportal_url']}" target="_blank">${c['attributes']['ak']}</a></td>
         </tr>
     % else:
         <tr>


### PR DESCRIPTION
the source attribute will contain full urls with the protocol. We therefore dont add the protocol in the htmlpopup anymore.