### PR TITLE
fix: ordered MapServer layers deterministically

### DIFF
--- a/chsdi/views/layers.py
+++ b/chsdi/views/layers.py
@@ -224,6 +224,7 @@ def get_layers_metadata_for_params(params, query, model, layerIds=None):
         model.staging,
         params.geodataStaging
     )
+    query = query.order_by(model.layerBodId)
     if layerIds is not None:
         for layerId in layerIds:
             layer = get_layer(query, model, layerId)


### PR DESCRIPTION
MapServer metadata responses exposed database row order, so updated BOD rows could change the order of the returned layers between requests.

The metadata query now orders results by the unique layerBodId primary key before generating the response.

should help to fix issues like this one in the e2e tests:
```
======================================================================
FAIL: test_map_server_accept_language:2
'de-CH' (tests.mf_chsdi3.test_functional.test_map_server.TestMapServer.test_map_server_accept_language:2
'de-CH')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/codebuild/output/src907/src/github.com/geoadmin/infra-e2e-tests/tests/mf_chsdi3/test_functional/test_map_server.py", line 119, in test_map_server_accept_language
    self.assertDictEqual(query_lang_data, response.json())
AssertionError: {'map[138 chars]r': 'Bundesamt für Landestopografie swisstopo'[2619396 chars]Map'} != {'map[138 chars]r': 'Amtliche Vermessung Schweiz', 'dataStatus[2619396 chars]Map'}
Diff is 6004370 characters long. Set self.maxDiff to None to see it.

-------------------- >> begin captured logging << --------------------
2026-09-01 12:07:28,475: utils.base: INFO: --- Set Up Test -------------------------------------------------------------
2026-09-01 12:07:28,477: utils.base: INFO: --- Set Up Test DONE --------------------------------------------------------
2026-09-01 12:07:28,477: utils.requests: DEBUG: Languages "de-CH" parsed into [{'full-tag': 'de-CH', 'tag': 'de', 'sub-tag': 'CH', 'weight': 1}] and filtered by ['de', 'fr', 'it', 'rm', 'en']
2026-09-01 12:07:28,477: curlified: DEBUG: 
     $: curl -X GET -H "If-None-Match: "a332078c-d13f-4744-a7d0-1459f1d7375f"" -H "X-E2E-Testing: 841112df-37d0-40ad-89e1-ff0a92ca4a24" -H "user-agent: python-requests/e2e-tests" https://api3.geo.admin.ch/rest/services/all/MapServer?lang=de
2026-09-01 12:07:28,624: curlified: DEBUG: Response for get https://api3.geo.admin.ch/rest/services/all/MapServer max_length=512:
    200 OK
    Content-Type:application/json
    Transfer-Encoding:chunked
    Connection:keep-alive
    Access-Control-Allow-Headers:*
    Access-Control-Allow-Methods:GET, HEAD, OPTIONS
    Access-Control-Allow-Origin:*
    Cache-Control:max-age=1800, public
    Content-Encoding:gzip
    Date:Tue, 01 Sep 2026 12:07:28 GMT
    Server:Apache/2.4.68 (Debian)
    X-Ua-Compatible:IE=Edge
    Vary:Accept-Encoding
    X-Cache:Miss from cloudfront
    Via:1.1 84294257ed643a88ee54d2e3f7d7ccea.cloudfront.net (CloudFront)
    X-Amz-Cf-Pop:FRA56-P2
    X-Amz-Cf-Id:yWiawbMxvLDFWjOkmEukDsTKq4tFm11Ks7el-QxyPBNdt-KadFFx2w==
{"mapName":"all","description":"Configuration for the map (topic) all","copyrightUnicode":"Data all","layers":[{"attributes":{"dataOwner":"Bundesamt f\u00fcr Landestopografie swisstopo","urlDetails":"https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d","dataStatus":"20260224","inspireUpperAbstract":"Infrastruktur und Kommunikation","abstract":"swissTLM3D Strassen und Wege enth\u00e4lt das Strassen- und Wegnetz der Schweiz und des F\u00fcrstentums Liechtenstein. Es ist Bestandteil des Datensatzes 
2026-09-01 12:07:28,655: curlified: DEBUG: 
     $: curl -X GET -H "accept-language: de-CH" -H "If-None-Match: "5fe38c85-dbb9-4729-9057-f85af5ef1291"" -H "X-E2E-Testing: 1534ec2a-c546-4806-b937-83c152529d20" -H "user-agent: python-requests/e2e-tests" https://api3.geo.admin.ch/rest/services/all/MapServer
2026-09-01 12:07:28,748: curlified: DEBUG: Response for get https://api3.geo.admin.ch/rest/services/all/MapServer max_length=512:
    200 OK
    Content-Type:application/json
    Transfer-Encoding:chunked
    Connection:keep-alive
    Access-Control-Allow-Headers:*
    Access-Control-Allow-Methods:GET, HEAD, OPTIONS
    Access-Control-Allow-Origin:*
    Cache-Control:max-age=1800, public
    Content-Encoding:gzip
    Date:Tue, 01 Sep 2026 12:07:28 GMT
    Server:Apache/2.4.68 (Debian)
    X-Ua-Compatible:IE=Edge
    Vary:Accept-Encoding
    X-Cache:Miss from cloudfront
    Via:1.1 84294257ed643a88ee54d2e3f7d7ccea.cloudfront.net (CloudFront)
    X-Amz-Cf-Pop:FRA56-P2
    X-Amz-Cf-Id:LczsQaoaS1H3L356tE50Jsa--xPOirX6bqflNYslzHGJcAWvf_22Cg==
{"mapName":"all","description":"Configuration for the map (topic) all","copyrightUnicode":"Data all","layers":[{"attributes":{"dataOwner":"Amtliche Vermessung Schweiz","dataStatus":"20260901 13:57","inspireUpperAbstract":"Basisdaten","abstract":"Die amtliche Vermessung (AV) beschreibt die Lage, die Form und den Inhalt eines Grundst\u00fcckes. Die digitalen AV-Daten sind in mehreren thematischen Informationsebenen gegliedert, die frei miteinander kombiniert werden k\u00f6nnen. OpenData AV basiert auf dem Dar
--------------------- >> end captured logging << ---------------------
======================================================================
FAIL: test_map_server_accept_language:5
'fr;q=0.5,de' (tests.mf_chsdi3.test_functional.test_map_server.TestMapServer.test_map_server_accept_language:5
'fr;q=0.5,de')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/codebuild/output/src907/src/github.com/geoadmin/infra-e2e-tests/tests/mf_chsdi3/test_functional/test_map_server.py", line 119, in test_map_server_accept_language
    self.assertDictEqual(query_lang_data, response.json())
AssertionError: {'map[138 chars]r': 'Amtliche Vermessung Schweiz', 'dataStatus[2619396 chars]Map'} != {'map[138 chars]r': 'Bundesamt für Landestopografie swisstopo'[2619396 chars]Map'}
Diff is 6004370 characters long. Set self.maxDiff to None to see it.

-------------------- >> begin captured logging << --------------------
2026-09-01 12:07:28,522: utils.base: INFO: --- Set Up Test -------------------------------------------------------------
2026-09-01 12:07:28,524: utils.base: INFO: --- Set Up Test DONE --------------------------------------------------------
2026-09-01 12:07:28,525: utils.requests: DEBUG: Languages "fr;q=0.5,de" parsed into [{'full-tag': 'de', 'tag': 'de', 'sub-tag': None, 'weight': 1}, {'full-tag': 'fr', 'tag': 'fr', 'sub-tag': None, 'weight': 0.5}] and filtered by ['de', 'fr', 'it', 'rm', 'en']
2026-09-01 12:07:28,525: curlified: DEBUG: 
     $: curl -X GET -H "If-None-Match: "bf5ebb8b-5ae8-4ff7-8a5b-0da5bf7d9b57"" -H "X-E2E-Testing: 01a4d635-a501-4169-b2c2-97b41031bb29" -H "user-agent: python-requests/e2e-tests" https://api3.geo.admin.ch/rest/services/all/MapServer?lang=de
2026-09-01 12:07:28,748: curlified: DEBUG: Response for get https://api3.geo.admin.ch/rest/services/all/MapServer max_length=512:
    200 OK
    Content-Type:application/json
    Transfer-Encoding:chunked
    Connection:keep-alive
    Access-Control-Allow-Headers:*
    Access-Control-Allow-Methods:GET, HEAD, OPTIONS
    Access-Control-Allow-Origin:*
    Cache-Control:max-age=1800, public
    Content-Encoding:gzip
    Date:Tue, 01 Sep 2026 12:07:28 GMT
    Server:Apache/2.4.68 (Debian)
    X-Ua-Compatible:IE=Edge
    Vary:Accept-Encoding
    X-Cache:Miss from cloudfront
    Via:1.1 83f1b8f73f37458f38e2ee1fc0b9e68c.cloudfront.net (CloudFront)
    X-Amz-Cf-Pop:FRA56-P2
    X-Amz-Cf-Id:mnYGFgg3kQZASwIiUbJ-Lhu_98FWfM2SxH9k06iSmwEW0poZFhWQLA==
{"mapName":"all","description":"Configuration for the map (topic) all","copyrightUnicode":"Data all","layers":[{"attributes":{"dataOwner":"Amtliche Vermessung Schweiz","dataStatus":"20260901 13:57","inspireUpperAbstract":"Basisdaten","abstract":"Die amtliche Vermessung (AV) beschreibt die Lage, die Form und den Inhalt eines Grundst\u00fcckes. Die digitalen AV-Daten sind in mehreren thematischen Informationsebenen gegliedert, die frei miteinander kombiniert werden k\u00f6nnen. OpenData AV basiert auf dem Dar
2026-09-01 12:07:28,769: curlified: DEBUG: 
     $: curl -X GET -H "accept-language: fr;q=0.5,de" -H "If-None-Match: "f425fddf-816e-4d82-9fa4-f8a39ab4c826"" -H "X-E2E-Testing: 4bfc0b6c-e143-4bfa-9669-a5f232051e6d" -H "user-agent: python-requests/e2e-tests" https://api3.geo.admin.ch/rest/services/all/MapServer
2026-09-01 12:07:28,863: curlified: DEBUG: Response for get https://api3.geo.admin.ch/rest/services/all/MapServer max_length=512:
    200 OK
    Content-Type:application/json
    Transfer-Encoding:chunked
    Connection:keep-alive
    Access-Control-Allow-Headers:*
    Access-Control-Allow-Methods:GET, HEAD, OPTIONS
    Access-Control-Allow-Origin:*
    Cache-Control:max-age=1800, public
    Content-Encoding:gzip
    Date:Tue, 01 Sep 2026 12:07:28 GMT
    Server:Apache/2.4.68 (Debian)
    X-Ua-Compatible:IE=Edge
    Vary:Accept-Encoding
    X-Cache:Miss from cloudfront
    Via:1.1 83f1b8f73f37458f38e2ee1fc0b9e68c.cloudfront.net (CloudFront)
    X-Amz-Cf-Pop:FRA56-P2
    X-Amz-Cf-Id:4vFsOAvLRTma7Qa62eMLPYyEHSR7p_DRSOwk5TAOGrl45Wd_5eouxQ==
{"mapName":"all","description":"Configuration for the map (topic) all","copyrightUnicode":"Data all","layers":[{"attributes":{"dataOwner":"Bundesamt f\u00fcr Landestopografie swisstopo","urlDetails":"https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d","dataStatus":"20260224","inspireUpperAbstract":"Infrastruktur und Kommunikation","abstract":"swissTLM3D Strassen und Wege enth\u00e4lt das Strassen- und Wegnetz der Schweiz und des F\u00fcrstentums Liechtenstein. Es ist Bestandteil des Datensatzes 
--------------------- >> end captured logging << ---------------------
======================================================================
FAIL: test_map_server_accept_language:1
'en' (tests.mf_chsdi3.test_functional.test_map_server.TestMapServer.test_map_server_accept_language:1
'en')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/codebuild/output/src907/src/github.com/geoadmin/infra-e2e-tests/tests/mf_chsdi3/test_functional/test_map_server.py", line 119, in test_map_server_accept_language
    self.assertDictEqual(query_lang_data, response.json())
AssertionError: {'map[13173 chars]'api,cadastre,ech,inspire,service-wms,swisstop[2530694 chars]Map'} != {'map[13173 chars]'api,bafu,ech,gewiss,inspire,service-wms', 'wm[2530694 chars]Map'}
Diff is 5741161 characters long. Set self.maxDiff to None to see it.

-------------------- >> begin captured logging << --------------------
2026-09-01 12:07:28,465: utils.base: INFO: --- Set Up Test -------------------------------------------------------------
2026-09-01 12:07:28,468: utils.base: INFO: --- Set Up Test DONE --------------------------------------------------------
2026-09-01 12:07:28,468: utils.requests: DEBUG: Languages "en" parsed into [{'full-tag': 'en', 'tag': 'en', 'sub-tag': None, 'weight': 1}] and filtered by ['de', 'fr', 'it', 'rm', 'en']
2026-09-01 12:07:28,468: curlified: DEBUG: 
     $: curl -X GET -H "If-None-Match: "4582e131-8af3-40f4-af08-4d155989b578"" -H "X-E2E-Testing: 3aaf1046-1ee6-40b4-83d2-0de64f3448a0" -H "user-agent: python-requests/e2e-tests" https://api3.geo.admin.ch/rest/services/all/MapServer?lang=en
2026-09-01 12:07:28,620: curlified: DEBUG: Response for get https://api3.geo.admin.ch/rest/services/all/MapServer max_length=512:
    200 OK
    Content-Type:application/json
    Transfer-Encoding:chunked
    Connection:keep-alive
    Access-Control-Allow-Headers:*
    Access-Control-Allow-Methods:GET, HEAD, OPTIONS
    Access-Control-Allow-Origin:*
    Cache-Control:max-age=1800, public
    Content-Encoding:gzip
    Date:Tue, 01 Sep 2026 12:07:28 GMT
    Server:Apache/2.4.68 (Debian)
    X-Ua-Compatible:IE=Edge
    Vary:Accept-Encoding
    X-Cache:Miss from cloudfront
    Via:1.1 3a3c1dcacd115187f53f40028ae4bd24.cloudfront.net (CloudFront)
    X-Amz-Cf-Pop:FRA56-P2
    X-Amz-Cf-Id:8cpeOEpIvQl33opB0Gh5VlZDkoUmzFaaWeN5w5vZrUNzeCYWXDz_XQ==
{"mapName":"all","description":"Configuration for the map (topic) all","copyrightUnicode":"Data all","layers":[{"attributes":{"wmsContactName":"Federal Office of Topography swisstopo","maps":"api,ech,geol,georessourcen,inspire,schule,service-wms","wmsUrlResource":"https://wms.geo.admin.ch/?REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0","scaleLimit":"-","dataOwner":"Federal Office of Topography swisstopo, Georesources Switzerland Group","urlDetails":"https://rawmaterials.swissgeol.ch/de","dataStatus":"20
2026-09-01 12:07:28,636: curlified: DEBUG: 
     $: curl -X GET -H "accept-language: en" -H "If-None-Match: "7958ab07-40b1-4e54-95c0-c654b37aad6b"" -H "X-E2E-Testing: 6bcccdd1-3e1f-44e6-9f99-6ae1df7a3acb" -H "user-agent: python-requests/e2e-tests" https://api3.geo.admin.ch/rest/services/all/MapServer
2026-09-01 12:07:28,821: curlified: DEBUG: Response for get https://api3.geo.admin.ch/rest/services/all/MapServer max_length=512:
    200 OK
    Content-Type:application/json
    Transfer-Encoding:chunked
    Connection:keep-alive
    Access-Control-Allow-Headers:*
    Access-Control-Allow-Methods:GET, HEAD, OPTIONS
    Access-Control-Allow-Origin:*
    Cache-Control:max-age=1800, public
    Content-Encoding:gzip
    Date:Tue, 01 Sep 2026 12:07:28 GMT
    Server:Apache/2.4.68 (Debian)
    X-Ua-Compatible:IE=Edge
    Vary:Accept-Encoding
    X-Cache:Miss from cloudfront
    Via:1.1 3a3c1dcacd115187f53f40028ae4bd24.cloudfront.net (CloudFront)
    X-Amz-Cf-Pop:FRA56-P2
    X-Amz-Cf-Id:eJHocjGQBoWppQd32oNgJvUgvAWsPk7foSeHlzXE4ijnHO34ZCrXog==
{"mapName":"all","description":"Configuration for the map (topic) all","copyrightUnicode":"Data all","layers":[{"attributes":{"wmsContactName":"Federal Office of Topography swisstopo","maps":"api,ech,geol,georessourcen,inspire,schule,service-wms","wmsUrlResource":"https://wms.geo.admin.ch/?REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.3.0","scaleLimit":"-","dataOwner":"Federal Office of Topography swisstopo, Georesources Switzerland Group","urlDetails":"https://rawmaterials.swissgeol.ch/de","dataStatus":"20
--------------------- >> end captured logging << ---------------------
```

Root cause: The test compared two independently fetched 914-layer responses for exact equality. Production updates dataStatus continuously, and layer ordering can also vary between requests, causing valid language-equivalent responses to differ.

This change normalizes the layer order and excludes only the volatile dataStatus field before comparison. All language-dependent content remains covered, so genuine Accept-Language regressions will still fail the test.