### PR TITLE
Fix TypeError when sorting attribute values by filtering out None

### DIFF
--- a/chsdi/views/features.py
+++ b/chsdi/views/features.py
@@ -599,7 +599,7 @@ def _attributes(request):
     for attr in query:
         if len(attr):
             attributes_values.append(attr[0])
-    return {'values': sorted(attributes_values)}
+    return {'values': sorted([v for v in attributes_values if v is not None])}
 
 
 def _find(request):


### PR DESCRIPTION
- Updated the _attributes function to filter out None values before sorting attribute values.
- Prevents TypeError caused by attempting to compare NoneType with strings when returning attribute samples.
- Ensures consistent and error-free API responses for attribute value previews.