### PR TITLE
PB-1892: Fix EsriJSON renderer

### DIFF
--- a/chsdi/renderers.py
+++ b/chsdi/renderers.py
@@ -33,7 +33,7 @@ class EsriJSON(GeoJSON):
     def __call__(self, info):
         def _render(value, system):
             if isinstance(value, (list, tuple)):
-                value = self.get_collection_type(value)
+                value = self.collection_type(value)
             ret = dumps(value)
             request = system.get('request')
             if request is not None:
@@ -49,9 +49,6 @@ class EsriJSON(GeoJSON):
                                                            'json': ret}
             return ret
         return _render
-
-    def get_collection_type(self, value):
-        return {'features': value}
 
 
 class CSVRenderer(object):


### PR DESCRIPTION
I introduced a unintended change in the [last PR](https://github.com/geoadmin/mf-chsdi3/commit/ea07a25e508b08fa7fd7471a352b47c0fd92a57c#diff-91ce34d74e9b8b015cb8d9804f4b74fc84992f95ec72c165651e20d86d2ee781). The correct thing is to remove the previously defined `collection_type` method as this is overwritten [by papyrus.renderers.GeoJSON](https://github.com/camptocamp/papyrus/blob/master/papyrus/renderers.py#L65) to `geojson.factory.FeatureCollection` which will correctly renders as:

```
{
  "type": "FeatureCollection",
  "features": [...]
}
```

.. compared to the method which only renders as:

```
{
  "features": [...]
}
```