### PR TITLE
BGDIDIC-1259: fix asset url

### DIFF
--- a/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
+++ b/chsdi/templates/htmlpopup/lubis_schraegaufnahmen.mako
@@ -23,7 +23,7 @@ tt_lubis_Quickview='tt_lubis_Quickview'
 image_width = None
 
 dataGeoAdminHost = request.registry.settings['datageoadminhost']
-asset_url=f"{dataGeoAdminHost}/{c['layerBodId']}/{c['featureId']}/{c['featureId']}_2056.tif"
+asset_url=f"{dataGeoAdminHost}/{c['layerBodId']}/{c['featureId']}/{c['featureId']}.tif"
 preview_url=f"{dataGeoAdminHost}/{c['layerBodId']}/{c['featureId']}/{c['featureId']}.jpg"
 meta_csv_url=f"{dataGeoAdminHost}/{c['layerBodId']}/{c['featureId']}/{c['featureId']}.csv"
 viewer_url=asset_url


### PR DESCRIPTION
the naming of the assets has been changed
the stac link has to be updated in the mako.