### PR TITLE
adapting models and mako for the new full vector  `geocover`

### DIFF
--- a/chsdi/lib/esrijson/feature.py
+++ b/chsdi/lib/esrijson/feature.py
@@ -7,7 +7,6 @@ class Feature(EsriJSON):
 
     def __init__(self, geometry=None, wkid=None, attributes=None, id=None,
                  **extra):
-
         """
         Initialises a Feature object with the given parameters.
 

--- a/chsdi/lib/helpers.py
+++ b/chsdi/lib/helpers.py
@@ -465,3 +465,21 @@ def get_payload(obj, trim=128):
 def strtobool(value: str) -> bool:
     from chsdi.utils.strtobool import strtobool as s
     return s(value)
+
+
+def pipe_links(value):
+    """Render a pipe-separated list of URLs as HTML anchor tags.
+
+    Each URL is displayed using its filename (last path component) as the
+    link text. A single URL renders as a single link. Returns '-' for empty
+    or placeholder values.
+    """
+    if not value or value in ('-', ''):
+        return '-'
+    parts = [u.strip() for u in value.split('|') if u.strip()]
+    return ' '.join(
+        '<a href="{url}" target="_blank">{name}</a>'.format(
+            url=url, name=url.split('/')[-1]
+        )
+        for url in parts
+    )

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2293,6 +2293,8 @@ class SteineHistBauwerke(Base, Vector):
 register(SteineHistBauwerke.__bodId__, SteineHistBauwerke)
 
 # Legacy ch.swisstopo.geologie-geocover
+
+
 class Geocover:
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = 'ch.swisstopo.geologie-geocover'
@@ -2498,13 +2500,10 @@ class SwissGeocover2dTectoLines(Base, Vector, SwissGeocover2dExtended):
 register(SwissGeocover2dTectoLines.__bodId__, SwissGeocover2dTectoLines)
 
 
-_SWISSGEOCOVER2D_POINTS_BOD_ID = 'ch.swisstopo.geologie-swissgeocover2d_points'
-
-
 class SwissGeocover2dPoints(Base, Vector, SwissGeocover2dExtended):
     __tablename__ = 'geocover_ltmom_point_objects'  # TODO: rename to geocover_point_objects
     __table_args__ = ({'schema': 'geol', 'autoload': False})
-    __bodId__ = _SWISSGEOCOVER2D_POINTS_BOD_ID
+    __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_points'
     __template__ = 'templates/htmlpopup/swissgeocover2d_points.mako'
     __label__ = 'kind_de'
     kind = Column('kind', Integer)
@@ -2526,32 +2525,32 @@ class SwissGeocover2dPoints(Base, Vector, SwissGeocover2dExtended):
     abor_depth_wt = Column('abor_depth_wt', Float)
 
 
-register(_SWISSGEOCOVER2D_POINTS_BOD_ID, SwissGeocover2dPoints)
+register(SwissGeocover2dPoints.__bodId__, SwissGeocover2dPoints)
 
 
 class SwissGeocover2dFossils(Base, Vector, SwissGeocover2dExtended):
     __tablename__ = 'geocover_ltmom_fossils'  # TODO: rename to geocover_fossils
     __table_args__ = ({'schema': 'geol', 'autoload': False})
-    __bodId__ = _SWISSGEOCOVER2D_POINTS_BOD_ID
+    __bodId__ = SwissGeocover2dPoints.__bodId__
     __template__ = 'templates/htmlpopup/swissgeocover2d_fossils.mako'
     __label__ = 'kind_de'
     kind_de = Column('kind_de', Unicode)
     kind_fr = Column('kind_fr', Unicode)
 
 
-register(_SWISSGEOCOVER2D_POINTS_BOD_ID, SwissGeocover2dFossils)
+register(SwissGeocover2dPoints.__bodId__, SwissGeocover2dFossils)
 
 
 class SwissGeocover2dExploitPoints(Base, Vector, SwissGeocover2dExtended):
     __tablename__ = 'geocover_ltmom_exploit_points'  # TODO: rename to geocover_exploit_points
     __table_args__ = ({'schema': 'geol', 'autoload': False})
-    __bodId__ = _SWISSGEOCOVER2D_POINTS_BOD_ID
+    __bodId__ = SwissGeocover2dPoints.__bodId__
     __template__ = 'templates/htmlpopup/swissgeocover2d_exploit_points.mako'
     __label__ = 'kind_de'
     kind_de = Column('kind_de', Unicode)
     kind_fr = Column('kind_fr', Unicode)
 
-register(_SWISSGEOCOVER2D_POINTS_BOD_ID, SwissGeocover2dExploitPoints)
+register(SwissGeocover2dPoints.__bodId__, SwissGeocover2dExploitPoints)
 
 
 class GeolGeocoverMetadata(Base, Vector):

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -1,5 +1,4 @@
 from sqlalchemy import Column
-
 from sqlalchemy.types import Numeric, Boolean, Integer, Float, Unicode, BigInteger, SmallInteger
 
 from chsdi.models import register, bases
@@ -2551,7 +2550,6 @@ class SwissGeocover2dExploitPoints(Base, Vector, SwissGeocover2dExtended):
     kind_fr = Column('kind_fr', Unicode)
 
 register(SwissGeocover2dPoints.__bodId__, SwissGeocover2dExploitPoints)
-
 
 
 class GeolGeocoverMetadata(Base, Vector):

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2553,11 +2553,12 @@ class SwissGeocover2dExploitPoints(Base, Vector, SwissGeocover2dExtended):
 register(SwissGeocover2dPoints.__bodId__, SwissGeocover2dExploitPoints)
 
 
+
 class GeolGeocoverMetadata(Base, Vector):
     __tablename__ = 'geocover_meta'
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/geocover_metadata.mako'
-    __bodId__ = 'ch.swisstopo.swissgeocover2d.metadata'
+    __bodId__ = 'ch.swisstopo.geologie-geocover.metadata'
     __label__ = 'map_title'
     id = Column('bgdi_id', Integer, primary_key=True)
     map_nbr = Column('map_nbr', Integer)

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2409,7 +2409,7 @@ class SwissGeocover2dExtended(SwissGeocover2d):
 
 
 class SwissGeocover2dBedrock(Base, Vector, SwissGeocover2d):
-    __tablename__ = 'geocover_ltmom_bedrock'  # TODO: rename to geocover_bedrock
+    __tablename__ = 'swissgeocover2d_bedrock'
     __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_bedrock'
     __template__ = 'templates/htmlpopup/swissgeocover2d_bedrock.mako'
 
@@ -2433,7 +2433,7 @@ register(SwissGeocover2dBedrock.__bodId__, SwissGeocover2dBedrock)
 
 
 class SwissGeocover2dUnconsolidated(Base, Vector, SwissGeocover2d):
-    __tablename__ = 'geocover_ltmom_unco_deposits'  # TODO: rename to geocover_unco_deposits
+    __tablename__ = 'swissgeocover2d_unconsolidated'
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_unconsolidated'
     __template__ = 'templates/htmlpopup/swissgeocover2d_unconsolidated.mako'
@@ -2461,7 +2461,7 @@ register(SwissGeocover2dUnconsolidated.__bodId__, SwissGeocover2dUnconsolidated)
 
 
 class SwissGeocover2dSurfaces(Base, Vector, SwissGeocover2dExtended):
-    __tablename__ = 'geocover_ltmom_surfaces'  # TODO: rename to geocover_surfaces
+    __tablename__ = 'swissgeocover2d_surfaces'  # TODO: rename to geocover_surfaces
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_surfaces'
     __template__ = 'templates/htmlpopup/swissgeocover2d_surfaces.mako'
@@ -2474,7 +2474,7 @@ register(SwissGeocover2dSurfaces.__bodId__, SwissGeocover2dSurfaces)
 
 
 class SwissGeocover2dLines(Base, Vector, SwissGeocover2dExtended):
-    __tablename__ = 'geocover_ltmom_linear_objects'  # TODO: rename to geocover_linear_objects
+    __tablename__ = 'swissgeocover2d_lines'  # TODO: rename to geocover_linear_objects
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_lines'
     __template__ = 'templates/htmlpopup/swissgeocover2d_lines.mako'
@@ -2488,7 +2488,7 @@ register(SwissGeocover2dLines.__bodId__, SwissGeocover2dLines)
 
 class SwissGeocover2dTectoLines(Base, Vector, SwissGeocover2dExtended):
     # Shares the geocover_ltmom_linear_objects PostGIS table
-    __tablename__ = 'geocover_ltmom_linear_objects'  # TODO: rename to geocover_linear_objects
+    __tablename__ = 'swissgeocover2d_tecto-lines'  # TODO: rename to geocover_linear_objects
     __table_args__ = ({'schema': 'geol', 'autoload': False, 'extend_existing': True})
     __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_tecto-lines'
     __template__ = 'templates/htmlpopup/swissgeocover2d_tecto_lines.mako'
@@ -2501,7 +2501,7 @@ register(SwissGeocover2dTectoLines.__bodId__, SwissGeocover2dTectoLines)
 
 
 class SwissGeocover2dPoints(Base, Vector, SwissGeocover2dExtended):
-    __tablename__ = 'geocover_ltmom_point_objects'  # TODO: rename to geocover_point_objects
+    __tablename__ = 'swissgeocover2d_points'
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_points'
     __template__ = 'templates/htmlpopup/swissgeocover2d_points.mako'
@@ -2529,7 +2529,7 @@ register(SwissGeocover2dPoints.__bodId__, SwissGeocover2dPoints)
 
 
 class SwissGeocover2dFossils(Base, Vector, SwissGeocover2dExtended):
-    __tablename__ = 'geocover_ltmom_fossils'  # TODO: rename to geocover_fossils
+    __tablename__ = 'swissgeocover2d_fossils'  # TODO: rename to geocover_fossils
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = SwissGeocover2dPoints.__bodId__
     __template__ = 'templates/htmlpopup/swissgeocover2d_fossils.mako'
@@ -2542,7 +2542,7 @@ register(SwissGeocover2dPoints.__bodId__, SwissGeocover2dFossils)
 
 
 class SwissGeocover2dExploitPoints(Base, Vector, SwissGeocover2dExtended):
-    __tablename__ = 'geocover_ltmom_exploit_points'  # TODO: rename to geocover_exploit_points
+    __tablename__ = 'swissgeocover2d_exploit_points'  # TODO: rename to geocover_exploit_points
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = SwissGeocover2dPoints.__bodId__
     __template__ = 'templates/htmlpopup/swissgeocover2d_exploit_points.mako'

--- a/chsdi/models/vector/stopo.py
+++ b/chsdi/models/vector/stopo.py
@@ -2292,7 +2292,7 @@ class SteineHistBauwerke(Base, Vector):
 
 register(SteineHistBauwerke.__bodId__, SteineHistBauwerke)
 
-
+# Legacy ch.swisstopo.geologie-geocover
 class Geocover:
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __bodId__ = 'ch.swisstopo.geologie-geocover'
@@ -2391,11 +2391,174 @@ register(Geocover.__bodId__, GeocoverPolygonAux2)
 register(Geocover.__bodId__, GeocoverPolygonMain)
 
 
+class SwissGeocover2d:
+    __table_args__ = ({'schema': 'geol', 'autoload': False})
+    __bodId__ = 'ch.swisstopo.swissgeocover2d'
+    __label__ = 'label'
+    id = Column('bgdi_id', Integer, primary_key=True)
+    erl_link = Column('erl_link', Unicode)
+    ber_link = Column('ber_link', Unicode)
+    the_geom = Column(Geometry2D)
+
+
+class SwissGeocover2dExtended(SwissGeocover2d):
+    spec_de = Column('spec_de', Unicode)
+    spec_fr = Column('spec_fr', Unicode)
+
+
+class SwissGeocover2dBedrock(Base, Vector, SwissGeocover2d):
+    __tablename__ = 'geocover_ltmom_bedrock'  # TODO: rename to geocover_bedrock
+    __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_bedrock'
+    __template__ = 'templates/htmlpopup/swissgeocover2d_bedrock.mako'
+
+    gmu_de = Column('gmu_de', Unicode)
+    gmu_fr = Column('gmu_fr', Unicode)
+    tecto_de = Column('tecto_de', Unicode)
+    tecto_fr = Column('tecto_fr', Unicode)
+    litho_combined_de = Column('litho_combined_de', Unicode)
+    litho_combined_fr = Column('litho_combined_fr', Unicode)
+    chrono_combined_de = Column('chrono_combined_de', Unicode)
+    chrono_combined_fr = Column('chrono_combined_fr', Unicode)
+    correlation_de = Column('correlation_de', Unicode)
+    correlation_fr = Column('correlation_fr', Unicode)
+    strati_link = Column('strati_link', Unicode)
+    litstrat_formation_bank_de = Column('litstrat_formation_bank_de', Unicode)
+    litstrat_formation_bank_fr = Column('litstrat_formation_bank_fr', Unicode)
+    label = Column('label', Unicode)
+
+
+register(SwissGeocover2dBedrock.__bodId__, SwissGeocover2dBedrock)
+
+
+class SwissGeocover2dUnconsolidated(Base, Vector, SwissGeocover2d):
+    __tablename__ = 'geocover_ltmom_unco_deposits'  # TODO: rename to geocover_unco_deposits
+    __table_args__ = ({'schema': 'geol', 'autoload': False})
+    __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_unconsolidated'
+    __template__ = 'templates/htmlpopup/swissgeocover2d_unconsolidated.mako'
+    __label__ = 'label'
+    runc_litho_de = Column('runc_litho_de', Unicode)
+    runc_litho_fr = Column('runc_litho_fr', Unicode)
+    runc_litstrat_de = Column('runc_litstrat_de', Unicode)
+    runc_litstrat_fr = Column('runc_litstrat_fr', Unicode)
+    runc_chrono_combined_de = Column('runc_chrono_combined_de', Unicode)
+    runc_chrono_combined_fr = Column('runc_chrono_combined_fr', Unicode)
+    runc_glac_typ_de = Column('runc_glac_typ_de', Unicode)
+    runc_glac_typ_fr = Column('runc_glac_typ_fr', Unicode)
+    runc_structur_de = Column('runc_structur_de', Unicode)
+    runc_structur_fr = Column('runc_structur_fr', Unicode)
+    runc_morpholo_de = Column('runc_morpholo_de', Unicode)
+    runc_morpholo_fr = Column('runc_morpholo_fr', Unicode)
+    runc_chrono_t_de = Column('runc_chrono_t_de', Unicode)
+    runc_chrono_t_fr = Column('runc_chrono_t_fr', Unicode)
+    runc_chrono_b_de = Column('runc_chrono_b_de', Unicode)
+    runc_chrono_b_fr = Column('runc_chrono_b_fr', Unicode)
+    label = Column('label', Unicode)
+
+
+register(SwissGeocover2dUnconsolidated.__bodId__, SwissGeocover2dUnconsolidated)
+
+
+class SwissGeocover2dSurfaces(Base, Vector, SwissGeocover2dExtended):
+    __tablename__ = 'geocover_ltmom_surfaces'  # TODO: rename to geocover_surfaces
+    __table_args__ = ({'schema': 'geol', 'autoload': False})
+    __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_surfaces'
+    __template__ = 'templates/htmlpopup/swissgeocover2d_surfaces.mako'
+    __label__ = 'kind_de'
+    kind_de = Column('kind_de', Unicode)
+    kind_fr = Column('kind_fr', Unicode)
+
+
+register(SwissGeocover2dSurfaces.__bodId__, SwissGeocover2dSurfaces)
+
+
+class SwissGeocover2dLines(Base, Vector, SwissGeocover2dExtended):
+    __tablename__ = 'geocover_ltmom_linear_objects'  # TODO: rename to geocover_linear_objects
+    __table_args__ = ({'schema': 'geol', 'autoload': False})
+    __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_lines'
+    __template__ = 'templates/htmlpopup/swissgeocover2d_lines.mako'
+    __label__ = 'kind_de'
+    kind_de = Column('kind_de', Unicode)
+    kind_fr = Column('kind_fr', Unicode)
+
+
+register(SwissGeocover2dLines.__bodId__, SwissGeocover2dLines)
+
+
+class SwissGeocover2dTectoLines(Base, Vector, SwissGeocover2dExtended):
+    # Shares the geocover_ltmom_linear_objects PostGIS table
+    __tablename__ = 'geocover_ltmom_linear_objects'  # TODO: rename to geocover_linear_objects
+    __table_args__ = ({'schema': 'geol', 'autoload': False, 'extend_existing': True})
+    __bodId__ = 'ch.swisstopo.geologie-swissgeocover2d_tecto-lines'
+    __template__ = 'templates/htmlpopup/swissgeocover2d_tecto_lines.mako'
+    __label__ = 'kind_de'
+    kind_de = Column('kind_de', Unicode)
+    kind_fr = Column('kind_fr', Unicode)
+
+
+register(SwissGeocover2dTectoLines.__bodId__, SwissGeocover2dTectoLines)
+
+
+_SWISSGEOCOVER2D_POINTS_BOD_ID = 'ch.swisstopo.geologie-swissgeocover2d_points'
+
+
+class SwissGeocover2dPoints(Base, Vector, SwissGeocover2dExtended):
+    __tablename__ = 'geocover_ltmom_point_objects'  # TODO: rename to geocover_point_objects
+    __table_args__ = ({'schema': 'geol', 'autoload': False})
+    __bodId__ = _SWISSGEOCOVER2D_POINTS_BOD_ID
+    __template__ = 'templates/htmlpopup/swissgeocover2d_points.mako'
+    __label__ = 'kind_de'
+    kind = Column('kind', Integer)
+    kind_de = Column('kind_de', Unicode)
+    kind_fr = Column('kind_fr', Unicode)
+    dip = Column('dip', Integer)
+    mpla_polarity_de = Column('mpla_polarity_de', Unicode)
+    mpla_polarity_fr = Column('mpla_polarity_fr', Unicode)
+    abor_ref_number = Column('abor_ref_number', Float)
+    azimuth = Column('azimuth', Float)
+    abor_depth_fm_a = Column('abor_depth_fm_a', Float)
+    abor_fm_a_de = Column('abor_fm_a_de', Unicode)
+    abor_fm_a_fr = Column('abor_fm_a_fr', Unicode)
+    abor_depth_fm_b = Column('abor_depth_fm_b', Float)
+    abor_fm_b_de = Column('abor_fm_b_de', Unicode)
+    abor_fm_b_fr = Column('abor_fm_b_fr', Unicode)
+    abor_depth_bedr = Column('abor_depth_bedr', Float)
+    abor_depth_tot = Column('abor_depth_tot', Float)
+    abor_depth_wt = Column('abor_depth_wt', Float)
+
+
+register(_SWISSGEOCOVER2D_POINTS_BOD_ID, SwissGeocover2dPoints)
+
+
+class SwissGeocover2dFossils(Base, Vector, SwissGeocover2dExtended):
+    __tablename__ = 'geocover_ltmom_fossils'  # TODO: rename to geocover_fossils
+    __table_args__ = ({'schema': 'geol', 'autoload': False})
+    __bodId__ = _SWISSGEOCOVER2D_POINTS_BOD_ID
+    __template__ = 'templates/htmlpopup/swissgeocover2d_fossils.mako'
+    __label__ = 'kind_de'
+    kind_de = Column('kind_de', Unicode)
+    kind_fr = Column('kind_fr', Unicode)
+
+
+register(_SWISSGEOCOVER2D_POINTS_BOD_ID, SwissGeocover2dFossils)
+
+
+class SwissGeocover2dExploitPoints(Base, Vector, SwissGeocover2dExtended):
+    __tablename__ = 'geocover_ltmom_exploit_points'  # TODO: rename to geocover_exploit_points
+    __table_args__ = ({'schema': 'geol', 'autoload': False})
+    __bodId__ = _SWISSGEOCOVER2D_POINTS_BOD_ID
+    __template__ = 'templates/htmlpopup/swissgeocover2d_exploit_points.mako'
+    __label__ = 'kind_de'
+    kind_de = Column('kind_de', Unicode)
+    kind_fr = Column('kind_fr', Unicode)
+
+register(_SWISSGEOCOVER2D_POINTS_BOD_ID, SwissGeocover2dExploitPoints)
+
+
 class GeolGeocoverMetadata(Base, Vector):
     __tablename__ = 'geocover_meta'
     __table_args__ = ({'schema': 'geol', 'autoload': False})
     __template__ = 'templates/htmlpopup/geocover_metadata.mako'
-    __bodId__ = 'ch.swisstopo.geologie-geocover.metadata'
+    __bodId__ = 'ch.swisstopo.swissgeocover2d.metadata'
     __label__ = 'map_title'
     id = Column('bgdi_id', Integer, primary_key=True)
     map_nbr = Column('map_nbr', Integer)

--- a/chsdi/templates/htmlpopup/geocover_metadata.mako
+++ b/chsdi/templates/htmlpopup/geocover_metadata.mako
@@ -6,23 +6,23 @@
         version_text = 'version_%s' % lang
     %>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.map_nbr')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.map_nbr')}</td>
         <td>${c['attributes']['map_nbr'] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.map_title')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.map_title')}</td>
         <td>${c['attributes']['map_title'] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.scale')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.scale')}</td>
         <td>${c['attributes']['scale'] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.version')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.version')}</td>
         <td>${c['attributes'][version_text] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.basis')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.basis')}</td>
         <td>${c['attributes']['basis'] or '-'}</td>
     </tr>
 </%def>

--- a/chsdi/templates/htmlpopup/geocover_metadata.mako
+++ b/chsdi/templates/htmlpopup/geocover_metadata.mako
@@ -6,23 +6,23 @@
         version_text = 'version_%s' % lang
     %>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.map_nbr')}</td>
+        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.map_nbr')}</td>
         <td>${c['attributes']['map_nbr'] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.map_title')}</td>
+        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.map_title')}</td>
         <td>${c['attributes']['map_title'] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.scale')}</td>
+        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.scale')}</td>
         <td>${c['attributes']['scale'] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.version')}</td>
+        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.version')}</td>
         <td>${c['attributes'][version_text] or '-'}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-geocover.metadata.basis')}</td>
+        <td class="cell-left">${_('ch.swisstopo.swissgeocover2d.metadata.basis')}</td>
         <td>${c['attributes']['basis'] or '-'}</td>
     </tr>
 </%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_bedrock.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_bedrock.mako
@@ -1,0 +1,53 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    gmu = 'gmu_%s' % lang
+    tecto = 'tecto_%s' % lang
+    litho = 'litho_combined_%s' % lang
+    chrono = 'chrono_combined_%s' % lang
+    correlation = 'correlation_%s' % lang
+    litstrat_bank = 'litstrat_formation_bank_%s' % lang
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.gmu')}</td>
+        <td>${c['attributes'][gmu] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.tecto')}</td>
+        <td>${c['attributes'][tecto] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.litho')}</td>
+        <td>${c['attributes'][litho] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.chrono')}</td>
+        <td>${c['attributes'][chrono] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.correlation')}</td>
+        <td>${c['attributes'][correlation] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.litstrat_formation_bank')}</td>
+        <td>${c['attributes'][litstrat_bank] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.strati_link')}</td>
+        % if c['attributes']['strati_link'] and c['attributes']['strati_link'] not in ('-', ''):
+            <td><a href="${c['attributes']['strati_link']}" target="_blank">${_('link')}</a></td>
+        % else:
+            <td>-</td>
+        % endif
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.erl_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_bedrock.ber_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_exploit_points.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_exploit_points.mako
@@ -1,0 +1,24 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    attrs = c['attributes']
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.kind')}</td>
+        <td>${attrs.get('kind_' + lang) or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.spec')}</td>
+        <td>${attrs.get('spec_' + lang) or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.erl_link')}</td>
+        <td>${h.pipe_links(attrs.get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.ber_link')}</td>
+        <td>${h.pipe_links(attrs.get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_fossils.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_fossils.mako
@@ -1,0 +1,24 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    attrs = c['attributes']
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.kind')}</td>
+        <td>${attrs.get('kind_' + lang) or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.spec')}</td>
+        <td>${attrs.get('spec_' + lang) or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.erl_link')}</td>
+        <td>${h.pipe_links(attrs.get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.ber_link')}</td>
+        <td>${h.pipe_links(attrs.get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_lines.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_lines.mako
@@ -1,0 +1,27 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    kind = 'kind_%s' % lang
+    spec = c['attributes'].get('spec_' + lang)
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_lines.kind')}</td>
+        <td>${c['attributes'][kind] or '-'}</td>
+    </tr>
+    % if spec:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_lines.spec')}</td>
+        <td>${spec}</td>
+    </tr>
+    % endif
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_lines.erl_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_lines.ber_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_points.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_points.mako
@@ -1,0 +1,112 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    attrs = c['attributes']
+    kind_label = attrs.get('kind_' + lang) or '-'
+    spec = attrs.get('spec_' + lang) or '-'
+    # Borehole-type kinds by integer code (10501001–10501004):
+    # Bohrung, Sondierschlitz, Handsondierung, Rammsondierung
+    BOREHOLE_KINDS = {10501001, 10501002, 10501003, 10501004}
+    # Structural/orientation measurement kinds (azimuth + dip ± polarity)
+    STRUCTURAL_KINDS = {
+        13601001, 13601002, 13601003,
+        13701001, 13701002, 13701004,
+        13801001, 13801002, 13801003, 13801004, 13801005, 13801006,
+        14601004,
+    }
+    is_bohrung = attrs.get('kind') in BOREHOLE_KINDS
+    is_structural = attrs.get('kind') in STRUCTURAL_KINDS
+
+    def fmt_num(val, sentinel=888):
+        if val is None or val >= sentinel:
+            return '-'
+        if val == int(val):
+            return str(int(val)) + ' m'
+        return str(val) + ' m'
+
+    def fmt_any(val):
+        if val is None or val == '' or val == 0:
+            return '-'
+        if isinstance(val, float) and val == int(val):
+            return str(int(val))
+        return str(val)
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.kind')}</td>
+        <td>${kind_label}</td>
+    </tr>
+    % if is_structural:
+    <%
+        _pol = attrs.get('mpla_polarity_' + lang) or ''
+        polarity = '-' if not _pol or 'not applicable' in _pol or 'nicht anwendbar' in _pol else _pol
+        azimuth_val = attrs.get('azimuth')
+        dip_val = attrs.get('dip')
+        azimuth_str = str(int(azimuth_val)) if azimuth_val is not None and azimuth_val < 999990 else '-'
+        dip_str = str(int(dip_val)) if dip_val is not None and dip_val < 999990 else '-'
+    %>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.mpla_polarity')}</td>
+        <td>${polarity}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.dip_direction')}</td>
+        <td>${azimuth_str}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.dip')}</td>
+        <td>${dip_str}</td>
+    </tr>
+    % elif not is_bohrung:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.spec')}</td>
+        <td>${spec}</td>
+    </tr>
+    % else:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_ref_number')}</td>
+        <td>${fmt_any(attrs.get('abor_ref_number'))}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.azimuth')}</td>
+        <td>${fmt_any(attrs.get('azimuth'))}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_depth_fm_a')}</td>
+        <td>${fmt_num(attrs.get('abor_depth_fm_a'))}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_fm_a')}</td>
+        <td>${attrs.get('abor_fm_a_' + lang) or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_depth_fm_b')}</td>
+        <td>${fmt_num(attrs.get('abor_depth_fm_b'))}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_fm_b')}</td>
+        <td>${attrs.get('abor_fm_b_' + lang) or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_depth_bedr')}</td>
+        <td>${fmt_num(attrs.get('abor_depth_bedr'))}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_depth_tot')}</td>
+        <td>${fmt_num(attrs.get('abor_depth_tot'), sentinel=999990)}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.abor_depth_wt')}</td>
+        <td>${fmt_num(attrs.get('abor_depth_wt'), sentinel=999990)}</td>
+    </tr>
+    % endif
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.erl_link')}</td>
+        <td>${h.pipe_links(attrs.get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_points.ber_link')}</td>
+        <td>${h.pipe_links(attrs.get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_surfaces.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_surfaces.mako
@@ -1,0 +1,27 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    kind = 'kind_%s' % lang
+    spec = c['attributes'].get('spec_' + lang)
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_surfaces.kind')}</td>
+        <td>${c['attributes'][kind] or '-'}</td>
+    </tr>
+    % if spec:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_surfaces.spec')}</td>
+        <td>${spec}</td>
+    </tr>
+    % endif
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_surfaces.erl_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_surfaces.ber_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_tecto_lines.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_tecto_lines.mako
@@ -7,21 +7,21 @@
     spec = c['attributes'].get('spec_' + lang)
 %>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.kind')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto_lines.kind')}</td>
         <td>${c['attributes'][kind] or '-'}</td>
     </tr>
     % if spec:
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.spec')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto_lines.spec')}</td>
         <td>${spec}</td>
     </tr>
     % endif
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.erl_link')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto_lines.erl_link')}</td>
         <td>${h.pipe_links(c['attributes'].get('erl_link')) | n}</td>
     </tr>
     <tr>
-        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.ber_link')}</td>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto_lines.ber_link')}</td>
         <td>${h.pipe_links(c['attributes'].get('ber_link')) | n}</td>
     </tr>
 </%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_tecto_lines.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_tecto_lines.mako
@@ -1,0 +1,27 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    kind = 'kind_%s' % lang
+    spec = c['attributes'].get('spec_' + lang)
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.kind')}</td>
+        <td>${c['attributes'][kind] or '-'}</td>
+    </tr>
+    % if spec:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.spec')}</td>
+        <td>${spec}</td>
+    </tr>
+    % endif
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.erl_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_tecto-lines.ber_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/chsdi/templates/htmlpopup/swissgeocover2d_unconsolidated.mako
+++ b/chsdi/templates/htmlpopup/swissgeocover2d_unconsolidated.mako
@@ -1,0 +1,51 @@
+<%inherit file="base.mako"/>
+
+<%def name="table_body(c, lang)">
+<%
+    lang = lang if lang in ('fr',) else 'de'
+    runc_litho = 'runc_litho_%s' % lang
+    runc_litstrat = 'runc_litstrat_%s' % lang
+    runc_chrono = 'runc_chrono_combined_%s' % lang
+    runc_glac_typ = 'runc_glac_typ_%s' % lang
+    runc_structur = 'runc_structur_%s' % lang
+    runc_morpholo = 'runc_morpholo_%s' % lang
+%>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.runc_litho')}</td>
+        <td>${c['attributes'][runc_litho] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.runc_litstrat')}</td>
+        <td>${c['attributes'][runc_litstrat] or '-'}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.runc_chrono')}</td>
+        <td>${c['attributes'][runc_chrono] or '-'}</td>
+    </tr>
+    % if c['attributes'][runc_glac_typ]:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.runc_glac_typ')}</td>
+        <td>${c['attributes'][runc_glac_typ]}</td>
+    </tr>
+    % endif
+    % if c['attributes'][runc_structur]:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.runc_structur')}</td>
+        <td>${c['attributes'][runc_structur]}</td>
+    </tr>
+    % endif
+    % if c['attributes'][runc_morpholo]:
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.runc_morpholo')}</td>
+        <td>${c['attributes'][runc_morpholo]}</td>
+    </tr>
+    % endif
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.erl_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('erl_link')) | n}</td>
+    </tr>
+    <tr>
+        <td class="cell-left">${_('ch.swisstopo.geologie-swissgeocover2d_unconsolidated.ber_link')}</td>
+        <td>${h.pipe_links(c['attributes'].get('ber_link')) | n}</td>
+    </tr>
+</%def>

--- a/tests/functional/test_helpers.py
+++ b/tests/functional/test_helpers.py
@@ -7,7 +7,8 @@ from chsdi.lib.helpers import (
     parse_box2d, center_from_box2d,
     parse_date_string, parse_date_datenstand, int_with_apostrophe, get_loaderjs_url,
     get_crs_from_srid, get_precision_for_proj, _round_bbox_coordinates, _round_shape_coordinates,
-    round_geometry_coordinates, _transform_coordinates, _transform_shape, transform_round_geometry
+    round_geometry_coordinates, _transform_coordinates, _transform_shape, transform_round_geometry,
+    pipe_links
 )
 from shapely.geometry import Point, Polygon
 from shapely.geometry import mapping
@@ -232,3 +233,35 @@ class TestHelpers(unittest.TestCase):
 
         self.assertEqual(mapping(point_wgs84_rounded), {'type': 'Point', 'coordinates': (7.438767, 37.274227)})
         assert_almost_equal(point_wgs84.coords[0], (7.438767146513139, 37.27422679580366), decimal=10)
+
+
+class TestPipeLinks(unittest.TestCase):
+
+    def test_single_url(self):
+        url = 'https://data.geo.admin.ch/ch.swisstopo.geologie-geocover/berichte/BER_96.pdf'
+        result = pipe_links(url)
+        self.assertEqual(result, '<a href="{}" target="_blank">BER_96.pdf</a>'.format(url))
+
+    def test_multiple_urls(self):
+        value = ('https://data.geo.admin.ch/ch.swisstopo.geologie-geocover/berichte/BER_96.pdf'
+                 '|https://data.geo.admin.ch/ch.swisstopo.geologie-geocover/berichte/BER_1.pdf')
+        result = pipe_links(value)
+        self.assertIn('<a href="https://data.geo.admin.ch/ch.swisstopo.geologie-geocover/berichte/BER_96.pdf" target="_blank">BER_96.pdf</a>', result)
+        self.assertIn('<a href="https://data.geo.admin.ch/ch.swisstopo.geologie-geocover/berichte/BER_1.pdf" target="_blank">BER_1.pdf</a>', result)
+        self.assertEqual(result.count('<a '), 2)
+
+    def test_whitespace_around_separator(self):
+        value = 'https://example.com/a.pdf | https://example.com/b.pdf'
+        result = pipe_links(value)
+        self.assertEqual(result.count('<a '), 2)
+        self.assertIn('href="https://example.com/a.pdf"', result)
+        self.assertIn('href="https://example.com/b.pdf"', result)
+
+    def test_empty_string(self):
+        self.assertEqual(pipe_links(''), '-')
+
+    def test_placeholder_dash(self):
+        self.assertEqual(pipe_links('-'), '-')
+
+    def test_none(self):
+        self.assertEqual(pipe_links(None), '-')


### PR DESCRIPTION
Updated htmlPopup  and models for the new `swissGEOCOVER2d` ( will utlimately replace completly  `ch.swssisstopo.geology-gecover`)

* New `mako`  templates (`swissgeocover2d*`)
* New models `SwissGeocover2d*`  (`ch.swisstopo.swissgeocover2d*`)
* Small mako helper function `pipe_links` + tests
* Old `Geocover*` classes and mako untouched (runs in parallel if needed)

Need `swissgeocover2d.gpkg` generated with `gcover >=0.8.11` ( added field `spec_de` and `spec_de`)