### PR TITLE
PB-1711: run docker image as geodata user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,8 @@ ENV APP_VERSION=${VERSION}
 RUN sed -i 's/${APP_VERSION}/'${APP_VERSION}'/g' chsdi/config/base.ini.in \
     && .venv/bin/python -m pip install -e .
 
+USER ${USER}
+
 # NOTE: Here below we cannot use environment variable with ENTRYPOINT using the `exec` form.
 # The ENTRYPOINT `exec` form is required in order to use the docker-entrypoint.sh as first
 # command to run before the CMD.


### PR DESCRIPTION
The dockerfile seems already designed to support running the image as `${USER}` (geodata) but final USER instruction was missing. This PR fix that.