### PR TITLE
feat-PB-1837: create layersTable endpoint

### DIFF
--- a/chsdi/__init__.py
+++ b/chsdi/__init__.py
@@ -91,6 +91,7 @@ def main(global_config, **settings):
     config.add_route('topics', '/rest/services', request_method=request_method)
     config.add_route('mapservice', '/rest/services/{map}/MapServer', request_method=request_method)
     config.add_route('layersConfig', '/rest/services/{map}/MapServer/layersConfig', request_method=request_method)
+    config.add_route('layersTable', '/rest/services/{map}/MapServer/layersTable', request_method=request_method)
     config.add_route('catalog', '/rest/services/{map}/CatalogServer', request_method=request_method)
     config.add_route('identify', '/rest/services/{map}/MapServer/identify', request_method=request_method)
     config.add_route('find', '/rest/services/{map}/MapServer/find', request_method=request_method)

--- a/chsdi/templates/layers_table.mako
+++ b/chsdi/templates/layers_table.mako
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Layers Table</title>
+  <style>
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      font-family: Arial, sans-serif;
+    }
+    th, td {
+      border: 1px solid #dddddd;
+      text-align: left;
+      padding: 8px;
+    }
+    th {
+      background-color: #f2f2f2;
+      font-weight: bold;
+    }
+    tr:nth-child(even) {
+      background-color: #f9f9f9;
+    }
+    tr:hover {
+      background-color: #e9e9e9;
+    }
+  </style>
+</head>
+<body>
+  <h1>Layers Configuration Table</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Technical Name</th>
+        <th>Official Name</th>
+        <th>Layer Type</th>
+        <th>Has Tooltip</th>
+        <th>Is Searchable</th>
+      </tr>
+    </thead>
+    <tbody>
+      % for layer_id, layer_config in layers.items():
+        <tr>
+          <td>${layer_config.get('serverLayerName', '-')}</td>
+          <td>${layer_config.get('label', '-')}</td>
+          <td>${layer_config.get('type', '-')}</td>
+          <td>${'Yes' if layer_config.get('tooltip', False) else 'No'}</td>
+          <td>${'Yes' if layer_config.get('searchable', False) else 'No'}</td>
+        </tr>
+      % endfor
+    </tbody>
+  </table>
+</body>
+</html>

--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -52,6 +52,26 @@ def layers_config(request):
     return layers
 
 
+@view_config(route_name='layersTable', renderer='jsonp')
+def layers_table(request):
+    params = BaseLayersValidation(request)
+    query = params.request.db.query(LayersConfig)
+    layers = {}
+    for layer in get_layers_config_for_params(params, query, LayersConfig):
+        layers = dict(chain(layers.items(), layer.items()))
+    
+    response = render_to_response(
+        'chsdi:templates/layers_table.mako',
+        {'layers': layers},
+        request=request
+    )
+    
+    if params.cbName is None:
+        return response
+        
+    return response.body.decode('utf8')
+
+
 @view_config(route_name='legend', renderer='jsonp')
 def legend(request):
     params = BaseLayersValidation(request)

--- a/tests/integration/test_layers_service.py
+++ b/tests/integration/test_layers_service.py
@@ -220,3 +220,37 @@ class TestMapServiceView(TestsBase):
         self.assertEqual(resp.content_type, 'application/json')
         resp = self.testapp.get('/rest/services/api/MapServer/ch.bfs.gebaeude_wohnungs_register', params={'callback': 'cb_'}, status=200)
         self.assertEqual(resp.content_type, 'application/javascript')
+        
+    def test_layerstable_valid(self):
+        resp = self.testapp.get('/rest/services/ech/MapServer/layersTable', status=200)
+        self.assertEqual(resp.content_type, 'text/html')
+        resp.mustcontain('<th>Technical Name</th>')
+        resp.mustcontain('<th>Official Name</th>')
+        resp.mustcontain('<th>Layer Type</th>')
+        resp.mustcontain('<th>Has Tooltip</th>')
+        resp.mustcontain('<th>Is Searchable</th>')
+        
+    def test_layerstable_valid_with_callback(self):
+        resp = self.testapp.get('/rest/services/ech/MapServer/layersTable', params={'callback': 'cb_'}, status=200)
+        self.assertEqual(resp.content_type, 'application/javascript')
+        resp.mustcontain('cb_(')
+        
+    def test_layerstable_content_check(self):
+        import re
+        resp = self.testapp.get('/rest/services/ech/MapServer/layersTable', status=200)
+        self.assertEqual(resp.content_type, 'text/html')
+        html_content = resp.text
+        
+        # Search for the row containing ch.swisstopo.pixelkarte-farbe
+        layer_row_pattern = r'<tr>.*?<td>ch\.swisstopo\.pixelkarte-farbe</td>(.*?)</tr>'
+        row_match = re.search(layer_row_pattern, html_content, re.DOTALL)
+        
+        self.assertIsNotNone(row_match, "Could not find row for ch.swisstopo.pixelkarte-farbe")
+        row_content = row_match.group(0)
+        
+        # Check that all required values are present in the row
+        self.assertIn('<td>ch.swisstopo.pixelkarte-farbe</td>', row_content)
+        self.assertIn('<td>National Maps (color)</td>', row_content)
+        self.assertIn('<td>wmts</td>', row_content)
+        self.assertTrue(row_content.count('<td>No</td>') >= 2, 
+                        "Expected at least 2 'No' values for tooltip and searchable attributes")


### PR DESCRIPTION
[Draft - leaving as draft as I currently don't have the AWS credentials to run and test locally]

The goal of this PR is to create a new endpoint that returns an HTML table with the following information about the available layers:

- Technical Name
- Official Name
- Layer Type
- Has Tooltip
- Is Searchable