### PR TITLE
PB-1992 : Add keepAlive timeout and set to 120s to extend Traefik timeout

### DIFF
--- a/apache/default.conf.in
+++ b/apache/default.conf.in
@@ -8,5 +8,9 @@
 
     RewriteRule ^/$ /static/index.html [R=301]
 
+    KeepAlive On
+
+    KeepAliveTimeout 120
+
 </VirtualHost>
 


### PR DESCRIPTION
After discussing with @ltclm , it seems we are not using Gunicorn, rather Apache to run mf-chsdi3 across our stagings. 
Therefore, I've changed the config to enable KeepAlive requests and set the timeout to 120s. I haven't set a maximum limit of requests, but we can easily do so. [Online guides seem to recommend a limit of 100](https://awjunaid.com/apache/how-to-enable-keep-alive-connections-in-apache/)

I don't know if its possible to customize an apache config through kubernetes overlays, as right now this means we have to manually change the config for the change to be reflected.