### PR TITLE
BGDIDIC-2043: Update model & mako-file

### DIFF
--- a/chsdi/models/vector/bafu.py
+++ b/chsdi/models/vector/bafu.py
@@ -1317,6 +1317,7 @@ class JB(Base, Vector):
     objektnummer = Column('objektnummer', Unicode)
     gebietsname = Column('gebietsname', Unicode)
     refobjblatt = Column('refobjblatt', Unicode)
+    flaeche_ha = Column('flaeche_ha', Float)
     typ_de = Column('typ_de', Unicode)
     typ_fr = Column('typ_fr', Unicode)
     typ_it = Column('typ_it', Unicode)

--- a/chsdi/templates/htmlpopup/jb.mako
+++ b/chsdi/templates/htmlpopup/jb.mako
@@ -8,9 +8,10 @@
         typ_text = 'typ_%s' %lang
         layer = c['layerBodId']
     %>
-  <tr><td class="cell-left">${_(layer + '.objektnummer')}</td><td>${c['attributes']['objektnummer']}</td></tr>
+  <tr><td class="cell-left">${_(layer + '.objektnummer')}</td><td>${c['attributes']['objektnummer'] or '-'}</td></tr>
   <tr><td class="cell-left">${_(layer + '.gebietsname')}</td><td>${c['attributes']['gebietsname'] or '-'}</td></tr>
   <tr><td class="cell-left">${_(layer + '.typ')}</td><td>${c['attributes'][typ_text] or '-'}</td></tr>
+  <tr><td class="cell-left">${_(layer + '.jb_fl')}</td><td>${c['attributes']['flaeche_ha'] or '-'}</td></tr>
   <tr>
     <td class="cell-left">${_(layer + '.refobjblatt' )}</td>
     <td>


### PR DESCRIPTION
Updating the model and mako-file for the additional attribute Shape_Area [ha] in BGDIDIC-2043: ch.bafu.bundesinventare-jagdbanngebiete.